### PR TITLE
feat(sdk): use optional mutation variables and update schema

### DIFF
--- a/.changeset/_generated_schema_19082443.md
+++ b/.changeset/_generated_schema_19082443.md
@@ -1,0 +1,48 @@
+---
+"@linear/sdk": minor
+---
+
+
+feat(schema): [dangerous] Input field 'clientAuthCode' was added to input object type 'EmailUserAccountAuthChallengeInput' (EmailUserAccountAuthChallengeInput.clientAuthCode)
+
+feat(schema): [dangerous] Input field 'snoozedById' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.snoozedById)
+
+feat(schema): [dangerous] Input field 'snoozedUntilAt' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.snoozedUntilAt)
+
+feat(schema): [non_breaking] Type 'OauthAuthStringAuthorizePayload' was added (OauthAuthStringAuthorizePayload)
+
+feat(schema): [non_breaking] Type 'OauthAuthStringChallengePayload' was added (OauthAuthStringChallengePayload)
+
+feat(schema): [non_breaking] Type 'OauthAuthStringCheckPayload' was added (OauthAuthStringCheckPayload)
+
+feat(schema): [non_breaking] Input field 'ApiKeyCreateInput.key' description changed from 'The API key value (format: /^[a-zA-Z0-9]{40}$/).' to 'The API key value.' (ApiKeyCreateInput.key)
+
+feat(schema): [non_breaking] Field 'snoozedBy' was added to object type 'Issue' (Issue.snoozedBy)
+
+feat(schema): [non_breaking] Field 'snoozedUntilAt' was added to object type 'Issue' (Issue.snoozedUntilAt)
+
+feat(schema): [non_breaking] Field 'issueImport' was added to object type 'IssueHistory' (IssueHistory.issueImport)
+
+feat(schema): [non_breaking] Field 'integrationLoom' was added to object type 'Mutation' (Mutation.integrationLoom)
+
+feat(schema): [non_breaking] Field 'oauthAuthStringAuthorize' was added to object type 'Mutation' (Mutation.oauthAuthStringAuthorize)
+
+feat(schema): [non_breaking] Field 'oauthAuthStringChallenge' was added to object type 'Mutation' (Mutation.oauthAuthStringChallenge)
+
+feat(schema): [non_breaking] Field 'oauthAuthStringCheck' was added to object type 'Mutation' (Mutation.oauthAuthStringCheck)
+
+feat(schema): [non_breaking] Field 'Mutation.apiKeyCreate' description changed from 'Creates a new API key.' to '[Internal] Creates a new API key.' (Mutation.apiKeyCreate)
+
+feat(schema): [non_breaking] Field 'Mutation.apiKeyDelete' description changed from 'Deletes an API key.' to '[Internal] Deletes an API key.' (Mutation.apiKeyDelete)
+
+feat(schema): [non_breaking] Description for argument 'githubRepoName' on field 'Mutation.issueImportCreateGithub' changed from 'Github repository name from which we will import data.' to 'GitHub repository name from which we will import data.' (Mutation.issueImportCreateGithub.githubRepoName)
+
+feat(schema): [non_breaking] Description for argument 'githubRepoOwner' on field 'Mutation.issueImportCreateGithub' changed from 'Github owner (user or org) for the repository from which we will import data.' to 'GitHub owner (user or org) for the repository from which we will import data.' (Mutation.issueImportCreateGithub.githubRepoOwner)
+
+feat(schema): [non_breaking] Description for argument 'githubToken' on field 'Mutation.issueImportCreateGithub' changed from 'Github token to fetch information from the Github API.' to 'GitHub token to fetch information from the GitHub API.' (Mutation.issueImportCreateGithub.githubToken)
+
+feat(schema): [non_breaking] Field 'url' was added to object type 'Project' (Project.url)
+
+feat(schema): [non_breaking] Field 'Query.apiKeys' description changed from 'All API keys for the user.' to '[Internal] All API keys for the user.' (Query.apiKeys)
+
+feat(schema): [non_breaking] Field 'url' was added to object type 'User' (User.url)

--- a/.changeset/_generated_schema_2958400.md
+++ b/.changeset/_generated_schema_2958400.md
@@ -1,0 +1,48 @@
+---
+"@linear/sdk": minor
+---
+
+
+feat(schema): [dangerous] Input field 'clientAuthCode' was added to input object type 'EmailUserAccountAuthChallengeInput' (EmailUserAccountAuthChallengeInput.clientAuthCode)
+
+feat(schema): [dangerous] Input field 'snoozedById' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.snoozedById)
+
+feat(schema): [dangerous] Input field 'snoozedUntilAt' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.snoozedUntilAt)
+
+feat(schema): [non_breaking] Type 'OauthAuthStringAuthorizePayload' was added (OauthAuthStringAuthorizePayload)
+
+feat(schema): [non_breaking] Type 'OauthAuthStringChallengePayload' was added (OauthAuthStringChallengePayload)
+
+feat(schema): [non_breaking] Type 'OauthAuthStringCheckPayload' was added (OauthAuthStringCheckPayload)
+
+feat(schema): [non_breaking] Input field 'ApiKeyCreateInput.key' description changed from 'The API key value (format: /^[a-zA-Z0-9]{40}$/).' to 'The API key value.' (ApiKeyCreateInput.key)
+
+feat(schema): [non_breaking] Field 'snoozedBy' was added to object type 'Issue' (Issue.snoozedBy)
+
+feat(schema): [non_breaking] Field 'snoozedUntilAt' was added to object type 'Issue' (Issue.snoozedUntilAt)
+
+feat(schema): [non_breaking] Field 'issueImport' was added to object type 'IssueHistory' (IssueHistory.issueImport)
+
+feat(schema): [non_breaking] Field 'integrationLoom' was added to object type 'Mutation' (Mutation.integrationLoom)
+
+feat(schema): [non_breaking] Field 'oauthAuthStringAuthorize' was added to object type 'Mutation' (Mutation.oauthAuthStringAuthorize)
+
+feat(schema): [non_breaking] Field 'oauthAuthStringChallenge' was added to object type 'Mutation' (Mutation.oauthAuthStringChallenge)
+
+feat(schema): [non_breaking] Field 'oauthAuthStringCheck' was added to object type 'Mutation' (Mutation.oauthAuthStringCheck)
+
+feat(schema): [non_breaking] Field 'Mutation.apiKeyCreate' description changed from 'Creates a new API key.' to '[Internal] Creates a new API key.' (Mutation.apiKeyCreate)
+
+feat(schema): [non_breaking] Field 'Mutation.apiKeyDelete' description changed from 'Deletes an API key.' to '[Internal] Deletes an API key.' (Mutation.apiKeyDelete)
+
+feat(schema): [non_breaking] Description for argument 'githubRepoName' on field 'Mutation.issueImportCreateGithub' changed from 'Github repository name from which we will import data.' to 'GitHub repository name from which we will import data.' (Mutation.issueImportCreateGithub.githubRepoName)
+
+feat(schema): [non_breaking] Description for argument 'githubRepoOwner' on field 'Mutation.issueImportCreateGithub' changed from 'Github owner (user or org) for the repository from which we will import data.' to 'GitHub owner (user or org) for the repository from which we will import data.' (Mutation.issueImportCreateGithub.githubRepoOwner)
+
+feat(schema): [non_breaking] Description for argument 'githubToken' on field 'Mutation.issueImportCreateGithub' changed from 'Github token to fetch information from the Github API.' to 'GitHub token to fetch information from the GitHub API.' (Mutation.issueImportCreateGithub.githubToken)
+
+feat(schema): [non_breaking] Field 'url' was added to object type 'Project' (Project.url)
+
+feat(schema): [non_breaking] Field 'Query.apiKeys' description changed from 'All API keys for the user.' to '[Internal] All API keys for the user.' (Query.apiKeys)
+
+feat(schema): [non_breaking] Field 'url' was added to object type 'User' (User.url)

--- a/.changeset/_generated_schema_35990194.md
+++ b/.changeset/_generated_schema_35990194.md
@@ -1,0 +1,48 @@
+---
+"@linear/sdk": minor
+---
+
+
+feat(schema): [dangerous] Input field 'clientAuthCode' was added to input object type 'EmailUserAccountAuthChallengeInput' (EmailUserAccountAuthChallengeInput.clientAuthCode)
+
+feat(schema): [dangerous] Input field 'snoozedById' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.snoozedById)
+
+feat(schema): [dangerous] Input field 'snoozedUntilAt' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.snoozedUntilAt)
+
+feat(schema): [non_breaking] Type 'OauthAuthStringAuthorizePayload' was added (OauthAuthStringAuthorizePayload)
+
+feat(schema): [non_breaking] Type 'OauthAuthStringChallengePayload' was added (OauthAuthStringChallengePayload)
+
+feat(schema): [non_breaking] Type 'OauthAuthStringCheckPayload' was added (OauthAuthStringCheckPayload)
+
+feat(schema): [non_breaking] Input field 'ApiKeyCreateInput.key' description changed from 'The API key value (format: /^[a-zA-Z0-9]{40}$/).' to 'The API key value.' (ApiKeyCreateInput.key)
+
+feat(schema): [non_breaking] Field 'snoozedBy' was added to object type 'Issue' (Issue.snoozedBy)
+
+feat(schema): [non_breaking] Field 'snoozedUntilAt' was added to object type 'Issue' (Issue.snoozedUntilAt)
+
+feat(schema): [non_breaking] Field 'issueImport' was added to object type 'IssueHistory' (IssueHistory.issueImport)
+
+feat(schema): [non_breaking] Field 'integrationLoom' was added to object type 'Mutation' (Mutation.integrationLoom)
+
+feat(schema): [non_breaking] Field 'oauthAuthStringAuthorize' was added to object type 'Mutation' (Mutation.oauthAuthStringAuthorize)
+
+feat(schema): [non_breaking] Field 'oauthAuthStringChallenge' was added to object type 'Mutation' (Mutation.oauthAuthStringChallenge)
+
+feat(schema): [non_breaking] Field 'oauthAuthStringCheck' was added to object type 'Mutation' (Mutation.oauthAuthStringCheck)
+
+feat(schema): [non_breaking] Field 'Mutation.apiKeyCreate' description changed from 'Creates a new API key.' to '[Internal] Creates a new API key.' (Mutation.apiKeyCreate)
+
+feat(schema): [non_breaking] Field 'Mutation.apiKeyDelete' description changed from 'Deletes an API key.' to '[Internal] Deletes an API key.' (Mutation.apiKeyDelete)
+
+feat(schema): [non_breaking] Description for argument 'githubRepoName' on field 'Mutation.issueImportCreateGithub' changed from 'Github repository name from which we will import data.' to 'GitHub repository name from which we will import data.' (Mutation.issueImportCreateGithub.githubRepoName)
+
+feat(schema): [non_breaking] Description for argument 'githubRepoOwner' on field 'Mutation.issueImportCreateGithub' changed from 'Github owner (user or org) for the repository from which we will import data.' to 'GitHub owner (user or org) for the repository from which we will import data.' (Mutation.issueImportCreateGithub.githubRepoOwner)
+
+feat(schema): [non_breaking] Description for argument 'githubToken' on field 'Mutation.issueImportCreateGithub' changed from 'Github token to fetch information from the Github API.' to 'GitHub token to fetch information from the GitHub API.' (Mutation.issueImportCreateGithub.githubToken)
+
+feat(schema): [non_breaking] Field 'url' was added to object type 'Project' (Project.url)
+
+feat(schema): [non_breaking] Field 'Query.apiKeys' description changed from 'All API keys for the user.' to '[Internal] All API keys for the user.' (Query.apiKeys)
+
+feat(schema): [non_breaking] Field 'url' was added to object type 'User' (User.url)

--- a/.changeset/_generated_schema_46759633.md
+++ b/.changeset/_generated_schema_46759633.md
@@ -1,0 +1,48 @@
+---
+"@linear/sdk": minor
+---
+
+
+feat(schema): [dangerous] Input field 'clientAuthCode' was added to input object type 'EmailUserAccountAuthChallengeInput' (EmailUserAccountAuthChallengeInput.clientAuthCode)
+
+feat(schema): [dangerous] Input field 'snoozedById' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.snoozedById)
+
+feat(schema): [dangerous] Input field 'snoozedUntilAt' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.snoozedUntilAt)
+
+feat(schema): [non_breaking] Type 'OauthAuthStringAuthorizePayload' was added (OauthAuthStringAuthorizePayload)
+
+feat(schema): [non_breaking] Type 'OauthAuthStringChallengePayload' was added (OauthAuthStringChallengePayload)
+
+feat(schema): [non_breaking] Type 'OauthAuthStringCheckPayload' was added (OauthAuthStringCheckPayload)
+
+feat(schema): [non_breaking] Input field 'ApiKeyCreateInput.key' description changed from 'The API key value (format: /^[a-zA-Z0-9]{40}$/).' to 'The API key value.' (ApiKeyCreateInput.key)
+
+feat(schema): [non_breaking] Field 'snoozedBy' was added to object type 'Issue' (Issue.snoozedBy)
+
+feat(schema): [non_breaking] Field 'snoozedUntilAt' was added to object type 'Issue' (Issue.snoozedUntilAt)
+
+feat(schema): [non_breaking] Field 'issueImport' was added to object type 'IssueHistory' (IssueHistory.issueImport)
+
+feat(schema): [non_breaking] Field 'integrationLoom' was added to object type 'Mutation' (Mutation.integrationLoom)
+
+feat(schema): [non_breaking] Field 'oauthAuthStringAuthorize' was added to object type 'Mutation' (Mutation.oauthAuthStringAuthorize)
+
+feat(schema): [non_breaking] Field 'oauthAuthStringChallenge' was added to object type 'Mutation' (Mutation.oauthAuthStringChallenge)
+
+feat(schema): [non_breaking] Field 'oauthAuthStringCheck' was added to object type 'Mutation' (Mutation.oauthAuthStringCheck)
+
+feat(schema): [non_breaking] Field 'Mutation.apiKeyCreate' description changed from 'Creates a new API key.' to '[Internal] Creates a new API key.' (Mutation.apiKeyCreate)
+
+feat(schema): [non_breaking] Field 'Mutation.apiKeyDelete' description changed from 'Deletes an API key.' to '[Internal] Deletes an API key.' (Mutation.apiKeyDelete)
+
+feat(schema): [non_breaking] Description for argument 'githubRepoName' on field 'Mutation.issueImportCreateGithub' changed from 'Github repository name from which we will import data.' to 'GitHub repository name from which we will import data.' (Mutation.issueImportCreateGithub.githubRepoName)
+
+feat(schema): [non_breaking] Description for argument 'githubRepoOwner' on field 'Mutation.issueImportCreateGithub' changed from 'Github owner (user or org) for the repository from which we will import data.' to 'GitHub owner (user or org) for the repository from which we will import data.' (Mutation.issueImportCreateGithub.githubRepoOwner)
+
+feat(schema): [non_breaking] Description for argument 'githubToken' on field 'Mutation.issueImportCreateGithub' changed from 'Github token to fetch information from the Github API.' to 'GitHub token to fetch information from the GitHub API.' (Mutation.issueImportCreateGithub.githubToken)
+
+feat(schema): [non_breaking] Field 'url' was added to object type 'Project' (Project.url)
+
+feat(schema): [non_breaking] Field 'Query.apiKeys' description changed from 'All API keys for the user.' to '[Internal] All API keys for the user.' (Query.apiKeys)
+
+feat(schema): [non_breaking] Field 'url' was added to object type 'User' (User.url)

--- a/.changeset/_generated_schema_49620367.md
+++ b/.changeset/_generated_schema_49620367.md
@@ -1,0 +1,12 @@
+---
+"@linear/sdk": minor
+---
+
+
+feat(schema): [dangerous] Input field 'snoozedById' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.snoozedById)
+
+feat(schema): [dangerous] Input field 'snoozedUntilAt' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.snoozedUntilAt)
+
+feat(schema): [non_breaking] Field 'snoozedBy' was added to object type 'Issue' (Issue.snoozedBy)
+
+feat(schema): [non_breaking] Field 'snoozedUntilAt' was added to object type 'Issue' (Issue.snoozedUntilAt)

--- a/.changeset/_generated_schema_60960090.md
+++ b/.changeset/_generated_schema_60960090.md
@@ -1,0 +1,48 @@
+---
+"@linear/sdk": minor
+---
+
+
+feat(schema): [dangerous] Input field 'clientAuthCode' was added to input object type 'EmailUserAccountAuthChallengeInput' (EmailUserAccountAuthChallengeInput.clientAuthCode)
+
+feat(schema): [dangerous] Input field 'snoozedById' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.snoozedById)
+
+feat(schema): [dangerous] Input field 'snoozedUntilAt' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.snoozedUntilAt)
+
+feat(schema): [non_breaking] Type 'OauthAuthStringAuthorizePayload' was added (OauthAuthStringAuthorizePayload)
+
+feat(schema): [non_breaking] Type 'OauthAuthStringChallengePayload' was added (OauthAuthStringChallengePayload)
+
+feat(schema): [non_breaking] Type 'OauthAuthStringCheckPayload' was added (OauthAuthStringCheckPayload)
+
+feat(schema): [non_breaking] Input field 'ApiKeyCreateInput.key' description changed from 'The API key value (format: /^[a-zA-Z0-9]{40}$/).' to 'The API key value.' (ApiKeyCreateInput.key)
+
+feat(schema): [non_breaking] Field 'snoozedBy' was added to object type 'Issue' (Issue.snoozedBy)
+
+feat(schema): [non_breaking] Field 'snoozedUntilAt' was added to object type 'Issue' (Issue.snoozedUntilAt)
+
+feat(schema): [non_breaking] Field 'issueImport' was added to object type 'IssueHistory' (IssueHistory.issueImport)
+
+feat(schema): [non_breaking] Field 'integrationLoom' was added to object type 'Mutation' (Mutation.integrationLoom)
+
+feat(schema): [non_breaking] Field 'oauthAuthStringAuthorize' was added to object type 'Mutation' (Mutation.oauthAuthStringAuthorize)
+
+feat(schema): [non_breaking] Field 'oauthAuthStringChallenge' was added to object type 'Mutation' (Mutation.oauthAuthStringChallenge)
+
+feat(schema): [non_breaking] Field 'oauthAuthStringCheck' was added to object type 'Mutation' (Mutation.oauthAuthStringCheck)
+
+feat(schema): [non_breaking] Field 'Mutation.apiKeyCreate' description changed from 'Creates a new API key.' to '[Internal] Creates a new API key.' (Mutation.apiKeyCreate)
+
+feat(schema): [non_breaking] Field 'Mutation.apiKeyDelete' description changed from 'Deletes an API key.' to '[Internal] Deletes an API key.' (Mutation.apiKeyDelete)
+
+feat(schema): [non_breaking] Description for argument 'githubRepoName' on field 'Mutation.issueImportCreateGithub' changed from 'Github repository name from which we will import data.' to 'GitHub repository name from which we will import data.' (Mutation.issueImportCreateGithub.githubRepoName)
+
+feat(schema): [non_breaking] Description for argument 'githubRepoOwner' on field 'Mutation.issueImportCreateGithub' changed from 'Github owner (user or org) for the repository from which we will import data.' to 'GitHub owner (user or org) for the repository from which we will import data.' (Mutation.issueImportCreateGithub.githubRepoOwner)
+
+feat(schema): [non_breaking] Description for argument 'githubToken' on field 'Mutation.issueImportCreateGithub' changed from 'Github token to fetch information from the Github API.' to 'GitHub token to fetch information from the GitHub API.' (Mutation.issueImportCreateGithub.githubToken)
+
+feat(schema): [non_breaking] Field 'url' was added to object type 'Project' (Project.url)
+
+feat(schema): [non_breaking] Field 'Query.apiKeys' description changed from 'All API keys for the user.' to '[Internal] All API keys for the user.' (Query.apiKeys)
+
+feat(schema): [non_breaking] Field 'url' was added to object type 'User' (User.url)

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -30,7 +30,7 @@ jobs:
         run: yarn build
 
       - name: Run tests
-        run: yarn test:ci
+        run: yarn test
 
       - name: Compare schema for changes
         uses: kamilkisiela/graphql-inspector@master

--- a/packages/codegen-sdk/src/constants.ts
+++ b/packages/codegen-sdk/src/constants.ts
@@ -31,7 +31,7 @@ export const Sdk = {
   REQUEST_NAME: "request",
   REQUEST_TYPE: "LinearRequest",
   RESPONSE_NAME: "response",
-  RESPONSE_TYPE: "LinearResponse",
+  RESPONSE_TYPE: "Response",
   SDK_CLASS: "LinearSdk",
   VARIABLE_NAME: "variables",
   VARIABLE_TYPE: "Variables",

--- a/packages/codegen-sdk/src/plugin.ts
+++ b/packages/codegen-sdk/src/plugin.ts
@@ -57,8 +57,6 @@ export const plugin: PluginFunction<SdkPluginConfig> = async (
 
     return {
       prepend: [
-        /** Ignore unused variables */
-        "/* eslint-disable @typescript-eslint/no-unused-vars */",
         /** Import DocumentNode */
         "import { DocumentNode } from 'graphql/language/ast'",
         /** Import document namespace */

--- a/packages/codegen-sdk/src/print-connection.ts
+++ b/packages/codegen-sdk/src/print-connection.ts
@@ -161,29 +161,23 @@ export function printConnection(): string {
       }
     
       ${printComment(["Fetch the next page of results and append to nodes"])}
-      public ${Sdk.FETCH_NAME}Next(): Promise<this> {
-        return ${printTernary(
-          `this.${Sdk.PAGEINFO_NAME}?.hasNextPage`,
-          `this._${Sdk.FETCH_NAME}({ after: this.${Sdk.PAGEINFO_NAME}?.endCursor }).then(${Sdk.RESPONSE_NAME} => {
-            this._appendNodes(${Sdk.RESPONSE_NAME}?.${Sdk.NODE_NAME})
-            this._appendPageInfo(${Sdk.RESPONSE_NAME}?.${Sdk.PAGEINFO_NAME})
-            return this
-          })`,
-          `Promise.resolve(this)`
-        )}
+      public async ${Sdk.FETCH_NAME}Next(): Promise<this> {
+        if (this.${Sdk.PAGEINFO_NAME}?.hasNextPage) {
+          const ${Sdk.RESPONSE_NAME} = await this._${Sdk.FETCH_NAME}({ after: this.${Sdk.PAGEINFO_NAME}?.endCursor })
+          this._appendNodes(${Sdk.RESPONSE_NAME}?.${Sdk.NODE_NAME})
+          this._appendPageInfo(${Sdk.RESPONSE_NAME}?.${Sdk.PAGEINFO_NAME})
+        }
+        return Promise.resolve(this)
       }
     
       ${printComment(["Fetch the previous page of results and prepend to nodes"])}
-      public ${Sdk.FETCH_NAME}Previous(): Promise<this> {
-        return ${printTernary(
-          `this.${Sdk.PAGEINFO_NAME}?.hasPreviousPage`,
-          `this._${Sdk.FETCH_NAME}({ before: this.${Sdk.PAGEINFO_NAME}?.startCursor }).then(${Sdk.RESPONSE_NAME} => {
-            this._prependNodes(${Sdk.RESPONSE_NAME}?.${Sdk.NODE_NAME})
-            this._prependPageInfo(${Sdk.RESPONSE_NAME}?.${Sdk.PAGEINFO_NAME})
-            return this
-          })`,
-          `Promise.resolve(this)`
-        )}
+      public async ${Sdk.FETCH_NAME}Previous(): Promise<this> {
+        if (this.${Sdk.PAGEINFO_NAME}?.hasPreviousPage) {
+          const ${Sdk.RESPONSE_NAME} = await this._${Sdk.FETCH_NAME}({ before: this.${Sdk.PAGEINFO_NAME}?.startCursor })
+          this._prependNodes(${Sdk.RESPONSE_NAME}?.${Sdk.NODE_NAME})
+          this._prependPageInfo(${Sdk.RESPONSE_NAME}?.${Sdk.PAGEINFO_NAME})
+        }
+        return Promise.resolve(this)
       }
     }`,
   ]);

--- a/packages/codegen-sdk/src/print-model.ts
+++ b/packages/codegen-sdk/src/print-model.ts
@@ -223,6 +223,7 @@ function printModel(context: SdkPluginContext, model: SdkModel): string {
               ...operation.requiredArgs.args.map(variable =>
                 modelFieldNames.includes(variable.name) ? `this.${variable.name}` : variable.name
               ),
+              operation.optionalArgs.printOutput,
             ]);
 
             const operationCall = `new ${operation.print.name}${operation.print.type}(this._${Sdk.REQUEST_NAME}).${Sdk.FETCH_NAME}(${operationArgs})`;

--- a/packages/codegen-sdk/src/print-operation.ts
+++ b/packages/codegen-sdk/src/print-operation.ts
@@ -53,35 +53,35 @@ function printOperation(context: SdkPluginContext, operation: SdkOperation): str
           `@returns parsed response from ${operation.print.response}`,
         ])}
         public async ${Sdk.FETCH_NAME}(${operation.fetchArgs.printInput}): ${operation.print.promise} {
-          return ${`this._${Sdk.REQUEST_NAME}<${printNamespaced(context, operation.print.response)}, ${
-            operation.print.variables
-          }>(${printList([operation.print.document, printOperationArgs(operation)])}).then(${Sdk.RESPONSE_NAME} => {
-            ${printSet(`const ${Sdk.DATA_NAME}`, `${printList([Sdk.RESPONSE_NAME, ...operation.path], "?.")}`)}
-            return ${printTernary(
-              Sdk.DATA_NAME,
-              operation.print.list
-                ? `${Sdk.DATA_NAME}.map(node => new ${operation.print.list}(${printList([
-                    `this._${Sdk.REQUEST_NAME}`,
-                    "node",
-                  ])}))`
-                : isConnectionModel(operation.model)
-                ? `new ${operation.print.model}(${printList([
-                    `this._${Sdk.REQUEST_NAME}`,
-                    `${Sdk.CONNECTION_NAME} => this.${Sdk.FETCH_NAME}(${printList([
-                      ...operation.requiredArgs.args
-                        .filter(arg => !parentArgNames.includes(arg.name))
-                        .map(arg => arg.name),
-                      `{ ${printList([
-                        ...optionalArgs.map(arg => `...this._${arg.name}`),
-                        `...${Sdk.VARIABLE_NAME}`,
-                        `...${Sdk.CONNECTION_NAME}`,
-                      ])} }`,
-                    ])})`,
-                    Sdk.DATA_NAME,
-                  ])})`
-                : `new ${operation.print.model}(${printList([`this._${Sdk.REQUEST_NAME}`, Sdk.DATA_NAME])})`
-            )}
-          })`}
+          const ${Sdk.RESPONSE_NAME} = await this._${Sdk.REQUEST_NAME}<${printNamespaced(
+      context,
+      operation.print.response
+    )}, ${operation.print.variables}>(${printList([operation.print.document, printOperationArgs(operation)])})
+          ${printSet(`const ${Sdk.DATA_NAME}`, `${printList([Sdk.RESPONSE_NAME, ...operation.path], "?.")}`)}
+          return ${printTernary(
+            Sdk.DATA_NAME,
+            operation.print.list
+              ? `${Sdk.DATA_NAME}.map(node => new ${operation.print.list}(${printList([
+                  `this._${Sdk.REQUEST_NAME}`,
+                  "node",
+                ])}))`
+              : isConnectionModel(operation.model)
+              ? `new ${operation.print.model}(${printList([
+                  `this._${Sdk.REQUEST_NAME}`,
+                  `${Sdk.CONNECTION_NAME} => this.${Sdk.FETCH_NAME}(${printList([
+                    ...operation.requiredArgs.args
+                      .filter(arg => !parentArgNames.includes(arg.name))
+                      .map(arg => arg.name),
+                    `{ ${printList([
+                      ...optionalArgs.map(arg => `...this._${arg.name}`),
+                      `...${Sdk.VARIABLE_NAME}`,
+                      `...${Sdk.CONNECTION_NAME}`,
+                    ])} }`,
+                  ])})`,
+                  Sdk.DATA_NAME,
+                ])})`
+              : `new ${operation.print.model}(${printList([`this._${Sdk.REQUEST_NAME}`, Sdk.DATA_NAME])})`
+          )}
         }
       }
     `,

--- a/packages/sdk/src/_generated_documents.graphql
+++ b/packages/sdk/src/_generated_documents.graphql
@@ -753,6 +753,8 @@ fragment Issue on Issue {
   completedAt
   # The time at which the issue was moved into started state.
   startedAt
+  # The time until an issue will be snoozed in Triage view.
+  snoozedUntilAt
   # The unique identifier of the entity.
   id
   # The user to whom the issue is assigned to.
@@ -761,6 +763,10 @@ fragment Issue on Issue {
   }
   # The user who created the issue.
   creator {
+    id
+  }
+  # The user who snoozed the issue.
+  snoozedBy {
     id
   }
   # The workflow state that the issue is associated with.

--- a/packages/sdk/src/_generated_documents.graphql
+++ b/packages/sdk/src/_generated_documents.graphql
@@ -140,6 +140,8 @@ fragment Notification on Notification {
 
 # A project.
 fragment Project on Project {
+  # Project URL.
+  url
   # The estimated completion date of the project.
   targetDate
   # The icon of the project.
@@ -236,6 +238,10 @@ fragment IssueHistory on IssueHistory {
   removedLabelIds
   # Information about the integration or application which created this history entry.
   source
+  # The import record.
+  issueImport {
+    ...IssueImport
+  }
   # The issue that was changed.
   issue {
     id
@@ -490,6 +496,8 @@ fragment User on User {
   name
   # Unique hash for the user to be used in invite URLs.
   inviteHash
+  # User's profile URL.
+  url
   # Whether the user account is active or disabled (suspended).
   active
   # Whether the user is an organization administrator.
@@ -2031,6 +2039,25 @@ fragment NotificationSubscriptionPayload on NotificationSubscriptionPayload {
   success
 }
 
+fragment OauthAuthStringAuthorizePayload on OauthAuthStringAuthorizePayload {
+  # Whether the operation was successful.
+  success
+}
+
+fragment OauthAuthStringChallengePayload on OauthAuthStringChallengePayload {
+  # The created authentication string.
+  authString
+  # Whether the operation was successful.
+  success
+}
+
+fragment OauthAuthStringCheckPayload on OauthAuthStringCheckPayload {
+  # Access token for use.
+  token
+  # Whether the operation was successful.
+  success
+}
+
 fragment OauthClientPayload on OauthClientPayload {
   # The OAuth client application that was created or updated.
   oauthClient {
@@ -2431,32 +2458,6 @@ fragment WorkflowStatePayload on WorkflowStatePayload {
   success
 }
 
-# All API keys for the user.
-query apiKeys(
-  # A cursor to be used with first for forward pagination
-  $after: String
-  # A cursor to be used with last for backward pagination.
-  $before: String
-  # The number of items to forward paginate (used with after). Defaults to 50.
-  $first: Int
-  # Should archived resources be included (default: false)
-  $includeArchived: Boolean
-  # The number of items to backward paginate (used with before). Defaults to 50.
-  $last: Int
-  # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
-  $orderBy: PaginationOrderBy
-) {
-  apiKeys(
-    after: $after
-    before: $before
-    first: $first
-    includeArchived: $includeArchived
-    last: $last
-    orderBy: $orderBy
-  ) {
-    ...ApiKeyConnection
-  }
-}
 # Get information for an application and whether a user has approved it for the given scopes.
 query applicationWithAuthorization(
   # The client ID of the application.
@@ -4823,24 +4824,6 @@ query workflowStates(
     ...WorkflowStateConnection
   }
 }
-# Creates a new API key.
-mutation apiKeyCreate(
-  # The api key object to create.
-  $input: ApiKeyCreateInput!
-) {
-  apiKeyCreate(input: $input) {
-    ...ApiKeyPayload
-  }
-}
-# Deletes an API key.
-mutation apiKeyDelete(
-  # The identifier of the API key to delete.
-  $id: String!
-) {
-  apiKeyDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
 # [DEPRECATED] Archives an issue attachment.
 mutation attachmentArchive(
   # The identifier of the attachment to archive.
@@ -5272,6 +5255,12 @@ mutation integrationIntercomDelete {
     ...IntegrationPayload
   }
 }
+# Enables Loom integration for the organization.
+mutation integrationLoom {
+  integrationLoom {
+    ...IntegrationPayload
+  }
+}
 # Archives an integration resource.
 mutation integrationResourceArchive(
   # The identifier of the integration resource to archive.
@@ -5449,13 +5438,13 @@ mutation issueImportCreateClubhouse(
 }
 # Kicks off a GitHub import job.
 mutation issueImportCreateGithub(
-  # Github repository name from which we will import data.
+  # GitHub repository name from which we will import data.
   $githubRepoName: String!
-  # Github owner (user or org) for the repository from which we will import data.
+  # GitHub owner (user or org) for the repository from which we will import data.
   $githubRepoOwner: String!
   # Whether or not we should import GitHub organization level projects.
   $githubShouldImportOrgProjects: Boolean
-  # Github token to fetch information from the Github API.
+  # GitHub token to fetch information from the GitHub API.
   $githubToken: String!
   # ID of issue import. If not provided it will be generated.
   $id: String

--- a/packages/sdk/src/_generated_documents.ts
+++ b/packages/sdk/src/_generated_documents.ts
@@ -1161,6 +1161,10 @@ export type Issue = Node & {
   project?: Maybe<Project>;
   /** Relations associated with this issue. */
   relations: IssueRelationConnection;
+  /** The user who snoozed the issue. */
+  snoozedBy?: Maybe<User>;
+  /** The time until an issue will be snoozed in Triage view. */
+  snoozedUntilAt?: Maybe<Scalars["DateTime"]>;
   /** The time at which the issue was moved into started state. */
   startedAt?: Maybe<Scalars["DateTime"]>;
   /** The workflow state that the issue is associated with. */
@@ -1701,6 +1705,10 @@ export type IssueUpdateInput = {
   priority?: Maybe<Scalars["Int"]>;
   /** The project associated with the issue. */
   projectId?: Maybe<Scalars["String"]>;
+  /** The identifier of the user who snoozed the issue. */
+  snoozedById?: Maybe<Scalars["String"]>;
+  /** The time until an issue will be snoozed in Triage view. */
+  snoozedUntilAt?: Maybe<Scalars["DateTime"]>;
   /** The team state of the issue. */
   stateId?: Maybe<Scalars["String"]>;
   /** The position of the issue in parent's sub-issue list. */
@@ -5706,6 +5714,7 @@ export type IssueFragment = { __typename?: "Issue" } & Pick<
   | "canceledAt"
   | "completedAt"
   | "startedAt"
+  | "snoozedUntilAt"
   | "id"
 > & {
     cycle?: Maybe<{ __typename?: "Cycle" } & Pick<Cycle, "id">>;
@@ -5714,6 +5723,7 @@ export type IssueFragment = { __typename?: "Issue" } & Pick<
     team: { __typename?: "Team" } & Pick<Team, "id">;
     assignee?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
     creator?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
+    snoozedBy?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
     state: { __typename?: "WorkflowState" } & Pick<WorkflowState, "id">;
   };
 
@@ -11123,6 +11133,7 @@ export const IssueFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "canceledAt" } },
           { kind: "Field", name: { kind: "Name", value: "completedAt" } },
           { kind: "Field", name: { kind: "Name", value: "startedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "snoozedUntilAt" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
           {
             kind: "Field",
@@ -11135,6 +11146,14 @@ export const IssueFragmentDoc = {
           {
             kind: "Field",
             name: { kind: "Name", value: "creator" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "snoozedBy" },
             selectionSet: {
               kind: "SelectionSet",
               selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],

--- a/packages/sdk/src/_generated_sdk.ts
+++ b/packages/sdk/src/_generated_sdk.ts
@@ -89,25 +89,23 @@ export class Connection<Node> extends LinearConnection<Node> {
   }
 
   /** Fetch the next page of results and append to nodes */
-  public fetchNext(): Promise<this> {
-    return this.pageInfo?.hasNextPage
-      ? this._fetch({ after: this.pageInfo?.endCursor }).then(response => {
-          this._appendNodes(response?.nodes);
-          this._appendPageInfo(response?.pageInfo);
-          return this;
-        })
-      : Promise.resolve(this);
+  public async fetchNext(): Promise<this> {
+    if (this.pageInfo?.hasNextPage) {
+      const response = await this._fetch({ after: this.pageInfo?.endCursor });
+      this._appendNodes(response?.nodes);
+      this._appendPageInfo(response?.pageInfo);
+    }
+    return Promise.resolve(this);
   }
 
   /** Fetch the previous page of results and prepend to nodes */
-  public fetchPrevious(): Promise<this> {
-    return this.pageInfo?.hasPreviousPage
-      ? this._fetch({ before: this.pageInfo?.startCursor }).then(response => {
-          this._prependNodes(response?.nodes);
-          this._prependPageInfo(response?.pageInfo);
-          return this;
-        })
-      : Promise.resolve(this);
+  public async fetchPrevious(): Promise<this> {
+    if (this.pageInfo?.hasPreviousPage) {
+      const response = await this._fetch({ before: this.pageInfo?.startCursor });
+      this._prependNodes(response?.nodes);
+      this._prependPageInfo(response?.pageInfo);
+    }
+    return Promise.resolve(this);
   }
 }
 
@@ -5508,17 +5506,16 @@ export class ApplicationWithAuthorizationQuery extends Request {
     scope: string[],
     variables?: Omit<L.ApplicationWithAuthorizationQueryVariables, "clientId" | "scope">
   ): LinearFetch<UserAuthorizedApplication> {
-    return this._request<L.ApplicationWithAuthorizationQuery, L.ApplicationWithAuthorizationQueryVariables>(
-      L.ApplicationWithAuthorizationDocument,
-      {
-        clientId,
-        scope,
-        ...variables,
-      }
-    ).then(response => {
-      const data = response?.applicationWithAuthorization;
-      return data ? new UserAuthorizedApplication(this._request, data) : undefined;
+    const response = await this._request<
+      L.ApplicationWithAuthorizationQuery,
+      L.ApplicationWithAuthorizationQueryVariables
+    >(L.ApplicationWithAuthorizationDocument, {
+      clientId,
+      scope,
+      ...variables,
     });
+    const data = response?.applicationWithAuthorization;
+    return data ? new UserAuthorizedApplication(this._request, data) : undefined;
   }
 }
 
@@ -5539,12 +5536,11 @@ export class AttachmentQuery extends Request {
    * @returns parsed response from AttachmentQuery
    */
   public async fetch(id: string): LinearFetch<Attachment> {
-    return this._request<L.AttachmentQuery, L.AttachmentQueryVariables>(L.AttachmentDocument, {
+    const response = await this._request<L.AttachmentQuery, L.AttachmentQueryVariables>(L.AttachmentDocument, {
       id,
-    }).then(response => {
-      const data = response?.attachment;
-      return data ? new Attachment(this._request, data) : undefined;
     });
+    const data = response?.attachment;
+    return data ? new Attachment(this._request, data) : undefined;
   }
 }
 
@@ -5565,12 +5561,14 @@ export class AttachmentIssueQuery extends Request {
    * @returns parsed response from AttachmentIssueQuery
    */
   public async fetch(id: string): LinearFetch<Issue> {
-    return this._request<L.AttachmentIssueQuery, L.AttachmentIssueQueryVariables>(L.AttachmentIssueDocument, {
-      id,
-    }).then(response => {
-      const data = response?.attachmentIssue;
-      return data ? new Issue(this._request, data) : undefined;
-    });
+    const response = await this._request<L.AttachmentIssueQuery, L.AttachmentIssueQueryVariables>(
+      L.AttachmentIssueDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.attachmentIssue;
+    return data ? new Issue(this._request, data) : undefined;
   }
 }
 
@@ -5591,14 +5589,14 @@ export class AttachmentsQuery extends Request {
    * @returns parsed response from AttachmentsQuery
    */
   public async fetch(variables?: L.AttachmentsQueryVariables): LinearFetch<AttachmentConnection> {
-    return this._request<L.AttachmentsQuery, L.AttachmentsQueryVariables>(L.AttachmentsDocument, variables).then(
-      response => {
-        const data = response?.attachments;
-        return data
-          ? new AttachmentConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-          : undefined;
-      }
+    const response = await this._request<L.AttachmentsQuery, L.AttachmentsQueryVariables>(
+      L.AttachmentsDocument,
+      variables
     );
+    const data = response?.attachments;
+    return data
+      ? new AttachmentConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -5623,15 +5621,17 @@ export class AttachmentsForUrlQuery extends Request {
     url: string,
     variables?: Omit<L.AttachmentsForUrlQueryVariables, "url">
   ): LinearFetch<AttachmentConnection> {
-    return this._request<L.AttachmentsForUrlQuery, L.AttachmentsForUrlQueryVariables>(L.AttachmentsForUrlDocument, {
-      url,
-      ...variables,
-    }).then(response => {
-      const data = response?.attachmentsForURL;
-      return data
-        ? new AttachmentConnection(this._request, connection => this.fetch(url, { ...variables, ...connection }), data)
-        : undefined;
-    });
+    const response = await this._request<L.AttachmentsForUrlQuery, L.AttachmentsForUrlQueryVariables>(
+      L.AttachmentsForUrlDocument,
+      {
+        url,
+        ...variables,
+      }
+    );
+    const data = response?.attachmentsForURL;
+    return data
+      ? new AttachmentConnection(this._request, connection => this.fetch(url, { ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -5651,13 +5651,12 @@ export class AuthorizedApplicationsQuery extends Request {
    * @returns parsed response from AuthorizedApplicationsQuery
    */
   public async fetch(): LinearFetch<AuthorizedApplication[]> {
-    return this._request<L.AuthorizedApplicationsQuery, L.AuthorizedApplicationsQueryVariables>(
+    const response = await this._request<L.AuthorizedApplicationsQuery, L.AuthorizedApplicationsQueryVariables>(
       L.AuthorizedApplicationsDocument,
       {}
-    ).then(response => {
-      const data = response?.authorizedApplications;
-      return data ? data.map(node => new AuthorizedApplication(this._request, node)) : undefined;
-    });
+    );
+    const data = response?.authorizedApplications;
+    return data ? data.map(node => new AuthorizedApplication(this._request, node)) : undefined;
   }
 }
 
@@ -5677,12 +5676,12 @@ export class AvailableUsersQuery extends Request {
    * @returns parsed response from AvailableUsersQuery
    */
   public async fetch(): LinearFetch<AuthResolverResponse> {
-    return this._request<L.AvailableUsersQuery, L.AvailableUsersQueryVariables>(L.AvailableUsersDocument, {}).then(
-      response => {
-        const data = response?.availableUsers;
-        return data ? new AuthResolverResponse(this._request, data) : undefined;
-      }
+    const response = await this._request<L.AvailableUsersQuery, L.AvailableUsersQueryVariables>(
+      L.AvailableUsersDocument,
+      {}
     );
+    const data = response?.availableUsers;
+    return data ? new AuthResolverResponse(this._request, data) : undefined;
   }
 }
 
@@ -5702,12 +5701,12 @@ export class BillingDetailsQuery extends Request {
    * @returns parsed response from BillingDetailsQuery
    */
   public async fetch(): LinearFetch<BillingDetailsPayload> {
-    return this._request<L.BillingDetailsQuery, L.BillingDetailsQueryVariables>(L.BillingDetailsDocument, {}).then(
-      response => {
-        const data = response?.billingDetails;
-        return data ? new BillingDetailsPayload(this._request, data) : undefined;
-      }
+    const response = await this._request<L.BillingDetailsQuery, L.BillingDetailsQueryVariables>(
+      L.BillingDetailsDocument,
+      {}
     );
+    const data = response?.billingDetails;
+    return data ? new BillingDetailsPayload(this._request, data) : undefined;
   }
 }
 
@@ -5734,17 +5733,16 @@ export class CollaborativeDocumentJoinQuery extends Request {
     issueId: string,
     version: number
   ): LinearFetch<CollaborationDocumentUpdatePayload> {
-    return this._request<L.CollaborativeDocumentJoinQuery, L.CollaborativeDocumentJoinQueryVariables>(
+    const response = await this._request<L.CollaborativeDocumentJoinQuery, L.CollaborativeDocumentJoinQueryVariables>(
       L.CollaborativeDocumentJoinDocument,
       {
         clientId,
         issueId,
         version,
       }
-    ).then(response => {
-      const data = response?.collaborativeDocumentJoin;
-      return data ? new CollaborationDocumentUpdatePayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.collaborativeDocumentJoin;
+    return data ? new CollaborationDocumentUpdatePayload(this._request, data) : undefined;
   }
 }
 
@@ -5765,12 +5763,11 @@ export class CommentQuery extends Request {
    * @returns parsed response from CommentQuery
    */
   public async fetch(id: string): LinearFetch<Comment> {
-    return this._request<L.CommentQuery, L.CommentQueryVariables>(L.CommentDocument, {
+    const response = await this._request<L.CommentQuery, L.CommentQueryVariables>(L.CommentDocument, {
       id,
-    }).then(response => {
-      const data = response?.comment;
-      return data ? new Comment(this._request, data) : undefined;
     });
+    const data = response?.comment;
+    return data ? new Comment(this._request, data) : undefined;
   }
 }
 
@@ -5791,12 +5788,11 @@ export class CommentsQuery extends Request {
    * @returns parsed response from CommentsQuery
    */
   public async fetch(variables?: L.CommentsQueryVariables): LinearFetch<CommentConnection> {
-    return this._request<L.CommentsQuery, L.CommentsQueryVariables>(L.CommentsDocument, variables).then(response => {
-      const data = response?.comments;
-      return data
-        ? new CommentConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-        : undefined;
-    });
+    const response = await this._request<L.CommentsQuery, L.CommentsQueryVariables>(L.CommentsDocument, variables);
+    const data = response?.comments;
+    return data
+      ? new CommentConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -5817,12 +5813,11 @@ export class CustomViewQuery extends Request {
    * @returns parsed response from CustomViewQuery
    */
   public async fetch(id: string): LinearFetch<CustomView> {
-    return this._request<L.CustomViewQuery, L.CustomViewQueryVariables>(L.CustomViewDocument, {
+    const response = await this._request<L.CustomViewQuery, L.CustomViewQueryVariables>(L.CustomViewDocument, {
       id,
-    }).then(response => {
-      const data = response?.customView;
-      return data ? new CustomView(this._request, data) : undefined;
     });
+    const data = response?.customView;
+    return data ? new CustomView(this._request, data) : undefined;
   }
 }
 
@@ -5843,14 +5838,14 @@ export class CustomViewsQuery extends Request {
    * @returns parsed response from CustomViewsQuery
    */
   public async fetch(variables?: L.CustomViewsQueryVariables): LinearFetch<CustomViewConnection> {
-    return this._request<L.CustomViewsQuery, L.CustomViewsQueryVariables>(L.CustomViewsDocument, variables).then(
-      response => {
-        const data = response?.customViews;
-        return data
-          ? new CustomViewConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-          : undefined;
-      }
+    const response = await this._request<L.CustomViewsQuery, L.CustomViewsQueryVariables>(
+      L.CustomViewsDocument,
+      variables
     );
+    const data = response?.customViews;
+    return data
+      ? new CustomViewConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -5871,12 +5866,11 @@ export class CycleQuery extends Request {
    * @returns parsed response from CycleQuery
    */
   public async fetch(id: string): LinearFetch<Cycle> {
-    return this._request<L.CycleQuery, L.CycleQueryVariables>(L.CycleDocument, {
+    const response = await this._request<L.CycleQuery, L.CycleQueryVariables>(L.CycleDocument, {
       id,
-    }).then(response => {
-      const data = response?.cycle;
-      return data ? new Cycle(this._request, data) : undefined;
     });
+    const data = response?.cycle;
+    return data ? new Cycle(this._request, data) : undefined;
   }
 }
 
@@ -5897,12 +5891,11 @@ export class CyclesQuery extends Request {
    * @returns parsed response from CyclesQuery
    */
   public async fetch(variables?: L.CyclesQueryVariables): LinearFetch<CycleConnection> {
-    return this._request<L.CyclesQuery, L.CyclesQueryVariables>(L.CyclesDocument, variables).then(response => {
-      const data = response?.cycles;
-      return data
-        ? new CycleConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-        : undefined;
-    });
+    const response = await this._request<L.CyclesQuery, L.CyclesQueryVariables>(L.CyclesDocument, variables);
+    const data = response?.cycles;
+    return data
+      ? new CycleConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -5923,12 +5916,11 @@ export class EmojiQuery extends Request {
    * @returns parsed response from EmojiQuery
    */
   public async fetch(id: string): LinearFetch<Emoji> {
-    return this._request<L.EmojiQuery, L.EmojiQueryVariables>(L.EmojiDocument, {
+    const response = await this._request<L.EmojiQuery, L.EmojiQueryVariables>(L.EmojiDocument, {
       id,
-    }).then(response => {
-      const data = response?.emoji;
-      return data ? new Emoji(this._request, data) : undefined;
     });
+    const data = response?.emoji;
+    return data ? new Emoji(this._request, data) : undefined;
   }
 }
 
@@ -5949,12 +5941,11 @@ export class EmojisQuery extends Request {
    * @returns parsed response from EmojisQuery
    */
   public async fetch(variables?: L.EmojisQueryVariables): LinearFetch<EmojiConnection> {
-    return this._request<L.EmojisQuery, L.EmojisQueryVariables>(L.EmojisDocument, variables).then(response => {
-      const data = response?.emojis;
-      return data
-        ? new EmojiConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-        : undefined;
-    });
+    const response = await this._request<L.EmojisQuery, L.EmojisQueryVariables>(L.EmojisDocument, variables);
+    const data = response?.emojis;
+    return data
+      ? new EmojiConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -5975,12 +5966,11 @@ export class FavoriteQuery extends Request {
    * @returns parsed response from FavoriteQuery
    */
   public async fetch(id: string): LinearFetch<Favorite> {
-    return this._request<L.FavoriteQuery, L.FavoriteQueryVariables>(L.FavoriteDocument, {
+    const response = await this._request<L.FavoriteQuery, L.FavoriteQueryVariables>(L.FavoriteDocument, {
       id,
-    }).then(response => {
-      const data = response?.favorite;
-      return data ? new Favorite(this._request, data) : undefined;
     });
+    const data = response?.favorite;
+    return data ? new Favorite(this._request, data) : undefined;
   }
 }
 
@@ -6001,12 +5991,11 @@ export class FavoritesQuery extends Request {
    * @returns parsed response from FavoritesQuery
    */
   public async fetch(variables?: L.FavoritesQueryVariables): LinearFetch<FavoriteConnection> {
-    return this._request<L.FavoritesQuery, L.FavoritesQueryVariables>(L.FavoritesDocument, variables).then(response => {
-      const data = response?.favorites;
-      return data
-        ? new FavoriteConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-        : undefined;
-    });
+    const response = await this._request<L.FavoritesQuery, L.FavoritesQueryVariables>(L.FavoritesDocument, variables);
+    const data = response?.favorites;
+    return data
+      ? new FavoriteConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -6031,13 +6020,15 @@ export class FigmaEmbedInfoQuery extends Request {
     fileId: string,
     variables?: Omit<L.FigmaEmbedInfoQueryVariables, "fileId">
   ): LinearFetch<FigmaEmbedPayload> {
-    return this._request<L.FigmaEmbedInfoQuery, L.FigmaEmbedInfoQueryVariables>(L.FigmaEmbedInfoDocument, {
-      fileId,
-      ...variables,
-    }).then(response => {
-      const data = response?.figmaEmbedInfo;
-      return data ? new FigmaEmbedPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.FigmaEmbedInfoQuery, L.FigmaEmbedInfoQueryVariables>(
+      L.FigmaEmbedInfoDocument,
+      {
+        fileId,
+        ...variables,
+      }
+    );
+    const data = response?.figmaEmbedInfo;
+    return data ? new FigmaEmbedPayload(this._request, data) : undefined;
   }
 }
 
@@ -6058,12 +6049,11 @@ export class IntegrationQuery extends Request {
    * @returns parsed response from IntegrationQuery
    */
   public async fetch(id: string): LinearFetch<Integration> {
-    return this._request<L.IntegrationQuery, L.IntegrationQueryVariables>(L.IntegrationDocument, {
+    const response = await this._request<L.IntegrationQuery, L.IntegrationQueryVariables>(L.IntegrationDocument, {
       id,
-    }).then(response => {
-      const data = response?.integration;
-      return data ? new Integration(this._request, data) : undefined;
     });
+    const data = response?.integration;
+    return data ? new Integration(this._request, data) : undefined;
   }
 }
 
@@ -6084,14 +6074,14 @@ export class IntegrationsQuery extends Request {
    * @returns parsed response from IntegrationsQuery
    */
   public async fetch(variables?: L.IntegrationsQueryVariables): LinearFetch<IntegrationConnection> {
-    return this._request<L.IntegrationsQuery, L.IntegrationsQueryVariables>(L.IntegrationsDocument, variables).then(
-      response => {
-        const data = response?.integrations;
-        return data
-          ? new IntegrationConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-          : undefined;
-      }
+    const response = await this._request<L.IntegrationsQuery, L.IntegrationsQueryVariables>(
+      L.IntegrationsDocument,
+      variables
     );
+    const data = response?.integrations;
+    return data
+      ? new IntegrationConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -6116,13 +6106,12 @@ export class InviteInfoQuery extends Request {
     userHash: string,
     variables?: Omit<L.InviteInfoQueryVariables, "userHash">
   ): LinearFetch<InvitePagePayload> {
-    return this._request<L.InviteInfoQuery, L.InviteInfoQueryVariables>(L.InviteInfoDocument, {
+    const response = await this._request<L.InviteInfoQuery, L.InviteInfoQueryVariables>(L.InviteInfoDocument, {
       userHash,
       ...variables,
-    }).then(response => {
-      const data = response?.inviteInfo;
-      return data ? new InvitePagePayload(this._request, data) : undefined;
     });
+    const data = response?.inviteInfo;
+    return data ? new InvitePagePayload(this._request, data) : undefined;
   }
 }
 
@@ -6143,12 +6132,11 @@ export class IssueQuery extends Request {
    * @returns parsed response from IssueQuery
    */
   public async fetch(id: string): LinearFetch<Issue> {
-    return this._request<L.IssueQuery, L.IssueQueryVariables>(L.IssueDocument, {
+    const response = await this._request<L.IssueQuery, L.IssueQueryVariables>(L.IssueDocument, {
       id,
-    }).then(response => {
-      const data = response?.issue;
-      return data ? new Issue(this._request, data) : undefined;
     });
+    const data = response?.issue;
+    return data ? new Issue(this._request, data) : undefined;
   }
 }
 
@@ -6169,15 +6157,14 @@ export class IssueImportFinishGithubOAuthQuery extends Request {
    * @returns parsed response from IssueImportFinishGithubOAuthQuery
    */
   public async fetch(code: string): LinearFetch<GithubOAuthTokenPayload> {
-    return this._request<L.IssueImportFinishGithubOAuthQuery, L.IssueImportFinishGithubOAuthQueryVariables>(
-      L.IssueImportFinishGithubOAuthDocument,
-      {
-        code,
-      }
-    ).then(response => {
-      const data = response?.issueImportFinishGithubOAuth;
-      return data ? new GithubOAuthTokenPayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.IssueImportFinishGithubOAuthQuery,
+      L.IssueImportFinishGithubOAuthQueryVariables
+    >(L.IssueImportFinishGithubOAuthDocument, {
+      code,
     });
+    const data = response?.issueImportFinishGithubOAuth;
+    return data ? new GithubOAuthTokenPayload(this._request, data) : undefined;
   }
 }
 
@@ -6198,12 +6185,11 @@ export class IssueLabelQuery extends Request {
    * @returns parsed response from IssueLabelQuery
    */
   public async fetch(id: string): LinearFetch<IssueLabel> {
-    return this._request<L.IssueLabelQuery, L.IssueLabelQueryVariables>(L.IssueLabelDocument, {
+    const response = await this._request<L.IssueLabelQuery, L.IssueLabelQueryVariables>(L.IssueLabelDocument, {
       id,
-    }).then(response => {
-      const data = response?.issueLabel;
-      return data ? new IssueLabel(this._request, data) : undefined;
     });
+    const data = response?.issueLabel;
+    return data ? new IssueLabel(this._request, data) : undefined;
   }
 }
 
@@ -6224,14 +6210,14 @@ export class IssueLabelsQuery extends Request {
    * @returns parsed response from IssueLabelsQuery
    */
   public async fetch(variables?: L.IssueLabelsQueryVariables): LinearFetch<IssueLabelConnection> {
-    return this._request<L.IssueLabelsQuery, L.IssueLabelsQueryVariables>(L.IssueLabelsDocument, variables).then(
-      response => {
-        const data = response?.issueLabels;
-        return data
-          ? new IssueLabelConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-          : undefined;
-      }
+    const response = await this._request<L.IssueLabelsQuery, L.IssueLabelsQueryVariables>(
+      L.IssueLabelsDocument,
+      variables
     );
+    const data = response?.issueLabels;
+    return data
+      ? new IssueLabelConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -6251,13 +6237,12 @@ export class IssuePriorityValuesQuery extends Request {
    * @returns parsed response from IssuePriorityValuesQuery
    */
   public async fetch(): LinearFetch<IssuePriorityValue[]> {
-    return this._request<L.IssuePriorityValuesQuery, L.IssuePriorityValuesQueryVariables>(
+    const response = await this._request<L.IssuePriorityValuesQuery, L.IssuePriorityValuesQueryVariables>(
       L.IssuePriorityValuesDocument,
       {}
-    ).then(response => {
-      const data = response?.issuePriorityValues;
-      return data ? data.map(node => new IssuePriorityValue(this._request, node)) : undefined;
-    });
+    );
+    const data = response?.issuePriorityValues;
+    return data ? data.map(node => new IssuePriorityValue(this._request, node)) : undefined;
   }
 }
 
@@ -6278,12 +6263,11 @@ export class IssueRelationQuery extends Request {
    * @returns parsed response from IssueRelationQuery
    */
   public async fetch(id: string): LinearFetch<IssueRelation> {
-    return this._request<L.IssueRelationQuery, L.IssueRelationQueryVariables>(L.IssueRelationDocument, {
+    const response = await this._request<L.IssueRelationQuery, L.IssueRelationQueryVariables>(L.IssueRelationDocument, {
       id,
-    }).then(response => {
-      const data = response?.issueRelation;
-      return data ? new IssueRelation(this._request, data) : undefined;
     });
+    const data = response?.issueRelation;
+    return data ? new IssueRelation(this._request, data) : undefined;
   }
 }
 
@@ -6304,15 +6288,14 @@ export class IssueRelationsQuery extends Request {
    * @returns parsed response from IssueRelationsQuery
    */
   public async fetch(variables?: L.IssueRelationsQueryVariables): LinearFetch<IssueRelationConnection> {
-    return this._request<L.IssueRelationsQuery, L.IssueRelationsQueryVariables>(
+    const response = await this._request<L.IssueRelationsQuery, L.IssueRelationsQueryVariables>(
       L.IssueRelationsDocument,
       variables
-    ).then(response => {
-      const data = response?.issueRelations;
-      return data
-        ? new IssueRelationConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-        : undefined;
-    });
+    );
+    const data = response?.issueRelations;
+    return data
+      ? new IssueRelationConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -6337,15 +6320,14 @@ export class IssueSearchQuery extends Request {
     query: string,
     variables?: Omit<L.IssueSearchQueryVariables, "query">
   ): LinearFetch<IssueConnection> {
-    return this._request<L.IssueSearchQuery, L.IssueSearchQueryVariables>(L.IssueSearchDocument, {
+    const response = await this._request<L.IssueSearchQuery, L.IssueSearchQueryVariables>(L.IssueSearchDocument, {
       query,
       ...variables,
-    }).then(response => {
-      const data = response?.issueSearch;
-      return data
-        ? new IssueConnection(this._request, connection => this.fetch(query, { ...variables, ...connection }), data)
-        : undefined;
     });
+    const data = response?.issueSearch;
+    return data
+      ? new IssueConnection(this._request, connection => this.fetch(query, { ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -6366,12 +6348,11 @@ export class IssuesQuery extends Request {
    * @returns parsed response from IssuesQuery
    */
   public async fetch(variables?: L.IssuesQueryVariables): LinearFetch<IssueConnection> {
-    return this._request<L.IssuesQuery, L.IssuesQueryVariables>(L.IssuesDocument, variables).then(response => {
-      const data = response?.issues;
-      return data
-        ? new IssueConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-        : undefined;
-    });
+    const response = await this._request<L.IssuesQuery, L.IssuesQueryVariables>(L.IssuesDocument, variables);
+    const data = response?.issues;
+    return data
+      ? new IssueConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -6392,12 +6373,11 @@ export class MilestoneQuery extends Request {
    * @returns parsed response from MilestoneQuery
    */
   public async fetch(id: string): LinearFetch<Milestone> {
-    return this._request<L.MilestoneQuery, L.MilestoneQueryVariables>(L.MilestoneDocument, {
+    const response = await this._request<L.MilestoneQuery, L.MilestoneQueryVariables>(L.MilestoneDocument, {
       id,
-    }).then(response => {
-      const data = response?.milestone;
-      return data ? new Milestone(this._request, data) : undefined;
     });
+    const data = response?.milestone;
+    return data ? new Milestone(this._request, data) : undefined;
   }
 }
 
@@ -6418,14 +6398,14 @@ export class MilestonesQuery extends Request {
    * @returns parsed response from MilestonesQuery
    */
   public async fetch(variables?: L.MilestonesQueryVariables): LinearFetch<MilestoneConnection> {
-    return this._request<L.MilestonesQuery, L.MilestonesQueryVariables>(L.MilestonesDocument, variables).then(
-      response => {
-        const data = response?.milestones;
-        return data
-          ? new MilestoneConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-          : undefined;
-      }
+    const response = await this._request<L.MilestonesQuery, L.MilestonesQueryVariables>(
+      L.MilestonesDocument,
+      variables
     );
+    const data = response?.milestones;
+    return data
+      ? new MilestoneConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -6446,12 +6426,11 @@ export class NotificationQuery extends Request {
    * @returns parsed response from NotificationQuery
    */
   public async fetch(id: string): LinearFetch<Notification> {
-    return this._request<L.NotificationQuery, L.NotificationQueryVariables>(L.NotificationDocument, {
+    const response = await this._request<L.NotificationQuery, L.NotificationQueryVariables>(L.NotificationDocument, {
       id,
-    }).then(response => {
-      const data = response?.notification;
-      return data ? new Notification(this._request, data) : undefined;
     });
+    const data = response?.notification;
+    return data ? new Notification(this._request, data) : undefined;
   }
 }
 
@@ -6472,15 +6451,14 @@ export class NotificationSubscriptionQuery extends Request {
    * @returns parsed response from NotificationSubscriptionQuery
    */
   public async fetch(id: string): LinearFetch<NotificationSubscription> {
-    return this._request<L.NotificationSubscriptionQuery, L.NotificationSubscriptionQueryVariables>(
+    const response = await this._request<L.NotificationSubscriptionQuery, L.NotificationSubscriptionQueryVariables>(
       L.NotificationSubscriptionDocument,
       {
         id,
       }
-    ).then(response => {
-      const data = response?.notificationSubscription;
-      return data ? new NotificationSubscription(this._request, data) : undefined;
-    });
+    );
+    const data = response?.notificationSubscription;
+    return data ? new NotificationSubscription(this._request, data) : undefined;
   }
 }
 
@@ -6503,19 +6481,18 @@ export class NotificationSubscriptionsQuery extends Request {
   public async fetch(
     variables?: L.NotificationSubscriptionsQueryVariables
   ): LinearFetch<NotificationSubscriptionConnection> {
-    return this._request<L.NotificationSubscriptionsQuery, L.NotificationSubscriptionsQueryVariables>(
+    const response = await this._request<L.NotificationSubscriptionsQuery, L.NotificationSubscriptionsQueryVariables>(
       L.NotificationSubscriptionsDocument,
       variables
-    ).then(response => {
-      const data = response?.notificationSubscriptions;
-      return data
-        ? new NotificationSubscriptionConnection(
-            this._request,
-            connection => this.fetch({ ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.notificationSubscriptions;
+    return data
+      ? new NotificationSubscriptionConnection(
+          this._request,
+          connection => this.fetch({ ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -6536,14 +6513,14 @@ export class NotificationsQuery extends Request {
    * @returns parsed response from NotificationsQuery
    */
   public async fetch(variables?: L.NotificationsQueryVariables): LinearFetch<NotificationConnection> {
-    return this._request<L.NotificationsQuery, L.NotificationsQueryVariables>(L.NotificationsDocument, variables).then(
-      response => {
-        const data = response?.notifications;
-        return data
-          ? new NotificationConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-          : undefined;
-      }
+    const response = await this._request<L.NotificationsQuery, L.NotificationsQueryVariables>(
+      L.NotificationsDocument,
+      variables
     );
+    const data = response?.notifications;
+    return data
+      ? new NotificationConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -6563,12 +6540,9 @@ export class OrganizationQuery extends Request {
    * @returns parsed response from OrganizationQuery
    */
   public async fetch(): LinearFetch<Organization> {
-    return this._request<L.OrganizationQuery, L.OrganizationQueryVariables>(L.OrganizationDocument, {}).then(
-      response => {
-        const data = response?.organization;
-        return data ? new Organization(this._request, data) : undefined;
-      }
-    );
+    const response = await this._request<L.OrganizationQuery, L.OrganizationQueryVariables>(L.OrganizationDocument, {});
+    const data = response?.organization;
+    return data ? new Organization(this._request, data) : undefined;
   }
 }
 
@@ -6589,12 +6563,14 @@ export class OrganizationExistsQuery extends Request {
    * @returns parsed response from OrganizationExistsQuery
    */
   public async fetch(urlKey: string): LinearFetch<OrganizationExistsPayload> {
-    return this._request<L.OrganizationExistsQuery, L.OrganizationExistsQueryVariables>(L.OrganizationExistsDocument, {
-      urlKey,
-    }).then(response => {
-      const data = response?.organizationExists;
-      return data ? new OrganizationExistsPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.OrganizationExistsQuery, L.OrganizationExistsQueryVariables>(
+      L.OrganizationExistsDocument,
+      {
+        urlKey,
+      }
+    );
+    const data = response?.organizationExists;
+    return data ? new OrganizationExistsPayload(this._request, data) : undefined;
   }
 }
 
@@ -6615,12 +6591,14 @@ export class OrganizationInviteQuery extends Request {
    * @returns parsed response from OrganizationInviteQuery
    */
   public async fetch(id: string): LinearFetch<IssueLabel> {
-    return this._request<L.OrganizationInviteQuery, L.OrganizationInviteQueryVariables>(L.OrganizationInviteDocument, {
-      id,
-    }).then(response => {
-      const data = response?.organizationInvite;
-      return data ? new IssueLabel(this._request, data) : undefined;
-    });
+    const response = await this._request<L.OrganizationInviteQuery, L.OrganizationInviteQueryVariables>(
+      L.OrganizationInviteDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.organizationInvite;
+    return data ? new IssueLabel(this._request, data) : undefined;
   }
 }
 
@@ -6641,19 +6619,14 @@ export class OrganizationInvitesQuery extends Request {
    * @returns parsed response from OrganizationInvitesQuery
    */
   public async fetch(variables?: L.OrganizationInvitesQueryVariables): LinearFetch<OrganizationInviteConnection> {
-    return this._request<L.OrganizationInvitesQuery, L.OrganizationInvitesQueryVariables>(
+    const response = await this._request<L.OrganizationInvitesQuery, L.OrganizationInvitesQueryVariables>(
       L.OrganizationInvitesDocument,
       variables
-    ).then(response => {
-      const data = response?.organizationInvites;
-      return data
-        ? new OrganizationInviteConnection(
-            this._request,
-            connection => this.fetch({ ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.organizationInvites;
+    return data
+      ? new OrganizationInviteConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -6674,12 +6647,11 @@ export class ProjectQuery extends Request {
    * @returns parsed response from ProjectQuery
    */
   public async fetch(id: string): LinearFetch<Project> {
-    return this._request<L.ProjectQuery, L.ProjectQueryVariables>(L.ProjectDocument, {
+    const response = await this._request<L.ProjectQuery, L.ProjectQueryVariables>(L.ProjectDocument, {
       id,
-    }).then(response => {
-      const data = response?.project;
-      return data ? new Project(this._request, data) : undefined;
     });
+    const data = response?.project;
+    return data ? new Project(this._request, data) : undefined;
   }
 }
 
@@ -6700,12 +6672,11 @@ export class ProjectLinkQuery extends Request {
    * @returns parsed response from ProjectLinkQuery
    */
   public async fetch(id: string): LinearFetch<ProjectLink> {
-    return this._request<L.ProjectLinkQuery, L.ProjectLinkQueryVariables>(L.ProjectLinkDocument, {
+    const response = await this._request<L.ProjectLinkQuery, L.ProjectLinkQueryVariables>(L.ProjectLinkDocument, {
       id,
-    }).then(response => {
-      const data = response?.projectLink;
-      return data ? new ProjectLink(this._request, data) : undefined;
     });
+    const data = response?.projectLink;
+    return data ? new ProjectLink(this._request, data) : undefined;
   }
 }
 
@@ -6726,14 +6697,14 @@ export class ProjectLinksQuery extends Request {
    * @returns parsed response from ProjectLinksQuery
    */
   public async fetch(variables?: L.ProjectLinksQueryVariables): LinearFetch<ProjectLinkConnection> {
-    return this._request<L.ProjectLinksQuery, L.ProjectLinksQueryVariables>(L.ProjectLinksDocument, variables).then(
-      response => {
-        const data = response?.projectLinks;
-        return data
-          ? new ProjectLinkConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-          : undefined;
-      }
+    const response = await this._request<L.ProjectLinksQuery, L.ProjectLinksQueryVariables>(
+      L.ProjectLinksDocument,
+      variables
     );
+    const data = response?.projectLinks;
+    return data
+      ? new ProjectLinkConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -6754,12 +6725,11 @@ export class ProjectsQuery extends Request {
    * @returns parsed response from ProjectsQuery
    */
   public async fetch(variables?: L.ProjectsQueryVariables): LinearFetch<ProjectConnection> {
-    return this._request<L.ProjectsQuery, L.ProjectsQueryVariables>(L.ProjectsDocument, variables).then(response => {
-      const data = response?.projects;
-      return data
-        ? new ProjectConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-        : undefined;
-    });
+    const response = await this._request<L.ProjectsQuery, L.ProjectsQueryVariables>(L.ProjectsDocument, variables);
+    const data = response?.projects;
+    return data
+      ? new ProjectConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -6779,13 +6749,12 @@ export class PushSubscriptionTestQuery extends Request {
    * @returns parsed response from PushSubscriptionTestQuery
    */
   public async fetch(): LinearFetch<PushSubscriptionTestPayload> {
-    return this._request<L.PushSubscriptionTestQuery, L.PushSubscriptionTestQueryVariables>(
+    const response = await this._request<L.PushSubscriptionTestQuery, L.PushSubscriptionTestQueryVariables>(
       L.PushSubscriptionTestDocument,
       {}
-    ).then(response => {
-      const data = response?.pushSubscriptionTest;
-      return data ? new PushSubscriptionTestPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.pushSubscriptionTest;
+    return data ? new PushSubscriptionTestPayload(this._request, data) : undefined;
   }
 }
 
@@ -6806,12 +6775,11 @@ export class ReactionQuery extends Request {
    * @returns parsed response from ReactionQuery
    */
   public async fetch(id: string): LinearFetch<Reaction> {
-    return this._request<L.ReactionQuery, L.ReactionQueryVariables>(L.ReactionDocument, {
+    const response = await this._request<L.ReactionQuery, L.ReactionQueryVariables>(L.ReactionDocument, {
       id,
-    }).then(response => {
-      const data = response?.reaction;
-      return data ? new Reaction(this._request, data) : undefined;
     });
+    const data = response?.reaction;
+    return data ? new Reaction(this._request, data) : undefined;
   }
 }
 
@@ -6832,12 +6800,11 @@ export class ReactionsQuery extends Request {
    * @returns parsed response from ReactionsQuery
    */
   public async fetch(variables?: L.ReactionsQueryVariables): LinearFetch<ReactionConnection> {
-    return this._request<L.ReactionsQuery, L.ReactionsQueryVariables>(L.ReactionsDocument, variables).then(response => {
-      const data = response?.reactions;
-      return data
-        ? new ReactionConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-        : undefined;
-    });
+    const response = await this._request<L.ReactionsQuery, L.ReactionsQueryVariables>(L.ReactionsDocument, variables);
+    const data = response?.reactions;
+    return data
+      ? new ReactionConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -6862,13 +6829,15 @@ export class SsoUrlFromEmailQuery extends Request {
     email: string,
     variables?: Omit<L.SsoUrlFromEmailQueryVariables, "email">
   ): LinearFetch<SsoUrlFromEmailResponse> {
-    return this._request<L.SsoUrlFromEmailQuery, L.SsoUrlFromEmailQueryVariables>(L.SsoUrlFromEmailDocument, {
-      email,
-      ...variables,
-    }).then(response => {
-      const data = response?.ssoUrlFromEmail;
-      return data ? new SsoUrlFromEmailResponse(this._request, data) : undefined;
-    });
+    const response = await this._request<L.SsoUrlFromEmailQuery, L.SsoUrlFromEmailQueryVariables>(
+      L.SsoUrlFromEmailDocument,
+      {
+        email,
+        ...variables,
+      }
+    );
+    const data = response?.ssoUrlFromEmail;
+    return data ? new SsoUrlFromEmailResponse(this._request, data) : undefined;
   }
 }
 
@@ -6888,12 +6857,9 @@ export class SubscriptionQuery extends Request {
    * @returns parsed response from SubscriptionQuery
    */
   public async fetch(): LinearFetch<Subscription> {
-    return this._request<L.SubscriptionQuery, L.SubscriptionQueryVariables>(L.SubscriptionDocument, {}).then(
-      response => {
-        const data = response?.subscription;
-        return data ? new Subscription(this._request, data) : undefined;
-      }
-    );
+    const response = await this._request<L.SubscriptionQuery, L.SubscriptionQueryVariables>(L.SubscriptionDocument, {});
+    const data = response?.subscription;
+    return data ? new Subscription(this._request, data) : undefined;
   }
 }
 
@@ -6914,12 +6880,11 @@ export class TeamQuery extends Request {
    * @returns parsed response from TeamQuery
    */
   public async fetch(id: string): LinearFetch<Team> {
-    return this._request<L.TeamQuery, L.TeamQueryVariables>(L.TeamDocument, {
+    const response = await this._request<L.TeamQuery, L.TeamQueryVariables>(L.TeamDocument, {
       id,
-    }).then(response => {
-      const data = response?.team;
-      return data ? new Team(this._request, data) : undefined;
     });
+    const data = response?.team;
+    return data ? new Team(this._request, data) : undefined;
   }
 }
 
@@ -6940,12 +6905,14 @@ export class TeamMembershipQuery extends Request {
    * @returns parsed response from TeamMembershipQuery
    */
   public async fetch(id: string): LinearFetch<TeamMembership> {
-    return this._request<L.TeamMembershipQuery, L.TeamMembershipQueryVariables>(L.TeamMembershipDocument, {
-      id,
-    }).then(response => {
-      const data = response?.teamMembership;
-      return data ? new TeamMembership(this._request, data) : undefined;
-    });
+    const response = await this._request<L.TeamMembershipQuery, L.TeamMembershipQueryVariables>(
+      L.TeamMembershipDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.teamMembership;
+    return data ? new TeamMembership(this._request, data) : undefined;
   }
 }
 
@@ -6966,15 +6933,14 @@ export class TeamMembershipsQuery extends Request {
    * @returns parsed response from TeamMembershipsQuery
    */
   public async fetch(variables?: L.TeamMembershipsQueryVariables): LinearFetch<TeamMembershipConnection> {
-    return this._request<L.TeamMembershipsQuery, L.TeamMembershipsQueryVariables>(
+    const response = await this._request<L.TeamMembershipsQuery, L.TeamMembershipsQueryVariables>(
       L.TeamMembershipsDocument,
       variables
-    ).then(response => {
-      const data = response?.teamMemberships;
-      return data
-        ? new TeamMembershipConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-        : undefined;
-    });
+    );
+    const data = response?.teamMemberships;
+    return data
+      ? new TeamMembershipConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -6995,12 +6961,11 @@ export class TeamsQuery extends Request {
    * @returns parsed response from TeamsQuery
    */
   public async fetch(variables?: L.TeamsQueryVariables): LinearFetch<TeamConnection> {
-    return this._request<L.TeamsQuery, L.TeamsQueryVariables>(L.TeamsDocument, variables).then(response => {
-      const data = response?.teams;
-      return data
-        ? new TeamConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-        : undefined;
-    });
+    const response = await this._request<L.TeamsQuery, L.TeamsQueryVariables>(L.TeamsDocument, variables);
+    const data = response?.teams;
+    return data
+      ? new TeamConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -7021,12 +6986,11 @@ export class TemplateQuery extends Request {
    * @returns parsed response from TemplateQuery
    */
   public async fetch(id: string): LinearFetch<Template> {
-    return this._request<L.TemplateQuery, L.TemplateQueryVariables>(L.TemplateDocument, {
+    const response = await this._request<L.TemplateQuery, L.TemplateQueryVariables>(L.TemplateDocument, {
       id,
-    }).then(response => {
-      const data = response?.template;
-      return data ? new Template(this._request, data) : undefined;
     });
+    const data = response?.template;
+    return data ? new Template(this._request, data) : undefined;
   }
 }
 
@@ -7046,10 +7010,9 @@ export class TemplatesQuery extends Request {
    * @returns parsed response from TemplatesQuery
    */
   public async fetch(): LinearFetch<Template[]> {
-    return this._request<L.TemplatesQuery, L.TemplatesQueryVariables>(L.TemplatesDocument, {}).then(response => {
-      const data = response?.templates;
-      return data ? data.map(node => new Template(this._request, node)) : undefined;
-    });
+    const response = await this._request<L.TemplatesQuery, L.TemplatesQueryVariables>(L.TemplatesDocument, {});
+    const data = response?.templates;
+    return data ? data.map(node => new Template(this._request, node)) : undefined;
   }
 }
 
@@ -7070,12 +7033,11 @@ export class UserQuery extends Request {
    * @returns parsed response from UserQuery
    */
   public async fetch(id: string): LinearFetch<User> {
-    return this._request<L.UserQuery, L.UserQueryVariables>(L.UserDocument, {
+    const response = await this._request<L.UserQuery, L.UserQueryVariables>(L.UserDocument, {
       id,
-    }).then(response => {
-      const data = response?.user;
-      return data ? new User(this._request, data) : undefined;
     });
+    const data = response?.user;
+    return data ? new User(this._request, data) : undefined;
   }
 }
 
@@ -7095,12 +7057,9 @@ export class UserSettingsQuery extends Request {
    * @returns parsed response from UserSettingsQuery
    */
   public async fetch(): LinearFetch<UserSettings> {
-    return this._request<L.UserSettingsQuery, L.UserSettingsQueryVariables>(L.UserSettingsDocument, {}).then(
-      response => {
-        const data = response?.userSettings;
-        return data ? new UserSettings(this._request, data) : undefined;
-      }
-    );
+    const response = await this._request<L.UserSettingsQuery, L.UserSettingsQueryVariables>(L.UserSettingsDocument, {});
+    const data = response?.userSettings;
+    return data ? new UserSettings(this._request, data) : undefined;
   }
 }
 
@@ -7121,12 +7080,11 @@ export class UsersQuery extends Request {
    * @returns parsed response from UsersQuery
    */
   public async fetch(variables?: L.UsersQueryVariables): LinearFetch<UserConnection> {
-    return this._request<L.UsersQuery, L.UsersQueryVariables>(L.UsersDocument, variables).then(response => {
-      const data = response?.users;
-      return data
-        ? new UserConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-        : undefined;
-    });
+    const response = await this._request<L.UsersQuery, L.UsersQueryVariables>(L.UsersDocument, variables);
+    const data = response?.users;
+    return data
+      ? new UserConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -7146,10 +7104,9 @@ export class ViewerQuery extends Request {
    * @returns parsed response from ViewerQuery
    */
   public async fetch(): LinearFetch<User> {
-    return this._request<L.ViewerQuery, L.ViewerQueryVariables>(L.ViewerDocument, {}).then(response => {
-      const data = response?.viewer;
-      return data ? new User(this._request, data) : undefined;
-    });
+    const response = await this._request<L.ViewerQuery, L.ViewerQueryVariables>(L.ViewerDocument, {});
+    const data = response?.viewer;
+    return data ? new User(this._request, data) : undefined;
   }
 }
 
@@ -7170,12 +7127,11 @@ export class WebhookQuery extends Request {
    * @returns parsed response from WebhookQuery
    */
   public async fetch(id: string): LinearFetch<Webhook> {
-    return this._request<L.WebhookQuery, L.WebhookQueryVariables>(L.WebhookDocument, {
+    const response = await this._request<L.WebhookQuery, L.WebhookQueryVariables>(L.WebhookDocument, {
       id,
-    }).then(response => {
-      const data = response?.webhook;
-      return data ? new Webhook(this._request, data) : undefined;
     });
+    const data = response?.webhook;
+    return data ? new Webhook(this._request, data) : undefined;
   }
 }
 
@@ -7196,12 +7152,11 @@ export class WebhooksQuery extends Request {
    * @returns parsed response from WebhooksQuery
    */
   public async fetch(variables?: L.WebhooksQueryVariables): LinearFetch<WebhookConnection> {
-    return this._request<L.WebhooksQuery, L.WebhooksQueryVariables>(L.WebhooksDocument, variables).then(response => {
-      const data = response?.webhooks;
-      return data
-        ? new WebhookConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-        : undefined;
-    });
+    const response = await this._request<L.WebhooksQuery, L.WebhooksQueryVariables>(L.WebhooksDocument, variables);
+    const data = response?.webhooks;
+    return data
+      ? new WebhookConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -7222,12 +7177,11 @@ export class WorkflowStateQuery extends Request {
    * @returns parsed response from WorkflowStateQuery
    */
   public async fetch(id: string): LinearFetch<WorkflowState> {
-    return this._request<L.WorkflowStateQuery, L.WorkflowStateQueryVariables>(L.WorkflowStateDocument, {
+    const response = await this._request<L.WorkflowStateQuery, L.WorkflowStateQueryVariables>(L.WorkflowStateDocument, {
       id,
-    }).then(response => {
-      const data = response?.workflowState;
-      return data ? new WorkflowState(this._request, data) : undefined;
     });
+    const data = response?.workflowState;
+    return data ? new WorkflowState(this._request, data) : undefined;
   }
 }
 
@@ -7248,15 +7202,14 @@ export class WorkflowStatesQuery extends Request {
    * @returns parsed response from WorkflowStatesQuery
    */
   public async fetch(variables?: L.WorkflowStatesQueryVariables): LinearFetch<WorkflowStateConnection> {
-    return this._request<L.WorkflowStatesQuery, L.WorkflowStatesQueryVariables>(
+    const response = await this._request<L.WorkflowStatesQuery, L.WorkflowStatesQueryVariables>(
       L.WorkflowStatesDocument,
       variables
-    ).then(response => {
-      const data = response?.workflowStates;
-      return data
-        ? new WorkflowStateConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
-        : undefined;
-    });
+    );
+    const data = response?.workflowStates;
+    return data
+      ? new WorkflowStateConnection(this._request, connection => this.fetch({ ...variables, ...connection }), data)
+      : undefined;
   }
 }
 
@@ -7277,15 +7230,14 @@ export class AttachmentArchiveMutation extends Request {
    * @returns parsed response from AttachmentArchiveMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.AttachmentArchiveMutation, L.AttachmentArchiveMutationVariables>(
+    const response = await this._request<L.AttachmentArchiveMutation, L.AttachmentArchiveMutationVariables>(
       L.AttachmentArchiveDocument,
       {
         id,
       }
-    ).then(response => {
-      const data = response?.attachmentArchive;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.attachmentArchive;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -7306,12 +7258,14 @@ export class AttachmentCreateMutation extends Request {
    * @returns parsed response from AttachmentCreateMutation
    */
   public async fetch(input: L.AttachmentCreateInput): LinearFetch<AttachmentPayload> {
-    return this._request<L.AttachmentCreateMutation, L.AttachmentCreateMutationVariables>(L.AttachmentCreateDocument, {
-      input,
-    }).then(response => {
-      const data = response?.attachmentCreate;
-      return data ? new AttachmentPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.AttachmentCreateMutation, L.AttachmentCreateMutationVariables>(
+      L.AttachmentCreateDocument,
+      {
+        input,
+      }
+    );
+    const data = response?.attachmentCreate;
+    return data ? new AttachmentPayload(this._request, data) : undefined;
   }
 }
 
@@ -7332,12 +7286,14 @@ export class AttachmentDeleteMutation extends Request {
    * @returns parsed response from AttachmentDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.AttachmentDeleteMutation, L.AttachmentDeleteMutationVariables>(L.AttachmentDeleteDocument, {
-      id,
-    }).then(response => {
-      const data = response?.attachmentDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.AttachmentDeleteMutation, L.AttachmentDeleteMutationVariables>(
+      L.AttachmentDeleteDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.attachmentDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -7359,16 +7315,15 @@ export class AttachmentLinkFrontMutation extends Request {
    * @returns parsed response from AttachmentLinkFrontMutation
    */
   public async fetch(conversationId: string, issueId: string): LinearFetch<AttachmentPayload> {
-    return this._request<L.AttachmentLinkFrontMutation, L.AttachmentLinkFrontMutationVariables>(
+    const response = await this._request<L.AttachmentLinkFrontMutation, L.AttachmentLinkFrontMutationVariables>(
       L.AttachmentLinkFrontDocument,
       {
         conversationId,
         issueId,
       }
-    ).then(response => {
-      const data = response?.attachmentLinkFront;
-      return data ? new AttachmentPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.attachmentLinkFront;
+    return data ? new AttachmentPayload(this._request, data) : undefined;
   }
 }
 
@@ -7390,16 +7345,15 @@ export class AttachmentLinkIntercomMutation extends Request {
    * @returns parsed response from AttachmentLinkIntercomMutation
    */
   public async fetch(conversationId: string, issueId: string): LinearFetch<AttachmentPayload> {
-    return this._request<L.AttachmentLinkIntercomMutation, L.AttachmentLinkIntercomMutationVariables>(
+    const response = await this._request<L.AttachmentLinkIntercomMutation, L.AttachmentLinkIntercomMutationVariables>(
       L.AttachmentLinkIntercomDocument,
       {
         conversationId,
         issueId,
       }
-    ).then(response => {
-      const data = response?.attachmentLinkIntercom;
-      return data ? new AttachmentPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.attachmentLinkIntercom;
+    return data ? new AttachmentPayload(this._request, data) : undefined;
   }
 }
 
@@ -7421,16 +7375,15 @@ export class AttachmentLinkUrlMutation extends Request {
    * @returns parsed response from AttachmentLinkUrlMutation
    */
   public async fetch(issueId: string, url: string): LinearFetch<AttachmentPayload> {
-    return this._request<L.AttachmentLinkUrlMutation, L.AttachmentLinkUrlMutationVariables>(
+    const response = await this._request<L.AttachmentLinkUrlMutation, L.AttachmentLinkUrlMutationVariables>(
       L.AttachmentLinkUrlDocument,
       {
         issueId,
         url,
       }
-    ).then(response => {
-      const data = response?.attachmentLinkURL;
-      return data ? new AttachmentPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.attachmentLinkURL;
+    return data ? new AttachmentPayload(this._request, data) : undefined;
   }
 }
 
@@ -7452,16 +7405,15 @@ export class AttachmentLinkZendeskMutation extends Request {
    * @returns parsed response from AttachmentLinkZendeskMutation
    */
   public async fetch(issueId: string, ticketId: string): LinearFetch<AttachmentPayload> {
-    return this._request<L.AttachmentLinkZendeskMutation, L.AttachmentLinkZendeskMutationVariables>(
+    const response = await this._request<L.AttachmentLinkZendeskMutation, L.AttachmentLinkZendeskMutationVariables>(
       L.AttachmentLinkZendeskDocument,
       {
         issueId,
         ticketId,
       }
-    ).then(response => {
-      const data = response?.attachmentLinkZendesk;
-      return data ? new AttachmentPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.attachmentLinkZendesk;
+    return data ? new AttachmentPayload(this._request, data) : undefined;
   }
 }
 
@@ -7483,13 +7435,15 @@ export class AttachmentUpdateMutation extends Request {
    * @returns parsed response from AttachmentUpdateMutation
    */
   public async fetch(id: string, input: L.AttachmentUpdateInput): LinearFetch<AttachmentPayload> {
-    return this._request<L.AttachmentUpdateMutation, L.AttachmentUpdateMutationVariables>(L.AttachmentUpdateDocument, {
-      id,
-      input,
-    }).then(response => {
-      const data = response?.attachmentUpdate;
-      return data ? new AttachmentPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.AttachmentUpdateMutation, L.AttachmentUpdateMutationVariables>(
+      L.AttachmentUpdateDocument,
+      {
+        id,
+        input,
+      }
+    );
+    const data = response?.attachmentUpdate;
+    return data ? new AttachmentPayload(this._request, data) : undefined;
   }
 }
 
@@ -7510,15 +7464,14 @@ export class BillingEmailUpdateMutation extends Request {
    * @returns parsed response from BillingEmailUpdateMutation
    */
   public async fetch(input: L.BillingEmailUpdateInput): LinearFetch<BillingEmailPayload> {
-    return this._request<L.BillingEmailUpdateMutation, L.BillingEmailUpdateMutationVariables>(
+    const response = await this._request<L.BillingEmailUpdateMutation, L.BillingEmailUpdateMutationVariables>(
       L.BillingEmailUpdateDocument,
       {
         input,
       }
-    ).then(response => {
-      const data = response?.billingEmailUpdate;
-      return data ? new BillingEmailPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.billingEmailUpdate;
+    return data ? new BillingEmailPayload(this._request, data) : undefined;
   }
 }
 
@@ -7539,15 +7492,14 @@ export class CollaborativeDocumentUpdateMutation extends Request {
    * @returns parsed response from CollaborativeDocumentUpdateMutation
    */
   public async fetch(input: L.CollaborationDocumentUpdateInput): LinearFetch<CollaborationDocumentUpdatePayload> {
-    return this._request<L.CollaborativeDocumentUpdateMutation, L.CollaborativeDocumentUpdateMutationVariables>(
-      L.CollaborativeDocumentUpdateDocument,
-      {
-        input,
-      }
-    ).then(response => {
-      const data = response?.collaborativeDocumentUpdate;
-      return data ? new CollaborationDocumentUpdatePayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.CollaborativeDocumentUpdateMutation,
+      L.CollaborativeDocumentUpdateMutationVariables
+    >(L.CollaborativeDocumentUpdateDocument, {
+      input,
     });
+    const data = response?.collaborativeDocumentUpdate;
+    return data ? new CollaborationDocumentUpdatePayload(this._request, data) : undefined;
   }
 }
 
@@ -7568,12 +7520,14 @@ export class CommentCreateMutation extends Request {
    * @returns parsed response from CommentCreateMutation
    */
   public async fetch(input: L.CommentCreateInput): LinearFetch<CommentPayload> {
-    return this._request<L.CommentCreateMutation, L.CommentCreateMutationVariables>(L.CommentCreateDocument, {
-      input,
-    }).then(response => {
-      const data = response?.commentCreate;
-      return data ? new CommentPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.CommentCreateMutation, L.CommentCreateMutationVariables>(
+      L.CommentCreateDocument,
+      {
+        input,
+      }
+    );
+    const data = response?.commentCreate;
+    return data ? new CommentPayload(this._request, data) : undefined;
   }
 }
 
@@ -7594,12 +7548,14 @@ export class CommentDeleteMutation extends Request {
    * @returns parsed response from CommentDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.CommentDeleteMutation, L.CommentDeleteMutationVariables>(L.CommentDeleteDocument, {
-      id,
-    }).then(response => {
-      const data = response?.commentDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.CommentDeleteMutation, L.CommentDeleteMutationVariables>(
+      L.CommentDeleteDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.commentDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -7621,13 +7577,15 @@ export class CommentUpdateMutation extends Request {
    * @returns parsed response from CommentUpdateMutation
    */
   public async fetch(id: string, input: L.CommentUpdateInput): LinearFetch<CommentPayload> {
-    return this._request<L.CommentUpdateMutation, L.CommentUpdateMutationVariables>(L.CommentUpdateDocument, {
-      id,
-      input,
-    }).then(response => {
-      const data = response?.commentUpdate;
-      return data ? new CommentPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.CommentUpdateMutation, L.CommentUpdateMutationVariables>(
+      L.CommentUpdateDocument,
+      {
+        id,
+        input,
+      }
+    );
+    const data = response?.commentUpdate;
+    return data ? new CommentPayload(this._request, data) : undefined;
   }
 }
 
@@ -7648,12 +7606,14 @@ export class ContactCreateMutation extends Request {
    * @returns parsed response from ContactCreateMutation
    */
   public async fetch(input: L.ContactCreateInput): LinearFetch<ContactPayload> {
-    return this._request<L.ContactCreateMutation, L.ContactCreateMutationVariables>(L.ContactCreateDocument, {
-      input,
-    }).then(response => {
-      const data = response?.contactCreate;
-      return data ? new ContactPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.ContactCreateMutation, L.ContactCreateMutationVariables>(
+      L.ContactCreateDocument,
+      {
+        input,
+      }
+    );
+    const data = response?.contactCreate;
+    return data ? new ContactPayload(this._request, data) : undefined;
   }
 }
 
@@ -7674,13 +7634,12 @@ export class CreateCsvExportReportMutation extends Request {
    * @returns parsed response from CreateCsvExportReportMutation
    */
   public async fetch(variables?: L.CreateCsvExportReportMutationVariables): LinearFetch<CreateCsvExportReportPayload> {
-    return this._request<L.CreateCsvExportReportMutation, L.CreateCsvExportReportMutationVariables>(
+    const response = await this._request<L.CreateCsvExportReportMutation, L.CreateCsvExportReportMutationVariables>(
       L.CreateCsvExportReportDocument,
       variables
-    ).then(response => {
-      const data = response?.createCsvExportReport;
-      return data ? new CreateCsvExportReportPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.createCsvExportReport;
+    return data ? new CreateCsvExportReportPayload(this._request, data) : undefined;
   }
 }
 
@@ -7705,16 +7664,15 @@ export class CreateOrganizationFromOnboardingMutation extends Request {
     input: L.CreateOrganizationInput,
     variables?: Omit<L.CreateOrganizationFromOnboardingMutationVariables, "input">
   ): LinearFetch<CreateOrJoinOrganizationResponse> {
-    return this._request<
+    const response = await this._request<
       L.CreateOrganizationFromOnboardingMutation,
       L.CreateOrganizationFromOnboardingMutationVariables
     >(L.CreateOrganizationFromOnboardingDocument, {
       input,
       ...variables,
-    }).then(response => {
-      const data = response?.createOrganizationFromOnboarding;
-      return data ? new CreateOrJoinOrganizationResponse(this._request, data) : undefined;
     });
+    const data = response?.createOrganizationFromOnboarding;
+    return data ? new CreateOrJoinOrganizationResponse(this._request, data) : undefined;
   }
 }
 
@@ -7735,12 +7693,14 @@ export class CustomViewCreateMutation extends Request {
    * @returns parsed response from CustomViewCreateMutation
    */
   public async fetch(input: L.CustomViewCreateInput): LinearFetch<CustomViewPayload> {
-    return this._request<L.CustomViewCreateMutation, L.CustomViewCreateMutationVariables>(L.CustomViewCreateDocument, {
-      input,
-    }).then(response => {
-      const data = response?.customViewCreate;
-      return data ? new CustomViewPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.CustomViewCreateMutation, L.CustomViewCreateMutationVariables>(
+      L.CustomViewCreateDocument,
+      {
+        input,
+      }
+    );
+    const data = response?.customViewCreate;
+    return data ? new CustomViewPayload(this._request, data) : undefined;
   }
 }
 
@@ -7761,12 +7721,14 @@ export class CustomViewDeleteMutation extends Request {
    * @returns parsed response from CustomViewDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.CustomViewDeleteMutation, L.CustomViewDeleteMutationVariables>(L.CustomViewDeleteDocument, {
-      id,
-    }).then(response => {
-      const data = response?.customViewDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.CustomViewDeleteMutation, L.CustomViewDeleteMutationVariables>(
+      L.CustomViewDeleteDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.customViewDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -7788,13 +7750,15 @@ export class CustomViewUpdateMutation extends Request {
    * @returns parsed response from CustomViewUpdateMutation
    */
   public async fetch(id: string, input: L.CustomViewUpdateInput): LinearFetch<CustomViewPayload> {
-    return this._request<L.CustomViewUpdateMutation, L.CustomViewUpdateMutationVariables>(L.CustomViewUpdateDocument, {
-      id,
-      input,
-    }).then(response => {
-      const data = response?.customViewUpdate;
-      return data ? new CustomViewPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.CustomViewUpdateMutation, L.CustomViewUpdateMutationVariables>(
+      L.CustomViewUpdateDocument,
+      {
+        id,
+        input,
+      }
+    );
+    const data = response?.customViewUpdate;
+    return data ? new CustomViewPayload(this._request, data) : undefined;
   }
 }
 
@@ -7815,12 +7779,14 @@ export class CycleArchiveMutation extends Request {
    * @returns parsed response from CycleArchiveMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.CycleArchiveMutation, L.CycleArchiveMutationVariables>(L.CycleArchiveDocument, {
-      id,
-    }).then(response => {
-      const data = response?.cycleArchive;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.CycleArchiveMutation, L.CycleArchiveMutationVariables>(
+      L.CycleArchiveDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.cycleArchive;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -7841,12 +7807,11 @@ export class CycleCreateMutation extends Request {
    * @returns parsed response from CycleCreateMutation
    */
   public async fetch(input: L.CycleCreateInput): LinearFetch<CyclePayload> {
-    return this._request<L.CycleCreateMutation, L.CycleCreateMutationVariables>(L.CycleCreateDocument, {
+    const response = await this._request<L.CycleCreateMutation, L.CycleCreateMutationVariables>(L.CycleCreateDocument, {
       input,
-    }).then(response => {
-      const data = response?.cycleCreate;
-      return data ? new CyclePayload(this._request, data) : undefined;
     });
+    const data = response?.cycleCreate;
+    return data ? new CyclePayload(this._request, data) : undefined;
   }
 }
 
@@ -7868,13 +7833,12 @@ export class CycleUpdateMutation extends Request {
    * @returns parsed response from CycleUpdateMutation
    */
   public async fetch(id: string, input: L.CycleUpdateInput): LinearFetch<CyclePayload> {
-    return this._request<L.CycleUpdateMutation, L.CycleUpdateMutationVariables>(L.CycleUpdateDocument, {
+    const response = await this._request<L.CycleUpdateMutation, L.CycleUpdateMutationVariables>(L.CycleUpdateDocument, {
       id,
       input,
-    }).then(response => {
-      const data = response?.cycleUpdate;
-      return data ? new CyclePayload(this._request, data) : undefined;
     });
+    const data = response?.cycleUpdate;
+    return data ? new CyclePayload(this._request, data) : undefined;
   }
 }
 
@@ -7894,13 +7858,12 @@ export class DebugCreateSamlOrgMutation extends Request {
    * @returns parsed response from DebugCreateSamlOrgMutation
    */
   public async fetch(): LinearFetch<DebugPayload> {
-    return this._request<L.DebugCreateSamlOrgMutation, L.DebugCreateSamlOrgMutationVariables>(
+    const response = await this._request<L.DebugCreateSamlOrgMutation, L.DebugCreateSamlOrgMutationVariables>(
       L.DebugCreateSamlOrgDocument,
       {}
-    ).then(response => {
-      const data = response?.debugCreateSAMLOrg;
-      return data ? new DebugPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.debugCreateSAMLOrg;
+    return data ? new DebugPayload(this._request, data) : undefined;
   }
 }
 
@@ -7920,13 +7883,12 @@ export class DebugFailWithInternalErrorMutation extends Request {
    * @returns parsed response from DebugFailWithInternalErrorMutation
    */
   public async fetch(): LinearFetch<DebugPayload> {
-    return this._request<L.DebugFailWithInternalErrorMutation, L.DebugFailWithInternalErrorMutationVariables>(
-      L.DebugFailWithInternalErrorDocument,
-      {}
-    ).then(response => {
-      const data = response?.debugFailWithInternalError;
-      return data ? new DebugPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<
+      L.DebugFailWithInternalErrorMutation,
+      L.DebugFailWithInternalErrorMutationVariables
+    >(L.DebugFailWithInternalErrorDocument, {});
+    const data = response?.debugFailWithInternalError;
+    return data ? new DebugPayload(this._request, data) : undefined;
   }
 }
 
@@ -7946,13 +7908,12 @@ export class DebugFailWithWarningMutation extends Request {
    * @returns parsed response from DebugFailWithWarningMutation
    */
   public async fetch(): LinearFetch<DebugPayload> {
-    return this._request<L.DebugFailWithWarningMutation, L.DebugFailWithWarningMutationVariables>(
+    const response = await this._request<L.DebugFailWithWarningMutation, L.DebugFailWithWarningMutationVariables>(
       L.DebugFailWithWarningDocument,
       {}
-    ).then(response => {
-      const data = response?.debugFailWithWarning;
-      return data ? new DebugPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.debugFailWithWarning;
+    return data ? new DebugPayload(this._request, data) : undefined;
   }
 }
 
@@ -7973,15 +7934,14 @@ export class EmailTokenUserAccountAuthMutation extends Request {
    * @returns parsed response from EmailTokenUserAccountAuthMutation
    */
   public async fetch(input: L.TokenUserAccountAuthInput): LinearFetch<AuthResolverResponse> {
-    return this._request<L.EmailTokenUserAccountAuthMutation, L.EmailTokenUserAccountAuthMutationVariables>(
-      L.EmailTokenUserAccountAuthDocument,
-      {
-        input,
-      }
-    ).then(response => {
-      const data = response?.emailTokenUserAccountAuth;
-      return data ? new AuthResolverResponse(this._request, data) : undefined;
+    const response = await this._request<
+      L.EmailTokenUserAccountAuthMutation,
+      L.EmailTokenUserAccountAuthMutationVariables
+    >(L.EmailTokenUserAccountAuthDocument, {
+      input,
     });
+    const data = response?.emailTokenUserAccountAuth;
+    return data ? new AuthResolverResponse(this._request, data) : undefined;
   }
 }
 
@@ -8002,12 +7962,14 @@ export class EmailUnsubscribeMutation extends Request {
    * @returns parsed response from EmailUnsubscribeMutation
    */
   public async fetch(input: L.EmailUnsubscribeInput): LinearFetch<EmailUnsubscribePayload> {
-    return this._request<L.EmailUnsubscribeMutation, L.EmailUnsubscribeMutationVariables>(L.EmailUnsubscribeDocument, {
-      input,
-    }).then(response => {
-      const data = response?.emailUnsubscribe;
-      return data ? new EmailUnsubscribePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.EmailUnsubscribeMutation, L.EmailUnsubscribeMutationVariables>(
+      L.EmailUnsubscribeDocument,
+      {
+        input,
+      }
+    );
+    const data = response?.emailUnsubscribe;
+    return data ? new EmailUnsubscribePayload(this._request, data) : undefined;
   }
 }
 
@@ -8028,15 +7990,14 @@ export class EmailUserAccountAuthChallengeMutation extends Request {
    * @returns parsed response from EmailUserAccountAuthChallengeMutation
    */
   public async fetch(input: L.EmailUserAccountAuthChallengeInput): LinearFetch<EmailUserAccountAuthChallengeResponse> {
-    return this._request<L.EmailUserAccountAuthChallengeMutation, L.EmailUserAccountAuthChallengeMutationVariables>(
-      L.EmailUserAccountAuthChallengeDocument,
-      {
-        input,
-      }
-    ).then(response => {
-      const data = response?.emailUserAccountAuthChallenge;
-      return data ? new EmailUserAccountAuthChallengeResponse(this._request, data) : undefined;
+    const response = await this._request<
+      L.EmailUserAccountAuthChallengeMutation,
+      L.EmailUserAccountAuthChallengeMutationVariables
+    >(L.EmailUserAccountAuthChallengeDocument, {
+      input,
     });
+    const data = response?.emailUserAccountAuthChallenge;
+    return data ? new EmailUserAccountAuthChallengeResponse(this._request, data) : undefined;
   }
 }
 
@@ -8057,12 +8018,11 @@ export class EmojiCreateMutation extends Request {
    * @returns parsed response from EmojiCreateMutation
    */
   public async fetch(input: L.EmojiCreateInput): LinearFetch<EmojiPayload> {
-    return this._request<L.EmojiCreateMutation, L.EmojiCreateMutationVariables>(L.EmojiCreateDocument, {
+    const response = await this._request<L.EmojiCreateMutation, L.EmojiCreateMutationVariables>(L.EmojiCreateDocument, {
       input,
-    }).then(response => {
-      const data = response?.emojiCreate;
-      return data ? new EmojiPayload(this._request, data) : undefined;
     });
+    const data = response?.emojiCreate;
+    return data ? new EmojiPayload(this._request, data) : undefined;
   }
 }
 
@@ -8083,12 +8043,11 @@ export class EmojiDeleteMutation extends Request {
    * @returns parsed response from EmojiDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.EmojiDeleteMutation, L.EmojiDeleteMutationVariables>(L.EmojiDeleteDocument, {
+    const response = await this._request<L.EmojiDeleteMutation, L.EmojiDeleteMutationVariables>(L.EmojiDeleteDocument, {
       id,
-    }).then(response => {
-      const data = response?.emojiDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
     });
+    const data = response?.emojiDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -8109,12 +8068,11 @@ export class EventCreateMutation extends Request {
    * @returns parsed response from EventCreateMutation
    */
   public async fetch(input: L.EventCreateInput): LinearFetch<EventPayload> {
-    return this._request<L.EventCreateMutation, L.EventCreateMutationVariables>(L.EventCreateDocument, {
+    const response = await this._request<L.EventCreateMutation, L.EventCreateMutationVariables>(L.EventCreateDocument, {
       input,
-    }).then(response => {
-      const data = response?.eventCreate;
-      return data ? new EventPayload(this._request, data) : undefined;
     });
+    const data = response?.eventCreate;
+    return data ? new EventPayload(this._request, data) : undefined;
   }
 }
 
@@ -8135,12 +8093,14 @@ export class FavoriteCreateMutation extends Request {
    * @returns parsed response from FavoriteCreateMutation
    */
   public async fetch(input: L.FavoriteCreateInput): LinearFetch<FavoritePayload> {
-    return this._request<L.FavoriteCreateMutation, L.FavoriteCreateMutationVariables>(L.FavoriteCreateDocument, {
-      input,
-    }).then(response => {
-      const data = response?.favoriteCreate;
-      return data ? new FavoritePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.FavoriteCreateMutation, L.FavoriteCreateMutationVariables>(
+      L.FavoriteCreateDocument,
+      {
+        input,
+      }
+    );
+    const data = response?.favoriteCreate;
+    return data ? new FavoritePayload(this._request, data) : undefined;
   }
 }
 
@@ -8161,12 +8121,14 @@ export class FavoriteDeleteMutation extends Request {
    * @returns parsed response from FavoriteDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.FavoriteDeleteMutation, L.FavoriteDeleteMutationVariables>(L.FavoriteDeleteDocument, {
-      id,
-    }).then(response => {
-      const data = response?.favoriteDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.FavoriteDeleteMutation, L.FavoriteDeleteMutationVariables>(
+      L.FavoriteDeleteDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.favoriteDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -8188,13 +8150,15 @@ export class FavoriteUpdateMutation extends Request {
    * @returns parsed response from FavoriteUpdateMutation
    */
   public async fetch(id: string, input: L.FavoriteUpdateInput): LinearFetch<FavoritePayload> {
-    return this._request<L.FavoriteUpdateMutation, L.FavoriteUpdateMutationVariables>(L.FavoriteUpdateDocument, {
-      id,
-      input,
-    }).then(response => {
-      const data = response?.favoriteUpdate;
-      return data ? new FavoritePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.FavoriteUpdateMutation, L.FavoriteUpdateMutationVariables>(
+      L.FavoriteUpdateDocument,
+      {
+        id,
+        input,
+      }
+    );
+    const data = response?.favoriteUpdate;
+    return data ? new FavoritePayload(this._request, data) : undefined;
   }
 }
 
@@ -8215,12 +8179,14 @@ export class FeedbackCreateMutation extends Request {
    * @returns parsed response from FeedbackCreateMutation
    */
   public async fetch(input: L.FeedbackCreateInput): LinearFetch<FeedbackPayload> {
-    return this._request<L.FeedbackCreateMutation, L.FeedbackCreateMutationVariables>(L.FeedbackCreateDocument, {
-      input,
-    }).then(response => {
-      const data = response?.feedbackCreate;
-      return data ? new FeedbackPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.FeedbackCreateMutation, L.FeedbackCreateMutationVariables>(
+      L.FeedbackCreateDocument,
+      {
+        input,
+      }
+    );
+    const data = response?.feedbackCreate;
+    return data ? new FeedbackPayload(this._request, data) : undefined;
   }
 }
 
@@ -8249,15 +8215,14 @@ export class FileUploadMutation extends Request {
     size: number,
     variables?: Omit<L.FileUploadMutationVariables, "contentType" | "filename" | "size">
   ): LinearFetch<UploadPayload> {
-    return this._request<L.FileUploadMutation, L.FileUploadMutationVariables>(L.FileUploadDocument, {
+    const response = await this._request<L.FileUploadMutation, L.FileUploadMutationVariables>(L.FileUploadDocument, {
       contentType,
       filename,
       size,
       ...variables,
-    }).then(response => {
-      const data = response?.fileUpload;
-      return data ? new UploadPayload(this._request, data) : undefined;
     });
+    const data = response?.fileUpload;
+    return data ? new UploadPayload(this._request, data) : undefined;
   }
 }
 
@@ -8278,15 +8243,14 @@ export class GoogleUserAccountAuthMutation extends Request {
    * @returns parsed response from GoogleUserAccountAuthMutation
    */
   public async fetch(input: L.GoogleUserAccountAuthInput): LinearFetch<AuthResolverResponse> {
-    return this._request<L.GoogleUserAccountAuthMutation, L.GoogleUserAccountAuthMutationVariables>(
+    const response = await this._request<L.GoogleUserAccountAuthMutation, L.GoogleUserAccountAuthMutationVariables>(
       L.GoogleUserAccountAuthDocument,
       {
         input,
       }
-    ).then(response => {
-      const data = response?.googleUserAccountAuth;
-      return data ? new AuthResolverResponse(this._request, data) : undefined;
-    });
+    );
+    const data = response?.googleUserAccountAuth;
+    return data ? new AuthResolverResponse(this._request, data) : undefined;
   }
 }
 
@@ -8307,15 +8271,14 @@ export class ImageUploadFromUrlMutation extends Request {
    * @returns parsed response from ImageUploadFromUrlMutation
    */
   public async fetch(url: string): LinearFetch<ImageUploadFromUrlPayload> {
-    return this._request<L.ImageUploadFromUrlMutation, L.ImageUploadFromUrlMutationVariables>(
+    const response = await this._request<L.ImageUploadFromUrlMutation, L.ImageUploadFromUrlMutationVariables>(
       L.ImageUploadFromUrlDocument,
       {
         url,
       }
-    ).then(response => {
-      const data = response?.imageUploadFromUrl;
-      return data ? new ImageUploadFromUrlPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.imageUploadFromUrl;
+    return data ? new ImageUploadFromUrlPayload(this._request, data) : undefined;
   }
 }
 
@@ -8336,15 +8299,14 @@ export class IntegrationDeleteMutation extends Request {
    * @returns parsed response from IntegrationDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.IntegrationDeleteMutation, L.IntegrationDeleteMutationVariables>(
+    const response = await this._request<L.IntegrationDeleteMutation, L.IntegrationDeleteMutationVariables>(
       L.IntegrationDeleteDocument,
       {
         id,
       }
-    ).then(response => {
-      const data = response?.integrationDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.integrationDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -8366,13 +8328,15 @@ export class IntegrationFigmaMutation extends Request {
    * @returns parsed response from IntegrationFigmaMutation
    */
   public async fetch(code: string, redirectUri: string): LinearFetch<IntegrationPayload> {
-    return this._request<L.IntegrationFigmaMutation, L.IntegrationFigmaMutationVariables>(L.IntegrationFigmaDocument, {
-      code,
-      redirectUri,
-    }).then(response => {
-      const data = response?.integrationFigma;
-      return data ? new IntegrationPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.IntegrationFigmaMutation, L.IntegrationFigmaMutationVariables>(
+      L.IntegrationFigmaDocument,
+      {
+        code,
+        redirectUri,
+      }
+    );
+    const data = response?.integrationFigma;
+    return data ? new IntegrationPayload(this._request, data) : undefined;
   }
 }
 
@@ -8394,13 +8358,15 @@ export class IntegrationFrontMutation extends Request {
    * @returns parsed response from IntegrationFrontMutation
    */
   public async fetch(code: string, redirectUri: string): LinearFetch<IntegrationPayload> {
-    return this._request<L.IntegrationFrontMutation, L.IntegrationFrontMutationVariables>(L.IntegrationFrontDocument, {
-      code,
-      redirectUri,
-    }).then(response => {
-      const data = response?.integrationFront;
-      return data ? new IntegrationPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.IntegrationFrontMutation, L.IntegrationFrontMutationVariables>(
+      L.IntegrationFrontDocument,
+      {
+        code,
+        redirectUri,
+      }
+    );
+    const data = response?.integrationFront;
+    return data ? new IntegrationPayload(this._request, data) : undefined;
   }
 }
 
@@ -8421,15 +8387,14 @@ export class IntegrationGithubConnectMutation extends Request {
    * @returns parsed response from IntegrationGithubConnectMutation
    */
   public async fetch(installationId: string): LinearFetch<IntegrationPayload> {
-    return this._request<L.IntegrationGithubConnectMutation, L.IntegrationGithubConnectMutationVariables>(
-      L.IntegrationGithubConnectDocument,
-      {
-        installationId,
-      }
-    ).then(response => {
-      const data = response?.integrationGithubConnect;
-      return data ? new IntegrationPayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.IntegrationGithubConnectMutation,
+      L.IntegrationGithubConnectMutationVariables
+    >(L.IntegrationGithubConnectDocument, {
+      installationId,
     });
+    const data = response?.integrationGithubConnect;
+    return data ? new IntegrationPayload(this._request, data) : undefined;
   }
 }
 
@@ -8451,16 +8416,15 @@ export class IntegrationGitlabConnectMutation extends Request {
    * @returns parsed response from IntegrationGitlabConnectMutation
    */
   public async fetch(accessToken: string, gitlabUrl: string): LinearFetch<IntegrationPayload> {
-    return this._request<L.IntegrationGitlabConnectMutation, L.IntegrationGitlabConnectMutationVariables>(
-      L.IntegrationGitlabConnectDocument,
-      {
-        accessToken,
-        gitlabUrl,
-      }
-    ).then(response => {
-      const data = response?.integrationGitlabConnect;
-      return data ? new IntegrationPayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.IntegrationGitlabConnectMutation,
+      L.IntegrationGitlabConnectMutationVariables
+    >(L.IntegrationGitlabConnectDocument, {
+      accessToken,
+      gitlabUrl,
     });
+    const data = response?.integrationGitlabConnect;
+    return data ? new IntegrationPayload(this._request, data) : undefined;
   }
 }
 
@@ -8481,15 +8445,14 @@ export class IntegrationGoogleSheetsMutation extends Request {
    * @returns parsed response from IntegrationGoogleSheetsMutation
    */
   public async fetch(code: string): LinearFetch<IntegrationPayload> {
-    return this._request<L.IntegrationGoogleSheetsMutation, L.IntegrationGoogleSheetsMutationVariables>(
+    const response = await this._request<L.IntegrationGoogleSheetsMutation, L.IntegrationGoogleSheetsMutationVariables>(
       L.IntegrationGoogleSheetsDocument,
       {
         code,
       }
-    ).then(response => {
-      const data = response?.integrationGoogleSheets;
-      return data ? new IntegrationPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.integrationGoogleSheets;
+    return data ? new IntegrationPayload(this._request, data) : undefined;
   }
 }
 
@@ -8511,16 +8474,15 @@ export class IntegrationIntercomMutation extends Request {
    * @returns parsed response from IntegrationIntercomMutation
    */
   public async fetch(code: string, redirectUri: string): LinearFetch<IntegrationPayload> {
-    return this._request<L.IntegrationIntercomMutation, L.IntegrationIntercomMutationVariables>(
+    const response = await this._request<L.IntegrationIntercomMutation, L.IntegrationIntercomMutationVariables>(
       L.IntegrationIntercomDocument,
       {
         code,
         redirectUri,
       }
-    ).then(response => {
-      const data = response?.integrationIntercom;
-      return data ? new IntegrationPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.integrationIntercom;
+    return data ? new IntegrationPayload(this._request, data) : undefined;
   }
 }
 
@@ -8540,13 +8502,12 @@ export class IntegrationIntercomDeleteMutation extends Request {
    * @returns parsed response from IntegrationIntercomDeleteMutation
    */
   public async fetch(): LinearFetch<IntegrationPayload> {
-    return this._request<L.IntegrationIntercomDeleteMutation, L.IntegrationIntercomDeleteMutationVariables>(
-      L.IntegrationIntercomDeleteDocument,
-      {}
-    ).then(response => {
-      const data = response?.integrationIntercomDelete;
-      return data ? new IntegrationPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<
+      L.IntegrationIntercomDeleteMutation,
+      L.IntegrationIntercomDeleteMutationVariables
+    >(L.IntegrationIntercomDeleteDocument, {});
+    const data = response?.integrationIntercomDelete;
+    return data ? new IntegrationPayload(this._request, data) : undefined;
   }
 }
 
@@ -8566,13 +8527,12 @@ export class IntegrationLoomMutation extends Request {
    * @returns parsed response from IntegrationLoomMutation
    */
   public async fetch(): LinearFetch<IntegrationPayload> {
-    return this._request<L.IntegrationLoomMutation, L.IntegrationLoomMutationVariables>(
+    const response = await this._request<L.IntegrationLoomMutation, L.IntegrationLoomMutationVariables>(
       L.IntegrationLoomDocument,
       {}
-    ).then(response => {
-      const data = response?.integrationLoom;
-      return data ? new IntegrationPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.integrationLoom;
+    return data ? new IntegrationPayload(this._request, data) : undefined;
   }
 }
 
@@ -8593,15 +8553,14 @@ export class IntegrationResourceArchiveMutation extends Request {
    * @returns parsed response from IntegrationResourceArchiveMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.IntegrationResourceArchiveMutation, L.IntegrationResourceArchiveMutationVariables>(
-      L.IntegrationResourceArchiveDocument,
-      {
-        id,
-      }
-    ).then(response => {
-      const data = response?.integrationResourceArchive;
-      return data ? new ArchivePayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.IntegrationResourceArchiveMutation,
+      L.IntegrationResourceArchiveMutationVariables
+    >(L.IntegrationResourceArchiveDocument, {
+      id,
     });
+    const data = response?.integrationResourceArchive;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -8624,17 +8583,16 @@ export class IntegrationSentryConnectMutation extends Request {
    * @returns parsed response from IntegrationSentryConnectMutation
    */
   public async fetch(code: string, installationId: string, organizationSlug: string): LinearFetch<IntegrationPayload> {
-    return this._request<L.IntegrationSentryConnectMutation, L.IntegrationSentryConnectMutationVariables>(
-      L.IntegrationSentryConnectDocument,
-      {
-        code,
-        installationId,
-        organizationSlug,
-      }
-    ).then(response => {
-      const data = response?.integrationSentryConnect;
-      return data ? new IntegrationPayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.IntegrationSentryConnectMutation,
+      L.IntegrationSentryConnectMutationVariables
+    >(L.IntegrationSentryConnectDocument, {
+      code,
+      installationId,
+      organizationSlug,
     });
+    const data = response?.integrationSentryConnect;
+    return data ? new IntegrationPayload(this._request, data) : undefined;
   }
 }
 
@@ -8661,14 +8619,16 @@ export class IntegrationSlackMutation extends Request {
     redirectUri: string,
     variables?: Omit<L.IntegrationSlackMutationVariables, "code" | "redirectUri">
   ): LinearFetch<IntegrationPayload> {
-    return this._request<L.IntegrationSlackMutation, L.IntegrationSlackMutationVariables>(L.IntegrationSlackDocument, {
-      code,
-      redirectUri,
-      ...variables,
-    }).then(response => {
-      const data = response?.integrationSlack;
-      return data ? new IntegrationPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.IntegrationSlackMutation, L.IntegrationSlackMutationVariables>(
+      L.IntegrationSlackDocument,
+      {
+        code,
+        redirectUri,
+        ...variables,
+      }
+    );
+    const data = response?.integrationSlack;
+    return data ? new IntegrationPayload(this._request, data) : undefined;
   }
 }
 
@@ -8690,16 +8650,15 @@ export class IntegrationSlackImportEmojisMutation extends Request {
    * @returns parsed response from IntegrationSlackImportEmojisMutation
    */
   public async fetch(code: string, redirectUri: string): LinearFetch<IntegrationPayload> {
-    return this._request<L.IntegrationSlackImportEmojisMutation, L.IntegrationSlackImportEmojisMutationVariables>(
-      L.IntegrationSlackImportEmojisDocument,
-      {
-        code,
-        redirectUri,
-      }
-    ).then(response => {
-      const data = response?.integrationSlackImportEmojis;
-      return data ? new IntegrationPayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.IntegrationSlackImportEmojisMutation,
+      L.IntegrationSlackImportEmojisMutationVariables
+    >(L.IntegrationSlackImportEmojisDocument, {
+      code,
+      redirectUri,
     });
+    const data = response?.integrationSlackImportEmojis;
+    return data ? new IntegrationPayload(this._request, data) : undefined;
   }
 }
 
@@ -8721,16 +8680,15 @@ export class IntegrationSlackPersonalMutation extends Request {
    * @returns parsed response from IntegrationSlackPersonalMutation
    */
   public async fetch(code: string, redirectUri: string): LinearFetch<IntegrationPayload> {
-    return this._request<L.IntegrationSlackPersonalMutation, L.IntegrationSlackPersonalMutationVariables>(
-      L.IntegrationSlackPersonalDocument,
-      {
-        code,
-        redirectUri,
-      }
-    ).then(response => {
-      const data = response?.integrationSlackPersonal;
-      return data ? new IntegrationPayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.IntegrationSlackPersonalMutation,
+      L.IntegrationSlackPersonalMutationVariables
+    >(L.IntegrationSlackPersonalDocument, {
+      code,
+      redirectUri,
     });
+    const data = response?.integrationSlackPersonal;
+    return data ? new IntegrationPayload(this._request, data) : undefined;
   }
 }
 
@@ -8759,7 +8717,7 @@ export class IntegrationSlackPostMutation extends Request {
     teamId: string,
     variables?: Omit<L.IntegrationSlackPostMutationVariables, "code" | "redirectUri" | "teamId">
   ): LinearFetch<IntegrationPayload> {
-    return this._request<L.IntegrationSlackPostMutation, L.IntegrationSlackPostMutationVariables>(
+    const response = await this._request<L.IntegrationSlackPostMutation, L.IntegrationSlackPostMutationVariables>(
       L.IntegrationSlackPostDocument,
       {
         code,
@@ -8767,10 +8725,9 @@ export class IntegrationSlackPostMutation extends Request {
         teamId,
         ...variables,
       }
-    ).then(response => {
-      const data = response?.integrationSlackPost;
-      return data ? new IntegrationPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.integrationSlackPost;
+    return data ? new IntegrationPayload(this._request, data) : undefined;
   }
 }
 
@@ -8793,17 +8750,16 @@ export class IntegrationSlackProjectPostMutation extends Request {
    * @returns parsed response from IntegrationSlackProjectPostMutation
    */
   public async fetch(code: string, projectId: string, redirectUri: string): LinearFetch<IntegrationPayload> {
-    return this._request<L.IntegrationSlackProjectPostMutation, L.IntegrationSlackProjectPostMutationVariables>(
-      L.IntegrationSlackProjectPostDocument,
-      {
-        code,
-        projectId,
-        redirectUri,
-      }
-    ).then(response => {
-      const data = response?.integrationSlackProjectPost;
-      return data ? new IntegrationPayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.IntegrationSlackProjectPostMutation,
+      L.IntegrationSlackProjectPostMutationVariables
+    >(L.IntegrationSlackProjectPostDocument, {
+      code,
+      projectId,
+      redirectUri,
     });
+    const data = response?.integrationSlackProjectPost;
+    return data ? new IntegrationPayload(this._request, data) : undefined;
   }
 }
 
@@ -8832,7 +8788,7 @@ export class IntegrationZendeskMutation extends Request {
     scope: string,
     subdomain: string
   ): LinearFetch<IntegrationPayload> {
-    return this._request<L.IntegrationZendeskMutation, L.IntegrationZendeskMutationVariables>(
+    const response = await this._request<L.IntegrationZendeskMutation, L.IntegrationZendeskMutationVariables>(
       L.IntegrationZendeskDocument,
       {
         code,
@@ -8840,10 +8796,9 @@ export class IntegrationZendeskMutation extends Request {
         scope,
         subdomain,
       }
-    ).then(response => {
-      const data = response?.integrationZendesk;
-      return data ? new IntegrationPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.integrationZendesk;
+    return data ? new IntegrationPayload(this._request, data) : undefined;
   }
 }
 
@@ -8865,13 +8820,15 @@ export class IssueArchiveMutation extends Request {
    * @returns parsed response from IssueArchiveMutation
    */
   public async fetch(id: string, variables?: Omit<L.IssueArchiveMutationVariables, "id">): LinearFetch<ArchivePayload> {
-    return this._request<L.IssueArchiveMutation, L.IssueArchiveMutationVariables>(L.IssueArchiveDocument, {
-      id,
-      ...variables,
-    }).then(response => {
-      const data = response?.issueArchive;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.IssueArchiveMutation, L.IssueArchiveMutationVariables>(
+      L.IssueArchiveDocument,
+      {
+        id,
+        ...variables,
+      }
+    );
+    const data = response?.issueArchive;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -8892,12 +8849,11 @@ export class IssueCreateMutation extends Request {
    * @returns parsed response from IssueCreateMutation
    */
   public async fetch(input: L.IssueCreateInput): LinearFetch<IssuePayload> {
-    return this._request<L.IssueCreateMutation, L.IssueCreateMutationVariables>(L.IssueCreateDocument, {
+    const response = await this._request<L.IssueCreateMutation, L.IssueCreateMutationVariables>(L.IssueCreateDocument, {
       input,
-    }).then(response => {
-      const data = response?.issueCreate;
-      return data ? new IssuePayload(this._request, data) : undefined;
     });
+    const data = response?.issueCreate;
+    return data ? new IssuePayload(this._request, data) : undefined;
   }
 }
 
@@ -8918,12 +8874,11 @@ export class IssueDeleteMutation extends Request {
    * @returns parsed response from IssueDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.IssueDeleteMutation, L.IssueDeleteMutationVariables>(L.IssueDeleteDocument, {
+    const response = await this._request<L.IssueDeleteMutation, L.IssueDeleteMutationVariables>(L.IssueDeleteDocument, {
       id,
-    }).then(response => {
-      const data = response?.issueDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
     });
+    const data = response?.issueDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -8952,7 +8907,7 @@ export class IssueImportCreateAsanaMutation extends Request {
     teamId: string,
     variables?: Omit<L.IssueImportCreateAsanaMutationVariables, "asanaTeamName" | "asanaToken" | "teamId">
   ): LinearFetch<IssueImportPayload> {
-    return this._request<L.IssueImportCreateAsanaMutation, L.IssueImportCreateAsanaMutationVariables>(
+    const response = await this._request<L.IssueImportCreateAsanaMutation, L.IssueImportCreateAsanaMutationVariables>(
       L.IssueImportCreateAsanaDocument,
       {
         asanaTeamName,
@@ -8960,10 +8915,9 @@ export class IssueImportCreateAsanaMutation extends Request {
         teamId,
         ...variables,
       }
-    ).then(response => {
-      const data = response?.issueImportCreateAsana;
-      return data ? new IssueImportPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.issueImportCreateAsana;
+    return data ? new IssueImportPayload(this._request, data) : undefined;
   }
 }
 
@@ -8992,18 +8946,17 @@ export class IssueImportCreateClubhouseMutation extends Request {
     teamId: string,
     variables?: Omit<L.IssueImportCreateClubhouseMutationVariables, "clubhouseTeamName" | "clubhouseToken" | "teamId">
   ): LinearFetch<IssueImportPayload> {
-    return this._request<L.IssueImportCreateClubhouseMutation, L.IssueImportCreateClubhouseMutationVariables>(
-      L.IssueImportCreateClubhouseDocument,
-      {
-        clubhouseTeamName,
-        clubhouseToken,
-        teamId,
-        ...variables,
-      }
-    ).then(response => {
-      const data = response?.issueImportCreateClubhouse;
-      return data ? new IssueImportPayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.IssueImportCreateClubhouseMutation,
+      L.IssueImportCreateClubhouseMutationVariables
+    >(L.IssueImportCreateClubhouseDocument, {
+      clubhouseTeamName,
+      clubhouseToken,
+      teamId,
+      ...variables,
     });
+    const data = response?.issueImportCreateClubhouse;
+    return data ? new IssueImportPayload(this._request, data) : undefined;
   }
 }
 
@@ -9037,7 +8990,7 @@ export class IssueImportCreateGithubMutation extends Request {
       "githubRepoName" | "githubRepoOwner" | "githubToken" | "teamId"
     >
   ): LinearFetch<IssueImportPayload> {
-    return this._request<L.IssueImportCreateGithubMutation, L.IssueImportCreateGithubMutationVariables>(
+    const response = await this._request<L.IssueImportCreateGithubMutation, L.IssueImportCreateGithubMutationVariables>(
       L.IssueImportCreateGithubDocument,
       {
         githubRepoName,
@@ -9046,10 +8999,9 @@ export class IssueImportCreateGithubMutation extends Request {
         teamId,
         ...variables,
       }
-    ).then(response => {
-      const data = response?.issueImportCreateGithub;
-      return data ? new IssueImportPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.issueImportCreateGithub;
+    return data ? new IssueImportPayload(this._request, data) : undefined;
   }
 }
 
@@ -9085,7 +9037,7 @@ export class IssueImportCreateJiraMutation extends Request {
       "jiraEmail" | "jiraHostname" | "jiraProject" | "jiraToken" | "teamId"
     >
   ): LinearFetch<IssueImportPayload> {
-    return this._request<L.IssueImportCreateJiraMutation, L.IssueImportCreateJiraMutationVariables>(
+    const response = await this._request<L.IssueImportCreateJiraMutation, L.IssueImportCreateJiraMutationVariables>(
       L.IssueImportCreateJiraDocument,
       {
         jiraEmail,
@@ -9095,10 +9047,9 @@ export class IssueImportCreateJiraMutation extends Request {
         teamId,
         ...variables,
       }
-    ).then(response => {
-      const data = response?.issueImportCreateJira;
-      return data ? new IssueImportPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.issueImportCreateJira;
+    return data ? new IssueImportPayload(this._request, data) : undefined;
   }
 }
 
@@ -9119,15 +9070,14 @@ export class IssueImportDeleteMutation extends Request {
    * @returns parsed response from IssueImportDeleteMutation
    */
   public async fetch(issueImportId: string): LinearFetch<IssueImportDeletePayload> {
-    return this._request<L.IssueImportDeleteMutation, L.IssueImportDeleteMutationVariables>(
+    const response = await this._request<L.IssueImportDeleteMutation, L.IssueImportDeleteMutationVariables>(
       L.IssueImportDeleteDocument,
       {
         issueImportId,
       }
-    ).then(response => {
-      const data = response?.issueImportDelete;
-      return data ? new IssueImportDeletePayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.issueImportDelete;
+    return data ? new IssueImportDeletePayload(this._request, data) : undefined;
   }
 }
 
@@ -9149,16 +9099,15 @@ export class IssueImportProcessMutation extends Request {
    * @returns parsed response from IssueImportProcessMutation
    */
   public async fetch(issueImportId: string, mapping: Record<string, unknown>): LinearFetch<IssueImportPayload> {
-    return this._request<L.IssueImportProcessMutation, L.IssueImportProcessMutationVariables>(
+    const response = await this._request<L.IssueImportProcessMutation, L.IssueImportProcessMutationVariables>(
       L.IssueImportProcessDocument,
       {
         issueImportId,
         mapping,
       }
-    ).then(response => {
-      const data = response?.issueImportProcess;
-      return data ? new IssueImportPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.issueImportProcess;
+    return data ? new IssueImportPayload(this._request, data) : undefined;
   }
 }
 
@@ -9179,15 +9128,14 @@ export class IssueLabelArchiveMutation extends Request {
    * @returns parsed response from IssueLabelArchiveMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.IssueLabelArchiveMutation, L.IssueLabelArchiveMutationVariables>(
+    const response = await this._request<L.IssueLabelArchiveMutation, L.IssueLabelArchiveMutationVariables>(
       L.IssueLabelArchiveDocument,
       {
         id,
       }
-    ).then(response => {
-      const data = response?.issueLabelArchive;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.issueLabelArchive;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -9208,12 +9156,14 @@ export class IssueLabelCreateMutation extends Request {
    * @returns parsed response from IssueLabelCreateMutation
    */
   public async fetch(input: L.IssueLabelCreateInput): LinearFetch<IssueLabelPayload> {
-    return this._request<L.IssueLabelCreateMutation, L.IssueLabelCreateMutationVariables>(L.IssueLabelCreateDocument, {
-      input,
-    }).then(response => {
-      const data = response?.issueLabelCreate;
-      return data ? new IssueLabelPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.IssueLabelCreateMutation, L.IssueLabelCreateMutationVariables>(
+      L.IssueLabelCreateDocument,
+      {
+        input,
+      }
+    );
+    const data = response?.issueLabelCreate;
+    return data ? new IssueLabelPayload(this._request, data) : undefined;
   }
 }
 
@@ -9235,13 +9185,15 @@ export class IssueLabelUpdateMutation extends Request {
    * @returns parsed response from IssueLabelUpdateMutation
    */
   public async fetch(id: string, input: L.IssueLabelUpdateInput): LinearFetch<IssueLabelPayload> {
-    return this._request<L.IssueLabelUpdateMutation, L.IssueLabelUpdateMutationVariables>(L.IssueLabelUpdateDocument, {
-      id,
-      input,
-    }).then(response => {
-      const data = response?.issueLabelUpdate;
-      return data ? new IssueLabelPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.IssueLabelUpdateMutation, L.IssueLabelUpdateMutationVariables>(
+      L.IssueLabelUpdateDocument,
+      {
+        id,
+        input,
+      }
+    );
+    const data = response?.issueLabelUpdate;
+    return data ? new IssueLabelPayload(this._request, data) : undefined;
   }
 }
 
@@ -9262,15 +9214,14 @@ export class IssueRelationCreateMutation extends Request {
    * @returns parsed response from IssueRelationCreateMutation
    */
   public async fetch(input: L.IssueRelationCreateInput): LinearFetch<IssueRelationPayload> {
-    return this._request<L.IssueRelationCreateMutation, L.IssueRelationCreateMutationVariables>(
+    const response = await this._request<L.IssueRelationCreateMutation, L.IssueRelationCreateMutationVariables>(
       L.IssueRelationCreateDocument,
       {
         input,
       }
-    ).then(response => {
-      const data = response?.issueRelationCreate;
-      return data ? new IssueRelationPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.issueRelationCreate;
+    return data ? new IssueRelationPayload(this._request, data) : undefined;
   }
 }
 
@@ -9291,15 +9242,14 @@ export class IssueRelationDeleteMutation extends Request {
    * @returns parsed response from IssueRelationDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.IssueRelationDeleteMutation, L.IssueRelationDeleteMutationVariables>(
+    const response = await this._request<L.IssueRelationDeleteMutation, L.IssueRelationDeleteMutationVariables>(
       L.IssueRelationDeleteDocument,
       {
         id,
       }
-    ).then(response => {
-      const data = response?.issueRelationDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.issueRelationDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -9321,16 +9271,15 @@ export class IssueRelationUpdateMutation extends Request {
    * @returns parsed response from IssueRelationUpdateMutation
    */
   public async fetch(id: string, input: L.IssueRelationUpdateInput): LinearFetch<IssueRelationPayload> {
-    return this._request<L.IssueRelationUpdateMutation, L.IssueRelationUpdateMutationVariables>(
+    const response = await this._request<L.IssueRelationUpdateMutation, L.IssueRelationUpdateMutationVariables>(
       L.IssueRelationUpdateDocument,
       {
         id,
         input,
       }
-    ).then(response => {
-      const data = response?.issueRelationUpdate;
-      return data ? new IssueRelationPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.issueRelationUpdate;
+    return data ? new IssueRelationPayload(this._request, data) : undefined;
   }
 }
 
@@ -9351,12 +9300,14 @@ export class IssueUnarchiveMutation extends Request {
    * @returns parsed response from IssueUnarchiveMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.IssueUnarchiveMutation, L.IssueUnarchiveMutationVariables>(L.IssueUnarchiveDocument, {
-      id,
-    }).then(response => {
-      const data = response?.issueUnarchive;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.IssueUnarchiveMutation, L.IssueUnarchiveMutationVariables>(
+      L.IssueUnarchiveDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.issueUnarchive;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -9378,13 +9329,12 @@ export class IssueUpdateMutation extends Request {
    * @returns parsed response from IssueUpdateMutation
    */
   public async fetch(id: string, input: L.IssueUpdateInput): LinearFetch<IssuePayload> {
-    return this._request<L.IssueUpdateMutation, L.IssueUpdateMutationVariables>(L.IssueUpdateDocument, {
+    const response = await this._request<L.IssueUpdateMutation, L.IssueUpdateMutationVariables>(L.IssueUpdateDocument, {
       id,
       input,
-    }).then(response => {
-      const data = response?.issueUpdate;
-      return data ? new IssuePayload(this._request, data) : undefined;
     });
+    const data = response?.issueUpdate;
+    return data ? new IssuePayload(this._request, data) : undefined;
   }
 }
 
@@ -9405,15 +9355,14 @@ export class JoinOrganizationFromOnboardingMutation extends Request {
    * @returns parsed response from JoinOrganizationFromOnboardingMutation
    */
   public async fetch(input: L.JoinOrganizationInput): LinearFetch<CreateOrJoinOrganizationResponse> {
-    return this._request<L.JoinOrganizationFromOnboardingMutation, L.JoinOrganizationFromOnboardingMutationVariables>(
-      L.JoinOrganizationFromOnboardingDocument,
-      {
-        input,
-      }
-    ).then(response => {
-      const data = response?.joinOrganizationFromOnboarding;
-      return data ? new CreateOrJoinOrganizationResponse(this._request, data) : undefined;
+    const response = await this._request<
+      L.JoinOrganizationFromOnboardingMutation,
+      L.JoinOrganizationFromOnboardingMutationVariables
+    >(L.JoinOrganizationFromOnboardingDocument, {
+      input,
     });
+    const data = response?.joinOrganizationFromOnboarding;
+    return data ? new CreateOrJoinOrganizationResponse(this._request, data) : undefined;
   }
 }
 
@@ -9434,15 +9383,14 @@ export class LeaveOrganizationMutation extends Request {
    * @returns parsed response from LeaveOrganizationMutation
    */
   public async fetch(organizationId: string): LinearFetch<CreateOrJoinOrganizationResponse> {
-    return this._request<L.LeaveOrganizationMutation, L.LeaveOrganizationMutationVariables>(
+    const response = await this._request<L.LeaveOrganizationMutation, L.LeaveOrganizationMutationVariables>(
       L.LeaveOrganizationDocument,
       {
         organizationId,
       }
-    ).then(response => {
-      const data = response?.leaveOrganization;
-      return data ? new CreateOrJoinOrganizationResponse(this._request, data) : undefined;
-    });
+    );
+    const data = response?.leaveOrganization;
+    return data ? new CreateOrJoinOrganizationResponse(this._request, data) : undefined;
   }
 }
 
@@ -9463,12 +9411,14 @@ export class MilestoneCreateMutation extends Request {
    * @returns parsed response from MilestoneCreateMutation
    */
   public async fetch(input: L.MilestoneCreateInput): LinearFetch<MilestonePayload> {
-    return this._request<L.MilestoneCreateMutation, L.MilestoneCreateMutationVariables>(L.MilestoneCreateDocument, {
-      input,
-    }).then(response => {
-      const data = response?.milestoneCreate;
-      return data ? new MilestonePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.MilestoneCreateMutation, L.MilestoneCreateMutationVariables>(
+      L.MilestoneCreateDocument,
+      {
+        input,
+      }
+    );
+    const data = response?.milestoneCreate;
+    return data ? new MilestonePayload(this._request, data) : undefined;
   }
 }
 
@@ -9489,12 +9439,14 @@ export class MilestoneDeleteMutation extends Request {
    * @returns parsed response from MilestoneDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.MilestoneDeleteMutation, L.MilestoneDeleteMutationVariables>(L.MilestoneDeleteDocument, {
-      id,
-    }).then(response => {
-      const data = response?.milestoneDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.MilestoneDeleteMutation, L.MilestoneDeleteMutationVariables>(
+      L.MilestoneDeleteDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.milestoneDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -9516,13 +9468,15 @@ export class MilestoneUpdateMutation extends Request {
    * @returns parsed response from MilestoneUpdateMutation
    */
   public async fetch(id: string, input: L.MilestoneUpdateInput): LinearFetch<MilestonePayload> {
-    return this._request<L.MilestoneUpdateMutation, L.MilestoneUpdateMutationVariables>(L.MilestoneUpdateDocument, {
-      id,
-      input,
-    }).then(response => {
-      const data = response?.milestoneUpdate;
-      return data ? new MilestonePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.MilestoneUpdateMutation, L.MilestoneUpdateMutationVariables>(
+      L.MilestoneUpdateDocument,
+      {
+        id,
+        input,
+      }
+    );
+    const data = response?.milestoneUpdate;
+    return data ? new MilestonePayload(this._request, data) : undefined;
   }
 }
 
@@ -9543,15 +9497,14 @@ export class NotificationArchiveMutation extends Request {
    * @returns parsed response from NotificationArchiveMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.NotificationArchiveMutation, L.NotificationArchiveMutationVariables>(
+    const response = await this._request<L.NotificationArchiveMutation, L.NotificationArchiveMutationVariables>(
       L.NotificationArchiveDocument,
       {
         id,
       }
-    ).then(response => {
-      const data = response?.notificationArchive;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.notificationArchive;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -9573,16 +9526,15 @@ export class NotificationCreateMutation extends Request {
    * @returns parsed response from NotificationCreateMutation
    */
   public async fetch(id: string, input: L.NotificationUpdateInput): LinearFetch<NotificationPayload> {
-    return this._request<L.NotificationCreateMutation, L.NotificationCreateMutationVariables>(
+    const response = await this._request<L.NotificationCreateMutation, L.NotificationCreateMutationVariables>(
       L.NotificationCreateDocument,
       {
         id,
         input,
       }
-    ).then(response => {
-      const data = response?.notificationCreate;
-      return data ? new NotificationPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.notificationCreate;
+    return data ? new NotificationPayload(this._request, data) : undefined;
   }
 }
 
@@ -9603,15 +9555,14 @@ export class NotificationSubscriptionCreateMutation extends Request {
    * @returns parsed response from NotificationSubscriptionCreateMutation
    */
   public async fetch(input: L.NotificationSubscriptionCreateInput): LinearFetch<NotificationSubscriptionPayload> {
-    return this._request<L.NotificationSubscriptionCreateMutation, L.NotificationSubscriptionCreateMutationVariables>(
-      L.NotificationSubscriptionCreateDocument,
-      {
-        input,
-      }
-    ).then(response => {
-      const data = response?.notificationSubscriptionCreate;
-      return data ? new NotificationSubscriptionPayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.NotificationSubscriptionCreateMutation,
+      L.NotificationSubscriptionCreateMutationVariables
+    >(L.NotificationSubscriptionCreateDocument, {
+      input,
     });
+    const data = response?.notificationSubscriptionCreate;
+    return data ? new NotificationSubscriptionPayload(this._request, data) : undefined;
   }
 }
 
@@ -9632,15 +9583,14 @@ export class NotificationSubscriptionDeleteMutation extends Request {
    * @returns parsed response from NotificationSubscriptionDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.NotificationSubscriptionDeleteMutation, L.NotificationSubscriptionDeleteMutationVariables>(
-      L.NotificationSubscriptionDeleteDocument,
-      {
-        id,
-      }
-    ).then(response => {
-      const data = response?.notificationSubscriptionDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.NotificationSubscriptionDeleteMutation,
+      L.NotificationSubscriptionDeleteMutationVariables
+    >(L.NotificationSubscriptionDeleteDocument, {
+      id,
     });
+    const data = response?.notificationSubscriptionDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -9661,15 +9611,14 @@ export class NotificationUnarchiveMutation extends Request {
    * @returns parsed response from NotificationUnarchiveMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.NotificationUnarchiveMutation, L.NotificationUnarchiveMutationVariables>(
+    const response = await this._request<L.NotificationUnarchiveMutation, L.NotificationUnarchiveMutationVariables>(
       L.NotificationUnarchiveDocument,
       {
         id,
       }
-    ).then(response => {
-      const data = response?.notificationUnarchive;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.notificationUnarchive;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -9691,16 +9640,15 @@ export class NotificationUpdateMutation extends Request {
    * @returns parsed response from NotificationUpdateMutation
    */
   public async fetch(id: string, input: L.NotificationUpdateInput): LinearFetch<NotificationPayload> {
-    return this._request<L.NotificationUpdateMutation, L.NotificationUpdateMutationVariables>(
+    const response = await this._request<L.NotificationUpdateMutation, L.NotificationUpdateMutationVariables>(
       L.NotificationUpdateDocument,
       {
         id,
         input,
       }
-    ).then(response => {
-      const data = response?.notificationUpdate;
-      return data ? new NotificationPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.notificationUpdate;
+    return data ? new NotificationPayload(this._request, data) : undefined;
   }
 }
 
@@ -9721,15 +9669,14 @@ export class OauthClientArchiveMutation extends Request {
    * @returns parsed response from OauthClientArchiveMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.OauthClientArchiveMutation, L.OauthClientArchiveMutationVariables>(
+    const response = await this._request<L.OauthClientArchiveMutation, L.OauthClientArchiveMutationVariables>(
       L.OauthClientArchiveDocument,
       {
         id,
       }
-    ).then(response => {
-      const data = response?.oauthClientArchive;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.oauthClientArchive;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -9750,15 +9697,14 @@ export class OauthClientCreateMutation extends Request {
    * @returns parsed response from OauthClientCreateMutation
    */
   public async fetch(input: L.OauthClientCreateInput): LinearFetch<OauthClientPayload> {
-    return this._request<L.OauthClientCreateMutation, L.OauthClientCreateMutationVariables>(
+    const response = await this._request<L.OauthClientCreateMutation, L.OauthClientCreateMutationVariables>(
       L.OauthClientCreateDocument,
       {
         input,
       }
-    ).then(response => {
-      const data = response?.oauthClientCreate;
-      return data ? new OauthClientPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.oauthClientCreate;
+    return data ? new OauthClientPayload(this._request, data) : undefined;
   }
 }
 
@@ -9779,15 +9725,14 @@ export class OauthClientRotateSecretMutation extends Request {
    * @returns parsed response from OauthClientRotateSecretMutation
    */
   public async fetch(id: string): LinearFetch<RotateSecretPayload> {
-    return this._request<L.OauthClientRotateSecretMutation, L.OauthClientRotateSecretMutationVariables>(
+    const response = await this._request<L.OauthClientRotateSecretMutation, L.OauthClientRotateSecretMutationVariables>(
       L.OauthClientRotateSecretDocument,
       {
         id,
       }
-    ).then(response => {
-      const data = response?.oauthClientRotateSecret;
-      return data ? new RotateSecretPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.oauthClientRotateSecret;
+    return data ? new RotateSecretPayload(this._request, data) : undefined;
   }
 }
 
@@ -9809,16 +9754,15 @@ export class OauthClientUpdateMutation extends Request {
    * @returns parsed response from OauthClientUpdateMutation
    */
   public async fetch(id: string, input: L.OauthClientUpdateInput): LinearFetch<OauthClientPayload> {
-    return this._request<L.OauthClientUpdateMutation, L.OauthClientUpdateMutationVariables>(
+    const response = await this._request<L.OauthClientUpdateMutation, L.OauthClientUpdateMutationVariables>(
       L.OauthClientUpdateDocument,
       {
         id,
         input,
       }
-    ).then(response => {
-      const data = response?.oauthClientUpdate;
-      return data ? new OauthClientPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.oauthClientUpdate;
+    return data ? new OauthClientPayload(this._request, data) : undefined;
   }
 }
 
@@ -9840,13 +9784,15 @@ export class OauthTokenRevokeMutation extends Request {
    * @returns parsed response from OauthTokenRevokeMutation
    */
   public async fetch(appId: string, scope: string[]): LinearFetch<OauthTokenRevokePayload> {
-    return this._request<L.OauthTokenRevokeMutation, L.OauthTokenRevokeMutationVariables>(L.OauthTokenRevokeDocument, {
-      appId,
-      scope,
-    }).then(response => {
-      const data = response?.oauthTokenRevoke;
-      return data ? new OauthTokenRevokePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.OauthTokenRevokeMutation, L.OauthTokenRevokeMutationVariables>(
+      L.OauthTokenRevokeDocument,
+      {
+        appId,
+        scope,
+      }
+    );
+    const data = response?.oauthTokenRevoke;
+    return data ? new OauthTokenRevokePayload(this._request, data) : undefined;
   }
 }
 
@@ -9866,13 +9812,12 @@ export class OrganizationCancelDeleteMutation extends Request {
    * @returns parsed response from OrganizationCancelDeleteMutation
    */
   public async fetch(): LinearFetch<OrganizationCancelDeletePayload> {
-    return this._request<L.OrganizationCancelDeleteMutation, L.OrganizationCancelDeleteMutationVariables>(
-      L.OrganizationCancelDeleteDocument,
-      {}
-    ).then(response => {
-      const data = response?.organizationCancelDelete;
-      return data ? new OrganizationCancelDeletePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<
+      L.OrganizationCancelDeleteMutation,
+      L.OrganizationCancelDeleteMutationVariables
+    >(L.OrganizationCancelDeleteDocument, {});
+    const data = response?.organizationCancelDelete;
+    return data ? new OrganizationCancelDeletePayload(this._request, data) : undefined;
   }
 }
 
@@ -9893,15 +9838,14 @@ export class OrganizationDeleteMutation extends Request {
    * @returns parsed response from OrganizationDeleteMutation
    */
   public async fetch(input: L.DeleteOrganizationInput): LinearFetch<OrganizationDeletePayload> {
-    return this._request<L.OrganizationDeleteMutation, L.OrganizationDeleteMutationVariables>(
+    const response = await this._request<L.OrganizationDeleteMutation, L.OrganizationDeleteMutationVariables>(
       L.OrganizationDeleteDocument,
       {
         input,
       }
-    ).then(response => {
-      const data = response?.organizationDelete;
-      return data ? new OrganizationDeletePayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.organizationDelete;
+    return data ? new OrganizationDeletePayload(this._request, data) : undefined;
   }
 }
 
@@ -9921,13 +9865,12 @@ export class OrganizationDeleteChallengeMutation extends Request {
    * @returns parsed response from OrganizationDeleteChallengeMutation
    */
   public async fetch(): LinearFetch<OrganizationDeletePayload> {
-    return this._request<L.OrganizationDeleteChallengeMutation, L.OrganizationDeleteChallengeMutationVariables>(
-      L.OrganizationDeleteChallengeDocument,
-      {}
-    ).then(response => {
-      const data = response?.organizationDeleteChallenge;
-      return data ? new OrganizationDeletePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<
+      L.OrganizationDeleteChallengeMutation,
+      L.OrganizationDeleteChallengeMutationVariables
+    >(L.OrganizationDeleteChallengeDocument, {});
+    const data = response?.organizationDeleteChallenge;
+    return data ? new OrganizationDeletePayload(this._request, data) : undefined;
   }
 }
 
@@ -9948,15 +9891,14 @@ export class OrganizationDomainCreateMutation extends Request {
    * @returns parsed response from OrganizationDomainCreateMutation
    */
   public async fetch(input: L.OrganizationDomainCreateInput): LinearFetch<OrganizationDomainPayload> {
-    return this._request<L.OrganizationDomainCreateMutation, L.OrganizationDomainCreateMutationVariables>(
-      L.OrganizationDomainCreateDocument,
-      {
-        input,
-      }
-    ).then(response => {
-      const data = response?.organizationDomainCreate;
-      return data ? new OrganizationDomainPayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.OrganizationDomainCreateMutation,
+      L.OrganizationDomainCreateMutationVariables
+    >(L.OrganizationDomainCreateDocument, {
+      input,
     });
+    const data = response?.organizationDomainCreate;
+    return data ? new OrganizationDomainPayload(this._request, data) : undefined;
   }
 }
 
@@ -9977,15 +9919,14 @@ export class OrganizationDomainDeleteMutation extends Request {
    * @returns parsed response from OrganizationDomainDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.OrganizationDomainDeleteMutation, L.OrganizationDomainDeleteMutationVariables>(
-      L.OrganizationDomainDeleteDocument,
-      {
-        id,
-      }
-    ).then(response => {
-      const data = response?.organizationDomainDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.OrganizationDomainDeleteMutation,
+      L.OrganizationDomainDeleteMutationVariables
+    >(L.OrganizationDomainDeleteDocument, {
+      id,
     });
+    const data = response?.organizationDomainDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -10006,15 +9947,14 @@ export class OrganizationDomainVerifyMutation extends Request {
    * @returns parsed response from OrganizationDomainVerifyMutation
    */
   public async fetch(input: L.OrganizationDomainVerificationInput): LinearFetch<OrganizationDomainPayload> {
-    return this._request<L.OrganizationDomainVerifyMutation, L.OrganizationDomainVerifyMutationVariables>(
-      L.OrganizationDomainVerifyDocument,
-      {
-        input,
-      }
-    ).then(response => {
-      const data = response?.organizationDomainVerify;
-      return data ? new OrganizationDomainPayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.OrganizationDomainVerifyMutation,
+      L.OrganizationDomainVerifyMutationVariables
+    >(L.OrganizationDomainVerifyDocument, {
+      input,
     });
+    const data = response?.organizationDomainVerify;
+    return data ? new OrganizationDomainPayload(this._request, data) : undefined;
   }
 }
 
@@ -10035,15 +9975,14 @@ export class OrganizationInviteCreateMutation extends Request {
    * @returns parsed response from OrganizationInviteCreateMutation
    */
   public async fetch(input: L.OrganizationInviteCreateInput): LinearFetch<OrganizationInvitePayload> {
-    return this._request<L.OrganizationInviteCreateMutation, L.OrganizationInviteCreateMutationVariables>(
-      L.OrganizationInviteCreateDocument,
-      {
-        input,
-      }
-    ).then(response => {
-      const data = response?.organizationInviteCreate;
-      return data ? new OrganizationInvitePayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.OrganizationInviteCreateMutation,
+      L.OrganizationInviteCreateMutationVariables
+    >(L.OrganizationInviteCreateDocument, {
+      input,
     });
+    const data = response?.organizationInviteCreate;
+    return data ? new OrganizationInvitePayload(this._request, data) : undefined;
   }
 }
 
@@ -10064,15 +10003,14 @@ export class OrganizationInviteDeleteMutation extends Request {
    * @returns parsed response from OrganizationInviteDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.OrganizationInviteDeleteMutation, L.OrganizationInviteDeleteMutationVariables>(
-      L.OrganizationInviteDeleteDocument,
-      {
-        id,
-      }
-    ).then(response => {
-      const data = response?.organizationInviteDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.OrganizationInviteDeleteMutation,
+      L.OrganizationInviteDeleteMutationVariables
+    >(L.OrganizationInviteDeleteDocument, {
+      id,
     });
+    const data = response?.organizationInviteDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -10093,15 +10031,14 @@ export class OrganizationUpdateMutation extends Request {
    * @returns parsed response from OrganizationUpdateMutation
    */
   public async fetch(input: L.UpdateOrganizationInput): LinearFetch<OrganizationPayload> {
-    return this._request<L.OrganizationUpdateMutation, L.OrganizationUpdateMutationVariables>(
+    const response = await this._request<L.OrganizationUpdateMutation, L.OrganizationUpdateMutationVariables>(
       L.OrganizationUpdateDocument,
       {
         input,
       }
-    ).then(response => {
-      const data = response?.organizationUpdate;
-      return data ? new OrganizationPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.organizationUpdate;
+    return data ? new OrganizationPayload(this._request, data) : undefined;
   }
 }
 
@@ -10122,12 +10059,14 @@ export class ProjectArchiveMutation extends Request {
    * @returns parsed response from ProjectArchiveMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.ProjectArchiveMutation, L.ProjectArchiveMutationVariables>(L.ProjectArchiveDocument, {
-      id,
-    }).then(response => {
-      const data = response?.projectArchive;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.ProjectArchiveMutation, L.ProjectArchiveMutationVariables>(
+      L.ProjectArchiveDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.projectArchive;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -10148,12 +10087,14 @@ export class ProjectCreateMutation extends Request {
    * @returns parsed response from ProjectCreateMutation
    */
   public async fetch(input: L.ProjectCreateInput): LinearFetch<ProjectPayload> {
-    return this._request<L.ProjectCreateMutation, L.ProjectCreateMutationVariables>(L.ProjectCreateDocument, {
-      input,
-    }).then(response => {
-      const data = response?.projectCreate;
-      return data ? new ProjectPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.ProjectCreateMutation, L.ProjectCreateMutationVariables>(
+      L.ProjectCreateDocument,
+      {
+        input,
+      }
+    );
+    const data = response?.projectCreate;
+    return data ? new ProjectPayload(this._request, data) : undefined;
   }
 }
 
@@ -10174,15 +10115,14 @@ export class ProjectLinkCreateMutation extends Request {
    * @returns parsed response from ProjectLinkCreateMutation
    */
   public async fetch(input: L.ProjectLinkCreateInput): LinearFetch<ProjectLinkPayload> {
-    return this._request<L.ProjectLinkCreateMutation, L.ProjectLinkCreateMutationVariables>(
+    const response = await this._request<L.ProjectLinkCreateMutation, L.ProjectLinkCreateMutationVariables>(
       L.ProjectLinkCreateDocument,
       {
         input,
       }
-    ).then(response => {
-      const data = response?.projectLinkCreate;
-      return data ? new ProjectLinkPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.projectLinkCreate;
+    return data ? new ProjectLinkPayload(this._request, data) : undefined;
   }
 }
 
@@ -10203,15 +10143,14 @@ export class ProjectLinkDeleteMutation extends Request {
    * @returns parsed response from ProjectLinkDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.ProjectLinkDeleteMutation, L.ProjectLinkDeleteMutationVariables>(
+    const response = await this._request<L.ProjectLinkDeleteMutation, L.ProjectLinkDeleteMutationVariables>(
       L.ProjectLinkDeleteDocument,
       {
         id,
       }
-    ).then(response => {
-      const data = response?.projectLinkDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.projectLinkDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -10232,12 +10171,14 @@ export class ProjectUnarchiveMutation extends Request {
    * @returns parsed response from ProjectUnarchiveMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.ProjectUnarchiveMutation, L.ProjectUnarchiveMutationVariables>(L.ProjectUnarchiveDocument, {
-      id,
-    }).then(response => {
-      const data = response?.projectUnarchive;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.ProjectUnarchiveMutation, L.ProjectUnarchiveMutationVariables>(
+      L.ProjectUnarchiveDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.projectUnarchive;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -10259,13 +10200,15 @@ export class ProjectUpdateMutation extends Request {
    * @returns parsed response from ProjectUpdateMutation
    */
   public async fetch(id: string, input: L.ProjectUpdateInput): LinearFetch<ProjectPayload> {
-    return this._request<L.ProjectUpdateMutation, L.ProjectUpdateMutationVariables>(L.ProjectUpdateDocument, {
-      id,
-      input,
-    }).then(response => {
-      const data = response?.projectUpdate;
-      return data ? new ProjectPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.ProjectUpdateMutation, L.ProjectUpdateMutationVariables>(
+      L.ProjectUpdateDocument,
+      {
+        id,
+        input,
+      }
+    );
+    const data = response?.projectUpdate;
+    return data ? new ProjectPayload(this._request, data) : undefined;
   }
 }
 
@@ -10286,15 +10229,14 @@ export class PushSubscriptionCreateMutation extends Request {
    * @returns parsed response from PushSubscriptionCreateMutation
    */
   public async fetch(input: L.PushSubscriptionCreateInput): LinearFetch<PushSubscriptionPayload> {
-    return this._request<L.PushSubscriptionCreateMutation, L.PushSubscriptionCreateMutationVariables>(
+    const response = await this._request<L.PushSubscriptionCreateMutation, L.PushSubscriptionCreateMutationVariables>(
       L.PushSubscriptionCreateDocument,
       {
         input,
       }
-    ).then(response => {
-      const data = response?.pushSubscriptionCreate;
-      return data ? new PushSubscriptionPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.pushSubscriptionCreate;
+    return data ? new PushSubscriptionPayload(this._request, data) : undefined;
   }
 }
 
@@ -10315,15 +10257,14 @@ export class PushSubscriptionDeleteMutation extends Request {
    * @returns parsed response from PushSubscriptionDeleteMutation
    */
   public async fetch(id: string): LinearFetch<PushSubscriptionPayload> {
-    return this._request<L.PushSubscriptionDeleteMutation, L.PushSubscriptionDeleteMutationVariables>(
+    const response = await this._request<L.PushSubscriptionDeleteMutation, L.PushSubscriptionDeleteMutationVariables>(
       L.PushSubscriptionDeleteDocument,
       {
         id,
       }
-    ).then(response => {
-      const data = response?.pushSubscriptionDelete;
-      return data ? new PushSubscriptionPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.pushSubscriptionDelete;
+    return data ? new PushSubscriptionPayload(this._request, data) : undefined;
   }
 }
 
@@ -10344,12 +10285,14 @@ export class ReactionCreateMutation extends Request {
    * @returns parsed response from ReactionCreateMutation
    */
   public async fetch(input: L.ReactionCreateInput): LinearFetch<ReactionPayload> {
-    return this._request<L.ReactionCreateMutation, L.ReactionCreateMutationVariables>(L.ReactionCreateDocument, {
-      input,
-    }).then(response => {
-      const data = response?.reactionCreate;
-      return data ? new ReactionPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.ReactionCreateMutation, L.ReactionCreateMutationVariables>(
+      L.ReactionCreateDocument,
+      {
+        input,
+      }
+    );
+    const data = response?.reactionCreate;
+    return data ? new ReactionPayload(this._request, data) : undefined;
   }
 }
 
@@ -10370,12 +10313,14 @@ export class ReactionDeleteMutation extends Request {
    * @returns parsed response from ReactionDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.ReactionDeleteMutation, L.ReactionDeleteMutationVariables>(L.ReactionDeleteDocument, {
-      id,
-    }).then(response => {
-      const data = response?.reactionDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.ReactionDeleteMutation, L.ReactionDeleteMutationVariables>(
+      L.ReactionDeleteDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.reactionDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -10396,15 +10341,14 @@ export class RefreshGoogleSheetsDataMutation extends Request {
    * @returns parsed response from RefreshGoogleSheetsDataMutation
    */
   public async fetch(id: string): LinearFetch<IntegrationPayload> {
-    return this._request<L.RefreshGoogleSheetsDataMutation, L.RefreshGoogleSheetsDataMutationVariables>(
+    const response = await this._request<L.RefreshGoogleSheetsDataMutation, L.RefreshGoogleSheetsDataMutationVariables>(
       L.RefreshGoogleSheetsDataDocument,
       {
         id,
       }
-    ).then(response => {
-      const data = response?.refreshGoogleSheetsData;
-      return data ? new IntegrationPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.refreshGoogleSheetsData;
+    return data ? new IntegrationPayload(this._request, data) : undefined;
   }
 }
 
@@ -10425,15 +10369,14 @@ export class ResentOrganizationInviteMutation extends Request {
    * @returns parsed response from ResentOrganizationInviteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.ResentOrganizationInviteMutation, L.ResentOrganizationInviteMutationVariables>(
-      L.ResentOrganizationInviteDocument,
-      {
-        id,
-      }
-    ).then(response => {
-      const data = response?.resentOrganizationInvite;
-      return data ? new ArchivePayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.ResentOrganizationInviteMutation,
+      L.ResentOrganizationInviteMutationVariables
+    >(L.ResentOrganizationInviteDocument, {
+      id,
     });
+    const data = response?.resentOrganizationInvite;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -10454,15 +10397,14 @@ export class SamlTokenUserAccountAuthMutation extends Request {
    * @returns parsed response from SamlTokenUserAccountAuthMutation
    */
   public async fetch(input: L.TokenUserAccountAuthInput): LinearFetch<AuthResolverResponse> {
-    return this._request<L.SamlTokenUserAccountAuthMutation, L.SamlTokenUserAccountAuthMutationVariables>(
-      L.SamlTokenUserAccountAuthDocument,
-      {
-        input,
-      }
-    ).then(response => {
-      const data = response?.samlTokenUserAccountAuth;
-      return data ? new AuthResolverResponse(this._request, data) : undefined;
+    const response = await this._request<
+      L.SamlTokenUserAccountAuthMutation,
+      L.SamlTokenUserAccountAuthMutationVariables
+    >(L.SamlTokenUserAccountAuthDocument, {
+      input,
     });
+    const data = response?.samlTokenUserAccountAuth;
+    return data ? new AuthResolverResponse(this._request, data) : undefined;
   }
 }
 
@@ -10483,15 +10425,14 @@ export class SubscriptionArchiveMutation extends Request {
    * @returns parsed response from SubscriptionArchiveMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.SubscriptionArchiveMutation, L.SubscriptionArchiveMutationVariables>(
+    const response = await this._request<L.SubscriptionArchiveMutation, L.SubscriptionArchiveMutationVariables>(
       L.SubscriptionArchiveDocument,
       {
         id,
       }
-    ).then(response => {
-      const data = response?.subscriptionArchive;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.subscriptionArchive;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -10512,15 +10453,14 @@ export class SubscriptionSessionCreateMutation extends Request {
    * @returns parsed response from SubscriptionSessionCreateMutation
    */
   public async fetch(plan: string): LinearFetch<SubscriptionSessionPayload> {
-    return this._request<L.SubscriptionSessionCreateMutation, L.SubscriptionSessionCreateMutationVariables>(
-      L.SubscriptionSessionCreateDocument,
-      {
-        plan,
-      }
-    ).then(response => {
-      const data = response?.subscriptionSessionCreate;
-      return data ? new SubscriptionSessionPayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.SubscriptionSessionCreateMutation,
+      L.SubscriptionSessionCreateMutationVariables
+    >(L.SubscriptionSessionCreateDocument, {
+      plan,
     });
+    const data = response?.subscriptionSessionCreate;
+    return data ? new SubscriptionSessionPayload(this._request, data) : undefined;
   }
 }
 
@@ -10542,16 +10482,15 @@ export class SubscriptionUpdateMutation extends Request {
    * @returns parsed response from SubscriptionUpdateMutation
    */
   public async fetch(id: string, input: L.SubscriptionUpdateInput): LinearFetch<SubscriptionPayload> {
-    return this._request<L.SubscriptionUpdateMutation, L.SubscriptionUpdateMutationVariables>(
+    const response = await this._request<L.SubscriptionUpdateMutation, L.SubscriptionUpdateMutationVariables>(
       L.SubscriptionUpdateDocument,
       {
         id,
         input,
       }
-    ).then(response => {
-      const data = response?.subscriptionUpdate;
-      return data ? new SubscriptionPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.subscriptionUpdate;
+    return data ? new SubscriptionPayload(this._request, data) : undefined;
   }
 }
 
@@ -10571,13 +10510,12 @@ export class SubscriptionUpdateSessionCreateMutation extends Request {
    * @returns parsed response from SubscriptionUpdateSessionCreateMutation
    */
   public async fetch(): LinearFetch<SubscriptionSessionPayload> {
-    return this._request<L.SubscriptionUpdateSessionCreateMutation, L.SubscriptionUpdateSessionCreateMutationVariables>(
-      L.SubscriptionUpdateSessionCreateDocument,
-      {}
-    ).then(response => {
-      const data = response?.subscriptionUpdateSessionCreate;
-      return data ? new SubscriptionSessionPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<
+      L.SubscriptionUpdateSessionCreateMutation,
+      L.SubscriptionUpdateSessionCreateMutationVariables
+    >(L.SubscriptionUpdateSessionCreateDocument, {});
+    const data = response?.subscriptionUpdateSessionCreate;
+    return data ? new SubscriptionSessionPayload(this._request, data) : undefined;
   }
 }
 
@@ -10599,16 +10537,15 @@ export class SubscriptionUpgradeMutation extends Request {
    * @returns parsed response from SubscriptionUpgradeMutation
    */
   public async fetch(id: string, type: string): LinearFetch<SubscriptionPayload> {
-    return this._request<L.SubscriptionUpgradeMutation, L.SubscriptionUpgradeMutationVariables>(
+    const response = await this._request<L.SubscriptionUpgradeMutation, L.SubscriptionUpgradeMutationVariables>(
       L.SubscriptionUpgradeDocument,
       {
         id,
         type,
       }
-    ).then(response => {
-      const data = response?.subscriptionUpgrade;
-      return data ? new SubscriptionPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.subscriptionUpgrade;
+    return data ? new SubscriptionPayload(this._request, data) : undefined;
   }
 }
 
@@ -10629,12 +10566,11 @@ export class TeamArchiveMutation extends Request {
    * @returns parsed response from TeamArchiveMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.TeamArchiveMutation, L.TeamArchiveMutationVariables>(L.TeamArchiveDocument, {
+    const response = await this._request<L.TeamArchiveMutation, L.TeamArchiveMutationVariables>(L.TeamArchiveDocument, {
       id,
-    }).then(response => {
-      const data = response?.teamArchive;
-      return data ? new ArchivePayload(this._request, data) : undefined;
     });
+    const data = response?.teamArchive;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -10659,13 +10595,12 @@ export class TeamCreateMutation extends Request {
     input: L.TeamCreateInput,
     variables?: Omit<L.TeamCreateMutationVariables, "input">
   ): LinearFetch<TeamPayload> {
-    return this._request<L.TeamCreateMutation, L.TeamCreateMutationVariables>(L.TeamCreateDocument, {
+    const response = await this._request<L.TeamCreateMutation, L.TeamCreateMutationVariables>(L.TeamCreateDocument, {
       input,
       ...variables,
-    }).then(response => {
-      const data = response?.teamCreate;
-      return data ? new TeamPayload(this._request, data) : undefined;
     });
+    const data = response?.teamCreate;
+    return data ? new TeamPayload(this._request, data) : undefined;
   }
 }
 
@@ -10686,12 +10621,11 @@ export class TeamDeleteMutation extends Request {
    * @returns parsed response from TeamDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.TeamDeleteMutation, L.TeamDeleteMutationVariables>(L.TeamDeleteDocument, {
+    const response = await this._request<L.TeamDeleteMutation, L.TeamDeleteMutationVariables>(L.TeamDeleteDocument, {
       id,
-    }).then(response => {
-      const data = response?.teamDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
     });
+    const data = response?.teamDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -10712,12 +10646,14 @@ export class TeamKeyDeleteMutation extends Request {
    * @returns parsed response from TeamKeyDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.TeamKeyDeleteMutation, L.TeamKeyDeleteMutationVariables>(L.TeamKeyDeleteDocument, {
-      id,
-    }).then(response => {
-      const data = response?.teamKeyDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.TeamKeyDeleteMutation, L.TeamKeyDeleteMutationVariables>(
+      L.TeamKeyDeleteDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.teamKeyDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -10738,15 +10674,14 @@ export class TeamMembershipCreateMutation extends Request {
    * @returns parsed response from TeamMembershipCreateMutation
    */
   public async fetch(input: L.TeamMembershipCreateInput): LinearFetch<TeamMembershipPayload> {
-    return this._request<L.TeamMembershipCreateMutation, L.TeamMembershipCreateMutationVariables>(
+    const response = await this._request<L.TeamMembershipCreateMutation, L.TeamMembershipCreateMutationVariables>(
       L.TeamMembershipCreateDocument,
       {
         input,
       }
-    ).then(response => {
-      const data = response?.teamMembershipCreate;
-      return data ? new TeamMembershipPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.teamMembershipCreate;
+    return data ? new TeamMembershipPayload(this._request, data) : undefined;
   }
 }
 
@@ -10767,15 +10702,14 @@ export class TeamMembershipDeleteMutation extends Request {
    * @returns parsed response from TeamMembershipDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.TeamMembershipDeleteMutation, L.TeamMembershipDeleteMutationVariables>(
+    const response = await this._request<L.TeamMembershipDeleteMutation, L.TeamMembershipDeleteMutationVariables>(
       L.TeamMembershipDeleteDocument,
       {
         id,
       }
-    ).then(response => {
-      const data = response?.teamMembershipDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.teamMembershipDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -10797,16 +10731,15 @@ export class TeamMembershipUpdateMutation extends Request {
    * @returns parsed response from TeamMembershipUpdateMutation
    */
   public async fetch(id: string, input: L.TeamMembershipUpdateInput): LinearFetch<TeamMembershipPayload> {
-    return this._request<L.TeamMembershipUpdateMutation, L.TeamMembershipUpdateMutationVariables>(
+    const response = await this._request<L.TeamMembershipUpdateMutation, L.TeamMembershipUpdateMutationVariables>(
       L.TeamMembershipUpdateDocument,
       {
         id,
         input,
       }
-    ).then(response => {
-      const data = response?.teamMembershipUpdate;
-      return data ? new TeamMembershipPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.teamMembershipUpdate;
+    return data ? new TeamMembershipPayload(this._request, data) : undefined;
   }
 }
 
@@ -10828,13 +10761,12 @@ export class TeamUpdateMutation extends Request {
    * @returns parsed response from TeamUpdateMutation
    */
   public async fetch(id: string, input: L.TeamUpdateInput): LinearFetch<TeamPayload> {
-    return this._request<L.TeamUpdateMutation, L.TeamUpdateMutationVariables>(L.TeamUpdateDocument, {
+    const response = await this._request<L.TeamUpdateMutation, L.TeamUpdateMutationVariables>(L.TeamUpdateDocument, {
       id,
       input,
-    }).then(response => {
-      const data = response?.teamUpdate;
-      return data ? new TeamPayload(this._request, data) : undefined;
     });
+    const data = response?.teamUpdate;
+    return data ? new TeamPayload(this._request, data) : undefined;
   }
 }
 
@@ -10855,12 +10787,14 @@ export class TemplateCreateMutation extends Request {
    * @returns parsed response from TemplateCreateMutation
    */
   public async fetch(input: L.TemplateCreateInput): LinearFetch<TemplatePayload> {
-    return this._request<L.TemplateCreateMutation, L.TemplateCreateMutationVariables>(L.TemplateCreateDocument, {
-      input,
-    }).then(response => {
-      const data = response?.templateCreate;
-      return data ? new TemplatePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.TemplateCreateMutation, L.TemplateCreateMutationVariables>(
+      L.TemplateCreateDocument,
+      {
+        input,
+      }
+    );
+    const data = response?.templateCreate;
+    return data ? new TemplatePayload(this._request, data) : undefined;
   }
 }
 
@@ -10881,12 +10815,14 @@ export class TemplateDeleteMutation extends Request {
    * @returns parsed response from TemplateDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.TemplateDeleteMutation, L.TemplateDeleteMutationVariables>(L.TemplateDeleteDocument, {
-      id,
-    }).then(response => {
-      const data = response?.templateDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.TemplateDeleteMutation, L.TemplateDeleteMutationVariables>(
+      L.TemplateDeleteDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.templateDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -10908,13 +10844,15 @@ export class TemplateUpdateMutation extends Request {
    * @returns parsed response from TemplateUpdateMutation
    */
   public async fetch(id: string, input: L.TemplateUpdateInput): LinearFetch<TemplatePayload> {
-    return this._request<L.TemplateUpdateMutation, L.TemplateUpdateMutationVariables>(L.TemplateUpdateDocument, {
-      id,
-      input,
-    }).then(response => {
-      const data = response?.templateUpdate;
-      return data ? new TemplatePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.TemplateUpdateMutation, L.TemplateUpdateMutationVariables>(
+      L.TemplateUpdateDocument,
+      {
+        id,
+        input,
+      }
+    );
+    const data = response?.templateUpdate;
+    return data ? new TemplatePayload(this._request, data) : undefined;
   }
 }
 
@@ -10935,12 +10873,14 @@ export class UserDemoteAdminMutation extends Request {
    * @returns parsed response from UserDemoteAdminMutation
    */
   public async fetch(id: string): LinearFetch<UserAdminPayload> {
-    return this._request<L.UserDemoteAdminMutation, L.UserDemoteAdminMutationVariables>(L.UserDemoteAdminDocument, {
-      id,
-    }).then(response => {
-      const data = response?.userDemoteAdmin;
-      return data ? new UserAdminPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.UserDemoteAdminMutation, L.UserDemoteAdminMutationVariables>(
+      L.UserDemoteAdminDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.userDemoteAdmin;
+    return data ? new UserAdminPayload(this._request, data) : undefined;
   }
 }
 
@@ -10962,13 +10902,15 @@ export class UserFlagUpdateMutation extends Request {
    * @returns parsed response from UserFlagUpdateMutation
    */
   public async fetch(flag: L.UserFlagType, operation: L.UserFlagUpdateOperation): LinearFetch<UserSettingsFlagPayload> {
-    return this._request<L.UserFlagUpdateMutation, L.UserFlagUpdateMutationVariables>(L.UserFlagUpdateDocument, {
-      flag,
-      operation,
-    }).then(response => {
-      const data = response?.userFlagUpdate;
-      return data ? new UserSettingsFlagPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.UserFlagUpdateMutation, L.UserFlagUpdateMutationVariables>(
+      L.UserFlagUpdateDocument,
+      {
+        flag,
+        operation,
+      }
+    );
+    const data = response?.userFlagUpdate;
+    return data ? new UserSettingsFlagPayload(this._request, data) : undefined;
   }
 }
 
@@ -10989,12 +10931,14 @@ export class UserPromoteAdminMutation extends Request {
    * @returns parsed response from UserPromoteAdminMutation
    */
   public async fetch(id: string): LinearFetch<UserAdminPayload> {
-    return this._request<L.UserPromoteAdminMutation, L.UserPromoteAdminMutationVariables>(L.UserPromoteAdminDocument, {
-      id,
-    }).then(response => {
-      const data = response?.userPromoteAdmin;
-      return data ? new UserAdminPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.UserPromoteAdminMutation, L.UserPromoteAdminMutationVariables>(
+      L.UserPromoteAdminDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.userPromoteAdmin;
+    return data ? new UserAdminPayload(this._request, data) : undefined;
   }
 }
 
@@ -11015,15 +10959,14 @@ export class UserSettingsFlagIncrementMutation extends Request {
    * @returns parsed response from UserSettingsFlagIncrementMutation
    */
   public async fetch(flag: string): LinearFetch<UserSettingsFlagPayload> {
-    return this._request<L.UserSettingsFlagIncrementMutation, L.UserSettingsFlagIncrementMutationVariables>(
-      L.UserSettingsFlagIncrementDocument,
-      {
-        flag,
-      }
-    ).then(response => {
-      const data = response?.userSettingsFlagIncrement;
-      return data ? new UserSettingsFlagPayload(this._request, data) : undefined;
+    const response = await this._request<
+      L.UserSettingsFlagIncrementMutation,
+      L.UserSettingsFlagIncrementMutationVariables
+    >(L.UserSettingsFlagIncrementDocument, {
+      flag,
     });
+    const data = response?.userSettingsFlagIncrement;
+    return data ? new UserSettingsFlagPayload(this._request, data) : undefined;
   }
 }
 
@@ -11043,13 +10986,12 @@ export class UserSettingsFlagsResetMutation extends Request {
    * @returns parsed response from UserSettingsFlagsResetMutation
    */
   public async fetch(): LinearFetch<UserSettingsFlagsResetPayload> {
-    return this._request<L.UserSettingsFlagsResetMutation, L.UserSettingsFlagsResetMutationVariables>(
+    const response = await this._request<L.UserSettingsFlagsResetMutation, L.UserSettingsFlagsResetMutationVariables>(
       L.UserSettingsFlagsResetDocument,
       {}
-    ).then(response => {
-      const data = response?.userSettingsFlagsReset;
-      return data ? new UserSettingsFlagsResetPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.userSettingsFlagsReset;
+    return data ? new UserSettingsFlagsResetPayload(this._request, data) : undefined;
   }
 }
 
@@ -11071,16 +11013,15 @@ export class UserSettingsUpdateMutation extends Request {
    * @returns parsed response from UserSettingsUpdateMutation
    */
   public async fetch(id: string, input: L.UserSettingsUpdateInput): LinearFetch<UserSettingsPayload> {
-    return this._request<L.UserSettingsUpdateMutation, L.UserSettingsUpdateMutationVariables>(
+    const response = await this._request<L.UserSettingsUpdateMutation, L.UserSettingsUpdateMutationVariables>(
       L.UserSettingsUpdateDocument,
       {
         id,
         input,
       }
-    ).then(response => {
-      const data = response?.userSettingsUpdate;
-      return data ? new UserSettingsPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.userSettingsUpdate;
+    return data ? new UserSettingsPayload(this._request, data) : undefined;
   }
 }
 
@@ -11100,13 +11041,12 @@ export class UserSubscribeToNewsletterMutation extends Request {
    * @returns parsed response from UserSubscribeToNewsletterMutation
    */
   public async fetch(): LinearFetch<UserSubscribeToNewsletterPayload> {
-    return this._request<L.UserSubscribeToNewsletterMutation, L.UserSubscribeToNewsletterMutationVariables>(
-      L.UserSubscribeToNewsletterDocument,
-      {}
-    ).then(response => {
-      const data = response?.userSubscribeToNewsletter;
-      return data ? new UserSubscribeToNewsletterPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<
+      L.UserSubscribeToNewsletterMutation,
+      L.UserSubscribeToNewsletterMutationVariables
+    >(L.UserSubscribeToNewsletterDocument, {});
+    const data = response?.userSubscribeToNewsletter;
+    return data ? new UserSubscribeToNewsletterPayload(this._request, data) : undefined;
   }
 }
 
@@ -11127,12 +11067,11 @@ export class UserSuspendMutation extends Request {
    * @returns parsed response from UserSuspendMutation
    */
   public async fetch(id: string): LinearFetch<UserAdminPayload> {
-    return this._request<L.UserSuspendMutation, L.UserSuspendMutationVariables>(L.UserSuspendDocument, {
+    const response = await this._request<L.UserSuspendMutation, L.UserSuspendMutationVariables>(L.UserSuspendDocument, {
       id,
-    }).then(response => {
-      const data = response?.userSuspend;
-      return data ? new UserAdminPayload(this._request, data) : undefined;
     });
+    const data = response?.userSuspend;
+    return data ? new UserAdminPayload(this._request, data) : undefined;
   }
 }
 
@@ -11153,12 +11092,14 @@ export class UserUnsuspendMutation extends Request {
    * @returns parsed response from UserUnsuspendMutation
    */
   public async fetch(id: string): LinearFetch<UserAdminPayload> {
-    return this._request<L.UserUnsuspendMutation, L.UserUnsuspendMutationVariables>(L.UserUnsuspendDocument, {
-      id,
-    }).then(response => {
-      const data = response?.userUnsuspend;
-      return data ? new UserAdminPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.UserUnsuspendMutation, L.UserUnsuspendMutationVariables>(
+      L.UserUnsuspendDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.userUnsuspend;
+    return data ? new UserAdminPayload(this._request, data) : undefined;
   }
 }
 
@@ -11180,13 +11121,12 @@ export class UserUpdateMutation extends Request {
    * @returns parsed response from UserUpdateMutation
    */
   public async fetch(id: string, input: L.UpdateUserInput): LinearFetch<UserPayload> {
-    return this._request<L.UserUpdateMutation, L.UserUpdateMutationVariables>(L.UserUpdateDocument, {
+    const response = await this._request<L.UserUpdateMutation, L.UserUpdateMutationVariables>(L.UserUpdateDocument, {
       id,
       input,
-    }).then(response => {
-      const data = response?.userUpdate;
-      return data ? new UserPayload(this._request, data) : undefined;
     });
+    const data = response?.userUpdate;
+    return data ? new UserPayload(this._request, data) : undefined;
   }
 }
 
@@ -11207,15 +11147,14 @@ export class ViewPreferencesCreateMutation extends Request {
    * @returns parsed response from ViewPreferencesCreateMutation
    */
   public async fetch(input: L.ViewPreferencesCreateInput): LinearFetch<ViewPreferencesPayload> {
-    return this._request<L.ViewPreferencesCreateMutation, L.ViewPreferencesCreateMutationVariables>(
+    const response = await this._request<L.ViewPreferencesCreateMutation, L.ViewPreferencesCreateMutationVariables>(
       L.ViewPreferencesCreateDocument,
       {
         input,
       }
-    ).then(response => {
-      const data = response?.viewPreferencesCreate;
-      return data ? new ViewPreferencesPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.viewPreferencesCreate;
+    return data ? new ViewPreferencesPayload(this._request, data) : undefined;
   }
 }
 
@@ -11236,15 +11175,14 @@ export class ViewPreferencesDeleteMutation extends Request {
    * @returns parsed response from ViewPreferencesDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.ViewPreferencesDeleteMutation, L.ViewPreferencesDeleteMutationVariables>(
+    const response = await this._request<L.ViewPreferencesDeleteMutation, L.ViewPreferencesDeleteMutationVariables>(
       L.ViewPreferencesDeleteDocument,
       {
         id,
       }
-    ).then(response => {
-      const data = response?.viewPreferencesDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.viewPreferencesDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -11266,16 +11204,15 @@ export class ViewPreferencesUpdateMutation extends Request {
    * @returns parsed response from ViewPreferencesUpdateMutation
    */
   public async fetch(id: string, input: L.ViewPreferencesUpdateInput): LinearFetch<ViewPreferencesPayload> {
-    return this._request<L.ViewPreferencesUpdateMutation, L.ViewPreferencesUpdateMutationVariables>(
+    const response = await this._request<L.ViewPreferencesUpdateMutation, L.ViewPreferencesUpdateMutationVariables>(
       L.ViewPreferencesUpdateDocument,
       {
         id,
         input,
       }
-    ).then(response => {
-      const data = response?.viewPreferencesUpdate;
-      return data ? new ViewPreferencesPayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.viewPreferencesUpdate;
+    return data ? new ViewPreferencesPayload(this._request, data) : undefined;
   }
 }
 
@@ -11296,12 +11233,14 @@ export class WebhookCreateMutation extends Request {
    * @returns parsed response from WebhookCreateMutation
    */
   public async fetch(input: L.WebhookCreateInput): LinearFetch<WebhookPayload> {
-    return this._request<L.WebhookCreateMutation, L.WebhookCreateMutationVariables>(L.WebhookCreateDocument, {
-      input,
-    }).then(response => {
-      const data = response?.webhookCreate;
-      return data ? new WebhookPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.WebhookCreateMutation, L.WebhookCreateMutationVariables>(
+      L.WebhookCreateDocument,
+      {
+        input,
+      }
+    );
+    const data = response?.webhookCreate;
+    return data ? new WebhookPayload(this._request, data) : undefined;
   }
 }
 
@@ -11322,12 +11261,14 @@ export class WebhookDeleteMutation extends Request {
    * @returns parsed response from WebhookDeleteMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.WebhookDeleteMutation, L.WebhookDeleteMutationVariables>(L.WebhookDeleteDocument, {
-      id,
-    }).then(response => {
-      const data = response?.webhookDelete;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.WebhookDeleteMutation, L.WebhookDeleteMutationVariables>(
+      L.WebhookDeleteDocument,
+      {
+        id,
+      }
+    );
+    const data = response?.webhookDelete;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -11349,13 +11290,15 @@ export class WebhookUpdateMutation extends Request {
    * @returns parsed response from WebhookUpdateMutation
    */
   public async fetch(id: string, input: L.WebhookUpdateInput): LinearFetch<WebhookPayload> {
-    return this._request<L.WebhookUpdateMutation, L.WebhookUpdateMutationVariables>(L.WebhookUpdateDocument, {
-      id,
-      input,
-    }).then(response => {
-      const data = response?.webhookUpdate;
-      return data ? new WebhookPayload(this._request, data) : undefined;
-    });
+    const response = await this._request<L.WebhookUpdateMutation, L.WebhookUpdateMutationVariables>(
+      L.WebhookUpdateDocument,
+      {
+        id,
+        input,
+      }
+    );
+    const data = response?.webhookUpdate;
+    return data ? new WebhookPayload(this._request, data) : undefined;
   }
 }
 
@@ -11376,15 +11319,14 @@ export class WorkflowStateArchiveMutation extends Request {
    * @returns parsed response from WorkflowStateArchiveMutation
    */
   public async fetch(id: string): LinearFetch<ArchivePayload> {
-    return this._request<L.WorkflowStateArchiveMutation, L.WorkflowStateArchiveMutationVariables>(
+    const response = await this._request<L.WorkflowStateArchiveMutation, L.WorkflowStateArchiveMutationVariables>(
       L.WorkflowStateArchiveDocument,
       {
         id,
       }
-    ).then(response => {
-      const data = response?.workflowStateArchive;
-      return data ? new ArchivePayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.workflowStateArchive;
+    return data ? new ArchivePayload(this._request, data) : undefined;
   }
 }
 
@@ -11405,15 +11347,14 @@ export class WorkflowStateCreateMutation extends Request {
    * @returns parsed response from WorkflowStateCreateMutation
    */
   public async fetch(input: L.WorkflowStateCreateInput): LinearFetch<WorkflowStatePayload> {
-    return this._request<L.WorkflowStateCreateMutation, L.WorkflowStateCreateMutationVariables>(
+    const response = await this._request<L.WorkflowStateCreateMutation, L.WorkflowStateCreateMutationVariables>(
       L.WorkflowStateCreateDocument,
       {
         input,
       }
-    ).then(response => {
-      const data = response?.workflowStateCreate;
-      return data ? new WorkflowStatePayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.workflowStateCreate;
+    return data ? new WorkflowStatePayload(this._request, data) : undefined;
   }
 }
 
@@ -11435,16 +11376,15 @@ export class WorkflowStateUpdateMutation extends Request {
    * @returns parsed response from WorkflowStateUpdateMutation
    */
   public async fetch(id: string, input: L.WorkflowStateUpdateInput): LinearFetch<WorkflowStatePayload> {
-    return this._request<L.WorkflowStateUpdateMutation, L.WorkflowStateUpdateMutationVariables>(
+    const response = await this._request<L.WorkflowStateUpdateMutation, L.WorkflowStateUpdateMutationVariables>(
       L.WorkflowStateUpdateDocument,
       {
         id,
         input,
       }
-    ).then(response => {
-      const data = response?.workflowStateUpdate;
-      return data ? new WorkflowStatePayload(this._request, data) : undefined;
-    });
+    );
+    const data = response?.workflowStateUpdate;
+    return data ? new WorkflowStatePayload(this._request, data) : undefined;
   }
 }
 
@@ -11478,23 +11418,22 @@ export class AttachmentIssue_AttachmentsQuery extends Request {
   public async fetch(
     variables?: Omit<L.AttachmentIssue_AttachmentsQueryVariables, "id">
   ): LinearFetch<AttachmentConnection> {
-    return this._request<L.AttachmentIssue_AttachmentsQuery, L.AttachmentIssue_AttachmentsQueryVariables>(
-      L.AttachmentIssue_AttachmentsDocument,
-      {
-        id: this._id,
-        ...this._variables,
-        ...variables,
-      }
-    ).then(response => {
-      const data = response?.attachmentIssue?.attachments;
-      return data
-        ? new AttachmentConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
+    const response = await this._request<
+      L.AttachmentIssue_AttachmentsQuery,
+      L.AttachmentIssue_AttachmentsQueryVariables
+    >(L.AttachmentIssue_AttachmentsDocument, {
+      id: this._id,
+      ...this._variables,
+      ...variables,
     });
+    const data = response?.attachmentIssue?.attachments;
+    return data
+      ? new AttachmentConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -11526,23 +11465,22 @@ export class AttachmentIssue_ChildrenQuery extends Request {
    * @returns parsed response from AttachmentIssue_ChildrenQuery
    */
   public async fetch(variables?: Omit<L.AttachmentIssue_ChildrenQueryVariables, "id">): LinearFetch<IssueConnection> {
-    return this._request<L.AttachmentIssue_ChildrenQuery, L.AttachmentIssue_ChildrenQueryVariables>(
+    const response = await this._request<L.AttachmentIssue_ChildrenQuery, L.AttachmentIssue_ChildrenQueryVariables>(
       L.AttachmentIssue_ChildrenDocument,
       {
         id: this._id,
         ...this._variables,
         ...variables,
       }
-    ).then(response => {
-      const data = response?.attachmentIssue?.children;
-      return data
-        ? new IssueConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.attachmentIssue?.children;
+    return data
+      ? new IssueConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -11574,23 +11512,22 @@ export class AttachmentIssue_CommentsQuery extends Request {
    * @returns parsed response from AttachmentIssue_CommentsQuery
    */
   public async fetch(variables?: Omit<L.AttachmentIssue_CommentsQueryVariables, "id">): LinearFetch<CommentConnection> {
-    return this._request<L.AttachmentIssue_CommentsQuery, L.AttachmentIssue_CommentsQueryVariables>(
+    const response = await this._request<L.AttachmentIssue_CommentsQuery, L.AttachmentIssue_CommentsQueryVariables>(
       L.AttachmentIssue_CommentsDocument,
       {
         id: this._id,
         ...this._variables,
         ...variables,
       }
-    ).then(response => {
-      const data = response?.attachmentIssue?.comments;
-      return data
-        ? new CommentConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.attachmentIssue?.comments;
+    return data
+      ? new CommentConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -11624,23 +11561,22 @@ export class AttachmentIssue_HistoryQuery extends Request {
   public async fetch(
     variables?: Omit<L.AttachmentIssue_HistoryQueryVariables, "id">
   ): LinearFetch<IssueHistoryConnection> {
-    return this._request<L.AttachmentIssue_HistoryQuery, L.AttachmentIssue_HistoryQueryVariables>(
+    const response = await this._request<L.AttachmentIssue_HistoryQuery, L.AttachmentIssue_HistoryQueryVariables>(
       L.AttachmentIssue_HistoryDocument,
       {
         id: this._id,
         ...this._variables,
         ...variables,
       }
-    ).then(response => {
-      const data = response?.attachmentIssue?.history;
-      return data
-        ? new IssueHistoryConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.attachmentIssue?.history;
+    return data
+      ? new IssueHistoryConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -11674,23 +11610,22 @@ export class AttachmentIssue_InverseRelationsQuery extends Request {
   public async fetch(
     variables?: Omit<L.AttachmentIssue_InverseRelationsQueryVariables, "id">
   ): LinearFetch<IssueRelationConnection> {
-    return this._request<L.AttachmentIssue_InverseRelationsQuery, L.AttachmentIssue_InverseRelationsQueryVariables>(
-      L.AttachmentIssue_InverseRelationsDocument,
-      {
-        id: this._id,
-        ...this._variables,
-        ...variables,
-      }
-    ).then(response => {
-      const data = response?.attachmentIssue?.inverseRelations;
-      return data
-        ? new IssueRelationConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
+    const response = await this._request<
+      L.AttachmentIssue_InverseRelationsQuery,
+      L.AttachmentIssue_InverseRelationsQueryVariables
+    >(L.AttachmentIssue_InverseRelationsDocument, {
+      id: this._id,
+      ...this._variables,
+      ...variables,
     });
+    const data = response?.attachmentIssue?.inverseRelations;
+    return data
+      ? new IssueRelationConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -11724,23 +11659,22 @@ export class AttachmentIssue_LabelsQuery extends Request {
   public async fetch(
     variables?: Omit<L.AttachmentIssue_LabelsQueryVariables, "id">
   ): LinearFetch<IssueLabelConnection> {
-    return this._request<L.AttachmentIssue_LabelsQuery, L.AttachmentIssue_LabelsQueryVariables>(
+    const response = await this._request<L.AttachmentIssue_LabelsQuery, L.AttachmentIssue_LabelsQueryVariables>(
       L.AttachmentIssue_LabelsDocument,
       {
         id: this._id,
         ...this._variables,
         ...variables,
       }
-    ).then(response => {
-      const data = response?.attachmentIssue?.labels;
-      return data
-        ? new IssueLabelConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.attachmentIssue?.labels;
+    return data
+      ? new IssueLabelConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -11774,23 +11708,22 @@ export class AttachmentIssue_RelationsQuery extends Request {
   public async fetch(
     variables?: Omit<L.AttachmentIssue_RelationsQueryVariables, "id">
   ): LinearFetch<IssueRelationConnection> {
-    return this._request<L.AttachmentIssue_RelationsQuery, L.AttachmentIssue_RelationsQueryVariables>(
+    const response = await this._request<L.AttachmentIssue_RelationsQuery, L.AttachmentIssue_RelationsQueryVariables>(
       L.AttachmentIssue_RelationsDocument,
       {
         id: this._id,
         ...this._variables,
         ...variables,
       }
-    ).then(response => {
-      const data = response?.attachmentIssue?.relations;
-      return data
-        ? new IssueRelationConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.attachmentIssue?.relations;
+    return data
+      ? new IssueRelationConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -11822,23 +11755,22 @@ export class AttachmentIssue_SubscribersQuery extends Request {
    * @returns parsed response from AttachmentIssue_SubscribersQuery
    */
   public async fetch(variables?: Omit<L.AttachmentIssue_SubscribersQueryVariables, "id">): LinearFetch<UserConnection> {
-    return this._request<L.AttachmentIssue_SubscribersQuery, L.AttachmentIssue_SubscribersQueryVariables>(
-      L.AttachmentIssue_SubscribersDocument,
-      {
-        id: this._id,
-        ...this._variables,
-        ...variables,
-      }
-    ).then(response => {
-      const data = response?.attachmentIssue?.subscribers;
-      return data
-        ? new UserConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
+    const response = await this._request<
+      L.AttachmentIssue_SubscribersQuery,
+      L.AttachmentIssue_SubscribersQueryVariables
+    >(L.AttachmentIssue_SubscribersDocument, {
+      id: this._id,
+      ...this._variables,
+      ...variables,
     });
+    const data = response?.attachmentIssue?.subscribers;
+    return data
+      ? new UserConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -11858,13 +11790,12 @@ export class BillingDetails_PaymentMethodQuery extends Request {
    * @returns parsed response from BillingDetails_PaymentMethodQuery
    */
   public async fetch(): LinearFetch<Card> {
-    return this._request<L.BillingDetails_PaymentMethodQuery, L.BillingDetails_PaymentMethodQueryVariables>(
-      L.BillingDetails_PaymentMethodDocument,
-      {}
-    ).then(response => {
-      const data = response?.billingDetails?.paymentMethod;
-      return data ? new Card(this._request, data) : undefined;
-    });
+    const response = await this._request<
+      L.BillingDetails_PaymentMethodQuery,
+      L.BillingDetails_PaymentMethodQueryVariables
+    >(L.BillingDetails_PaymentMethodDocument, {});
+    const data = response?.billingDetails?.paymentMethod;
+    return data ? new Card(this._request, data) : undefined;
   }
 }
 
@@ -11894,17 +11825,16 @@ export class CollaborativeDocumentJoin_StepsQuery extends Request {
    * @returns parsed response from CollaborativeDocumentJoin_StepsQuery
    */
   public async fetch(): LinearFetch<StepsResponse> {
-    return this._request<L.CollaborativeDocumentJoin_StepsQuery, L.CollaborativeDocumentJoin_StepsQueryVariables>(
-      L.CollaborativeDocumentJoin_StepsDocument,
-      {
-        clientId: this._clientId,
-        issueId: this._issueId,
-        version: this._version,
-      }
-    ).then(response => {
-      const data = response?.collaborativeDocumentJoin?.steps;
-      return data ? new StepsResponse(this._request, data) : undefined;
+    const response = await this._request<
+      L.CollaborativeDocumentJoin_StepsQuery,
+      L.CollaborativeDocumentJoin_StepsQueryVariables
+    >(L.CollaborativeDocumentJoin_StepsDocument, {
+      clientId: this._clientId,
+      issueId: this._issueId,
+      version: this._version,
     });
+    const data = response?.collaborativeDocumentJoin?.steps;
+    return data ? new StepsResponse(this._request, data) : undefined;
   }
 }
 
@@ -11932,20 +11862,19 @@ export class Cycle_IssuesQuery extends Request {
    * @returns parsed response from Cycle_IssuesQuery
    */
   public async fetch(variables?: Omit<L.Cycle_IssuesQueryVariables, "id">): LinearFetch<IssueConnection> {
-    return this._request<L.Cycle_IssuesQuery, L.Cycle_IssuesQueryVariables>(L.Cycle_IssuesDocument, {
+    const response = await this._request<L.Cycle_IssuesQuery, L.Cycle_IssuesQueryVariables>(L.Cycle_IssuesDocument, {
       id: this._id,
       ...this._variables,
       ...variables,
-    }).then(response => {
-      const data = response?.cycle?.issues;
-      return data
-        ? new IssueConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
     });
+    const data = response?.cycle?.issues;
+    return data
+      ? new IssueConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -11979,23 +11908,22 @@ export class Cycle_UncompletedIssuesUponCloseQuery extends Request {
   public async fetch(
     variables?: Omit<L.Cycle_UncompletedIssuesUponCloseQueryVariables, "id">
   ): LinearFetch<IssueConnection> {
-    return this._request<L.Cycle_UncompletedIssuesUponCloseQuery, L.Cycle_UncompletedIssuesUponCloseQueryVariables>(
-      L.Cycle_UncompletedIssuesUponCloseDocument,
-      {
-        id: this._id,
-        ...this._variables,
-        ...variables,
-      }
-    ).then(response => {
-      const data = response?.cycle?.uncompletedIssuesUponClose;
-      return data
-        ? new IssueConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
+    const response = await this._request<
+      L.Cycle_UncompletedIssuesUponCloseQuery,
+      L.Cycle_UncompletedIssuesUponCloseQueryVariables
+    >(L.Cycle_UncompletedIssuesUponCloseDocument, {
+      id: this._id,
+      ...this._variables,
+      ...variables,
     });
+    const data = response?.cycle?.uncompletedIssuesUponClose;
+    return data
+      ? new IssueConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12027,17 +11955,16 @@ export class FigmaEmbedInfo_FigmaEmbedQuery extends Request {
    * @returns parsed response from FigmaEmbedInfo_FigmaEmbedQuery
    */
   public async fetch(variables?: Omit<L.FigmaEmbedInfo_FigmaEmbedQueryVariables, "fileId">): LinearFetch<FigmaEmbed> {
-    return this._request<L.FigmaEmbedInfo_FigmaEmbedQuery, L.FigmaEmbedInfo_FigmaEmbedQueryVariables>(
+    const response = await this._request<L.FigmaEmbedInfo_FigmaEmbedQuery, L.FigmaEmbedInfo_FigmaEmbedQueryVariables>(
       L.FigmaEmbedInfo_FigmaEmbedDocument,
       {
         fileId: this._fileId,
         ...this._variables,
         ...variables,
       }
-    ).then(response => {
-      const data = response?.figmaEmbedInfo?.figmaEmbed;
-      return data ? new FigmaEmbed(this._request, data) : undefined;
-    });
+    );
+    const data = response?.figmaEmbedInfo?.figmaEmbed;
+    return data ? new FigmaEmbed(this._request, data) : undefined;
   }
 }
 
@@ -12069,17 +11996,16 @@ export class InviteInfo_InviteDataQuery extends Request {
    * @returns parsed response from InviteInfo_InviteDataQuery
    */
   public async fetch(variables?: Omit<L.InviteInfo_InviteDataQueryVariables, "userHash">): LinearFetch<InviteData> {
-    return this._request<L.InviteInfo_InviteDataQuery, L.InviteInfo_InviteDataQueryVariables>(
+    const response = await this._request<L.InviteInfo_InviteDataQuery, L.InviteInfo_InviteDataQueryVariables>(
       L.InviteInfo_InviteDataDocument,
       {
         userHash: this._userHash,
         ...this._variables,
         ...variables,
       }
-    ).then(response => {
-      const data = response?.inviteInfo?.inviteData;
-      return data ? new InviteData(this._request, data) : undefined;
-    });
+    );
+    const data = response?.inviteInfo?.inviteData;
+    return data ? new InviteData(this._request, data) : undefined;
   }
 }
 
@@ -12107,20 +12033,22 @@ export class Issue_AttachmentsQuery extends Request {
    * @returns parsed response from Issue_AttachmentsQuery
    */
   public async fetch(variables?: Omit<L.Issue_AttachmentsQueryVariables, "id">): LinearFetch<AttachmentConnection> {
-    return this._request<L.Issue_AttachmentsQuery, L.Issue_AttachmentsQueryVariables>(L.Issue_AttachmentsDocument, {
-      id: this._id,
-      ...this._variables,
-      ...variables,
-    }).then(response => {
-      const data = response?.issue?.attachments;
-      return data
-        ? new AttachmentConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    const response = await this._request<L.Issue_AttachmentsQuery, L.Issue_AttachmentsQueryVariables>(
+      L.Issue_AttachmentsDocument,
+      {
+        id: this._id,
+        ...this._variables,
+        ...variables,
+      }
+    );
+    const data = response?.issue?.attachments;
+    return data
+      ? new AttachmentConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12148,20 +12076,22 @@ export class Issue_ChildrenQuery extends Request {
    * @returns parsed response from Issue_ChildrenQuery
    */
   public async fetch(variables?: Omit<L.Issue_ChildrenQueryVariables, "id">): LinearFetch<IssueConnection> {
-    return this._request<L.Issue_ChildrenQuery, L.Issue_ChildrenQueryVariables>(L.Issue_ChildrenDocument, {
-      id: this._id,
-      ...this._variables,
-      ...variables,
-    }).then(response => {
-      const data = response?.issue?.children;
-      return data
-        ? new IssueConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    const response = await this._request<L.Issue_ChildrenQuery, L.Issue_ChildrenQueryVariables>(
+      L.Issue_ChildrenDocument,
+      {
+        id: this._id,
+        ...this._variables,
+        ...variables,
+      }
+    );
+    const data = response?.issue?.children;
+    return data
+      ? new IssueConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12189,20 +12119,22 @@ export class Issue_CommentsQuery extends Request {
    * @returns parsed response from Issue_CommentsQuery
    */
   public async fetch(variables?: Omit<L.Issue_CommentsQueryVariables, "id">): LinearFetch<CommentConnection> {
-    return this._request<L.Issue_CommentsQuery, L.Issue_CommentsQueryVariables>(L.Issue_CommentsDocument, {
-      id: this._id,
-      ...this._variables,
-      ...variables,
-    }).then(response => {
-      const data = response?.issue?.comments;
-      return data
-        ? new CommentConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    const response = await this._request<L.Issue_CommentsQuery, L.Issue_CommentsQueryVariables>(
+      L.Issue_CommentsDocument,
+      {
+        id: this._id,
+        ...this._variables,
+        ...variables,
+      }
+    );
+    const data = response?.issue?.comments;
+    return data
+      ? new CommentConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12230,20 +12162,19 @@ export class Issue_HistoryQuery extends Request {
    * @returns parsed response from Issue_HistoryQuery
    */
   public async fetch(variables?: Omit<L.Issue_HistoryQueryVariables, "id">): LinearFetch<IssueHistoryConnection> {
-    return this._request<L.Issue_HistoryQuery, L.Issue_HistoryQueryVariables>(L.Issue_HistoryDocument, {
+    const response = await this._request<L.Issue_HistoryQuery, L.Issue_HistoryQueryVariables>(L.Issue_HistoryDocument, {
       id: this._id,
       ...this._variables,
       ...variables,
-    }).then(response => {
-      const data = response?.issue?.history;
-      return data
-        ? new IssueHistoryConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
     });
+    const data = response?.issue?.history;
+    return data
+      ? new IssueHistoryConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12277,23 +12208,22 @@ export class Issue_InverseRelationsQuery extends Request {
   public async fetch(
     variables?: Omit<L.Issue_InverseRelationsQueryVariables, "id">
   ): LinearFetch<IssueRelationConnection> {
-    return this._request<L.Issue_InverseRelationsQuery, L.Issue_InverseRelationsQueryVariables>(
+    const response = await this._request<L.Issue_InverseRelationsQuery, L.Issue_InverseRelationsQueryVariables>(
       L.Issue_InverseRelationsDocument,
       {
         id: this._id,
         ...this._variables,
         ...variables,
       }
-    ).then(response => {
-      const data = response?.issue?.inverseRelations;
-      return data
-        ? new IssueRelationConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.issue?.inverseRelations;
+    return data
+      ? new IssueRelationConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12321,20 +12251,19 @@ export class Issue_LabelsQuery extends Request {
    * @returns parsed response from Issue_LabelsQuery
    */
   public async fetch(variables?: Omit<L.Issue_LabelsQueryVariables, "id">): LinearFetch<IssueLabelConnection> {
-    return this._request<L.Issue_LabelsQuery, L.Issue_LabelsQueryVariables>(L.Issue_LabelsDocument, {
+    const response = await this._request<L.Issue_LabelsQuery, L.Issue_LabelsQueryVariables>(L.Issue_LabelsDocument, {
       id: this._id,
       ...this._variables,
       ...variables,
-    }).then(response => {
-      const data = response?.issue?.labels;
-      return data
-        ? new IssueLabelConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
     });
+    const data = response?.issue?.labels;
+    return data
+      ? new IssueLabelConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12362,20 +12291,22 @@ export class Issue_RelationsQuery extends Request {
    * @returns parsed response from Issue_RelationsQuery
    */
   public async fetch(variables?: Omit<L.Issue_RelationsQueryVariables, "id">): LinearFetch<IssueRelationConnection> {
-    return this._request<L.Issue_RelationsQuery, L.Issue_RelationsQueryVariables>(L.Issue_RelationsDocument, {
-      id: this._id,
-      ...this._variables,
-      ...variables,
-    }).then(response => {
-      const data = response?.issue?.relations;
-      return data
-        ? new IssueRelationConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    const response = await this._request<L.Issue_RelationsQuery, L.Issue_RelationsQueryVariables>(
+      L.Issue_RelationsDocument,
+      {
+        id: this._id,
+        ...this._variables,
+        ...variables,
+      }
+    );
+    const data = response?.issue?.relations;
+    return data
+      ? new IssueRelationConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12403,20 +12334,22 @@ export class Issue_SubscribersQuery extends Request {
    * @returns parsed response from Issue_SubscribersQuery
    */
   public async fetch(variables?: Omit<L.Issue_SubscribersQueryVariables, "id">): LinearFetch<UserConnection> {
-    return this._request<L.Issue_SubscribersQuery, L.Issue_SubscribersQueryVariables>(L.Issue_SubscribersDocument, {
-      id: this._id,
-      ...this._variables,
-      ...variables,
-    }).then(response => {
-      const data = response?.issue?.subscribers;
-      return data
-        ? new UserConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    const response = await this._request<L.Issue_SubscribersQuery, L.Issue_SubscribersQueryVariables>(
+      L.Issue_SubscribersDocument,
+      {
+        id: this._id,
+        ...this._variables,
+        ...variables,
+      }
+    );
+    const data = response?.issue?.subscribers;
+    return data
+      ? new UserConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12444,20 +12377,22 @@ export class IssueLabel_IssuesQuery extends Request {
    * @returns parsed response from IssueLabel_IssuesQuery
    */
   public async fetch(variables?: Omit<L.IssueLabel_IssuesQueryVariables, "id">): LinearFetch<IssueConnection> {
-    return this._request<L.IssueLabel_IssuesQuery, L.IssueLabel_IssuesQueryVariables>(L.IssueLabel_IssuesDocument, {
-      id: this._id,
-      ...this._variables,
-      ...variables,
-    }).then(response => {
-      const data = response?.issueLabel?.issues;
-      return data
-        ? new IssueConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    const response = await this._request<L.IssueLabel_IssuesQuery, L.IssueLabel_IssuesQueryVariables>(
+      L.IssueLabel_IssuesDocument,
+      {
+        id: this._id,
+        ...this._variables,
+        ...variables,
+      }
+    );
+    const data = response?.issueLabel?.issues;
+    return data
+      ? new IssueConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12485,20 +12420,22 @@ export class Milestone_ProjectsQuery extends Request {
    * @returns parsed response from Milestone_ProjectsQuery
    */
   public async fetch(variables?: Omit<L.Milestone_ProjectsQueryVariables, "id">): LinearFetch<ProjectConnection> {
-    return this._request<L.Milestone_ProjectsQuery, L.Milestone_ProjectsQueryVariables>(L.Milestone_ProjectsDocument, {
-      id: this._id,
-      ...this._variables,
-      ...variables,
-    }).then(response => {
-      const data = response?.milestone?.projects;
-      return data
-        ? new ProjectConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    const response = await this._request<L.Milestone_ProjectsQuery, L.Milestone_ProjectsQueryVariables>(
+      L.Milestone_ProjectsDocument,
+      {
+        id: this._id,
+        ...this._variables,
+        ...variables,
+      }
+    );
+    const data = response?.milestone?.projects;
+    return data
+      ? new ProjectConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12524,19 +12461,18 @@ export class Organization_IntegrationsQuery extends Request {
    * @returns parsed response from Organization_IntegrationsQuery
    */
   public async fetch(variables?: L.Organization_IntegrationsQueryVariables): LinearFetch<IntegrationConnection> {
-    return this._request<L.Organization_IntegrationsQuery, L.Organization_IntegrationsQueryVariables>(
+    const response = await this._request<L.Organization_IntegrationsQuery, L.Organization_IntegrationsQueryVariables>(
       L.Organization_IntegrationsDocument,
       variables
-    ).then(response => {
-      const data = response?.organization?.integrations;
-      return data
-        ? new IntegrationConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.organization?.integrations;
+    return data
+      ? new IntegrationConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12562,19 +12498,18 @@ export class Organization_MilestonesQuery extends Request {
    * @returns parsed response from Organization_MilestonesQuery
    */
   public async fetch(variables?: L.Organization_MilestonesQueryVariables): LinearFetch<MilestoneConnection> {
-    return this._request<L.Organization_MilestonesQuery, L.Organization_MilestonesQueryVariables>(
+    const response = await this._request<L.Organization_MilestonesQuery, L.Organization_MilestonesQueryVariables>(
       L.Organization_MilestonesDocument,
       variables
-    ).then(response => {
-      const data = response?.organization?.milestones;
-      return data
-        ? new MilestoneConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.organization?.milestones;
+    return data
+      ? new MilestoneConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12600,19 +12535,18 @@ export class Organization_TeamsQuery extends Request {
    * @returns parsed response from Organization_TeamsQuery
    */
   public async fetch(variables?: L.Organization_TeamsQueryVariables): LinearFetch<TeamConnection> {
-    return this._request<L.Organization_TeamsQuery, L.Organization_TeamsQueryVariables>(
+    const response = await this._request<L.Organization_TeamsQuery, L.Organization_TeamsQueryVariables>(
       L.Organization_TeamsDocument,
       variables
-    ).then(response => {
-      const data = response?.organization?.teams;
-      return data
-        ? new TeamConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.organization?.teams;
+    return data
+      ? new TeamConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12638,19 +12572,18 @@ export class Organization_UsersQuery extends Request {
    * @returns parsed response from Organization_UsersQuery
    */
   public async fetch(variables?: L.Organization_UsersQueryVariables): LinearFetch<UserConnection> {
-    return this._request<L.Organization_UsersQuery, L.Organization_UsersQueryVariables>(
+    const response = await this._request<L.Organization_UsersQuery, L.Organization_UsersQueryVariables>(
       L.Organization_UsersDocument,
       variables
-    ).then(response => {
-      const data = response?.organization?.users;
-      return data
-        ? new UserConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.organization?.users;
+    return data
+      ? new UserConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12682,23 +12615,22 @@ export class OrganizationInvite_IssuesQuery extends Request {
    * @returns parsed response from OrganizationInvite_IssuesQuery
    */
   public async fetch(variables?: Omit<L.OrganizationInvite_IssuesQueryVariables, "id">): LinearFetch<IssueConnection> {
-    return this._request<L.OrganizationInvite_IssuesQuery, L.OrganizationInvite_IssuesQueryVariables>(
+    const response = await this._request<L.OrganizationInvite_IssuesQuery, L.OrganizationInvite_IssuesQueryVariables>(
       L.OrganizationInvite_IssuesDocument,
       {
         id: this._id,
         ...this._variables,
         ...variables,
       }
-    ).then(response => {
-      const data = response?.organizationInvite?.issues;
-      return data
-        ? new IssueConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.organizationInvite?.issues;
+    return data
+      ? new IssueConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12726,20 +12658,22 @@ export class Project_IssuesQuery extends Request {
    * @returns parsed response from Project_IssuesQuery
    */
   public async fetch(variables?: Omit<L.Project_IssuesQueryVariables, "id">): LinearFetch<IssueConnection> {
-    return this._request<L.Project_IssuesQuery, L.Project_IssuesQueryVariables>(L.Project_IssuesDocument, {
-      id: this._id,
-      ...this._variables,
-      ...variables,
-    }).then(response => {
-      const data = response?.project?.issues;
-      return data
-        ? new IssueConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    const response = await this._request<L.Project_IssuesQuery, L.Project_IssuesQueryVariables>(
+      L.Project_IssuesDocument,
+      {
+        id: this._id,
+        ...this._variables,
+        ...variables,
+      }
+    );
+    const data = response?.project?.issues;
+    return data
+      ? new IssueConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12767,20 +12701,19 @@ export class Project_LinksQuery extends Request {
    * @returns parsed response from Project_LinksQuery
    */
   public async fetch(variables?: Omit<L.Project_LinksQueryVariables, "id">): LinearFetch<ProjectLinkConnection> {
-    return this._request<L.Project_LinksQuery, L.Project_LinksQueryVariables>(L.Project_LinksDocument, {
+    const response = await this._request<L.Project_LinksQuery, L.Project_LinksQueryVariables>(L.Project_LinksDocument, {
       id: this._id,
       ...this._variables,
       ...variables,
-    }).then(response => {
-      const data = response?.project?.links;
-      return data
-        ? new ProjectLinkConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
     });
+    const data = response?.project?.links;
+    return data
+      ? new ProjectLinkConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12808,20 +12741,22 @@ export class Project_MembersQuery extends Request {
    * @returns parsed response from Project_MembersQuery
    */
   public async fetch(variables?: Omit<L.Project_MembersQueryVariables, "id">): LinearFetch<UserConnection> {
-    return this._request<L.Project_MembersQuery, L.Project_MembersQueryVariables>(L.Project_MembersDocument, {
-      id: this._id,
-      ...this._variables,
-      ...variables,
-    }).then(response => {
-      const data = response?.project?.members;
-      return data
-        ? new UserConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    const response = await this._request<L.Project_MembersQuery, L.Project_MembersQueryVariables>(
+      L.Project_MembersDocument,
+      {
+        id: this._id,
+        ...this._variables,
+        ...variables,
+      }
+    );
+    const data = response?.project?.members;
+    return data
+      ? new UserConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12849,20 +12784,19 @@ export class Project_TeamsQuery extends Request {
    * @returns parsed response from Project_TeamsQuery
    */
   public async fetch(variables?: Omit<L.Project_TeamsQueryVariables, "id">): LinearFetch<TeamConnection> {
-    return this._request<L.Project_TeamsQuery, L.Project_TeamsQueryVariables>(L.Project_TeamsDocument, {
+    const response = await this._request<L.Project_TeamsQuery, L.Project_TeamsQueryVariables>(L.Project_TeamsDocument, {
       id: this._id,
       ...this._variables,
       ...variables,
-    }).then(response => {
-      const data = response?.project?.teams;
-      return data
-        ? new TeamConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
     });
+    const data = response?.project?.teams;
+    return data
+      ? new TeamConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12890,20 +12824,19 @@ export class Team_CyclesQuery extends Request {
    * @returns parsed response from Team_CyclesQuery
    */
   public async fetch(variables?: Omit<L.Team_CyclesQueryVariables, "id">): LinearFetch<CycleConnection> {
-    return this._request<L.Team_CyclesQuery, L.Team_CyclesQueryVariables>(L.Team_CyclesDocument, {
+    const response = await this._request<L.Team_CyclesQuery, L.Team_CyclesQueryVariables>(L.Team_CyclesDocument, {
       id: this._id,
       ...this._variables,
       ...variables,
-    }).then(response => {
-      const data = response?.team?.cycles;
-      return data
-        ? new CycleConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
     });
+    const data = response?.team?.cycles;
+    return data
+      ? new CycleConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12931,20 +12864,19 @@ export class Team_IssuesQuery extends Request {
    * @returns parsed response from Team_IssuesQuery
    */
   public async fetch(variables?: Omit<L.Team_IssuesQueryVariables, "id">): LinearFetch<IssueConnection> {
-    return this._request<L.Team_IssuesQuery, L.Team_IssuesQueryVariables>(L.Team_IssuesDocument, {
+    const response = await this._request<L.Team_IssuesQuery, L.Team_IssuesQueryVariables>(L.Team_IssuesDocument, {
       id: this._id,
       ...this._variables,
       ...variables,
-    }).then(response => {
-      const data = response?.team?.issues;
-      return data
-        ? new IssueConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
     });
+    const data = response?.team?.issues;
+    return data
+      ? new IssueConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -12972,20 +12904,19 @@ export class Team_LabelsQuery extends Request {
    * @returns parsed response from Team_LabelsQuery
    */
   public async fetch(variables?: Omit<L.Team_LabelsQueryVariables, "id">): LinearFetch<IssueLabelConnection> {
-    return this._request<L.Team_LabelsQuery, L.Team_LabelsQueryVariables>(L.Team_LabelsDocument, {
+    const response = await this._request<L.Team_LabelsQuery, L.Team_LabelsQueryVariables>(L.Team_LabelsDocument, {
       id: this._id,
       ...this._variables,
       ...variables,
-    }).then(response => {
-      const data = response?.team?.labels;
-      return data
-        ? new IssueLabelConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
     });
+    const data = response?.team?.labels;
+    return data
+      ? new IssueLabelConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -13013,20 +12944,19 @@ export class Team_MembersQuery extends Request {
    * @returns parsed response from Team_MembersQuery
    */
   public async fetch(variables?: Omit<L.Team_MembersQueryVariables, "id">): LinearFetch<UserConnection> {
-    return this._request<L.Team_MembersQuery, L.Team_MembersQueryVariables>(L.Team_MembersDocument, {
+    const response = await this._request<L.Team_MembersQuery, L.Team_MembersQueryVariables>(L.Team_MembersDocument, {
       id: this._id,
       ...this._variables,
       ...variables,
-    }).then(response => {
-      const data = response?.team?.members;
-      return data
-        ? new UserConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
     });
+    const data = response?.team?.members;
+    return data
+      ? new UserConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -13054,20 +12984,22 @@ export class Team_MembershipsQuery extends Request {
    * @returns parsed response from Team_MembershipsQuery
    */
   public async fetch(variables?: Omit<L.Team_MembershipsQueryVariables, "id">): LinearFetch<TeamMembershipConnection> {
-    return this._request<L.Team_MembershipsQuery, L.Team_MembershipsQueryVariables>(L.Team_MembershipsDocument, {
-      id: this._id,
-      ...this._variables,
-      ...variables,
-    }).then(response => {
-      const data = response?.team?.memberships;
-      return data
-        ? new TeamMembershipConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    const response = await this._request<L.Team_MembershipsQuery, L.Team_MembershipsQueryVariables>(
+      L.Team_MembershipsDocument,
+      {
+        id: this._id,
+        ...this._variables,
+        ...variables,
+      }
+    );
+    const data = response?.team?.memberships;
+    return data
+      ? new TeamMembershipConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -13095,20 +13027,19 @@ export class Team_ProjectsQuery extends Request {
    * @returns parsed response from Team_ProjectsQuery
    */
   public async fetch(variables?: Omit<L.Team_ProjectsQueryVariables, "id">): LinearFetch<ProjectConnection> {
-    return this._request<L.Team_ProjectsQuery, L.Team_ProjectsQueryVariables>(L.Team_ProjectsDocument, {
+    const response = await this._request<L.Team_ProjectsQuery, L.Team_ProjectsQueryVariables>(L.Team_ProjectsDocument, {
       id: this._id,
       ...this._variables,
       ...variables,
-    }).then(response => {
-      const data = response?.team?.projects;
-      return data
-        ? new ProjectConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
     });
+    const data = response?.team?.projects;
+    return data
+      ? new ProjectConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -13136,20 +13067,19 @@ export class Team_StatesQuery extends Request {
    * @returns parsed response from Team_StatesQuery
    */
   public async fetch(variables?: Omit<L.Team_StatesQueryVariables, "id">): LinearFetch<WorkflowStateConnection> {
-    return this._request<L.Team_StatesQuery, L.Team_StatesQueryVariables>(L.Team_StatesDocument, {
+    const response = await this._request<L.Team_StatesQuery, L.Team_StatesQueryVariables>(L.Team_StatesDocument, {
       id: this._id,
       ...this._variables,
       ...variables,
-    }).then(response => {
-      const data = response?.team?.states;
-      return data
-        ? new WorkflowStateConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
     });
+    const data = response?.team?.states;
+    return data
+      ? new WorkflowStateConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -13177,14 +13107,16 @@ export class Team_TemplatesQuery extends Request {
    * @returns parsed response from Team_TemplatesQuery
    */
   public async fetch(variables?: Omit<L.Team_TemplatesQueryVariables, "id">): LinearFetch<TemplateConnection> {
-    return this._request<L.Team_TemplatesQuery, L.Team_TemplatesQueryVariables>(L.Team_TemplatesDocument, {
-      id: this._id,
-      ...this._variables,
-      ...variables,
-    }).then(response => {
-      const data = response?.team?.templates;
-      return data ? new TemplateConnection(this._request, data) : undefined;
-    });
+    const response = await this._request<L.Team_TemplatesQuery, L.Team_TemplatesQueryVariables>(
+      L.Team_TemplatesDocument,
+      {
+        id: this._id,
+        ...this._variables,
+        ...variables,
+      }
+    );
+    const data = response?.team?.templates;
+    return data ? new TemplateConnection(this._request, data) : undefined;
   }
 }
 
@@ -13212,20 +13144,19 @@ export class Team_WebhooksQuery extends Request {
    * @returns parsed response from Team_WebhooksQuery
    */
   public async fetch(variables?: Omit<L.Team_WebhooksQueryVariables, "id">): LinearFetch<WebhookConnection> {
-    return this._request<L.Team_WebhooksQuery, L.Team_WebhooksQueryVariables>(L.Team_WebhooksDocument, {
+    const response = await this._request<L.Team_WebhooksQuery, L.Team_WebhooksQueryVariables>(L.Team_WebhooksDocument, {
       id: this._id,
       ...this._variables,
       ...variables,
-    }).then(response => {
-      const data = response?.team?.webhooks;
-      return data
-        ? new WebhookConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
     });
+    const data = response?.team?.webhooks;
+    return data
+      ? new WebhookConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -13253,23 +13184,22 @@ export class User_AssignedIssuesQuery extends Request {
    * @returns parsed response from User_AssignedIssuesQuery
    */
   public async fetch(variables?: Omit<L.User_AssignedIssuesQueryVariables, "id">): LinearFetch<IssueConnection> {
-    return this._request<L.User_AssignedIssuesQuery, L.User_AssignedIssuesQueryVariables>(
+    const response = await this._request<L.User_AssignedIssuesQuery, L.User_AssignedIssuesQueryVariables>(
       L.User_AssignedIssuesDocument,
       {
         id: this._id,
         ...this._variables,
         ...variables,
       }
-    ).then(response => {
-      const data = response?.user?.assignedIssues;
-      return data
-        ? new IssueConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.user?.assignedIssues;
+    return data
+      ? new IssueConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -13297,20 +13227,22 @@ export class User_CreatedIssuesQuery extends Request {
    * @returns parsed response from User_CreatedIssuesQuery
    */
   public async fetch(variables?: Omit<L.User_CreatedIssuesQueryVariables, "id">): LinearFetch<IssueConnection> {
-    return this._request<L.User_CreatedIssuesQuery, L.User_CreatedIssuesQueryVariables>(L.User_CreatedIssuesDocument, {
-      id: this._id,
-      ...this._variables,
-      ...variables,
-    }).then(response => {
-      const data = response?.user?.createdIssues;
-      return data
-        ? new IssueConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    const response = await this._request<L.User_CreatedIssuesQuery, L.User_CreatedIssuesQueryVariables>(
+      L.User_CreatedIssuesDocument,
+      {
+        id: this._id,
+        ...this._variables,
+        ...variables,
+      }
+    );
+    const data = response?.user?.createdIssues;
+    return data
+      ? new IssueConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -13340,23 +13272,22 @@ export class User_TeamMembershipsQuery extends Request {
   public async fetch(
     variables?: Omit<L.User_TeamMembershipsQueryVariables, "id">
   ): LinearFetch<TeamMembershipConnection> {
-    return this._request<L.User_TeamMembershipsQuery, L.User_TeamMembershipsQueryVariables>(
+    const response = await this._request<L.User_TeamMembershipsQuery, L.User_TeamMembershipsQueryVariables>(
       L.User_TeamMembershipsDocument,
       {
         id: this._id,
         ...this._variables,
         ...variables,
       }
-    ).then(response => {
-      const data = response?.user?.teamMemberships;
-      return data
-        ? new TeamMembershipConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.user?.teamMemberships;
+    return data
+      ? new TeamMembershipConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -13384,20 +13315,19 @@ export class User_TeamsQuery extends Request {
    * @returns parsed response from User_TeamsQuery
    */
   public async fetch(variables?: Omit<L.User_TeamsQueryVariables, "id">): LinearFetch<TeamConnection> {
-    return this._request<L.User_TeamsQuery, L.User_TeamsQueryVariables>(L.User_TeamsDocument, {
+    const response = await this._request<L.User_TeamsQuery, L.User_TeamsQueryVariables>(L.User_TeamsDocument, {
       id: this._id,
       ...this._variables,
       ...variables,
-    }).then(response => {
-      const data = response?.user?.teams;
-      return data
-        ? new TeamConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
     });
+    const data = response?.user?.teams;
+    return data
+      ? new TeamConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -13423,19 +13353,18 @@ export class Viewer_AssignedIssuesQuery extends Request {
    * @returns parsed response from Viewer_AssignedIssuesQuery
    */
   public async fetch(variables?: L.Viewer_AssignedIssuesQueryVariables): LinearFetch<IssueConnection> {
-    return this._request<L.Viewer_AssignedIssuesQuery, L.Viewer_AssignedIssuesQueryVariables>(
+    const response = await this._request<L.Viewer_AssignedIssuesQuery, L.Viewer_AssignedIssuesQueryVariables>(
       L.Viewer_AssignedIssuesDocument,
       variables
-    ).then(response => {
-      const data = response?.viewer?.assignedIssues;
-      return data
-        ? new IssueConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.viewer?.assignedIssues;
+    return data
+      ? new IssueConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -13461,19 +13390,18 @@ export class Viewer_CreatedIssuesQuery extends Request {
    * @returns parsed response from Viewer_CreatedIssuesQuery
    */
   public async fetch(variables?: L.Viewer_CreatedIssuesQueryVariables): LinearFetch<IssueConnection> {
-    return this._request<L.Viewer_CreatedIssuesQuery, L.Viewer_CreatedIssuesQueryVariables>(
+    const response = await this._request<L.Viewer_CreatedIssuesQuery, L.Viewer_CreatedIssuesQueryVariables>(
       L.Viewer_CreatedIssuesDocument,
       variables
-    ).then(response => {
-      const data = response?.viewer?.createdIssues;
-      return data
-        ? new IssueConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.viewer?.createdIssues;
+    return data
+      ? new IssueConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -13499,19 +13427,18 @@ export class Viewer_TeamMembershipsQuery extends Request {
    * @returns parsed response from Viewer_TeamMembershipsQuery
    */
   public async fetch(variables?: L.Viewer_TeamMembershipsQueryVariables): LinearFetch<TeamMembershipConnection> {
-    return this._request<L.Viewer_TeamMembershipsQuery, L.Viewer_TeamMembershipsQueryVariables>(
+    const response = await this._request<L.Viewer_TeamMembershipsQuery, L.Viewer_TeamMembershipsQueryVariables>(
       L.Viewer_TeamMembershipsDocument,
       variables
-    ).then(response => {
-      const data = response?.viewer?.teamMemberships;
-      return data
-        ? new TeamMembershipConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.viewer?.teamMemberships;
+    return data
+      ? new TeamMembershipConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -13537,18 +13464,18 @@ export class Viewer_TeamsQuery extends Request {
    * @returns parsed response from Viewer_TeamsQuery
    */
   public async fetch(variables?: L.Viewer_TeamsQueryVariables): LinearFetch<TeamConnection> {
-    return this._request<L.Viewer_TeamsQuery, L.Viewer_TeamsQueryVariables>(L.Viewer_TeamsDocument, variables).then(
-      response => {
-        const data = response?.viewer?.teams;
-        return data
-          ? new TeamConnection(
-              this._request,
-              connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-              data
-            )
-          : undefined;
-      }
+    const response = await this._request<L.Viewer_TeamsQuery, L.Viewer_TeamsQueryVariables>(
+      L.Viewer_TeamsDocument,
+      variables
     );
+    const data = response?.viewer?.teams;
+    return data
+      ? new TeamConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 
@@ -13576,23 +13503,22 @@ export class WorkflowState_IssuesQuery extends Request {
    * @returns parsed response from WorkflowState_IssuesQuery
    */
   public async fetch(variables?: Omit<L.WorkflowState_IssuesQueryVariables, "id">): LinearFetch<IssueConnection> {
-    return this._request<L.WorkflowState_IssuesQuery, L.WorkflowState_IssuesQueryVariables>(
+    const response = await this._request<L.WorkflowState_IssuesQuery, L.WorkflowState_IssuesQueryVariables>(
       L.WorkflowState_IssuesDocument,
       {
         id: this._id,
         ...this._variables,
         ...variables,
       }
-    ).then(response => {
-      const data = response?.workflowState?.issues;
-      return data
-        ? new IssueConnection(
-            this._request,
-            connection => this.fetch({ ...this._variables, ...variables, ...connection }),
-            data
-          )
-        : undefined;
-    });
+    );
+    const data = response?.workflowState?.issues;
+    return data
+      ? new IssueConnection(
+          this._request,
+          connection => this.fetch({ ...this._variables, ...variables, ...connection }),
+          data
+        )
+      : undefined;
   }
 }
 

--- a/packages/sdk/src/_generated_sdk.ts
+++ b/packages/sdk/src/_generated_sdk.ts
@@ -1788,6 +1788,7 @@ export class Issue extends Request {
   private _cycle?: L.IssueFragment["cycle"];
   private _parent?: L.IssueFragment["parent"];
   private _project?: L.IssueFragment["project"];
+  private _snoozedBy?: L.IssueFragment["snoozedBy"];
   private _state?: L.IssueFragment["state"];
   private _team?: L.IssueFragment["team"];
 
@@ -1811,6 +1812,7 @@ export class Issue extends Request {
     this.previousIdentifiers = data.previousIdentifiers ?? undefined;
     this.priority = data.priority ?? undefined;
     this.priorityLabel = data.priorityLabel ?? undefined;
+    this.snoozedUntilAt = parseDate(data.snoozedUntilAt) ?? undefined;
     this.startedAt = parseDate(data.startedAt) ?? undefined;
     this.subIssueSortOrder = data.subIssueSortOrder ?? undefined;
     this.title = data.title ?? undefined;
@@ -1822,6 +1824,7 @@ export class Issue extends Request {
     this._cycle = data.cycle ?? undefined;
     this._parent = data.parent ?? undefined;
     this._project = data.project ?? undefined;
+    this._snoozedBy = data.snoozedBy ?? undefined;
     this._state = data.state ?? undefined;
     this._team = data.team ?? undefined;
   }
@@ -1862,6 +1865,8 @@ export class Issue extends Request {
   public priority?: number;
   /** Label for the priority. */
   public priorityLabel?: string;
+  /** The time until an issue will be snoozed in Triage view. */
+  public snoozedUntilAt?: Date;
   /** The time at which the issue was moved into started state. */
   public startedAt?: Date;
   /** The order of the item in the sub-issue list. Only set if the issue has a parent. */
@@ -1896,6 +1901,10 @@ export class Issue extends Request {
   /** The project that the issue is associated with. */
   public get project(): LinearFetch<Project> | undefined {
     return this._project?.id ? new ProjectQuery(this._request).fetch(this._project?.id) : undefined;
+  }
+  /** The user who snoozed the issue. */
+  public get snoozedBy(): LinearFetch<User> | undefined {
+    return this._snoozedBy?.id ? new UserQuery(this._request).fetch(this._snoozedBy?.id) : undefined;
   }
   /** The workflow state that the issue is associated with. */
   public get state(): LinearFetch<WorkflowState> | undefined {

--- a/packages/sdk/src/_generated_sdk.ts
+++ b/packages/sdk/src/_generated_sdk.ts
@@ -1,12 +1,11 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { DocumentNode } from "graphql/language/ast";
 import * as L from "./_generated_documents";
 
 /** The function for calling the graphql client */
-export type LinearRequest = <LinearResponse, Variables extends Record<string, unknown>>(
+export type LinearRequest = <Response, Variables extends Record<string, unknown>>(
   doc: DocumentNode,
   variables?: Variables
-) => Promise<LinearResponse>;
+) => Promise<Response>;
 
 /**
  * Base class to provide a request function
@@ -22,7 +21,7 @@ export class Request {
 }
 
 /** Fetch return type wrapped in a promise */
-export type LinearFetch<LinearResponse> = Promise<LinearResponse | undefined>;
+export type LinearFetch<Response> = Promise<Response | undefined>;
 
 /**
  * Variables required for pagination
@@ -1943,7 +1942,7 @@ export class Issue extends Request {
   }
   /** Archives an issue. */
   public archive(variables?: Omit<L.IssueArchiveMutationVariables, "id">) {
-    return this.id ? new IssueArchiveMutation(this._request).fetch(this.id) : undefined;
+    return this.id ? new IssueArchiveMutation(this._request).fetch(this.id, variables) : undefined;
   }
   /** Deletes (trashes) an issue. */
   public delete() {

--- a/packages/sdk/src/_tests/_generated.test.ts
+++ b/packages/sdk/src/_tests/_generated.test.ts
@@ -19,15 +19,6 @@ describe("generated", () => {
     stopClient();
   });
 
-  /** Test all ApiKey queries */
-  describe("ApiKeys", () => {
-    /** Test the root connection query for the ApiKey */
-    it("apiKeys", async () => {
-      const apiKeys: L.ApiKeyConnection | undefined = await client.apiKeys();
-      expect(apiKeys instanceof L.ApiKeyConnection);
-    });
-  });
-
   /** Test ApplicationWithAuthorization query */
   describe("ApplicationWithAuthorization", () => {
     /** Test the root model query for ApplicationWithAuthorization */

--- a/packages/sdk/src/_tests/_generated.test.ts
+++ b/packages/sdk/src/_tests/_generated.test.ts
@@ -924,6 +924,16 @@ describe("generated", () => {
       }
     });
 
+    /** Test the issue.snoozedBy query for L.User */
+    it("issue.snoozedBy", async () => {
+      if (_issue) {
+        const issue_snoozedBy: L.User | undefined = await _issue.snoozedBy;
+        expect(issue_snoozedBy instanceof L.User);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.snoozedBy query");
+      }
+    });
+
     /** Test the issue.state query for L.WorkflowState */
     it("issue.state", async () => {
       if (_issue) {
@@ -1096,6 +1106,16 @@ describe("generated", () => {
         expect(issue_project instanceof L.Project);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.project query");
+      }
+    });
+
+    /** Test the issue.snoozedBy query for L.User */
+    it("issue.snoozedBy", async () => {
+      if (_issue) {
+        const issue_snoozedBy: L.User | undefined = await _issue.snoozedBy;
+        expect(issue_snoozedBy instanceof L.User);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.snoozedBy query");
       }
     });
 

--- a/packages/sdk/src/schema.graphql
+++ b/packages/sdk/src/schema.graphql
@@ -43,7 +43,7 @@ input ApiKeyCreateInput {
   """
   id: String
   """
-  The API key value (format: /^[a-zA-Z0-9]{40}$/).
+  The API key value.
   """
   key: String!
   """
@@ -1040,6 +1040,10 @@ type EmailUnsubscribePayload {
 }
 
 input EmailUserAccountAuthChallengeInput {
+  """
+  Auth code for the client initiating the sequence.
+  """
+  clientAuthCode: String
   """
   The email for which to generate the magic login code.
   """
@@ -2286,6 +2290,10 @@ type IssueHistory implements Node {
   """
   issue: Issue!
   """
+  The import record.
+  """
+  issueImport: IssueImport
+  """
   Changed issue relationships.
   """
   relationChanges: [IssueRelationHistoryPayload!]
@@ -2960,7 +2968,7 @@ input MilestoneUpdateInput {
 
 type Mutation {
   """
-  Creates a new API key.
+  [Internal] Creates a new API key.
   """
   apiKeyCreate(
     """
@@ -2969,7 +2977,7 @@ type Mutation {
     input: ApiKeyCreateInput!
   ): ApiKeyPayload!
   """
-  Deletes an API key.
+  [Internal] Deletes an API key.
   """
   apiKeyDelete(
     """
@@ -3430,6 +3438,10 @@ type Mutation {
   """
   integrationIntercomDelete: IntegrationPayload!
   """
+  Enables Loom integration for the organization.
+  """
+  integrationLoom: IntegrationPayload!
+  """
   Archives an integration resource.
   """
   integrationResourceArchive(
@@ -3643,11 +3655,11 @@ type Mutation {
   """
   issueImportCreateGithub(
     """
-    Github repository name from which we will import data.
+    GitHub repository name from which we will import data.
     """
     githubRepoName: String!
     """
-    Github owner (user or org) for the repository from which we will import data.
+    GitHub owner (user or org) for the repository from which we will import data.
     """
     githubRepoOwner: String!
     """
@@ -3655,7 +3667,7 @@ type Mutation {
     """
     githubShouldImportOrgProjects: Boolean
     """
-    Github token to fetch information from the Github API.
+    GitHub token to fetch information from the GitHub API.
     """
     githubToken: String!
     """
@@ -3921,6 +3933,45 @@ type Mutation {
     """
     input: NotificationUpdateInput!
   ): NotificationPayload!
+  """
+  [Internal] Authenticates an auth string by the user.
+  """
+  oauthAuthStringAuthorize(
+    """
+    The identifier of the OAuth client that's trying to authenticate.
+    """
+    appId: String!
+    """
+    The auth string to authenticate.
+    """
+    authString: String!
+  ): OauthAuthStringAuthorizePayload!
+  """
+  [Internal] Creates a temporary authentication code that can be exchanged for an OAuth token.
+  """
+  oauthAuthStringChallenge(
+    """
+    The identifier of the OAuth client that's trying to authenticate.
+    """
+    appId: String!
+    """
+    The group of scopes that are being requested.
+    """
+    scope: [String!]!
+  ): OauthAuthStringChallengePayload!
+  """
+  [Internal] Returns an access token once the auth string has been authenticated.
+  """
+  oauthAuthStringCheck(
+    """
+    The identifier of the OAuth client that's trying to authenticate.
+    """
+    appId: String!
+    """
+    The auth string to authenticate.
+    """
+    authString: String!
+  ): OauthAuthStringCheckPayload!
   """
   Archives an OAuth client.
   """
@@ -4704,6 +4755,35 @@ input NotificationUpdateInput {
   The time until a notification will be snoozed. After that it will appear in the inbox again.
   """
   snoozedUntilAt: DateTime
+}
+
+type OauthAuthStringAuthorizePayload {
+  """
+  Whether the operation was successful.
+  """
+  success: Boolean!
+}
+
+type OauthAuthStringChallengePayload {
+  """
+  The created authentication string.
+  """
+  authString: String!
+  """
+  Whether the operation was successful.
+  """
+  success: Boolean!
+}
+
+type OauthAuthStringCheckPayload {
+  """
+  Whether the operation was successful.
+  """
+  success: Boolean!
+  """
+  Access token for use.
+  """
+  token: String
 }
 
 """
@@ -5547,6 +5627,10 @@ type Project implements Node {
       entity hasn't been update after creation.
   """
   updatedAt: DateTime!
+  """
+  Project URL.
+  """
+  url: String!
 }
 
 type ProjectConnection {
@@ -5884,7 +5968,7 @@ type PushSubscriptionTestPayload {
 
 type Query {
   """
-  All API keys for the user.
+  [Internal] All API keys for the user.
   """
   apiKeys(
     """
@@ -8670,6 +8754,10 @@ type User implements Node {
       entity hasn't been update after creation.
   """
   updatedAt: DateTime!
+  """
+  User's profile URL.
+  """
+  url: String!
 }
 
 """

--- a/packages/sdk/src/schema.graphql
+++ b/packages/sdk/src/schema.graphql
@@ -2017,6 +2017,14 @@ type Issue implements Node {
     orderBy: PaginationOrderBy
   ): IssueRelationConnection!
   """
+  The user who snoozed the issue.
+  """
+  snoozedBy: User
+  """
+  The time until an issue will be snoozed in Triage view.
+  """
+  snoozedUntilAt: DateTime
+  """
   The time at which the issue was moved into started state.
   """
   startedAt: DateTime
@@ -2780,6 +2788,14 @@ input IssueUpdateInput {
   The project associated with the issue.
   """
   projectId: String
+  """
+  The identifier of the user who snoozed the issue.
+  """
+  snoozedById: String
+  """
+  The time until an issue will be snoozed in Triage view.
+  """
+  snoozedUntilAt: DateTime
   """
   The team state of the issue.
   """

--- a/packages/sdk/src/schema.json
+++ b/packages/sdk/src/schema.json
@@ -7093,6 +7093,18 @@
             "deprecationReason": null
           },
           {
+            "name": "snoozedUntilAt",
+            "description": "The time until an issue will be snoozed in Triage view.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "previousIdentifiers",
             "description": "Previous identifiers of the issue if it has been moved between teams.",
             "args": [],
@@ -7112,6 +7124,18 @@
                   }
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "snoozedBy",
+            "description": "The user who snoozed the issue.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -10868,6 +10892,30 @@
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "snoozedUntilAt",
+            "description": "The time until an issue will be snoozed in Triage view.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "snoozedById",
+            "description": "The identifier of the user who snoozed the issue.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null,

--- a/packages/sdk/src/schema.json
+++ b/packages/sdk/src/schema.json
@@ -234,7 +234,7 @@
           },
           {
             "name": "key",
-            "description": "The API key value (format: /^[a-zA-Z0-9]{40}$/).",
+            "description": "The API key value.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -4228,6 +4228,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "clientAuthCode",
+            "description": "Auth code for the client initiating the sequence.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null,
@@ -8986,6 +8998,18 @@
             "deprecationReason": null
           },
           {
+            "name": "issueImport",
+            "description": "The import record.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "IssueImport",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "addedLabelIds",
             "description": "ID's of labels that were added.",
             "args": [],
@@ -11487,7 +11511,7 @@
           },
           {
             "name": "apiKeyCreate",
-            "description": "Creates a new API key.",
+            "description": "[Internal] Creates a new API key.",
             "args": [
               {
                 "name": "input",
@@ -11520,7 +11544,7 @@
           },
           {
             "name": "apiKeyDelete",
-            "description": "Deletes an API key.",
+            "description": "[Internal] Deletes an API key.",
             "args": [
               {
                 "name": "id",
@@ -13746,6 +13770,22 @@
             "deprecationReason": null
           },
           {
+            "name": "integrationLoom",
+            "description": "Enables Loom integration for the organization.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IntegrationPayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "integrationDelete",
             "description": "Deletes an integration.",
             "args": [
@@ -13853,7 +13893,7 @@
               },
               {
                 "name": "githubRepoOwner",
-                "description": "Github owner (user or org) for the repository from which we will import data.",
+                "description": "GitHub owner (user or org) for the repository from which we will import data.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -13869,7 +13909,7 @@
               },
               {
                 "name": "githubRepoName",
-                "description": "Github repository name from which we will import data.",
+                "description": "GitHub repository name from which we will import data.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -13885,7 +13925,7 @@
               },
               {
                 "name": "githubToken",
-                "description": "Github token to fetch information from the Github API.",
+                "description": "GitHub token to fetch information from the GitHub API.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -15071,6 +15111,161 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "ArchivePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "oauthAuthStringChallenge",
+            "description": "[Internal] Creates a temporary authentication code that can be exchanged for an OAuth token.",
+            "args": [
+              {
+                "name": "scope",
+                "description": "The group of scopes that are being requested.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "appId",
+                "description": "The identifier of the OAuth client that's trying to authenticate.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "OauthAuthStringChallengePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "oauthAuthStringAuthorize",
+            "description": "[Internal] Authenticates an auth string by the user.",
+            "args": [
+              {
+                "name": "authString",
+                "description": "The auth string to authenticate.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "appId",
+                "description": "The identifier of the OAuth client that's trying to authenticate.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "OauthAuthStringAuthorizePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "oauthAuthStringCheck",
+            "description": "[Internal] Returns an access token once the auth string has been authenticated.",
+            "args": [
+              {
+                "name": "authString",
+                "description": "The auth string to authenticate.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "appId",
+                "description": "The identifier of the OAuth client that's trying to authenticate.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "OauthAuthStringCheckPayload",
                 "ofType": null
               }
             },
@@ -18234,6 +18429,115 @@
       },
       {
         "kind": "OBJECT",
+        "name": "OauthAuthStringAuthorizePayload",
+        "description": null,
+        "fields": [
+          {
+            "name": "success",
+            "description": "Whether the operation was successful.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "OauthAuthStringChallengePayload",
+        "description": null,
+        "fields": [
+          {
+            "name": "success",
+            "description": "Whether the operation was successful.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "authString",
+            "description": "The created authentication string.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "OauthAuthStringCheckPayload",
+        "description": null,
+        "fields": [
+          {
+            "name": "success",
+            "description": "Whether the operation was successful.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "token",
+            "description": "Access token for use.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "OauthClient",
         "description": "OAuth2 client application",
         "fields": [
@@ -20907,6 +21211,22 @@
             "deprecationReason": null
           },
           {
+            "name": "url",
+            "description": "Project URL.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "teams",
             "description": "Teams associated with this project.",
             "args": [
@@ -23149,7 +23469,7 @@
           },
           {
             "name": "apiKeys",
-            "description": "All API keys for the user.",
+            "description": "[Internal] All API keys for the user.",
             "args": [
               {
                 "name": "before",
@@ -32399,6 +32719,22 @@
               "kind": "SCALAR",
               "name": "DateTime",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": "User's profile URL.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null


### PR DESCRIPTION
- pass optional variables to mutations
- no need for eslint ignore unused variables in generated sdk now 🥳
- use async await syntax in generated sdk
- cleanup internal Response type name
- fix schema action test script rename
- update schema