### PR TITLE
Add support for interfaces

### DIFF
--- a/packages/codegen-doc/src/context-visitor.ts
+++ b/packages/codegen-doc/src/context-visitor.ts
@@ -1,6 +1,12 @@
 import { DEFAULT_SCALARS } from "@graphql-codegen/visitor-plugin-common";
 import autoBind from "auto-bind";
-import { FieldDefinitionNode, GraphQLSchema, ObjectTypeDefinitionNode, ScalarTypeDefinitionNode } from "graphql";
+import {
+  FieldDefinitionNode,
+  GraphQLSchema,
+  InterfaceTypeDefinitionNode,
+  ObjectTypeDefinitionNode,
+  ScalarTypeDefinitionNode,
+} from "graphql";
 import { OperationType, PluginConfig, PluginContext } from "./types";
 
 /**
@@ -11,6 +17,7 @@ export class ContextVisitor<Config extends PluginConfig> {
   private _config: Config;
   private _scalars: typeof DEFAULT_SCALARS = DEFAULT_SCALARS;
   private _objects: ObjectTypeDefinitionNode[] = [];
+  private _interfaces: InterfaceTypeDefinitionNode[] = [];
   private _queries: FieldDefinitionNode[] = [];
   private _mutations: FieldDefinitionNode[] = [];
 
@@ -31,6 +38,7 @@ export class ContextVisitor<Config extends PluginConfig> {
       config: this._config,
       scalars: this._scalars,
       objects: this._objects,
+      interfaces: this._interfaces,
       queries: this._queries,
       mutations: this._mutations,
       operationMap: {
@@ -63,6 +71,14 @@ export class ContextVisitor<Config extends PluginConfig> {
         this._mutations = node.fields as FieldDefinitionNode[];
       }
 
+      return node;
+    },
+  };
+
+  public InterfaceTypeDefinition = {
+    /** Record all interface types */
+    enter: (node: InterfaceTypeDefinitionNode): InterfaceTypeDefinitionNode => {
+      this._interfaces = [...this._interfaces, node];
       return node;
     },
   };

--- a/packages/codegen-doc/src/fragment.ts
+++ b/packages/codegen-doc/src/fragment.ts
@@ -1,4 +1,9 @@
-import { FieldDefinitionNode, ObjectTypeDefinitionNode, OperationTypeDefinitionNode } from "graphql";
+import {
+  FieldDefinitionNode,
+  InterfaceTypeDefinitionNode,
+  ObjectTypeDefinitionNode,
+  OperationTypeDefinitionNode,
+} from "graphql";
 import { isEdge, isOperationRoot } from "./object";
 import { printTypescriptType } from "./print";
 import { Named, NamedFields, PluginContext } from "./types";
@@ -9,7 +14,7 @@ import { Named, NamedFields, PluginContext } from "./types";
 export function findFragment(
   context: PluginContext,
   node?: OperationTypeDefinitionNode | FieldDefinitionNode | Named<FieldDefinitionNode>
-): NamedFields<ObjectTypeDefinitionNode> | undefined {
+): NamedFields<ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode> | undefined {
   if (node) {
     const type = printTypescriptType(context, node.type).replace("[]", "");
     return context.fragments.find(operation => operation.name === type);
@@ -18,9 +23,9 @@ export function findFragment(
 }
 
 /**
- * Check whether this fragment has valid content and is not a connection, edge or root
+ * Check whether this object has valid content and is not a connection, edge or root
  */
-export function isValidFragment(context: PluginContext, fragment: NamedFields<ObjectTypeDefinitionNode>): boolean {
+export function isValidObject(context: PluginContext, fragment: NamedFields<ObjectTypeDefinitionNode>): boolean {
   const hasFields = (fragment.fields ?? []).filter(Boolean).length;
   return Boolean(hasFields && !isEdge(fragment) && !isOperationRoot(context, fragment));
 }

--- a/packages/codegen-doc/src/object.ts
+++ b/packages/codegen-doc/src/object.ts
@@ -1,4 +1,4 @@
-import { FieldDefinitionNode, ObjectTypeDefinitionNode } from "graphql";
+import { FieldDefinitionNode, InterfaceTypeDefinitionNode, ObjectTypeDefinitionNode } from "graphql";
 import { Named, NamedFields, PluginContext } from "./types";
 import { reduceTypeName } from "./utils";
 
@@ -12,6 +12,20 @@ export function findObject(
   if (field) {
     const type = reduceTypeName(field.type);
     return context.objects.find(operation => operation.name.value === type);
+  }
+  return undefined;
+}
+
+/**
+ * Get the interface type matching the name arg
+ */
+export function findInterface(
+  context: PluginContext,
+  field?: FieldDefinitionNode | Named<FieldDefinitionNode>
+): InterfaceTypeDefinitionNode | undefined {
+  if (field) {
+    const type = reduceTypeName(field.type);
+    return context.interfaces.find(operation => operation.name.value === type);
   }
   return undefined;
 }

--- a/packages/codegen-doc/src/types.ts
+++ b/packages/codegen-doc/src/types.ts
@@ -1,5 +1,11 @@
 import { DEFAULT_SCALARS } from "@graphql-codegen/visitor-plugin-common";
-import { ASTNode, FieldDefinitionNode, GraphQLSchema, ObjectTypeDefinitionNode } from "graphql";
+import {
+  ASTNode,
+  FieldDefinitionNode,
+  GraphQLSchema,
+  InterfaceTypeDefinitionNode,
+  ObjectTypeDefinitionNode,
+} from "graphql";
 
 /**
  * Changes name and type properties to string
@@ -25,9 +31,9 @@ export enum OperationType {
 }
 
 /**
- * The processed fragment object definition
+ * The processed fragment object or interface definition
  */
-export type Fragment = NamedFields<ObjectTypeDefinitionNode>;
+export type Fragment = NamedFields<ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode>;
 
 export interface PluginConfig {
   /**
@@ -96,6 +102,8 @@ export interface PluginContext<C extends PluginConfig = PluginConfig> {
   fragments: Fragment[];
   /** All object definitions */
   objects: ObjectTypeDefinitionNode[];
+  /** All interface definitions */
+  interfaces: InterfaceTypeDefinitionNode[];
   /** All query field definitions */
   queries: readonly FieldDefinitionNode[];
   /** All mutation field definitions */

--- a/packages/sdk/src/_generated_documents.graphql
+++ b/packages/sdk/src/_generated_documents.graphql
@@ -2254,6 +2254,10 @@ fragment MilestonePayload on MilestonePayload {
   success
 }
 
+fragment Node on Node {
+  # The unique identifier of the entity.
+  id
+}
 fragment NotificationConnection on NotificationConnection {
   nodes {
     ...Notification

--- a/packages/sdk/src/_generated_documents.ts
+++ b/packages/sdk/src/_generated_documents.ts
@@ -8080,6 +8080,125 @@ export type MilestonePayloadFragment = { __typename?: "MilestonePayload" } & Pic
   "lastSyncId" | "success"
 > & { milestone?: Maybe<{ __typename?: "Milestone" } & Pick<Milestone, "id">> };
 
+type Node_ApiKey_Fragment = { __typename?: "ApiKey" } & Pick<ApiKey, "id">;
+
+type Node_Attachment_Fragment = { __typename?: "Attachment" } & Pick<Attachment, "id">;
+
+type Node_AuditEntry_Fragment = { __typename?: "AuditEntry" } & Pick<AuditEntry, "id">;
+
+type Node_Comment_Fragment = { __typename?: "Comment" } & Pick<Comment, "id">;
+
+type Node_CustomView_Fragment = { __typename?: "CustomView" } & Pick<CustomView, "id">;
+
+type Node_Cycle_Fragment = { __typename?: "Cycle" } & Pick<Cycle, "id">;
+
+type Node_Document_Fragment = { __typename?: "Document" } & Pick<Document, "id">;
+
+type Node_DocumentStep_Fragment = { __typename?: "DocumentStep" } & Pick<DocumentStep, "id">;
+
+type Node_DocumentVersion_Fragment = { __typename?: "DocumentVersion" } & Pick<DocumentVersion, "id">;
+
+type Node_Emoji_Fragment = { __typename?: "Emoji" } & Pick<Emoji, "id">;
+
+type Node_Favorite_Fragment = { __typename?: "Favorite" } & Pick<Favorite, "id">;
+
+type Node_Integration_Fragment = { __typename?: "Integration" } & Pick<Integration, "id">;
+
+type Node_IntegrationResource_Fragment = { __typename?: "IntegrationResource" } & Pick<IntegrationResource, "id">;
+
+type Node_Issue_Fragment = { __typename?: "Issue" } & Pick<Issue, "id">;
+
+type Node_IssueHistory_Fragment = { __typename?: "IssueHistory" } & Pick<IssueHistory, "id">;
+
+type Node_IssueImport_Fragment = { __typename?: "IssueImport" } & Pick<IssueImport, "id">;
+
+type Node_IssueLabel_Fragment = { __typename?: "IssueLabel" } & Pick<IssueLabel, "id">;
+
+type Node_IssueRelation_Fragment = { __typename?: "IssueRelation" } & Pick<IssueRelation, "id">;
+
+type Node_Milestone_Fragment = { __typename?: "Milestone" } & Pick<Milestone, "id">;
+
+type Node_Notification_Fragment = { __typename?: "Notification" } & Pick<Notification, "id">;
+
+type Node_NotificationSubscription_Fragment = { __typename?: "NotificationSubscription" } & Pick<
+  NotificationSubscription,
+  "id"
+>;
+
+type Node_OauthClient_Fragment = { __typename?: "OauthClient" } & Pick<OauthClient, "id">;
+
+type Node_Organization_Fragment = { __typename?: "Organization" } & Pick<Organization, "id">;
+
+type Node_OrganizationDomain_Fragment = { __typename?: "OrganizationDomain" } & Pick<OrganizationDomain, "id">;
+
+type Node_OrganizationInvite_Fragment = { __typename?: "OrganizationInvite" } & Pick<OrganizationInvite, "id">;
+
+type Node_Project_Fragment = { __typename?: "Project" } & Pick<Project, "id">;
+
+type Node_ProjectLink_Fragment = { __typename?: "ProjectLink" } & Pick<ProjectLink, "id">;
+
+type Node_PushSubscription_Fragment = { __typename?: "PushSubscription" } & Pick<PushSubscription, "id">;
+
+type Node_Reaction_Fragment = { __typename?: "Reaction" } & Pick<Reaction, "id">;
+
+type Node_Subscription_Fragment = { __typename?: "Subscription" } & Pick<Subscription, "id">;
+
+type Node_Team_Fragment = { __typename?: "Team" } & Pick<Team, "id">;
+
+type Node_TeamMembership_Fragment = { __typename?: "TeamMembership" } & Pick<TeamMembership, "id">;
+
+type Node_Template_Fragment = { __typename?: "Template" } & Pick<Template, "id">;
+
+type Node_User_Fragment = { __typename?: "User" } & Pick<User, "id">;
+
+type Node_UserSettings_Fragment = { __typename?: "UserSettings" } & Pick<UserSettings, "id">;
+
+type Node_ViewPreferences_Fragment = { __typename?: "ViewPreferences" } & Pick<ViewPreferences, "id">;
+
+type Node_Webhook_Fragment = { __typename?: "Webhook" } & Pick<Webhook, "id">;
+
+type Node_WorkflowState_Fragment = { __typename?: "WorkflowState" } & Pick<WorkflowState, "id">;
+
+export type NodeFragment =
+  | Node_ApiKey_Fragment
+  | Node_Attachment_Fragment
+  | Node_AuditEntry_Fragment
+  | Node_Comment_Fragment
+  | Node_CustomView_Fragment
+  | Node_Cycle_Fragment
+  | Node_Document_Fragment
+  | Node_DocumentStep_Fragment
+  | Node_DocumentVersion_Fragment
+  | Node_Emoji_Fragment
+  | Node_Favorite_Fragment
+  | Node_Integration_Fragment
+  | Node_IntegrationResource_Fragment
+  | Node_Issue_Fragment
+  | Node_IssueHistory_Fragment
+  | Node_IssueImport_Fragment
+  | Node_IssueLabel_Fragment
+  | Node_IssueRelation_Fragment
+  | Node_Milestone_Fragment
+  | Node_Notification_Fragment
+  | Node_NotificationSubscription_Fragment
+  | Node_OauthClient_Fragment
+  | Node_Organization_Fragment
+  | Node_OrganizationDomain_Fragment
+  | Node_OrganizationInvite_Fragment
+  | Node_Project_Fragment
+  | Node_ProjectLink_Fragment
+  | Node_PushSubscription_Fragment
+  | Node_Reaction_Fragment
+  | Node_Subscription_Fragment
+  | Node_Team_Fragment
+  | Node_TeamMembership_Fragment
+  | Node_Template_Fragment
+  | Node_User_Fragment
+  | Node_UserSettings_Fragment
+  | Node_ViewPreferences_Fragment
+  | Node_Webhook_Fragment
+  | Node_WorkflowState_Fragment;
+
 export type NotificationConnectionFragment = { __typename?: "NotificationConnection" } & {
   nodes: Array<{ __typename?: "Notification" } & NotificationFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
@@ -14401,6 +14520,17 @@ export const MilestonePayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<MilestonePayloadFragment, unknown>;
+export const NodeFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "Node" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Node" } },
+      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }] },
+    },
+  ],
+} as unknown as DocumentNode<NodeFragment, unknown>;
 export const NotificationFragmentDoc = {
   kind: "Document",
   definitions: [

--- a/packages/sdk/src/_generated_sdk.ts
+++ b/packages/sdk/src/_generated_sdk.ts
@@ -3116,6 +3116,21 @@ export class MilestonePayload extends Request {
   }
 }
 /**
+ * Node model
+ *
+ * @param request - function to call the graphql client
+ * @param data - L.NodeFragment response data
+ */
+export class Node extends Request {
+  public constructor(request: LinearRequest, data: L.NodeFragment) {
+    super(request);
+    this.id = data.id;
+  }
+
+  /** The unique identifier of the entity. */
+  public id: string;
+}
+/**
  * A notification sent to a user.
  *
  * @param request - function to call the graphql client


### PR DESCRIPTION
Adds support for interfaces.
1. ContextVisitor picks them up
2. Codegen-doc generates fragments for them
3. Codegen-sdk also picks them up (which in turn generates classes for them)

This had the side-effect of adding the Node interface (which was our only used interface).