### PR TITLE
feat(import): transferring Linear to Linear CSV importer from old repo

### DIFF
--- a/.changeset/green-avocados-shout.md
+++ b/.changeset/green-avocados-shout.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": patch
+---
+
+feat(import): transferring Linear to Linear CSV importer from old repo

--- a/packages/import/README.md
+++ b/packages/import/README.md
@@ -100,6 +100,18 @@ Following fields are supported:
 - `URL` - URL of Trello card
 - `Labels` - Added as a label
 
+### Linear CSV
+
+Linear CSV exports (Settings → Import / Export → Export CSV) can be imported into Linear again. You can use this to import issues from one workspace to another. Archived issues won't be imported.
+
+Following fields are supported:
+
+- `Title` - Issue title
+- `Description` - Issue description
+- `Priority` - Issue priority
+- `Status` - Issue state (workflow)
+- `Assignee` - Issue assignee
+- `Labels` - Added as a label
 ## Todo
 
 - [x] Automatic image uploads

--- a/packages/import/src/cli.ts
+++ b/packages/import/src/cli.ts
@@ -6,6 +6,7 @@ import { asanaCsvImport } from "./importers/asanaCsv";
 import { clubhouseCsvImport } from "./importers/clubhouseCsv";
 import { githubImport } from "./importers/github";
 import { jiraCsvImport } from "./importers/jiraCsv";
+import { linearCsvImporter } from "./importers/linearCsv";
 import { pivotalCsvImport } from "./importers/pivotalCsv";
 import { trelloJsonImport } from "./importers/trelloJson";
 import { importIssues } from "./importIssues";
@@ -50,6 +51,10 @@ inquirer.registerPrompt("filePath", require("inquirer-file-path"));
             name: "Trello (JSON export)",
             value: "trelloJson",
           },
+          {
+            name: "Linear (CSV export)",
+            value: "linearCsv",
+          },
         ],
       },
     ]);
@@ -74,6 +79,9 @@ inquirer.registerPrompt("filePath", require("inquirer-file-path"));
         break;
       case "trelloJson":
         importer = await trelloJsonImport();
+        break;
+      case "linearCsv":
+        importer = await linearCsvImporter();
         break;
       default:
         console.log(chalk.red(`Invalid importer`));

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -28,7 +28,7 @@ const defaultStateColors = {
  * Import issues into Linear via the API.
  */
 export const importIssues = async (apiKey: string, importer: Importer): Promise<void> => {
-  const client = new LinearClient({ apiKey, apiUrl: "http://localhost:8090/graphql" });
+  const client = new LinearClient({ apiKey });
   const importData = await importer.import();
 
   const teamsQuery = await client.teams();

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -18,11 +18,17 @@ interface ImportAnswers {
   teamName?: string;
 }
 
+const defaultStateColors = {
+  backlog: "#bec2c8",
+  started: "#f2c94c",
+  completed: "#5e6ad2",
+};
+
 /**
  * Import issues into Linear via the API.
  */
 export const importIssues = async (apiKey: string, importer: Importer): Promise<void> => {
-  const client = new LinearClient({ apiKey });
+  const client = new LinearClient({ apiKey, apiUrl: "http://localhost:8090/graphql" });
   const importData = await importer.import();
 
   const teamsQuery = await client.teams();
@@ -227,7 +233,29 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
 
     const labelIds = issue.labels ? issue.labels.map(labelId => labelMapping[labelId]) : undefined;
 
-    const stateId = !!issue.status ? existingStateMap[issue.status.toLowerCase()] : undefined;
+    let stateId = !!issue.status ? existingStateMap[issue.status.toLowerCase()] : undefined;
+    // Create a new state since one doesn't already exist with this name
+    if (!stateId && issue.status) {
+      let stateType = "backlog";
+      if (issue.completedAt) {
+        stateType = "completed";
+      } else if (issue.startedAt) {
+        stateType = "started";
+      }
+      const newStateResult = await client.workflowStateCreate({
+        name: issue.status,
+        teamId,
+        color: defaultStateColors[stateType],
+        type: stateType,
+      });
+      if (newStateResult?.success) {
+        const newState = await newStateResult.workflowState;
+        if (newState?.id) {
+          existingStateMap[issue.status.toLowerCase()] = newState.id;
+          stateId = newState.id;
+        }
+      }
+    }
 
     const existingAssigneeId: string | undefined = !!issue.assigneeId
       ? existingUserMap[issue.assigneeId.toLowerCase()]

--- a/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
+++ b/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
@@ -77,6 +77,8 @@ export class LinearCsvImporter implements Importer {
         priority: mapPriority(row.Priority),
         status: row.Status,
         assigneeId: row.Assignee,
+        completedAt: !!row.Completed ? new Date(row.Completed) : undefined,
+        startedAt: !!row.Started ? new Date(row.Started) : undefined,
         labels,
       });
 

--- a/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
+++ b/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
@@ -1,0 +1,110 @@
+import csv from "csvtojson";
+import { Importer, ImportResult } from "../../types";
+
+type LinearPriority = "No priority" | "Urgent" | "High" | "Medium" | "Low";
+
+interface LinearIssueType {
+  Id: string;
+  Team: string;
+  Title: string;
+  Description: string;
+  Status: string;
+  Estimate: string;
+  Priority: LinearPriority;
+  Project: string;
+  Creator: string;
+  Assignee: string;
+  Labels: string;
+  "Cycle Number": string;
+  "Cycle Name": string;
+  "Cycle Start": string;
+  "Cycle End": string;
+  Created: string;
+  Updated: string;
+  Started: string;
+  Completed: string;
+  Canceled: string;
+  Archived: string;
+}
+
+/**
+ * Import issues from Linear CSV export.
+ *
+ * @param filePath  path to csv file
+ */
+export class LinearCsvImporter implements Importer {
+  public constructor(filePath: string) {
+    this.filePath = filePath;
+  }
+
+  public get name(): string {
+    return "Linear (CSV)";
+  }
+
+  public get defaultTeamName(): string {
+    return "Linear";
+  }
+
+  public import = async (): Promise<ImportResult> => {
+    const data = (await csv().fromFile(this.filePath)) as LinearIssueType[];
+
+    const importData: ImportResult = {
+      issues: [],
+      labels: {},
+      users: {},
+      statuses: {},
+    };
+
+    const assignees = Array.from(new Set(data.map(row => row.Assignee)));
+
+    for (const user of assignees) {
+      importData.users[user] = {
+        name: user,
+      };
+    }
+
+    for (const row of data) {
+      if (!!row.Archived) {
+        continue;
+      }
+
+      const tags = row.Labels.split(", ");
+      const labels = tags.filter(tag => !!tag);
+
+      importData.issues.push({
+        title: row.Title,
+        description: row.Description,
+        priority: mapPriority(row.Priority),
+        status: row.Status,
+        assigneeId: row.Assignee,
+        labels,
+      });
+
+      for (const lab of labels) {
+        if (!importData.labels[lab]) {
+          importData.labels[lab] = {
+            name: lab,
+          };
+        }
+      }
+    }
+
+    return importData;
+  };
+
+  // -- Private interface
+
+  private filePath: string;
+}
+
+const mapPriority = (input: LinearPriority): number => {
+  const priorityMap = {
+    "No priority": 0,
+    Urgent: 1,
+    High: 2,
+    Medium: 3,
+    Low: 4,
+  };
+
+  return priorityMap[input] || 0;
+};

--- a/packages/import/src/importers/linearCsv/index.ts
+++ b/packages/import/src/importers/linearCsv/index.ts
@@ -1,0 +1,25 @@
+import * as inquirer from "inquirer";
+
+import { Importer } from "../../types";
+import { LinearCsvImporter } from "./LinearCsvImporter";
+
+const BASE_PATH = process.cwd();
+
+export const linearCsvImporter = async (): Promise<Importer> => {
+  const answers = await inquirer.prompt<LinearImportAnswers>(questions);
+  const linearImporter = new LinearCsvImporter(answers.linearFilePath);
+  return linearImporter;
+};
+
+interface LinearImportAnswers {
+  linearFilePath: string;
+}
+
+const questions = [
+  {
+    basePath: BASE_PATH,
+    type: "filePath",
+    name: "linearFilePath",
+    message: "Select your exported CSV file of Linear issues",
+  },
+];

--- a/packages/import/src/types.ts
+++ b/packages/import/src/types.ts
@@ -20,6 +20,10 @@ export interface Issue {
   createdAt?: Date;
   /** When the issue is due. This is a date string of the format yyyy-MM-dd. */
   dueDate?: Date;
+  /** When the issue was completed. */
+  completedAt?: Date;
+  /** When the issue was started. */
+  startedAt?: Date;
 }
 
 /** Issue comment */


### PR DESCRIPTION
Transferring over this PR that wasn't merged from the older import repo: https://github.com/linear/linear-import/pull/32

Added additional functionality to it to infer status types and transfer custom statuses.

Closes: https://github.com/linear/linear/issues/80