### PR TITLE
fix(actions): unique generated changeset filenames

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -32,9 +32,6 @@ jobs:
       - name: Run tests
         run: yarn test:ci
 
-      - name: Add empty changeset for editing later
-        run: yarn changeset add --empty
-
       - name: Create dependencies pull request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -39,9 +39,6 @@ jobs:
           schema: "master:packages/sdk/src/schema.graphql"
           fail-on-breaking: false
 
-      - name: Add empty changeset for editing later
-        run: yarn changeset add --empty
-
       - name: Create schema pull request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/packages/sdk/scripts/generate-dependencies-changeset.ts
+++ b/packages/sdk/scripts/generate-dependencies-changeset.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { promisify } from "util";
 import { logger, printLines } from "../../codegen-doc/src/index";
 
-const filename = path.resolve(`../../.changeset/_generated_dependencies_${Math.ceil(Math.random() * 100000000)}.md`);
+const filename = path.resolve(`../../.changeset/_generated_dependencies.md`);
 
 const changeset = printLines([
   "---",

--- a/packages/sdk/scripts/generate-dependencies-changeset.ts
+++ b/packages/sdk/scripts/generate-dependencies-changeset.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { promisify } from "util";
 import { logger, printLines } from "../../codegen-doc/src/index";
 
-const filename = path.resolve("../../.changeset/_generated_dependencies.md");
+const filename = path.resolve(`../../.changeset/_generated_dependencies_${Math.ceil(Math.random() * 100000000)}.md`);
 
 const changeset = printLines([
   "---",

--- a/packages/sdk/scripts/generate-dependencies-changeset.ts
+++ b/packages/sdk/scripts/generate-dependencies-changeset.ts
@@ -1,21 +1,25 @@
-import { writeFileSync } from "fs";
+import { writeFile } from "fs";
 import path from "path";
-import { logger } from "../../codegen-doc/src/index";
+import { promisify } from "util";
+import { logger, printLines } from "../../codegen-doc/src/index";
 
+const filename = path.resolve("../../.changeset/_generated_dependencies.md");
+
+const changeset = printLines([
+  "---",
+  '"@linear/sdk": patch',
+  '"@linear/import": patch',
+  '"@linear/codegen-doc": patch',
+  '"@linear/codegen-sdk": patch',
+  '"@linear/codegen-test": patch',
+  "---",
+]);
+
+/**
+ * Generate a changeset file for updating patch dependencies
+ */
 async function generateChangeset() {
-  writeFileSync(
-    path.resolve("../../.changeset/_generated_dependencies.md"),
-    `---
-"@linear/sdk": patch
-"@linear/import": patch
-"@linear/codegen-doc": patch
-"@linear/codegen-sdk": patch
-"@linear/codegen-test": patch
----
-  
-chore(deps): update dependency patch versions
-`
-  );
+  await promisify(writeFile)(filename, printLines([changeset, "\n", "chore(deps): update dependency patch versions"]));
 }
 
 generateChangeset()

--- a/packages/sdk/scripts/generate-schema-changeset.ts
+++ b/packages/sdk/scripts/generate-schema-changeset.ts
@@ -13,7 +13,7 @@ const levelOrder = {
   [CriticalityLevel.NonBreaking]: 0,
 };
 
-const filename = path.resolve(`../../.changeset/_generated_schema+${Math.ceil(Math.random() * 100000000)}.md`);
+const filename = path.resolve(`../../.changeset/_generated_schema_${Math.ceil(Math.random() * 100000000)}.md`);
 
 const changeset = printLines(["---", '"@linear/sdk": minor', "---"]);
 


### PR DESCRIPTION
Fixes the changeset getting overwritten if the version package PR has not been merged before another schema PR is merged into master

![image](https://user-images.githubusercontent.com/2467416/112370124-ebaef800-8cd4-11eb-8ae0-aed3d80ab519.png)
