### PR TITLE
GitLab issues import 

### DIFF
--- a/packages/import/README.md
+++ b/packages/import/README.md
@@ -33,6 +33,22 @@ Supported fields:
 - Labels
 - (Optional) Comments
 
+### GitLab for Personal
+
+Open GitLab issues can be imported with your personal access token from GitLab's API.
+
+Supported fields:
+
+- `title` - Issue Title
+- `description` - Issue Description
+- `url` - Issue URL
+- `labels` - Issue Labels
+- `assignees` - Issue Assignees
+- `createdAt` - Issue Creation Date
+- `dueDate` - Issue Due Date
+- `priority` - Issue Priority
+- `status` - Issue Status
+
 ### Jira CSV
 
 Jira project can be imported into a Linear team from the CSV export file.

--- a/packages/import/src/cli.ts
+++ b/packages/import/src/cli.ts
@@ -11,6 +11,7 @@ import { pivotalCsvImport } from "./importers/pivotalCsv";
 import { trelloJsonImport } from "./importers/trelloJson";
 import { importIssues } from "./importIssues";
 import { ImportAnswers } from "./types";
+import { gitlabImport } from "./importers/gitlab";
 
 inquirer.registerPrompt("filePath", require("inquirer-file-path"));
 
@@ -30,6 +31,10 @@ inquirer.registerPrompt("filePath", require("inquirer-file-path"));
           {
             name: "GitHub",
             value: "github",
+          },
+          {
+            name: "GitLab",
+            value: "gitlab",
           },
           {
             name: "Jira (CSV export)",
@@ -64,6 +69,9 @@ inquirer.registerPrompt("filePath", require("inquirer-file-path"));
     switch (importAnswers.service) {
       case "github":
         importer = await githubImport();
+        break;
+      case "gitlab":
+        importer = await gitlabImport();
         break;
       case "jiraCsv":
         importer = await jiraCsvImport();

--- a/packages/import/src/importers/gitlab/GitlabImporter.ts
+++ b/packages/import/src/importers/gitlab/GitlabImporter.ts
@@ -1,0 +1,151 @@
+/* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Importer, ImportResult } from "../../types";
+import { getGitlabIssuesFromRepo, getGitlabProjectId } from "./client";
+
+export interface GITLAB_ISSUE {
+  id: number;
+  title: string;
+  description: string;
+  labels: string[];
+  assignees: Assignee[];
+  due_date: string;
+  severity: string;
+  web_url: string;
+  created_at: Date;
+  state: string;
+}
+
+type LinearPriority = "No priority" | "Urgent" | "High" | "Medium" | "Low";
+
+export interface Author {
+  state: string;
+  id: number;
+  web_url: string;
+  name: string;
+  avatar_url: any;
+  username: string;
+}
+
+export interface Milestone {
+  project_id: number;
+  description: string;
+  state: string;
+  due_date: any;
+  iid: number;
+  created_at: string;
+  title: string;
+  id: number;
+  updated_at: string;
+}
+
+export interface Assignee {
+  state: string;
+  id: number;
+  name: string;
+  web_url: string;
+  avatar_url: any;
+  username: string;
+}
+
+export interface References {
+  short: string;
+  relative: string;
+  full: string;
+}
+
+export interface TimeStats {
+  time_estimate: number;
+  total_time_spent: number;
+  human_time_estimate: any;
+  human_total_time_spent: any;
+}
+
+export interface Links {
+  self: string;
+  notes: string;
+  award_emoji: string;
+  project: string;
+}
+
+export interface TaskCompletionStatus {
+  count: number;
+  completed_count: number;
+}
+
+/**
+ * Fetch and paginate through all Github issues.
+ *
+ * @param accessToken GitLab access token for authentication
+ */
+export class GitLabImporter implements Importer {
+  private readonly accessToken: string;
+  private readonly projectName: string;
+
+  public constructor(projectId: string, accessToken: string) {
+    this.projectName = projectId;
+    this.accessToken = accessToken;
+  }
+
+  public get name(): string {
+    return "GitLab";
+  }
+
+  public get defaultTeamName(): string {
+    return "GitLab";
+  }
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  public import = async (): Promise<ImportResult> => {
+    const projectId = await getGitlabProjectId(this.accessToken, this.projectName);
+
+    const issues: GITLAB_ISSUE[] = await getGitlabIssuesFromRepo(this.accessToken, projectId);
+
+    const importData: ImportResult = {
+      issues: [],
+      labels: {},
+      users: {},
+    };
+
+    for (const issue of issues) {
+      importData.issues.push({
+        title: issue.title,
+        description: issue.description,
+        url: issue.web_url,
+        labels: issue.labels,
+        createdAt: new Date(issue.created_at),
+        dueDate: issue.due_date ? new Date(issue.due_date) : undefined,
+        priority: mapPriority("Low"),
+        status: issue.state,
+      });
+
+      for (const assignee of issue.assignees) {
+        importData.users[assignee.id] = {
+          name: assignee.name,
+          avatarUrl: assignee.avatar_url,
+        };
+      }
+
+      for (const label of issue.labels) {
+        importData.labels[label] = {
+          name: label,
+        };
+      }
+    }
+
+    return importData;
+  };
+}
+
+const mapPriority = (input: LinearPriority): number => {
+  const priorityMap = {
+    "No priority": 0,
+    Urgent: 1,
+    High: 2,
+    Medium: 3,
+    Low: 4,
+  };
+
+  return priorityMap[input] || 0;
+};

--- a/packages/import/src/importers/gitlab/client.ts
+++ b/packages/import/src/importers/gitlab/client.ts
@@ -1,0 +1,74 @@
+import fetch from "node-fetch";
+import { GITLAB_ISSUE } from "./GitlabImporter";
+
+const GITLAB_API = "https://gitlab.com/api/v4";
+
+export const gitlabClient = (apiKey: string) => {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  return async (path: string, method: string, body?: never) => {
+    const headers = {
+      "Content-Type": "application/json",
+      "PRIVATE-TOKEN": apiKey,
+    };
+
+    const response = await fetch(`${GITLAB_API}/${path}`, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (response.status === 401) {
+      throw new Error("Invalid API key");
+    }
+
+    if (response.status === 404) {
+      throw new Error("Not found");
+    }
+
+    if (response.status !== 200) {
+      throw new Error(`Unexpected status code: ${response.status}`);
+    }
+
+    return response.json();
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const getGitlabProjectId = (apiKey: string, projectName: string) => {
+  return gitlabClient(apiKey)("projects?per_page=100&visibility=private", "GET")
+    .then(projects => {
+      // eslint-disable-next-line @typescript-eslint/no-shadow
+      const { id } = projects.find((project: { path: string }) => project.path === projectName);
+
+      if (!id) {
+        throw new Error(`Project ${projectName} not found`);
+      }
+
+      return id;
+    })
+    .catch(error => {
+      throw new Error(`Failed to get project: ${error.message}`);
+    });
+};
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const getGitlabIssuesFromRepo = async (apiKey: string, projectId: number) => {
+  return await gitlabClient(apiKey)(`projects/${projectId}/issues?per_page=100`, "GET")
+    .then(issues =>
+      issues.map((issue: GITLAB_ISSUE) => ({
+        id: issue.id,
+        title: issue.title,
+        description: issue.description,
+        labels: issue.labels,
+        assignees: issue.assignees,
+        due_date: issue.due_date,
+        severity: issue.severity,
+        web_url: issue.web_url,
+        created_at: issue.created_at,
+        state: issue.state,
+      }))
+    )
+    .catch(error => {
+      throw new Error(`Failed to get issues: ${error.message}`);
+    });
+};

--- a/packages/import/src/importers/gitlab/index.ts
+++ b/packages/import/src/importers/gitlab/index.ts
@@ -1,0 +1,40 @@
+import * as inquirer from "inquirer";
+import { Importer } from "../../types";
+import { GitLabImporter } from "./GitlabImporter";
+
+export const gitlabImport = async (): Promise<Importer> => {
+  const answer = await inquirer.prompt<GitLabImportAnswers>(gitlabImportQuestions);
+
+  const [, projectName] = answer.repo.split("/");
+  return new GitLabImporter(projectName, answer.gitlabAccessToken);
+};
+
+interface GitLabImportAnswers {
+  gitlabAccessToken: string;
+  repo: string;
+}
+
+const gitlabImportQuestions = [
+  {
+    type: "input",
+    name: "gitlabAccessToken",
+    message: "GitLab Access Token(personal):",
+    validate: (input: string) => {
+      if (input.length > 0) {
+        return true;
+      }
+      return "Please enter your GitLab access token";
+    },
+  },
+  {
+    type: "input",
+    name: "repo",
+    message: "Repository(account/project):",
+    validate: (input: string) => {
+      if (input.length > 0) {
+        return true;
+      }
+      return "Please enter the repository";
+    },
+  },
+];

--- a/packages/import/src/importers/index.ts
+++ b/packages/import/src/importers/index.ts
@@ -1,1 +1,2 @@
 export * from "./github";
+export * from "./gitlab";


### PR DESCRIPTION
You can be able to import your issues from the personal gitlab account.

Supported fields:

- `title` - Issue Title
- `description` - Issue Description
- `url` - Issue URL
- `labels` - Issue Labels
- `assignees` - Issue Assignees
- `createdAt` - Issue Creation Date
- `dueDate` - Issue Due Date
- `priority` - Issue Priority
- `status` - Issue Status