### PR TITLE
feat(import): adding checklists and comments to Trello import

### DIFF
--- a/.changeset/funny-spies-sell.md
+++ b/.changeset/funny-spies-sell.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": patch
+---
+
+feat(import): adding checklists and comments to Trello import


### PR DESCRIPTION
# Changes
* Adding Trello checklists to imported issue descriptions
* Parsing through actions in the Trello JSON export to find created comments and attaching them to issues

<img width="580" alt="Screen Shot 2021-08-02 at 4 38 36 PM" src="https://user-images.githubusercontent.com/4577711/127936750-66e80e52-1426-420b-a600-9002dc8dcbd5.png">

Fixes #121 