### PR TITLE
 feat(import): add attachments to issue description for Trello imports

### DIFF
--- a/.changeset/nine-shirts-cheer.md
+++ b/.changeset/nine-shirts-cheer.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": patch
+---
+
+ feat(import): add attachments to issue description for Trello imports

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -272,7 +272,7 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
 
     await client.issueCreate({
       teamId,
-      projectId: projectId as unknown as string,
+      projectId: (projectId as unknown) as string,
       title: issue.title,
       description,
       priority: issue.priority,

--- a/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
+++ b/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
@@ -14,6 +14,10 @@ interface TrelloCard {
     name: string;
     color: TrelloLabelColor;
   }[];
+  attachments: {
+    name: string;
+    url: string;
+  }[];
   id: string;
   idList: string;
 }
@@ -62,7 +66,7 @@ export class TrelloJsonImporter implements Importer {
 
   public import = async (): Promise<ImportResult> => {
     const bytes = fs.readFileSync(this.filePath);
-    const data = JSON.parse(bytes as unknown as string);
+    const data = JSON.parse((bytes as unknown) as string);
 
     const importData: ImportResult = {
       issues: [],
@@ -108,9 +112,12 @@ export class TrelloJsonImporter implements Importer {
           .map(item => `- [${item.state === "complete" ? "x" : " "}] ${item.name}`)
           .join("\n");
       }
+      const formattedAttachments = card.attachments
+        .map(attachment => `[${attachment.name}](${attachment.url})`)
+        .join("\n");
 
-      const description = `${mdDesc}${
-        formattedChecklist && `\n${formattedChecklist}`
+      const description = `${mdDesc}${formattedChecklist && `\n${formattedChecklist}`}${
+        formattedAttachments && `\n\nAttachments:\n${formattedAttachments}`
       }\n\n[View original card in Trello](${url})`;
       const labels = card.labels.map(l => l.id);
 


### PR DESCRIPTION
# Changes
* Add the list of Trello attachments as a list within the description of an imported issue
* Looks like some auto formatting came along for the ride

<img width="1005" alt="Screen Shot 2021-09-15 at 4 09 45 PM" src="https://user-images.githubusercontent.com/4577711/133525141-acadc0bb-1820-48a7-8645-b61ef44f62c3.png">
