### PR TITLE
feat(import): add importer for deque's axe auditor export

### DIFF
--- a/.changeset/slimy-bulldogs-hug.md
+++ b/.changeset/slimy-bulldogs-hug.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": minor
+---
+
+Introduces import capabilities for Deque's Axe Auditor CSV exports

--- a/packages/import/src/cli.ts
+++ b/packages/import/src/cli.ts
@@ -7,6 +7,7 @@ import { clubhouseCsvImport } from "./importers/clubhouseCsv";
 import { githubImport } from "./importers/github";
 import { jiraCsvImport } from "./importers/jiraCsv";
 import { linearCsvImporter } from "./importers/linearCsv";
+import { dequeCsvImporter } from "./importers/dequeCsv";
 import { pivotalCsvImport } from "./importers/pivotalCsv";
 import { trelloJsonImport } from "./importers/trelloJson";
 import { importIssues } from "./importIssues";
@@ -34,6 +35,10 @@ inquirer.registerPrompt("filePath", require("inquirer-file-path"));
           {
             name: "Jira (CSV export)",
             value: "jiraCsv",
+          },
+          {
+            name: "Deque (CSV export)",
+            value: "dequeCsv",
           },
           {
             name: "Asana (CSV export)",
@@ -70,6 +75,9 @@ inquirer.registerPrompt("filePath", require("inquirer-file-path"));
         break;
       case "asanaCsv":
         importer = await asanaCsvImport();
+        break;
+      case "dequeCsv":
+        importer = await dequeCsvImporter();
         break;
       case "pivotalCsv":
         importer = await pivotalCsvImport();

--- a/packages/import/src/importers/dequeCsv/DequeCsvImporter.ts
+++ b/packages/import/src/importers/dequeCsv/DequeCsvImporter.ts
@@ -1,0 +1,145 @@
+import csv from "csvtojson";
+import { Importer, ImportResult } from "../../types";
+
+type DequePriority = "Blocker" | "Critical" | "Serious" | "Moderate" | "Minor";
+
+interface DequeIssueType {
+  "Issue ID": string;
+  Summary: string;
+  Description: string;
+  Impact: DequePriority;
+  "Checkpoint Group": string;
+  "Issue Type": string;
+  "Test Unit": string;
+  "Recommended to fix": string;
+  User: string;
+  "Group Name": string;
+  "Group Description": string;
+  Status: string;
+  "Assign To": string;
+  "Date Created": string;
+  "Digital Asset Type": string;
+  Releases: string;
+  Environment: string;
+  "Assistive technology": string;
+  "Source Code": string;
+  Checkpoint: string;
+  Method: string;
+  "Test Case Name": string;
+  Standards: string;
+  Product: string;
+  URL: string;
+  Screenshots: string;
+  Flagged: string;
+  "Flagged for Reason": string;
+  "Flagged By": string;
+  "Unit Type ": string;
+  "More Info": string;
+  "Issue Comments": string;
+  "Group Notes": string;
+  "Test Unit Screenshot": string;
+  "Test Run Name": string;
+}
+
+/**
+ * Import issues from Deque Auditor CSV export.
+ *
+ * @param filePath  path to csv file
+ */
+export class DequeCsvImporter implements Importer {
+  public constructor(filePath: string) {
+    this.filePath = filePath;
+  }
+
+  public get name(): string {
+    return "Deque (CSV)";
+  }
+
+  public get defaultTeamName(): string {
+    return "Deque";
+  }
+
+  public import = async (): Promise<ImportResult> => {
+    const data = (await csv().fromFile(this.filePath)) as DequeIssueType[];
+
+    const importData: ImportResult = {
+      issues: [],
+      labels: {},
+      users: {},
+      statuses: {},
+    };
+
+    for (const row of data) {
+      importData.issues.push({
+        title: buildTitle(row),
+        description: buildDescription(row),
+        priority: mapPriority(row.Impact),
+        status: "Backlog",
+        assigneeId: undefined,
+        completedAt: undefined,
+        startedAt: undefined,
+      });
+    }
+
+    return importData;
+  };
+
+  // -- Private interface
+
+  private filePath: string;
+}
+
+const buildTitle = (row: DequeIssueType): string => {
+  return `${row["Issue ID"]} - ${row.Summary}`;
+};
+
+const buildDescription = (row: DequeIssueType): string => {
+  let description = "";
+  const issueId = row["Issue ID"];
+  const method = row.Method;
+  const checkpoint = row.Checkpoint;
+  const testCaseName = row["Test Case Name"];
+  const testUnit = row["Test Unit"];
+  const url = row.URL;
+  const screenshots = row.Screenshots;
+  const testUnitScreenshot = row["Test Unit Screenshot"];
+  const dequeDescription = row.Description;
+  const recommendedToFix = row["Recommended to fix"];
+  const sourceCode = row["Source Code"];
+  const moreInfo = row["More Info"];
+
+  description += "## Description\n";
+  description += dequeDescription;
+  description += "\n\n";
+  description += "## Recommended to fix\n";
+  description += recommendedToFix;
+  description += "\n\n";
+  description += "## Source code\n";
+  description += `${sourceCode}`;
+  description += "\n\n";
+  description += "## More info\n";
+  description += moreInfo;
+  description += "\n\n";
+  description += `Test case name: ${testCaseName}\n`;
+  description += `Checkpoint: ${checkpoint}\n`;
+  description += `Test unit: ${testUnit}\n`;
+  description += `URL: ${url}\n`;
+  description += `Deque Auditor Issue ID: ${issueId}\n`;
+  description += `Method: ${method}\n`;
+  description += `Test unit screenshot: ${testUnitScreenshot}\n`;
+  description += `Screenshots: ${screenshots}\n`;
+
+  return description;
+};
+
+const mapPriority = (input: DequePriority): number => {
+  const priorityMap = {
+    Minor: 4,
+    Moderate: 4,
+    Serious: 3,
+    Critical: 2,
+    Blocker: 1,
+  };
+
+  return priorityMap[input] || 0;
+};

--- a/packages/import/src/importers/dequeCsv/index.ts
+++ b/packages/import/src/importers/dequeCsv/index.ts
@@ -1,0 +1,25 @@
+import * as inquirer from "inquirer";
+
+import { Importer } from "../../types";
+import { DequeCsvImporter } from "./DequeCsvImporter";
+
+const BASE_PATH = process.cwd();
+
+export const dequeCsvImporter = async (): Promise<Importer> => {
+  const answers = await inquirer.prompt<DequeImportAnswers>(questions);
+  const dequeImporter = new DequeCsvImporter(answers.dequeFilePath);
+  return dequeImporter;
+};
+
+interface DequeImportAnswers {
+  dequeFilePath: string;
+}
+
+const questions = [
+  {
+    basePath: BASE_PATH,
+    type: "filePath",
+    name: "dequeFilePath",
+    message: "Select your exported CSV file of Deque Auditor issues",
+  },
+];


### PR DESCRIPTION
Deque's Axe Auditor is an issue tracking system used in-house by them
when running accessibility audits. This commit matches the CSV export
structure they use and munges that data into a format that works with
Linear's import API.