### PR TITLE
Added option to discard archived lists with the Trello JSON file import.

### DIFF
--- a/.changeset/real-camels-remain.md
+++ b/.changeset/real-camels-remain.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": patch
+---
+
+feat(import): added option to discard archived lists with the Trello JSON file import.

--- a/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
+++ b/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
@@ -14,12 +14,19 @@ interface TrelloCard {
     name: string;
     color: TrelloLabelColor;
   }[];
+  idList: string
+}
+
+interface TrelloList {
+  id: string;
+  closed: boolean;
 }
 
 export class TrelloJsonImporter implements Importer {
-  public constructor(filePath: string, discardArchived: boolean) {
+  public constructor(filePath: string, discardArchivedCards: boolean, discardArchivedLists: boolean) {
     this.filePath = filePath;
-    this.discardArchived = discardArchived;
+    this.discardArchivedCards = discardArchivedCards;
+    this.discardArchivedLists = discardArchivedLists;
   }
 
   public get name(): string {
@@ -47,7 +54,14 @@ export class TrelloJsonImporter implements Importer {
       const description = `${mdDesc}\n\n[View original card in Trello](${url})`;
       const labels = card.labels.map(l => l.id);
 
-      if (this.discardArchived && card.closed) {
+      if (this.discardArchivedCards && card.closed) {
+        continue;
+      }
+
+      if (
+        this.discardArchivedLists
+        && (data.lists as TrelloList[]).find((list) => list.id === card.idList && list.closed)
+      ) {
         continue;
       }
 
@@ -76,7 +90,8 @@ export class TrelloJsonImporter implements Importer {
 
   // -- Private interface
   private filePath: string;
-  private discardArchived: boolean;
+  private discardArchivedCards: boolean;
+  private discardArchivedLists: boolean;
 }
 
 // Maps Trello colors to Linear branded colors

--- a/packages/import/src/importers/trelloJson/index.ts
+++ b/packages/import/src/importers/trelloJson/index.ts
@@ -6,13 +6,18 @@ const BASE_PATH = process.cwd();
 
 export const trelloJsonImport = async (): Promise<Importer> => {
   const answers = await inquirer.prompt<TrelloImportAnswers>(questions);
-  const trelloImporter = new TrelloJsonImporter(answers.trelloFilePath, answers.discardArchived);
+  const trelloImporter = new TrelloJsonImporter(
+    answers.trelloFilePath,
+    answers.discardArchivedCards,
+    answers.discardArchivedLists
+  );
   return trelloImporter;
 };
 
 interface TrelloImportAnswers {
   trelloFilePath: string;
-  discardArchived: boolean;
+  discardArchivedCards: boolean;
+  discardArchivedLists: boolean;
 }
 
 const questions = [
@@ -24,8 +29,14 @@ const questions = [
   },
   {
     type: "confirm",
-    name: "discardArchived",
+    name: "discardArchivedCards",
     message: "Would you like to discard the archived cards?",
+    default: true,
+  },
+  {
+    type: "confirm",
+    name: "discardArchivedLists",
+    message: "Would you like to discard the (possibly unarchived) cards within archived lists?",
     default: true,
   },
 ];


### PR DESCRIPTION
This PR adds the ability to discard unarchived cards from archived lists (resolves #92). The existing _"Would you like to discard the archived cards?"_ question is followed by a new _"Would you like to discard the (possibly unarchived) cards within archived lists?"_ question.

In the for loop on `data.cards` the flag (`discardArchivedLists`) will be used to determine if a is-list-archived check is necessary. If so the `.find` method is used. Performing this check is not the most efficient way to include/exclude the card from the export but it is the least convoluted due to the logic residing in a single if statement. The following would be more performant:

```typescript
const listIdsToIgnore: string[] = this.discardArchivedLists
    ? (data.lists as TrelloList[])
        .filter((list) => list.closed)
        .map((list) => list.id)
    : []
```

A way of applying filters in a consistent matter would be:

```typescript
const archivedCardFilter = (card) => !card.closed
const archivedListFilter = (card) => !listIdsToIgnore.includes(card.listId)

const cards = (data.cards as TrelloCard[])
    .filter(this.discardArchivedCards ? archivedCardFilter : () => true)
    .filter(this.discardArchivedLists ? archivedListFilter : () => true)

for (const card of cards) {

}
```

_code above is untested and could use some cleaning_