### PR TITLE
Enhance Trello import process - issue status, order

### DIFF
--- a/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
+++ b/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
@@ -173,6 +173,10 @@ export class TrelloJsonImporter implements Importer {
       }
     }
 
+    // reverse order, so that the order of cards in Trello is maintained in
+    // Linear, since linear's UI orders by recency
+    importData.issues.reverse();
+
     return importData;
   };
 

--- a/packages/import/src/importers/trelloJson/index.ts
+++ b/packages/import/src/importers/trelloJson/index.ts
@@ -9,7 +9,8 @@ export const trelloJsonImport = async (): Promise<Importer> => {
   const trelloImporter = new TrelloJsonImporter(
     answers.trelloFilePath,
     answers.discardArchivedCards,
-    answers.discardArchivedLists
+    answers.discardArchivedLists,
+    answers.listToStatusMap
   );
   return trelloImporter;
 };
@@ -18,6 +19,7 @@ interface TrelloImportAnswers {
   trelloFilePath: string;
   discardArchivedCards: boolean;
   discardArchivedLists: boolean;
+  listToStatusMap: string;
 }
 
 const questions = [
@@ -38,5 +40,12 @@ const questions = [
     name: "discardArchivedLists",
     message: "Would you like to discard the (possibly unarchived) cards within archived lists?",
     default: true,
+  },
+  {
+    type: "input",
+    name: "listToStatusMap",
+    message: "Enter a mapping for list name to linear status, e.g. ListName1=Status1,Listname2=Status2",
+    default:
+      "Backlog=Backlog,Todo=Todo,In Progress=In Progress,In Review=In Review,Done=Done,Canceled=Canceled,Triage=Triage",
   },
 ];


### PR DESCRIPTION
When importing a kanban-style trello board to Linear, it's helpful to maintain the status of issues. This PR adds a customisable mapping of Trello list name to Linear status to facilitate this. Issue order is also reversed, as this keeps things visually consistent with Trello - the top trello cards get imported first, meaning they'd otherwise end up at the bottom of the linear backlog.

Both of these changes have been tested out importing issues into our org (Atomic.io)

