### PR TITLE
fix(import): create name for Trello labels with no name

### DIFF
--- a/.changeset/grumpy-goats-heal.md
+++ b/.changeset/grumpy-goats-heal.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": patch
+---
+
+fix(import): create name for Trello labels with no name

--- a/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
+++ b/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
@@ -61,7 +61,8 @@ export class TrelloJsonImporter implements Importer {
       const allLabels = card.labels.map(label => ({
         id: label.id,
         color: mapLabelColor(label.color),
-        name: label.name,
+        // Trello allows labels with no name and only a color value, but we must specify a name
+        name: label.name || `Trello-${label.color}`,
       }));
 
       for (const label of allLabels) {


### PR DESCRIPTION
Trello labels can be created with no name, but all Linear issue labels must have a name. Set a default name for labels without one.

Fixes this issue: https://github.com/linear/linear-import/issues/53