### PR TITLE
feat(sdk): fix interface support

### DIFF
--- a/.changeset/_generated_schema_2268650.md
+++ b/.changeset/_generated_schema_2268650.md
@@ -1,0 +1,10 @@
+---
+"@linear/sdk": minor
+---
+
+
+feat(schema): [breaking] 'Notification' kind changed from 'ObjectTypeDefinition' to 'InterfaceTypeDefinition' (Notification)
+
+feat(schema): [non_breaking] Type 'Entity' was added (Entity)
+
+feat(schema): [non_breaking] Type 'IssueNotification' was added (IssueNotification)

--- a/packages/codegen-doc/package.json
+++ b/packages/codegen-doc/package.json
@@ -17,7 +17,7 @@
     "dist"
   ],
   "scripts": {
-    "build:clean": "npx rimraf dist",
+    "build:clean": "npx rimraf -G dist .rollup-cache tsconfig.tsbuildinfo",
     "build:codegen-doc": "run-s build:clean build:rollup",
     "build:rollup": "npx rollup -c"
   },

--- a/packages/codegen-doc/src/context-visitor.ts
+++ b/packages/codegen-doc/src/context-visitor.ts
@@ -20,6 +20,7 @@ export class ContextVisitor<Config extends PluginConfig> {
   private _interfaces: InterfaceTypeDefinitionNode[] = [];
   private _queries: FieldDefinitionNode[] = [];
   private _mutations: FieldDefinitionNode[] = [];
+  private _interfaceImplementations: { [interfaceName: string]: ObjectTypeDefinitionNode[] } = {};
 
   /** Initialize the visitor */
   public constructor(schema: GraphQLSchema, config: Config) {
@@ -45,6 +46,16 @@ export class ContextVisitor<Config extends PluginConfig> {
         [OperationType.query]: this._schema.getQueryType()?.name ?? "Query",
         [OperationType.mutation]: this._schema.getMutationType()?.name ?? "Mutation",
       },
+      interfaceImplementations: Object.fromEntries(
+        this._interfaces
+          .filter(interfaceDefinition => !["Node", "Entity"].includes(interfaceDefinition.name.value))
+          .map(interfaceDefinition => [
+            interfaceDefinition.name.value,
+            this._objects.filter(objectDefinition =>
+              objectDefinition.interfaces?.some(i => i.name.value === interfaceDefinition.name.value)
+            ),
+          ])
+      ),
     };
   }
 

--- a/packages/codegen-doc/src/fragment-visitor.ts
+++ b/packages/codegen-doc/src/fragment-visitor.ts
@@ -66,6 +66,7 @@ export class FragmentVisitor {
           printGraphqlDescription(node.description?.value),
           printGraphqlDebug(node),
           `fragment ${node.name} on ${node.name} {
+            __typename
             ${printLines(node.fields.sort())}
           }`,
           " ",
@@ -88,8 +89,18 @@ export class FragmentVisitor {
         printGraphqlDescription(node.description?.value),
         printGraphqlDebug(node),
         `fragment ${node.name} on ${node.name} {
+          __typename
           ${printLines(node.fields.sort())}
-        }`,
+          ${(
+            this._context.interfaceImplementations[node.name]?.map(
+              obj => `
+                ... on ${obj.name.value} {
+                  ... ${obj.name.value}
+                }`
+            ) ?? []
+          ).join("\n")}
+          }
+        `,
       ]);
     },
   };

--- a/packages/codegen-doc/src/types.ts
+++ b/packages/codegen-doc/src/types.ts
@@ -110,6 +110,8 @@ export interface PluginContext<C extends PluginConfig = PluginConfig> {
   mutations: readonly FieldDefinitionNode[];
   /** A map for determining operation type names */
   operationMap: Record<OperationType, string>;
+  /** All implementations of an interface */
+  interfaceImplementations: { [interfaceName: string]: ObjectTypeDefinitionNode[] };
   /** The plugin config */
   config: C;
 }

--- a/packages/codegen-sdk/package.json
+++ b/packages/codegen-sdk/package.json
@@ -17,7 +17,7 @@
     "dist"
   ],
   "scripts": {
-    "build:clean": "npx rimraf dist",
+    "build:clean": "npx rimraf -G dist .rollup-cache tsconfig.tsbuildinfo",
     "build:codegen-sdk": "run-s build:clean build:rollup",
     "build:rollup": "npx rollup -c"
   },

--- a/packages/codegen-sdk/src/model-visitor.ts
+++ b/packages/codegen-sdk/src/model-visitor.ts
@@ -23,6 +23,7 @@ import { Sdk } from "./constants";
 import { printNamespaced } from "./print";
 import {
   SdkConnectionField,
+  SdkInterfaceField,
   SdkListField,
   SdkModel,
   SdkModelField,
@@ -185,6 +186,8 @@ function leaveObjectOrInterface(_node: ObjectTypeDefinitionNode | InterfaceTypeD
         scalar: (fields?.filter(field => field.__typename === SdkModelFieldType.scalar) ?? []) as SdkScalarField[],
         query: (fields?.filter(field => field.__typename === SdkModelFieldType.query) ?? []) as SdkQueryField[],
         object: (fields?.filter(field => field.__typename === SdkModelFieldType.object) ?? []) as SdkObjectField[],
+        interface: (fields?.filter(field => field.__typename === SdkModelFieldType.interface) ??
+          []) as SdkInterfaceField[],
         list: (fields?.filter(field => field.__typename === SdkModelFieldType.list) ?? []) as SdkListField[],
         scalarList: (fields?.filter(field => field.__typename === SdkModelFieldType.scalarList) ??
           []) as SdkScalarListField[],

--- a/packages/codegen-sdk/src/types.ts
+++ b/packages/codegen-sdk/src/types.ts
@@ -1,5 +1,10 @@
 import { ArgDefinition, ArgList, PluginConfig, PluginContext } from "@linear/codegen-doc";
-import { FieldDefinitionNode, ObjectTypeDefinitionNode, OperationDefinitionNode } from "graphql";
+import {
+  FieldDefinitionNode,
+  InterfaceTypeDefinitionNode,
+  ObjectTypeDefinitionNode,
+  OperationDefinitionNode,
+} from "graphql";
 
 /**
  * Parsed sdk plugin config
@@ -65,7 +70,7 @@ export interface SdkOperation {
   /** The query for this operation */
   query?: FieldDefinitionNode;
   /** The fragment returned by this operation */
-  fragment?: ObjectTypeDefinitionNode;
+  fragment?: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode;
   /** The model for this operation */
   model?: SdkModel;
   /** All args for this operation */
@@ -120,6 +125,7 @@ export enum SdkModelFieldType {
   scalar = "SdkScalarField ",
   query = "SdkQueryField ",
   object = "SdkObjectField ",
+  interface = "SdkInterfaceField ",
   list = "SdkListField ",
   scalarList = "SdkScalarListField",
   connection = "SdkConnectionField",
@@ -170,6 +176,15 @@ export interface SdkObjectField extends Omit<SdkScalarField, "__typename"> {
 }
 
 /**
+ * A field with interface type
+ */
+export interface SdkInterfaceField extends Omit<SdkScalarField, "__typename"> {
+  __typename: SdkModelFieldType.interface;
+  /** The interface matching this field */
+  object: InterfaceTypeDefinitionNode;
+}
+
+/**
  * A field with connection object type
  */
 export interface SdkConnectionField extends Omit<SdkScalarField, "__typename"> {
@@ -194,6 +209,7 @@ export type SdkModelField =
   | SdkScalarField
   | SdkQueryField
   | SdkObjectField
+  | SdkInterfaceField
   | SdkListField
   | SdkScalarListField
   | SdkConnectionField;
@@ -201,7 +217,7 @@ export type SdkModelField =
 /**
  * The processed sdk model node
  */
-export interface SdkModelNode extends Omit<ObjectTypeDefinitionNode, "fields"> {
+export interface SdkModelNode extends Omit<ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode, "fields"> {
   /** The processed field nodes */
   fields?: SdkModelField[];
 }
@@ -222,6 +238,7 @@ export interface SdkModel {
     scalar: SdkScalarField[];
     query: SdkQueryField[];
     object: SdkObjectField[];
+    interface: SdkInterfaceField[];
     list: SdkListField[];
     scalarList: SdkScalarListField[];
     connection: SdkConnectionField[];

--- a/packages/codegen-test/package.json
+++ b/packages/codegen-test/package.json
@@ -17,7 +17,7 @@
     "dist"
   ],
   "scripts": {
-    "build:clean": "npx rimraf dist",
+    "build:clean": "npx rimraf -G dist .rollup-cache tsconfig.tsbuildinfo",
     "build:codegen-test": "run-s build:clean build:rollup",
     "build:rollup": "npx rollup -c"
   },

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -23,7 +23,7 @@
     "dev:import": "NODE_ENV=development yarn build:import",
     "build:import": "run-s build:clean build:rollup",
     "build:rollup": "npx rollup -c",
-    "build:clean": "npx rimraf dist"
+    "build:clean": "npx rimraf -G dist .rollup-cache tsconfig.tsbuildinfo"
   },
   "dependencies": {
     "@linear/sdk": "^1.21.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -17,7 +17,7 @@
     "dist"
   ],
   "scripts": {
-    "build:clean": "npx rimraf dist",
+    "build:clean": "npx rimraf -G dist .rollup-cache tsconfig.tsbuildinfo",
     "build:sdk": "run-s build:clean build:rollup",
     "build:rollup": "npx rollup -c",
     "generate:changeset:dependencies": "ts-node scripts/generate-dependencies-changeset.ts",

--- a/packages/sdk/src/_generated_documents.graphql
+++ b/packages/sdk/src/_generated_documents.graphql
@@ -1,5 +1,20 @@
+# A basic entity.
+fragment Entity on Entity {
+  __typename
+  # The last time at which the entity was updated. This is the same as the creation time if the
+  #     entity hasn't been updated after creation.
+  updatedAt
+  # The time at which the entity was archived. Null if the entity has not been archived.
+  archivedAt
+  # The time at which the entity was created.
+  createdAt
+  # The unique identifier of the entity.
+  id
+}
+
 # A comment associated with an issue.
 fragment Comment on Comment {
+  __typename
   # Comment's URL.
   url
   # The comment content in markdown format.
@@ -31,6 +46,7 @@ fragment Comment on Comment {
 
 # A custom emoji.
 fragment Emoji on Emoji {
+  __typename
   # The emoji image URL.
   url
   # The emoji's name.
@@ -54,6 +70,7 @@ fragment Emoji on Emoji {
 
 # A custom view that has been saved by a user.
 fragment CustomView on CustomView {
+  __typename
   # The color of the icon of the custom view.
   color
   # The description of the custom view.
@@ -89,6 +106,7 @@ fragment CustomView on CustomView {
 
 # A document for a project.
 fragment Document on Document {
+  __typename
   # The color of the icon.
   color
   # The document content as JSON.
@@ -126,6 +144,7 @@ fragment Document on Document {
 
 # A milestone that contains projects.
 fragment Milestone on Milestone {
+  __typename
   # The last time at which the entity was updated. This is the same as the creation time if the
   #     entity hasn't been updated after creation.
   updatedAt
@@ -143,29 +162,12 @@ fragment Milestone on Milestone {
 
 # A notification sent to a user.
 fragment Notification on Notification {
-  # Name of the reaction emoji associated with the notification.
-  reactionEmoji
+  __typename
   # Notification type
   type
-  # The comment which the notification is associated with.
-  comment {
-    id
-  }
-  # The issue that the notification is associated with.
-  issue {
-    id
-  }
   # The last time at which the entity was updated. This is the same as the creation time if the
   #     entity hasn't been updated after creation.
   updatedAt
-  # The recipient of the notification.
-  user {
-    id
-  }
-  # The team which the notification is associated with.
-  team {
-    id
-  }
   # The time at when an email reminder for this notification was sent to the user. Null, if no email
   #     reminder has been sent.
   emailedAt
@@ -179,10 +181,19 @@ fragment Notification on Notification {
   snoozedUntilAt
   # The unique identifier of the entity.
   id
+  # The user that received the notification.
+  user {
+    id
+  }
+
+  ... on IssueNotification {
+    ...IssueNotification
+  }
 }
 
 # A project.
 fragment Project on Project {
+  __typename
   # Project URL.
   url
   # The estimated completion date of the project.
@@ -250,6 +261,7 @@ fragment Project on Project {
 
 # A reaction associated with a comment.
 fragment Reaction on Reaction {
+  __typename
   # Name of the reaction's emoji.
   emoji
   # The comment that the reaction is associated with.
@@ -273,6 +285,7 @@ fragment Reaction on Reaction {
 
 # A record of changes to an issue.
 fragment IssueHistory on IssueHistory {
+  __typename
   # Changed issue relationships.
   relationChanges {
     ...IssueRelationHistoryPayload
@@ -384,6 +397,7 @@ fragment IssueHistory on IssueHistory {
 
 # A relation between two issues.
 fragment IssueRelation on IssueRelation {
+  __typename
   # The issue whose relationship is being described.
   issue {
     id
@@ -407,6 +421,7 @@ fragment IssueRelation on IssueRelation {
 
 # A set of issues to be resolved in a specified amount of time.
 fragment Cycle on Cycle {
+  __typename
   # The completion time of the cycle. If null, the cycle hasn't been completed.
   completedAt
   # The custom name of the cycle.
@@ -446,6 +461,7 @@ fragment Cycle on Cycle {
 
 # A state in a team workflow.
 fragment WorkflowState on WorkflowState {
+  __typename
   # Description of the state.
   description
   # The last time at which the entity was updated. This is the same as the creation time if the
@@ -473,6 +489,7 @@ fragment WorkflowState on WorkflowState {
 
 # A template object used for creating entities faster.
 fragment Template on Template {
+  __typename
   # Template data.
   templateData
   # Template description.
@@ -502,6 +519,7 @@ fragment Template on Template {
 
 # A user account.
 fragment UserAccount on UserAccount {
+  __typename
   # The authentication service used to create the account.
   service
   # The models identifier.
@@ -524,6 +542,7 @@ fragment UserAccount on UserAccount {
 
 # A user that has access to the the resources of an organization.
 fragment User on User {
+  __typename
   # A date at which the user current status should be cleared.
   statusUntilAt
   # A short description of the user, either its title or bio.
@@ -573,6 +592,7 @@ fragment User on User {
 
 # A user's web browser push notification subscription.
 fragment PushSubscription on PushSubscription {
+  __typename
   # The last time at which the entity was updated. This is the same as the creation time if the
   #     entity hasn't been updated after creation.
   updatedAt
@@ -586,6 +606,7 @@ fragment PushSubscription on PushSubscription {
 
 # A version of a document.
 fragment DocumentVersion on DocumentVersion {
+  __typename
   # The document's content in markdown format.
   content
   # The document's title.
@@ -613,6 +634,7 @@ fragment DocumentVersion on DocumentVersion {
 
 # A webhook used to send HTTP notifications over data updates
 fragment Webhook on Webhook {
+  __typename
   # Secret token for verifying the origin on the recipient side.
   secret
   # The last time at which the entity was updated. This is the same as the creation time if the
@@ -646,6 +668,7 @@ fragment Webhook on Webhook {
 
 # An API key. Grants access to the user's resources.
 fragment ApiKey on ApiKey {
+  __typename
   # The label of the API key.
   label
   # The last time at which the entity was updated. This is the same as the creation time if the
@@ -661,6 +684,7 @@ fragment ApiKey on ApiKey {
 
 # An external link for a project.
 fragment ProjectLink on ProjectLink {
+  __typename
   # The last time at which the entity was updated. This is the same as the creation time if the
   #     entity hasn't been updated after creation.
   updatedAt
@@ -686,6 +710,7 @@ fragment ProjectLink on ProjectLink {
 
 # An import job for data from an external service
 fragment IssueImport on IssueImport {
+  __typename
   # The data mapping configuration for the import job.
   mapping
   # The id for the user that started the job.
@@ -709,6 +734,7 @@ fragment IssueImport on IssueImport {
 
 # An integration resource created by an external service.
 fragment IntegrationResource on IntegrationResource {
+  __typename
   # Detailed information about the external resource.
   data {
     ...IntegrationResourceData
@@ -742,6 +768,7 @@ fragment IntegrationResource on IntegrationResource {
 
 # An integration with an external service.
 fragment Integration on Integration {
+  __typename
   # The integration's type.
   service
   # The last time at which the entity was updated. This is the same as the creation time if the
@@ -765,6 +792,7 @@ fragment Integration on Integration {
 
 # An invitation to the organization that has been sent via email.
 fragment OrganizationInvite on OrganizationInvite {
+  __typename
   # The invite was sent to external address.
   external
   # The invitees email address.
@@ -794,8 +822,50 @@ fragment OrganizationInvite on OrganizationInvite {
   }
 }
 
+# An issue related notification
+fragment IssueNotification on IssueNotification {
+  __typename
+  # Name of the reaction emoji related to the notification.
+  reactionEmoji
+  # Notification type
+  type
+  # The comment related to the notification.
+  comment {
+    id
+  }
+  # The issue related to the notification.
+  issue {
+    id
+  }
+  # The last time at which the entity was updated. This is the same as the creation time if the
+  #     entity hasn't been updated after creation.
+  updatedAt
+  # The team related to the notification.
+  team {
+    id
+  }
+  # The time at when an email reminder for this notification was sent to the user. Null, if no email
+  #     reminder has been sent.
+  emailedAt
+  # The time at when the user marked the notification as read. Null, if the the user hasn't read the notification
+  readAt
+  # The time at which the entity was archived. Null if the entity has not been archived.
+  archivedAt
+  # The time at which the entity was created.
+  createdAt
+  # The time until a notification will be snoozed. After that it will appear in the inbox again.
+  snoozedUntilAt
+  # The unique identifier of the entity.
+  id
+  # The user that received the notification.
+  user {
+    id
+  }
+}
+
 # An issue.
 fragment Issue on Issue {
+  __typename
   # A flag that indicates whether the issue is in the trash bin.
   trashed
   # Issue URL.
@@ -885,6 +955,7 @@ fragment Issue on Issue {
 
 # An organization. Organizations are root-level objects that contain user accounts and teams.
 fragment Organization on Organization {
+  __typename
   # Allowed authentication providers, empty array means all are allowed
   allowedAuthServices
   # How git branches are formatted. If null, default formatting will be used.
@@ -924,6 +995,7 @@ fragment Organization on Organization {
 
 # An organizational unit that contains issues.
 fragment Team on Team {
+  __typename
   # Auto assign completed issues to current cycle.
   cycleIssueAutoAssignCompleted
   # Auto assign started issues to current cycle.
@@ -1041,6 +1113,7 @@ fragment Team on Team {
 
 # Collaborative editing steps for documents.
 fragment DocumentStep on DocumentStep {
+  __typename
   # Connected client ID.
   clientId
   # Step data.
@@ -1060,6 +1133,7 @@ fragment DocumentStep on DocumentStep {
 
 # Contains a delta sync.
 fragment SyncDeltaResponse on SyncDeltaResponse {
+  __typename
   # A JSON serialized collection of delta packets.
   updates
   # Whether loading the delta was successful. In case it wasn't, the client is instructed to do a full bootstrap.
@@ -1071,6 +1145,7 @@ fragment SyncDeltaResponse on SyncDeltaResponse {
 # Contains either the full serialized state of the application or delta packets that the requester can
 # apply to the local data set in order to be up-to-date.
 fragment SyncResponse on SyncResponse {
+  __typename
   # JSON serialized delta changes that the client can apply to its local state
   #     in order to catch up with the state of the world.
   delta
@@ -1087,6 +1162,7 @@ fragment SyncResponse on SyncResponse {
 
 # Contains requested archived model objects.
 fragment ArchiveResponse on ArchiveResponse {
+  __typename
   # A JSON serialized collection of model objects loaded from the archive
   archive
   # The total number of entities in the archive.
@@ -1099,18 +1175,21 @@ fragment ArchiveResponse on ArchiveResponse {
 
 # Contains the requested dependencies.
 fragment DependencyResponse on DependencyResponse {
+  __typename
   # A JSON serialized collection of dependencies.
   dependencies
 }
 
 # Contains the requested relations.
 fragment SyncBatchResponse on SyncBatchResponse {
+  __typename
   # A JSON serialized collection of relations model object.
   models
 }
 
 # Defines the membership of a user to a team.
 fragment TeamMembership on TeamMembership {
+  __typename
   # The last time at which the entity was updated. This is the same as the creation time if the
   #     entity hasn't been updated after creation.
   updatedAt
@@ -1134,6 +1213,7 @@ fragment TeamMembership on TeamMembership {
 
 # Defines the use of a domain by an organization.
 fragment OrganizationDomain on OrganizationDomain {
+  __typename
   # Domain name
   name
   # E-mail used to verify this domain
@@ -1157,6 +1237,7 @@ fragment OrganizationDomain on OrganizationDomain {
 
 # GitHub OAuth token, plus information about the organizations the user is a member of.
 fragment GithubOAuthTokenPayload on GithubOAuthTokenPayload {
+  __typename
   # A list of the GitHub organizations the user is a member of with attached repositories.
   organizations {
     ...GithubOrg
@@ -1167,6 +1248,7 @@ fragment GithubOAuthTokenPayload on GithubOAuthTokenPayload {
 
 # GitHub's commit data
 fragment CommitPayload on CommitPayload {
+  __typename
   added
   id
   message
@@ -1178,6 +1260,7 @@ fragment CommitPayload on CommitPayload {
 
 # Google Sheets specific settings.
 fragment GoogleSheetsSettings on GoogleSheetsSettings {
+  __typename
   sheetId
   spreadsheetId
   spreadsheetUrl
@@ -1186,6 +1269,7 @@ fragment GoogleSheetsSettings on GoogleSheetsSettings {
 
 # Integration resource's payload
 fragment IntegrationResourceData on IntegrationResourceData {
+  __typename
   # The payload for an IntegrationResource of type 'githubCommit'
   githubCommit {
     ...CommitPayload
@@ -1206,6 +1290,7 @@ fragment IntegrationResourceData on IntegrationResourceData {
 
 # Intercom specific settings.
 fragment IntercomSettings on IntercomSettings {
+  __typename
   # Whether an internal message should be added when a Linear issue changes status (for status types except completed or canceled).
   sendNoteOnStatusChange
   # Whether an internal message should be added when someone comments on an issue.
@@ -1214,6 +1299,7 @@ fragment IntercomSettings on IntercomSettings {
 
 # Issue relation history's payload
 fragment IssueRelationHistoryPayload on IssueRelationHistoryPayload {
+  __typename
   # The identifier of the related issue.
   identifier
   # The type of the change.
@@ -1222,6 +1308,7 @@ fragment IssueRelationHistoryPayload on IssueRelationHistoryPayload {
 
 # Jira specific settings.
 fragment JiraSettings on JiraSettings {
+  __typename
   # The Jira projects for the organization.
   projects {
     ...JiraProjectData
@@ -1234,6 +1321,7 @@ fragment JiraSettings on JiraSettings {
 
 # Labels that can be associated with issues.
 fragment IssueLabel on IssueLabel {
+  __typename
   # The label's color as a HEX string.
   color
   # The label's description.
@@ -1261,6 +1349,7 @@ fragment IssueLabel on IssueLabel {
 
 # Metadata about a Jira project.
 fragment JiraProjectData on JiraProjectData {
+  __typename
   # The Jira id for this project.
   id
   # The Jira key for this project, such as ENG.
@@ -1271,6 +1360,7 @@ fragment JiraProjectData on JiraProjectData {
 
 # Notification subscriptions for models.
 fragment NotificationSubscription on NotificationSubscription {
+  __typename
   # Subscribed project.
   project {
     id
@@ -1298,6 +1388,7 @@ fragment NotificationSubscription on NotificationSubscription {
 
 # OAuth2 client application
 fragment OauthClient on OauthClient {
+  __typename
   # Image of the application.
   imageUrl
   # Information about the application.
@@ -1333,6 +1424,7 @@ fragment OauthClient on OauthClient {
 
 # Object representing Figma preview information.
 fragment FigmaEmbed on FigmaEmbed {
+  __typename
   # Date when the file was updated at the time of embedding.
   lastModified
   # Figma file name.
@@ -1345,6 +1437,7 @@ fragment FigmaEmbed on FigmaEmbed {
 
 # Object representing Google Cloud upload policy, plus additional data.
 fragment UploadFile on UploadFile {
+  __typename
   # The asset URL for the uploaded file. (assigned automatically)
   assetUrl
   # The content type.
@@ -1363,6 +1456,7 @@ fragment UploadFile on UploadFile {
 
 # Public information of the OAuth application, plus the authorized scopes for a given user.
 fragment AuthorizedApplication on AuthorizedApplication {
+  __typename
   # Application name.
   name
   # Image of the application.
@@ -1386,6 +1480,7 @@ fragment AuthorizedApplication on AuthorizedApplication {
 # Public information of the OAuth application, plus whether the application has been authorized for
 # the given scopes.
 fragment UserAuthorizedApplication on UserAuthorizedApplication {
+  __typename
   # Application name.
   name
   # Image of the application.
@@ -1408,6 +1503,7 @@ fragment UserAuthorizedApplication on UserAuthorizedApplication {
 
 # Public information of the OAuth application.
 fragment Application on Application {
+  __typename
   # Application name.
   name
   # Image of the application.
@@ -1424,6 +1520,7 @@ fragment Application on Application {
 
 # Pull request data
 fragment PullRequestPayload on PullRequestPayload {
+  __typename
   branch
   closedAt
   createdAt
@@ -1443,6 +1540,7 @@ fragment PullRequestPayload on PullRequestPayload {
 
 # Relevant information for the GitHub organization.
 fragment GithubOrg on GithubOrg {
+  __typename
   # GitHub organization id.
   id
   # Repositories that the organization owns.
@@ -1457,6 +1555,7 @@ fragment GithubOrg on GithubOrg {
 
 # Relevant information for the GitHub repository.
 fragment GithubRepo on GithubRepo {
+  __typename
   # The id of the GitHub repository.
   id
   # The name of the GitHub repository.
@@ -1465,6 +1564,7 @@ fragment GithubRepo on GithubRepo {
 
 # Sentry issue data
 fragment SentryIssuePayload on SentryIssuePayload {
+  __typename
   # The Sentry identifier for the issue.
   issueId
   # The Sentry identifier of the actor who created the issue.
@@ -1491,12 +1591,14 @@ fragment SentryIssuePayload on SentryIssuePayload {
 
 # Sentry specific settings.
 fragment SentrySettings on SentrySettings {
+  __typename
   # The slug of the Sentry organization being connected.
   organizationSlug
 }
 
 # Slack notification specific settings.
 fragment SlackPostSettings on SlackPostSettings {
+  __typename
   channel
   channelId
   configurationUrl
@@ -1504,6 +1606,7 @@ fragment SlackPostSettings on SlackPostSettings {
 
 # The integration resource's settings
 fragment IntegrationSettings on IntegrationSettings {
+  __typename
   googleSheets {
     ...GoogleSheetsSettings
   }
@@ -1529,6 +1632,7 @@ fragment IntegrationSettings on IntegrationSettings {
 
 # The organization's SAML configuration
 fragment SamlConfigurationPayload on SamlConfigurationPayload {
+  __typename
   # Binding method for authentication call. Can be either `post` (default) or `redirect`.
   ssoBinding
   # List of allowed email domains for SAML authentication.
@@ -1543,6 +1647,7 @@ fragment SamlConfigurationPayload on SamlConfigurationPayload {
 
 # The settings of a user as a JSON object.
 fragment UserSettings on UserSettings {
+  __typename
   # The email types the user has unsubscribed from.
   unsubscribedFrom
   # The last time at which the entity was updated. This is the same as the creation time if the
@@ -1564,6 +1669,7 @@ fragment UserSettings on UserSettings {
 
 # The subscription of an organization.
 fragment Subscription on Subscription {
+  __typename
   # The creator of the subscription.
   creator {
     id
@@ -1591,6 +1697,7 @@ fragment Subscription on Subscription {
 
 # Tuple for mapping Jira projects to Linear teams.
 fragment JiraLinearMapping on JiraLinearMapping {
+  __typename
   # The Jira id for this project.
   jiraProjectId
   # The Linear team id to map to the given project.
@@ -1599,6 +1706,7 @@ fragment JiraLinearMapping on JiraLinearMapping {
 
 # User favorites presented in the sidebar.
 fragment Favorite on Favorite {
+  __typename
   # The favorited custom view.
   customView {
     id
@@ -1660,6 +1768,7 @@ fragment Favorite on Favorite {
 
 # View preferences.
 fragment ViewPreferences on ViewPreferences {
+  __typename
   # The last time at which the entity was updated. This is the same as the creation time if the
   #     entity hasn't been updated after creation.
   updatedAt
@@ -1677,6 +1786,7 @@ fragment ViewPreferences on ViewPreferences {
 
 # Workspace audit log entry object.
 fragment AuditEntry on AuditEntry {
+  __typename
   # Additional metadata related to the audit entry.
   metadata
   # Country code of request resulting to audit entry.
@@ -1703,6 +1813,7 @@ fragment AuditEntry on AuditEntry {
 
 # Zendesk specific settings.
 fragment ZendeskSettings on ZendeskSettings {
+  __typename
   # The ID of the Linear bot user.
   botUserId
   # The URL of the connected Zendesk organization.
@@ -1713,6 +1824,7 @@ fragment ZendeskSettings on ZendeskSettings {
 
 # [Alpha] Issue attachment (e.g. support ticket, pull request).
 fragment Attachment on Attachment {
+  __typename
   # An accessor helper to source.type, defines the source type of the attachment.
   sourceType
   # Content for the subtitle line in the Linear attachment widget.
@@ -1747,6 +1859,7 @@ fragment Attachment on Attachment {
 }
 
 fragment ApiKeyConnection on ApiKeyConnection {
+  __typename
   nodes {
     ...ApiKey
   }
@@ -1756,6 +1869,7 @@ fragment ApiKeyConnection on ApiKeyConnection {
 }
 
 fragment ApiKeyPayload on ApiKeyPayload {
+  __typename
   # The API key that was created.
   apiKey {
     ...ApiKey
@@ -1767,6 +1881,7 @@ fragment ApiKeyPayload on ApiKeyPayload {
 }
 
 fragment ArchivePayload on ArchivePayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # Whether the operation was successful.
@@ -1774,6 +1889,7 @@ fragment ArchivePayload on ArchivePayload {
 }
 
 fragment AttachmentConnection on AttachmentConnection {
+  __typename
   nodes {
     ...Attachment
   }
@@ -1783,6 +1899,7 @@ fragment AttachmentConnection on AttachmentConnection {
 }
 
 fragment AttachmentPayload on AttachmentPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The issue attachment that was created.
@@ -1794,6 +1911,7 @@ fragment AttachmentPayload on AttachmentPayload {
 }
 
 fragment AuditEntryConnection on AuditEntryConnection {
+  __typename
   nodes {
     ...AuditEntry
   }
@@ -1803,6 +1921,7 @@ fragment AuditEntryConnection on AuditEntryConnection {
 }
 
 fragment AuditEntryType on AuditEntryType {
+  __typename
   # Description of the audit entry type.
   description
   # The audit entry type.
@@ -1810,6 +1929,7 @@ fragment AuditEntryType on AuditEntryType {
 }
 
 fragment AuthResolverResponse on AuthResolverResponse {
+  __typename
   # Email for the authenticated account.
   email
   # ID of the organization last accessed by the user.
@@ -1831,6 +1951,7 @@ fragment AuthResolverResponse on AuthResolverResponse {
 }
 
 fragment BillingDetailsPayload on BillingDetailsPayload {
+  __typename
   # List of invoices, if any.
   invoices {
     ...Invoice
@@ -1846,6 +1967,7 @@ fragment BillingDetailsPayload on BillingDetailsPayload {
 }
 
 fragment BillingEmailPayload on BillingEmailPayload {
+  __typename
   # The customer's email address the invoices are sent to.
   email
   # Whether the operation was successful.
@@ -1853,6 +1975,7 @@ fragment BillingEmailPayload on BillingEmailPayload {
 }
 
 fragment Card on Card {
+  __typename
   # The brand of the card, e.g. Visa.
   brand
   # The last four digits used to identify the card.
@@ -1860,6 +1983,7 @@ fragment Card on Card {
 }
 
 fragment CollaborationDocumentUpdatePayload on CollaborationDocumentUpdatePayload {
+  __typename
   # Document steps the client has not seen yet and need to rebase it's local steps on.
   steps {
     ...StepsResponse
@@ -1869,6 +1993,7 @@ fragment CollaborationDocumentUpdatePayload on CollaborationDocumentUpdatePayloa
 }
 
 fragment CommentConnection on CommentConnection {
+  __typename
   nodes {
     ...Comment
   }
@@ -1878,6 +2003,7 @@ fragment CommentConnection on CommentConnection {
 }
 
 fragment CommentPayload on CommentPayload {
+  __typename
   # The comment that was created or updated.
   comment {
     id
@@ -1889,22 +2015,26 @@ fragment CommentPayload on CommentPayload {
 }
 
 fragment ContactPayload on ContactPayload {
+  __typename
   # Whether the operation was successful.
   success
 }
 
 fragment CreateCsvExportReportPayload on CreateCsvExportReportPayload {
+  __typename
   # Whether the operation was successful.
   success
 }
 
 fragment CreateOrJoinOrganizationResponse on CreateOrJoinOrganizationResponse {
+  __typename
   user {
     id
   }
 }
 
 fragment CustomViewConnection on CustomViewConnection {
+  __typename
   nodes {
     ...CustomView
   }
@@ -1914,6 +2044,7 @@ fragment CustomViewConnection on CustomViewConnection {
 }
 
 fragment CustomViewPayload on CustomViewPayload {
+  __typename
   # The custom view that was created or updated.
   customView {
     id
@@ -1925,6 +2056,7 @@ fragment CustomViewPayload on CustomViewPayload {
 }
 
 fragment CycleConnection on CycleConnection {
+  __typename
   nodes {
     ...Cycle
   }
@@ -1934,6 +2066,7 @@ fragment CycleConnection on CycleConnection {
 }
 
 fragment CyclePayload on CyclePayload {
+  __typename
   # The Cycle that was created or updated.
   cycle {
     id
@@ -1945,11 +2078,13 @@ fragment CyclePayload on CyclePayload {
 }
 
 fragment DebugPayload on DebugPayload {
+  __typename
   # Whether the operation was successful.
   success
 }
 
 fragment DocumentConnection on DocumentConnection {
+  __typename
   nodes {
     ...Document
   }
@@ -1959,6 +2094,7 @@ fragment DocumentConnection on DocumentConnection {
 }
 
 fragment DocumentPayload on DocumentPayload {
+  __typename
   # The document that was created or updated.
   document {
     id
@@ -1970,6 +2106,7 @@ fragment DocumentPayload on DocumentPayload {
 }
 
 fragment DocumentVersionConnection on DocumentVersionConnection {
+  __typename
   nodes {
     ...DocumentVersion
   }
@@ -1979,16 +2116,19 @@ fragment DocumentVersionConnection on DocumentVersionConnection {
 }
 
 fragment EmailSubscribePayload on EmailSubscribePayload {
+  __typename
   # Whether the operation was successful.
   success
 }
 
 fragment EmailUnsubscribePayload on EmailUnsubscribePayload {
+  __typename
   # Whether the operation was successful.
   success
 }
 
 fragment EmailUserAccountAuthChallengeResponse on EmailUserAccountAuthChallengeResponse {
+  __typename
   # Supported challenge for this user account. Can be either verificationCode or password.
   authType
   # Whether the operation was successful.
@@ -1996,6 +2136,7 @@ fragment EmailUserAccountAuthChallengeResponse on EmailUserAccountAuthChallengeR
 }
 
 fragment EmojiConnection on EmojiConnection {
+  __typename
   nodes {
     ...Emoji
   }
@@ -2005,6 +2146,7 @@ fragment EmojiConnection on EmojiConnection {
 }
 
 fragment EmojiPayload on EmojiPayload {
+  __typename
   # The emoji that was created.
   emoji {
     id
@@ -2016,11 +2158,13 @@ fragment EmojiPayload on EmojiPayload {
 }
 
 fragment EventPayload on EventPayload {
+  __typename
   # Whether the operation was successful.
   success
 }
 
 fragment FavoriteConnection on FavoriteConnection {
+  __typename
   nodes {
     ...Favorite
   }
@@ -2030,6 +2174,7 @@ fragment FavoriteConnection on FavoriteConnection {
 }
 
 fragment FavoritePayload on FavoritePayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The object that was added as a favorite.
@@ -2041,11 +2186,13 @@ fragment FavoritePayload on FavoritePayload {
 }
 
 fragment FeedbackPayload on FeedbackPayload {
+  __typename
   # Whether the operation was successful.
   success
 }
 
 fragment FigmaEmbedPayload on FigmaEmbedPayload {
+  __typename
   # Figma embed information.
   figmaEmbed {
     ...FigmaEmbed
@@ -2055,6 +2202,7 @@ fragment FigmaEmbedPayload on FigmaEmbedPayload {
 }
 
 fragment FrontAttachmentPayload on FrontAttachmentPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # Whether the operation was successful.
@@ -2062,6 +2210,7 @@ fragment FrontAttachmentPayload on FrontAttachmentPayload {
 }
 
 fragment GitHubCommitIntegrationPayload on GitHubCommitIntegrationPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The integration that was created or updated.
@@ -2075,6 +2224,7 @@ fragment GitHubCommitIntegrationPayload on GitHubCommitIntegrationPayload {
 }
 
 fragment ImageUploadFromUrlPayload on ImageUploadFromUrlPayload {
+  __typename
   # The URL containing the image.
   url
   # The identifier of the last sync operation.
@@ -2084,6 +2234,7 @@ fragment ImageUploadFromUrlPayload on ImageUploadFromUrlPayload {
 }
 
 fragment IntegrationConnection on IntegrationConnection {
+  __typename
   nodes {
     ...Integration
   }
@@ -2093,6 +2244,7 @@ fragment IntegrationConnection on IntegrationConnection {
 }
 
 fragment IntegrationPayload on IntegrationPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The integration that was created or updated.
@@ -2104,6 +2256,7 @@ fragment IntegrationPayload on IntegrationPayload {
 }
 
 fragment IntegrationResourceConnection on IntegrationResourceConnection {
+  __typename
   nodes {
     ...IntegrationResource
   }
@@ -2113,6 +2266,7 @@ fragment IntegrationResourceConnection on IntegrationResourceConnection {
 }
 
 fragment Invoice on Invoice {
+  __typename
   # The URL at which the invoice can be viewed or paid.
   url
   # The creation date of the invoice.
@@ -2126,6 +2280,7 @@ fragment Invoice on Invoice {
 }
 
 fragment IssueBatchPayload on IssueBatchPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The issues that were updated.
@@ -2137,6 +2292,7 @@ fragment IssueBatchPayload on IssueBatchPayload {
 }
 
 fragment IssueConnection on IssueConnection {
+  __typename
   nodes {
     ...Issue
   }
@@ -2146,6 +2302,7 @@ fragment IssueConnection on IssueConnection {
 }
 
 fragment IssueHistoryConnection on IssueHistoryConnection {
+  __typename
   nodes {
     ...IssueHistory
   }
@@ -2155,6 +2312,7 @@ fragment IssueHistoryConnection on IssueHistoryConnection {
 }
 
 fragment IssueImportDeletePayload on IssueImportDeletePayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The import job that was deleted.
@@ -2166,6 +2324,7 @@ fragment IssueImportDeletePayload on IssueImportDeletePayload {
 }
 
 fragment IssueImportPayload on IssueImportPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The import job that was created or updated.
@@ -2177,6 +2336,7 @@ fragment IssueImportPayload on IssueImportPayload {
 }
 
 fragment IssueLabelConnection on IssueLabelConnection {
+  __typename
   nodes {
     ...IssueLabel
   }
@@ -2186,6 +2346,7 @@ fragment IssueLabelConnection on IssueLabelConnection {
 }
 
 fragment IssueLabelPayload on IssueLabelPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The label that was created or updated.
@@ -2197,6 +2358,7 @@ fragment IssueLabelPayload on IssueLabelPayload {
 }
 
 fragment IssuePayload on IssuePayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The issue that was created or updated.
@@ -2208,6 +2370,7 @@ fragment IssuePayload on IssuePayload {
 }
 
 fragment IssuePriorityValue on IssuePriorityValue {
+  __typename
   # Priority's label.
   label
   # Priority's number value.
@@ -2215,6 +2378,7 @@ fragment IssuePriorityValue on IssuePriorityValue {
 }
 
 fragment IssueRelationConnection on IssueRelationConnection {
+  __typename
   nodes {
     ...IssueRelation
   }
@@ -2224,6 +2388,7 @@ fragment IssueRelationConnection on IssueRelationConnection {
 }
 
 fragment IssueRelationPayload on IssueRelationPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The issue relation that was created or updated.
@@ -2235,6 +2400,7 @@ fragment IssueRelationPayload on IssueRelationPayload {
 }
 
 fragment MilestoneConnection on MilestoneConnection {
+  __typename
   nodes {
     ...Milestone
   }
@@ -2244,6 +2410,7 @@ fragment MilestoneConnection on MilestoneConnection {
 }
 
 fragment MilestonePayload on MilestonePayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The milesteone that was created or updated.
@@ -2255,10 +2422,13 @@ fragment MilestonePayload on MilestonePayload {
 }
 
 fragment Node on Node {
+  __typename
   # The unique identifier of the entity.
   id
 }
+
 fragment NotificationConnection on NotificationConnection {
+  __typename
   nodes {
     ...Notification
   }
@@ -2268,17 +2438,19 @@ fragment NotificationConnection on NotificationConnection {
 }
 
 fragment NotificationPayload on NotificationPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The notification that was created or updated.
   notification {
-    id
+    ...Notification
   }
   # Whether the operation was successful.
   success
 }
 
 fragment NotificationSubscriptionConnection on NotificationSubscriptionConnection {
+  __typename
   nodes {
     ...NotificationSubscription
   }
@@ -2288,6 +2460,7 @@ fragment NotificationSubscriptionConnection on NotificationSubscriptionConnectio
 }
 
 fragment NotificationSubscriptionPayload on NotificationSubscriptionPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The notification subscription that was created or updated.
@@ -2299,11 +2472,13 @@ fragment NotificationSubscriptionPayload on NotificationSubscriptionPayload {
 }
 
 fragment OauthAuthStringAuthorizePayload on OauthAuthStringAuthorizePayload {
+  __typename
   # Whether the operation was successful.
   success
 }
 
 fragment OauthAuthStringChallengePayload on OauthAuthStringChallengePayload {
+  __typename
   # The created authentication string.
   authString
   # Whether the operation was successful.
@@ -2311,6 +2486,7 @@ fragment OauthAuthStringChallengePayload on OauthAuthStringChallengePayload {
 }
 
 fragment OauthAuthStringCheckPayload on OauthAuthStringCheckPayload {
+  __typename
   # Access token for use.
   token
   # Whether the operation was successful.
@@ -2318,6 +2494,7 @@ fragment OauthAuthStringCheckPayload on OauthAuthStringCheckPayload {
 }
 
 fragment OauthClientPayload on OauthClientPayload {
+  __typename
   # The OAuth client application that was created or updated.
   oauthClient {
     ...OauthClient
@@ -2329,21 +2506,25 @@ fragment OauthClientPayload on OauthClientPayload {
 }
 
 fragment OauthTokenRevokePayload on OauthTokenRevokePayload {
+  __typename
   # Whether the operation was successful.
   success
 }
 
 fragment OrganizationCancelDeletePayload on OrganizationCancelDeletePayload {
+  __typename
   # Whether the operation was successful.
   success
 }
 
 fragment OrganizationDeletePayload on OrganizationDeletePayload {
+  __typename
   # Whether the operation was successful.
   success
 }
 
 fragment OrganizationDomainPayload on OrganizationDomainPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The organization domain that was created or updated.
@@ -2355,11 +2536,13 @@ fragment OrganizationDomainPayload on OrganizationDomainPayload {
 }
 
 fragment OrganizationDomainSimplePayload on OrganizationDomainSimplePayload {
+  __typename
   # Whether the operation was successful.
   success
 }
 
 fragment OrganizationExistsPayload on OrganizationExistsPayload {
+  __typename
   # Whether the operation was successful.
   success
   # Whether the organization exists.
@@ -2367,6 +2550,7 @@ fragment OrganizationExistsPayload on OrganizationExistsPayload {
 }
 
 fragment OrganizationInviteConnection on OrganizationInviteConnection {
+  __typename
   nodes {
     ...OrganizationInvite
   }
@@ -2376,6 +2560,7 @@ fragment OrganizationInviteConnection on OrganizationInviteConnection {
 }
 
 fragment OrganizationInviteDetailsPayload on OrganizationInviteDetailsPayload {
+  __typename
   # ID of the workspace the invite is for.
   organizationId
   # Name of the workspace the invite is for.
@@ -2397,6 +2582,7 @@ fragment OrganizationInviteDetailsPayload on OrganizationInviteDetailsPayload {
 }
 
 fragment OrganizationInvitePayload on OrganizationInvitePayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The organization invite that was created or updated.
@@ -2408,6 +2594,7 @@ fragment OrganizationInvitePayload on OrganizationInvitePayload {
 }
 
 fragment OrganizationPayload on OrganizationPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # Whether the operation was successful.
@@ -2415,6 +2602,7 @@ fragment OrganizationPayload on OrganizationPayload {
 }
 
 fragment PageInfo on PageInfo {
+  __typename
   # Cursor representing the first result in the paginated results.
   startCursor
   # Cursor representing the last result in the paginated results.
@@ -2426,6 +2614,7 @@ fragment PageInfo on PageInfo {
 }
 
 fragment ProjectConnection on ProjectConnection {
+  __typename
   nodes {
     ...Project
   }
@@ -2435,6 +2624,7 @@ fragment ProjectConnection on ProjectConnection {
 }
 
 fragment ProjectLinkConnection on ProjectLinkConnection {
+  __typename
   nodes {
     ...ProjectLink
   }
@@ -2444,6 +2634,7 @@ fragment ProjectLinkConnection on ProjectLinkConnection {
 }
 
 fragment ProjectLinkPayload on ProjectLinkPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The project that was created or updated.
@@ -2455,6 +2646,7 @@ fragment ProjectLinkPayload on ProjectLinkPayload {
 }
 
 fragment ProjectPayload on ProjectPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The project that was created or updated.
@@ -2466,6 +2658,7 @@ fragment ProjectPayload on ProjectPayload {
 }
 
 fragment PushSubscriptionConnection on PushSubscriptionConnection {
+  __typename
   nodes {
     ...PushSubscription
   }
@@ -2475,6 +2668,7 @@ fragment PushSubscriptionConnection on PushSubscriptionConnection {
 }
 
 fragment PushSubscriptionPayload on PushSubscriptionPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # Whether the operation was successful.
@@ -2482,11 +2676,13 @@ fragment PushSubscriptionPayload on PushSubscriptionPayload {
 }
 
 fragment PushSubscriptionTestPayload on PushSubscriptionTestPayload {
+  __typename
   # Whether the operation was successful.
   success
 }
 
 fragment RateLimitPayload on RateLimitPayload {
+  __typename
   # The identifier we rate limit on.
   identifier
   # The kind of rate limit selected for this request.
@@ -2498,6 +2694,7 @@ fragment RateLimitPayload on RateLimitPayload {
 }
 
 fragment RateLimitResultPayload on RateLimitResultPayload {
+  __typename
   # The period in which the rate limit is fully replenished in ms.
   period
   # The remaining quantity for this type of limit after this request.
@@ -2513,6 +2710,7 @@ fragment RateLimitResultPayload on RateLimitResultPayload {
 }
 
 fragment ReactionConnection on ReactionConnection {
+  __typename
   nodes {
     ...Reaction
   }
@@ -2522,6 +2720,7 @@ fragment ReactionConnection on ReactionConnection {
 }
 
 fragment ReactionPayload on ReactionPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   reaction {
@@ -2531,6 +2730,7 @@ fragment ReactionPayload on ReactionPayload {
 }
 
 fragment RotateSecretPayload on RotateSecretPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # Whether the operation was successful.
@@ -2538,6 +2738,7 @@ fragment RotateSecretPayload on RotateSecretPayload {
 }
 
 fragment SamlConfiguration on SamlConfiguration {
+  __typename
   # Binding method for authentication call. Can be either `post` (default) or `redirect`.
   ssoBinding
   # List of allowed email domains for SAML authentication.
@@ -2553,6 +2754,7 @@ fragment SamlConfiguration on SamlConfiguration {
 }
 
 fragment SsoUrlFromEmailResponse on SsoUrlFromEmailResponse {
+  __typename
   # SAML SSO sign-in URL.
   samlSsoUrl
   # Whether the operation was successful.
@@ -2560,6 +2762,7 @@ fragment SsoUrlFromEmailResponse on SsoUrlFromEmailResponse {
 }
 
 fragment StepsResponse on StepsResponse {
+  __typename
   # Client's document version.
   version
   # List of client IDs for the document steps.
@@ -2569,6 +2772,7 @@ fragment StepsResponse on StepsResponse {
 }
 
 fragment SubscriptionPayload on SubscriptionPayload {
+  __typename
   # The date the subscription was set to cancel at the end of the billing period, if any.
   canceledAt
   # The identifier of the last sync operation.
@@ -2578,16 +2782,19 @@ fragment SubscriptionPayload on SubscriptionPayload {
 }
 
 fragment SubscriptionSessionPayload on SubscriptionSessionPayload {
+  __typename
   # The subscription session that was created or updated.
   session
 }
 
 fragment SynchronizedPayload on SynchronizedPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
 }
 
 fragment TeamConnection on TeamConnection {
+  __typename
   nodes {
     ...Team
   }
@@ -2597,6 +2804,7 @@ fragment TeamConnection on TeamConnection {
 }
 
 fragment TeamMembershipConnection on TeamMembershipConnection {
+  __typename
   nodes {
     ...TeamMembership
   }
@@ -2606,6 +2814,7 @@ fragment TeamMembershipConnection on TeamMembershipConnection {
 }
 
 fragment TeamMembershipPayload on TeamMembershipPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The team membership that was created or updated.
@@ -2617,6 +2826,7 @@ fragment TeamMembershipPayload on TeamMembershipPayload {
 }
 
 fragment TeamPayload on TeamPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The team that was created or updated.
@@ -2628,12 +2838,14 @@ fragment TeamPayload on TeamPayload {
 }
 
 fragment TemplateConnection on TemplateConnection {
+  __typename
   pageInfo {
     ...PageInfo
   }
 }
 
 fragment TemplatePayload on TemplatePayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The template that was created or updated.
@@ -2645,6 +2857,7 @@ fragment TemplatePayload on TemplatePayload {
 }
 
 fragment UploadFileHeader on UploadFileHeader {
+  __typename
   # Upload file header key.
   key
   # Upload file header value.
@@ -2652,6 +2865,7 @@ fragment UploadFileHeader on UploadFileHeader {
 }
 
 fragment UploadPayload on UploadPayload {
+  __typename
   # Object describing the file to be uploaded.
   uploadFile {
     ...UploadFile
@@ -2663,11 +2877,13 @@ fragment UploadPayload on UploadPayload {
 }
 
 fragment UserAdminPayload on UserAdminPayload {
+  __typename
   # Whether the operation was successful.
   success
 }
 
 fragment UserConnection on UserConnection {
+  __typename
   nodes {
     ...User
   }
@@ -2677,6 +2893,7 @@ fragment UserConnection on UserConnection {
 }
 
 fragment UserPayload on UserPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The user that was created or updated.
@@ -2688,6 +2905,7 @@ fragment UserPayload on UserPayload {
 }
 
 fragment UserSettingsFlagPayload on UserSettingsFlagPayload {
+  __typename
   # The flag key which was updated.
   flag
   # The flag value after update.
@@ -2699,6 +2917,7 @@ fragment UserSettingsFlagPayload on UserSettingsFlagPayload {
 }
 
 fragment UserSettingsFlagsResetPayload on UserSettingsFlagsResetPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # Whether the operation was successful.
@@ -2706,6 +2925,7 @@ fragment UserSettingsFlagsResetPayload on UserSettingsFlagsResetPayload {
 }
 
 fragment UserSettingsPayload on UserSettingsPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # Whether the operation was successful.
@@ -2713,11 +2933,13 @@ fragment UserSettingsPayload on UserSettingsPayload {
 }
 
 fragment UserSubscribeToNewsletterPayload on UserSubscribeToNewsletterPayload {
+  __typename
   # Whether the operation was successful.
   success
 }
 
 fragment ViewPreferencesPayload on ViewPreferencesPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The view preferences entity being mutated.
@@ -2729,6 +2951,7 @@ fragment ViewPreferencesPayload on ViewPreferencesPayload {
 }
 
 fragment WebhookConnection on WebhookConnection {
+  __typename
   nodes {
     ...Webhook
   }
@@ -2738,6 +2961,7 @@ fragment WebhookConnection on WebhookConnection {
 }
 
 fragment WebhookPayload on WebhookPayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The webhook entity being mutated.
@@ -2749,6 +2973,7 @@ fragment WebhookPayload on WebhookPayload {
 }
 
 fragment WorkflowStateConnection on WorkflowStateConnection {
+  __typename
   nodes {
     ...WorkflowState
   }
@@ -2758,6 +2983,7 @@ fragment WorkflowStateConnection on WorkflowStateConnection {
 }
 
 fragment WorkflowStatePayload on WorkflowStatePayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # The state that was created or updated.

--- a/packages/sdk/src/_generated_documents.ts
+++ b/packages/sdk/src/_generated_documents.ts
@@ -1135,6 +1135,21 @@ export type EmojiPayload = {
   success: Scalars["Boolean"];
 };
 
+/** A basic entity. */
+export type Entity = {
+  /** The time at which the entity was archived. Null if the entity has not been archived. */
+  archivedAt?: Maybe<Scalars["DateTime"]>;
+  /** The time at which the entity was created. */
+  createdAt: Scalars["DateTime"];
+  /** The unique identifier of the entity. */
+  id: Scalars["ID"];
+  /**
+   * The last time at which the entity was updated. This is the same as the creation time if the
+   *     entity hasn't been updated after creation.
+   */
+  updatedAt: Scalars["DateTime"];
+};
+
 export type EventCreateInput = {
   /** The category of the event to create. */
   category: Scalars["String"];
@@ -2232,6 +2247,45 @@ export type IssueLabelUpdateInput = {
   /** The name of the label. */
   name?: Maybe<Scalars["String"]>;
 };
+
+/** An issue related notification */
+export type IssueNotification = Entity &
+  Node &
+  Notification & {
+    __typename?: "IssueNotification";
+    /** The time at which the entity was archived. Null if the entity has not been archived. */
+    archivedAt?: Maybe<Scalars["DateTime"]>;
+    /** The comment related to the notification. */
+    comment?: Maybe<Comment>;
+    /** The time at which the entity was created. */
+    createdAt: Scalars["DateTime"];
+    /**
+     * The time at when an email reminder for this notification was sent to the user. Null, if no email
+     *     reminder has been sent.
+     */
+    emailedAt?: Maybe<Scalars["DateTime"]>;
+    /** The unique identifier of the entity. */
+    id: Scalars["ID"];
+    /** The issue related to the notification. */
+    issue: Issue;
+    /** Name of the reaction emoji related to the notification. */
+    reactionEmoji?: Maybe<Scalars["String"]>;
+    /** The time at when the user marked the notification as read. Null, if the the user hasn't read the notification */
+    readAt?: Maybe<Scalars["DateTime"]>;
+    /** The time until a notification will be snoozed. After that it will appear in the inbox again. */
+    snoozedUntilAt?: Maybe<Scalars["DateTime"]>;
+    /** The team related to the notification. */
+    team: Team;
+    /** Notification type */
+    type: Scalars["String"];
+    /**
+     * The last time at which the entity was updated. This is the same as the creation time if the
+     *     entity hasn't been updated after creation.
+     */
+    updatedAt: Scalars["DateTime"];
+    /** The user that received the notification. */
+    user: User;
+  };
 
 export type IssuePayload = {
   __typename?: "IssuePayload";
@@ -3663,12 +3717,9 @@ export type Node = {
 };
 
 /** A notification sent to a user. */
-export type Notification = Node & {
-  __typename?: "Notification";
+export type Notification = {
   /** The time at which the entity was archived. Null if the entity has not been archived. */
   archivedAt?: Maybe<Scalars["DateTime"]>;
-  /** The comment which the notification is associated with. */
-  comment?: Maybe<Comment>;
   /** The time at which the entity was created. */
   createdAt: Scalars["DateTime"];
   /**
@@ -3678,16 +3729,10 @@ export type Notification = Node & {
   emailedAt?: Maybe<Scalars["DateTime"]>;
   /** The unique identifier of the entity. */
   id: Scalars["ID"];
-  /** The issue that the notification is associated with. */
-  issue: Issue;
-  /** Name of the reaction emoji associated with the notification. */
-  reactionEmoji?: Maybe<Scalars["String"]>;
   /** The time at when the user marked the notification as read. Null, if the the user hasn't read the notification */
   readAt?: Maybe<Scalars["DateTime"]>;
   /** The time until a notification will be snoozed. After that it will appear in the inbox again. */
   snoozedUntilAt?: Maybe<Scalars["DateTime"]>;
-  /** The team which the notification is associated with. */
-  team: Team;
   /** Notification type */
   type: Scalars["String"];
   /**
@@ -3695,7 +3740,7 @@ export type Notification = Node & {
    *     entity hasn't been updated after creation.
    */
   updatedAt: Scalars["DateTime"];
-  /** The recipient of the notification. */
+  /** The user that received the notification. */
   user: User;
 };
 
@@ -7161,7 +7206,12 @@ export type ZendeskSettingsInput = {
   url: Scalars["String"];
 };
 
-export type CommentFragment = { __typename?: "Comment" } & Pick<
+export type EntityFragment = { __typename: "IssueNotification" } & Pick<
+  IssueNotification,
+  "updatedAt" | "archivedAt" | "createdAt" | "id"
+>;
+
+export type CommentFragment = { __typename: "Comment" } & Pick<
   Comment,
   "url" | "body" | "updatedAt" | "archivedAt" | "createdAt" | "editedAt" | "id"
 > & {
@@ -7170,12 +7220,12 @@ export type CommentFragment = { __typename?: "Comment" } & Pick<
     user?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
   };
 
-export type EmojiFragment = { __typename?: "Emoji" } & Pick<
+export type EmojiFragment = { __typename: "Emoji" } & Pick<
   Emoji,
   "url" | "name" | "updatedAt" | "source" | "archivedAt" | "createdAt" | "id"
 > & { creator: { __typename?: "User" } & Pick<User, "id"> };
 
-export type CustomViewFragment = { __typename?: "CustomView" } & Pick<
+export type CustomViewFragment = { __typename: "CustomView" } & Pick<
   CustomView,
   | "color"
   | "description"
@@ -7190,7 +7240,7 @@ export type CustomViewFragment = { __typename?: "CustomView" } & Pick<
   | "filterData"
 > & { team?: Maybe<{ __typename?: "Team" } & Pick<Team, "id">>; creator: { __typename?: "User" } & Pick<User, "id"> };
 
-export type DocumentFragment = { __typename?: "Document" } & Pick<
+export type DocumentFragment = { __typename: "Document" } & Pick<
   Document,
   "color" | "contentData" | "content" | "title" | "slugId" | "icon" | "updatedAt" | "archivedAt" | "createdAt" | "id"
 > & {
@@ -7199,22 +7249,17 @@ export type DocumentFragment = { __typename?: "Document" } & Pick<
     updatedBy: { __typename?: "User" } & Pick<User, "id">;
   };
 
-export type MilestoneFragment = { __typename?: "Milestone" } & Pick<
+export type MilestoneFragment = { __typename: "Milestone" } & Pick<
   Milestone,
   "updatedAt" | "name" | "sortOrder" | "archivedAt" | "createdAt" | "id"
 >;
 
-export type NotificationFragment = { __typename?: "Notification" } & Pick<
-  Notification,
-  "reactionEmoji" | "type" | "updatedAt" | "emailedAt" | "readAt" | "archivedAt" | "createdAt" | "snoozedUntilAt" | "id"
-> & {
-    comment?: Maybe<{ __typename?: "Comment" } & Pick<Comment, "id">>;
-    issue: { __typename?: "Issue" } & Pick<Issue, "id">;
-    user: { __typename?: "User" } & Pick<User, "id">;
-    team: { __typename?: "Team" } & Pick<Team, "id">;
-  };
+export type NotificationFragment = { __typename: "IssueNotification" } & Pick<
+  IssueNotification,
+  "type" | "updatedAt" | "emailedAt" | "readAt" | "archivedAt" | "createdAt" | "snoozedUntilAt" | "id"
+> & { user: { __typename?: "User" } & Pick<User, "id"> } & IssueNotificationFragment;
 
-export type ProjectFragment = { __typename?: "Project" } & Pick<
+export type ProjectFragment = { __typename: "Project" } & Pick<
   Project,
   | "url"
   | "targetDate"
@@ -7247,12 +7292,12 @@ export type ProjectFragment = { __typename?: "Project" } & Pick<
     creator: { __typename?: "User" } & Pick<User, "id">;
   };
 
-export type ReactionFragment = { __typename?: "Reaction" } & Pick<
+export type ReactionFragment = { __typename: "Reaction" } & Pick<
   Reaction,
   "emoji" | "updatedAt" | "archivedAt" | "createdAt" | "id"
 > & { comment: { __typename?: "Comment" } & Pick<Comment, "id">; user: { __typename?: "User" } & Pick<User, "id"> };
 
-export type IssueHistoryFragment = { __typename?: "IssueHistory" } & Pick<
+export type IssueHistoryFragment = { __typename: "IssueHistory" } & Pick<
   IssueHistory,
   | "addedLabelIds"
   | "removedLabelIds"
@@ -7296,12 +7341,12 @@ export type IssueHistoryFragment = { __typename?: "IssueHistory" } & Pick<
     actor?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
   };
 
-export type IssueRelationFragment = { __typename?: "IssueRelation" } & Pick<
+export type IssueRelationFragment = { __typename: "IssueRelation" } & Pick<
   IssueRelation,
   "updatedAt" | "type" | "archivedAt" | "createdAt" | "id"
 > & { issue: { __typename?: "Issue" } & Pick<Issue, "id">; relatedIssue: { __typename?: "Issue" } & Pick<Issue, "id"> };
 
-export type CycleFragment = { __typename?: "Cycle" } & Pick<
+export type CycleFragment = { __typename: "Cycle" } & Pick<
   Cycle,
   | "completedAt"
   | "name"
@@ -7320,12 +7365,12 @@ export type CycleFragment = { __typename?: "Cycle" } & Pick<
   | "id"
 > & { team: { __typename?: "Team" } & Pick<Team, "id"> };
 
-export type WorkflowStateFragment = { __typename?: "WorkflowState" } & Pick<
+export type WorkflowStateFragment = { __typename: "WorkflowState" } & Pick<
   WorkflowState,
   "description" | "updatedAt" | "position" | "color" | "name" | "archivedAt" | "createdAt" | "type" | "id"
 > & { team: { __typename?: "Team" } & Pick<Team, "id"> };
 
-export type TemplateFragment = { __typename?: "Template" } & Pick<
+export type TemplateFragment = { __typename: "Template" } & Pick<
   Template,
   "templateData" | "description" | "type" | "updatedAt" | "name" | "archivedAt" | "createdAt" | "id"
 > & {
@@ -7333,12 +7378,12 @@ export type TemplateFragment = { __typename?: "Template" } & Pick<
     creator?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
   };
 
-export type UserAccountFragment = { __typename?: "UserAccount" } & Pick<
+export type UserAccountFragment = { __typename: "UserAccount" } & Pick<
   UserAccount,
   "service" | "id" | "archivedAt" | "createdAt" | "updatedAt" | "email" | "name"
 > & { users: Array<{ __typename?: "User" } & UserFragment> };
 
-export type UserFragment = { __typename?: "User" } & Pick<
+export type UserFragment = { __typename: "User" } & Pick<
   User,
   | "statusUntilAt"
   | "description"
@@ -7364,17 +7409,17 @@ export type UserFragment = { __typename?: "User" } & Pick<
   | "isMe"
 >;
 
-export type PushSubscriptionFragment = { __typename?: "PushSubscription" } & Pick<
+export type PushSubscriptionFragment = { __typename: "PushSubscription" } & Pick<
   PushSubscription,
   "updatedAt" | "archivedAt" | "createdAt" | "id"
 >;
 
-export type DocumentVersionFragment = { __typename?: "DocumentVersion" } & Pick<
+export type DocumentVersionFragment = { __typename: "DocumentVersion" } & Pick<
   DocumentVersion,
   "content" | "title" | "updatedAt" | "archivedAt" | "createdAt" | "id" | "revision"
 > & { project: { __typename?: "Project" } & Pick<Project, "id">; creator: { __typename?: "User" } & Pick<User, "id"> };
 
-export type WebhookFragment = { __typename?: "Webhook" } & Pick<
+export type WebhookFragment = { __typename: "Webhook" } & Pick<
   Webhook,
   | "secret"
   | "updatedAt"
@@ -7391,22 +7436,22 @@ export type WebhookFragment = { __typename?: "Webhook" } & Pick<
     creator?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
   };
 
-export type ApiKeyFragment = { __typename?: "ApiKey" } & Pick<
+export type ApiKeyFragment = { __typename: "ApiKey" } & Pick<
   ApiKey,
   "label" | "updatedAt" | "archivedAt" | "createdAt" | "id"
 >;
 
-export type ProjectLinkFragment = { __typename?: "ProjectLink" } & Pick<
+export type ProjectLinkFragment = { __typename: "ProjectLink" } & Pick<
   ProjectLink,
   "updatedAt" | "url" | "label" | "archivedAt" | "createdAt" | "id"
 > & { project: { __typename?: "Project" } & Pick<Project, "id">; creator: { __typename?: "User" } & Pick<User, "id"> };
 
-export type IssueImportFragment = { __typename?: "IssueImport" } & Pick<
+export type IssueImportFragment = { __typename: "IssueImport" } & Pick<
   IssueImport,
   "mapping" | "creatorId" | "updatedAt" | "service" | "status" | "archivedAt" | "createdAt" | "id" | "error"
 >;
 
-export type IntegrationResourceFragment = { __typename?: "IntegrationResource" } & Pick<
+export type IntegrationResourceFragment = { __typename: "IntegrationResource" } & Pick<
   IntegrationResource,
   "resourceId" | "resourceType" | "updatedAt" | "archivedAt" | "createdAt" | "id"
 > & {
@@ -7416,12 +7461,12 @@ export type IntegrationResourceFragment = { __typename?: "IntegrationResource" }
     issue: { __typename?: "Issue" } & Pick<Issue, "id">;
   };
 
-export type IntegrationFragment = { __typename?: "Integration" } & Pick<
+export type IntegrationFragment = { __typename: "Integration" } & Pick<
   Integration,
   "service" | "updatedAt" | "archivedAt" | "createdAt" | "id"
 > & { team?: Maybe<{ __typename?: "Team" } & Pick<Team, "id">>; creator: { __typename?: "User" } & Pick<User, "id"> };
 
-export type OrganizationInviteFragment = { __typename?: "OrganizationInvite" } & Pick<
+export type OrganizationInviteFragment = { __typename: "OrganizationInvite" } & Pick<
   OrganizationInvite,
   "external" | "email" | "updatedAt" | "permission" | "archivedAt" | "createdAt" | "acceptedAt" | "expiresAt" | "id"
 > & {
@@ -7429,7 +7474,17 @@ export type OrganizationInviteFragment = { __typename?: "OrganizationInvite" } &
     invitee?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
   };
 
-export type IssueFragment = { __typename?: "Issue" } & Pick<
+export type IssueNotificationFragment = { __typename: "IssueNotification" } & Pick<
+  IssueNotification,
+  "reactionEmoji" | "type" | "updatedAt" | "emailedAt" | "readAt" | "archivedAt" | "createdAt" | "snoozedUntilAt" | "id"
+> & {
+    comment?: Maybe<{ __typename?: "Comment" } & Pick<Comment, "id">>;
+    issue: { __typename?: "Issue" } & Pick<Issue, "id">;
+    team: { __typename?: "Team" } & Pick<Team, "id">;
+    user: { __typename?: "User" } & Pick<User, "id">;
+  };
+
+export type IssueFragment = { __typename: "Issue" } & Pick<
   Issue,
   | "trashed"
   | "url"
@@ -7468,7 +7523,7 @@ export type IssueFragment = { __typename?: "Issue" } & Pick<
     state: { __typename?: "WorkflowState" } & Pick<WorkflowState, "id">;
   };
 
-export type OrganizationFragment = { __typename?: "Organization" } & Pick<
+export type OrganizationFragment = { __typename: "Organization" } & Pick<
   Organization,
   | "allowedAuthServices"
   | "gitBranchFormat"
@@ -7489,7 +7544,7 @@ export type OrganizationFragment = { __typename?: "Organization" } & Pick<
   | "roadmapEnabled"
 >;
 
-export type TeamFragment = { __typename?: "Team" } & Pick<
+export type TeamFragment = { __typename: "Team" } & Pick<
   Team,
   | "cycleIssueAutoAssignCompleted"
   | "cycleIssueAutoAssignStarted"
@@ -7540,81 +7595,81 @@ export type TeamFragment = { __typename?: "Team" } & Pick<
     triageIssueState?: Maybe<{ __typename?: "WorkflowState" } & Pick<WorkflowState, "id">>;
   };
 
-export type DocumentStepFragment = { __typename?: "DocumentStep" } & Pick<
+export type DocumentStepFragment = { __typename: "DocumentStep" } & Pick<
   DocumentStep,
   "clientId" | "step" | "version" | "updatedAt" | "archivedAt" | "createdAt" | "id"
 >;
 
-export type SyncDeltaResponseFragment = { __typename?: "SyncDeltaResponse" } & Pick<
+export type SyncDeltaResponseFragment = { __typename: "SyncDeltaResponse" } & Pick<
   SyncDeltaResponse,
   "updates" | "success" | "loadMore"
 >;
 
-export type SyncResponseFragment = { __typename?: "SyncResponse" } & Pick<
+export type SyncResponseFragment = { __typename: "SyncResponse" } & Pick<
   SyncResponse,
   "delta" | "state" | "lastSyncId" | "subscribedSyncGroups" | "databaseVersion"
 >;
 
-export type ArchiveResponseFragment = { __typename?: "ArchiveResponse" } & Pick<
+export type ArchiveResponseFragment = { __typename: "ArchiveResponse" } & Pick<
   ArchiveResponse,
   "archive" | "totalCount" | "databaseVersion" | "includesDependencies"
 >;
 
-export type DependencyResponseFragment = { __typename?: "DependencyResponse" } & Pick<
+export type DependencyResponseFragment = { __typename: "DependencyResponse" } & Pick<
   DependencyResponse,
   "dependencies"
 >;
 
-export type SyncBatchResponseFragment = { __typename?: "SyncBatchResponse" } & Pick<SyncBatchResponse, "models">;
+export type SyncBatchResponseFragment = { __typename: "SyncBatchResponse" } & Pick<SyncBatchResponse, "models">;
 
-export type TeamMembershipFragment = { __typename?: "TeamMembership" } & Pick<
+export type TeamMembershipFragment = { __typename: "TeamMembership" } & Pick<
   TeamMembership,
   "updatedAt" | "archivedAt" | "createdAt" | "id" | "owner"
 > & { team: { __typename?: "Team" } & Pick<Team, "id">; user: { __typename?: "User" } & Pick<User, "id"> };
 
-export type OrganizationDomainFragment = { __typename?: "OrganizationDomain" } & Pick<
+export type OrganizationDomainFragment = { __typename: "OrganizationDomain" } & Pick<
   OrganizationDomain,
   "name" | "verificationEmail" | "verified" | "updatedAt" | "archivedAt" | "createdAt" | "id"
 > & { creator?: Maybe<{ __typename?: "User" } & Pick<User, "id">> };
 
-export type GithubOAuthTokenPayloadFragment = { __typename?: "GithubOAuthTokenPayload" } & Pick<
+export type GithubOAuthTokenPayloadFragment = { __typename: "GithubOAuthTokenPayload" } & Pick<
   GithubOAuthTokenPayload,
   "token"
 > & { organizations?: Maybe<Array<{ __typename?: "GithubOrg" } & GithubOrgFragment>> };
 
-export type CommitPayloadFragment = { __typename?: "CommitPayload" } & Pick<
+export type CommitPayloadFragment = { __typename: "CommitPayload" } & Pick<
   CommitPayload,
   "added" | "id" | "message" | "modified" | "removed" | "timestamp" | "url"
 >;
 
-export type GoogleSheetsSettingsFragment = { __typename?: "GoogleSheetsSettings" } & Pick<
+export type GoogleSheetsSettingsFragment = { __typename: "GoogleSheetsSettings" } & Pick<
   GoogleSheetsSettings,
   "sheetId" | "spreadsheetId" | "spreadsheetUrl" | "updatedIssuesAt"
 >;
 
-export type IntegrationResourceDataFragment = { __typename?: "IntegrationResourceData" } & {
+export type IntegrationResourceDataFragment = { __typename: "IntegrationResourceData" } & {
   githubCommit?: Maybe<{ __typename?: "CommitPayload" } & CommitPayloadFragment>;
   githubPullRequest?: Maybe<{ __typename?: "PullRequestPayload" } & PullRequestPayloadFragment>;
   gitlabMergeRequest?: Maybe<{ __typename?: "PullRequestPayload" } & PullRequestPayloadFragment>;
   sentryIssue?: Maybe<{ __typename?: "SentryIssuePayload" } & SentryIssuePayloadFragment>;
 };
 
-export type IntercomSettingsFragment = { __typename?: "IntercomSettings" } & Pick<
+export type IntercomSettingsFragment = { __typename: "IntercomSettings" } & Pick<
   IntercomSettings,
   "sendNoteOnStatusChange" | "sendNoteOnComment"
 >;
 
-export type IssueRelationHistoryPayloadFragment = { __typename?: "IssueRelationHistoryPayload" } & Pick<
+export type IssueRelationHistoryPayloadFragment = { __typename: "IssueRelationHistoryPayload" } & Pick<
   IssueRelationHistoryPayload,
   "identifier" | "type"
 >;
 
-export type JiraSettingsFragment = { __typename?: "JiraSettings" } & {
+export type JiraSettingsFragment = { __typename: "JiraSettings" } & {
   projects: Array<{ __typename?: "JiraProjectData" } & JiraProjectDataFragment>;
   projectMapping?: Maybe<Array<{ __typename?: "JiraLinearMapping" } & JiraLinearMappingFragment>>;
 };
 
-export type IssueLabelFragment = { __typename?: "IssueLabel" } & Pick<
+export type IssueLabelFragment = { __typename: "IssueLabel" } & Pick<
   IssueLabel,
   "color" | "description" | "name" | "updatedAt" | "archivedAt" | "createdAt" | "id"
 > & {
@@ -7622,9 +7677,9 @@ export type IssueLabelFragment = { __typename?: "IssueLabel" } & Pick<
     creator?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
   };
 
-export type JiraProjectDataFragment = { __typename?: "JiraProjectData" } & Pick<JiraProjectData, "id" | "key" | "name">;
+export type JiraProjectDataFragment = { __typename: "JiraProjectData" } & Pick<JiraProjectData, "id" | "key" | "name">;
 
-export type NotificationSubscriptionFragment = { __typename?: "NotificationSubscription" } & Pick<
+export type NotificationSubscriptionFragment = { __typename: "NotificationSubscription" } & Pick<
   NotificationSubscription,
   "updatedAt" | "archivedAt" | "createdAt" | "type" | "id"
 > & {
@@ -7633,7 +7688,7 @@ export type NotificationSubscriptionFragment = { __typename?: "NotificationSubsc
     user: { __typename?: "User" } & Pick<User, "id">;
   };
 
-export type OauthClientFragment = { __typename?: "OauthClient" } & Pick<
+export type OauthClientFragment = { __typename: "OauthClient" } & Pick<
   OauthClient,
   | "imageUrl"
   | "description"
@@ -7652,17 +7707,17 @@ export type OauthClientFragment = { __typename?: "OauthClient" } & Pick<
   | "publicEnabled"
 >;
 
-export type FigmaEmbedFragment = { __typename?: "FigmaEmbed" } & Pick<
+export type FigmaEmbedFragment = { __typename: "FigmaEmbed" } & Pick<
   FigmaEmbed,
   "lastModified" | "name" | "url" | "nodeName"
 >;
 
-export type UploadFileFragment = { __typename?: "UploadFile" } & Pick<
+export type UploadFileFragment = { __typename: "UploadFile" } & Pick<
   UploadFile,
   "assetUrl" | "contentType" | "filename" | "uploadUrl" | "size" | "metaData"
 > & { headers: Array<{ __typename?: "UploadFileHeader" } & UploadFileHeaderFragment> };
 
-export type AuthorizedApplicationFragment = { __typename?: "AuthorizedApplication" } & Pick<
+export type AuthorizedApplicationFragment = { __typename: "AuthorizedApplication" } & Pick<
   AuthorizedApplication,
   | "name"
   | "imageUrl"
@@ -7675,7 +7730,7 @@ export type AuthorizedApplicationFragment = { __typename?: "AuthorizedApplicatio
   | "webhooksEnabled"
 >;
 
-export type UserAuthorizedApplicationFragment = { __typename?: "UserAuthorizedApplication" } & Pick<
+export type UserAuthorizedApplicationFragment = { __typename: "UserAuthorizedApplication" } & Pick<
   UserAuthorizedApplication,
   | "name"
   | "imageUrl"
@@ -7688,12 +7743,12 @@ export type UserAuthorizedApplicationFragment = { __typename?: "UserAuthorizedAp
   | "isAuthorized"
 >;
 
-export type ApplicationFragment = { __typename?: "Application" } & Pick<
+export type ApplicationFragment = { __typename: "Application" } & Pick<
   Application,
   "name" | "imageUrl" | "description" | "developer" | "clientId" | "developerUrl"
 >;
 
-export type PullRequestPayloadFragment = { __typename?: "PullRequestPayload" } & Pick<
+export type PullRequestPayloadFragment = { __typename: "PullRequestPayload" } & Pick<
   PullRequestPayload,
   | "branch"
   | "closedAt"
@@ -7712,13 +7767,13 @@ export type PullRequestPayloadFragment = { __typename?: "PullRequestPayload" } &
   | "userLogin"
 >;
 
-export type GithubOrgFragment = { __typename?: "GithubOrg" } & Pick<GithubOrg, "id" | "login" | "name"> & {
+export type GithubOrgFragment = { __typename: "GithubOrg" } & Pick<GithubOrg, "id" | "login" | "name"> & {
     repositories: Array<{ __typename?: "GithubRepo" } & GithubRepoFragment>;
   };
 
-export type GithubRepoFragment = { __typename?: "GithubRepo" } & Pick<GithubRepo, "id" | "name">;
+export type GithubRepoFragment = { __typename: "GithubRepo" } & Pick<GithubRepo, "id" | "name">;
 
-export type SentryIssuePayloadFragment = { __typename?: "SentryIssuePayload" } & Pick<
+export type SentryIssuePayloadFragment = { __typename: "SentryIssuePayload" } & Pick<
   SentryIssuePayload,
   | "issueId"
   | "actorId"
@@ -7733,14 +7788,14 @@ export type SentryIssuePayloadFragment = { __typename?: "SentryIssuePayload" } &
   | "actorType"
 >;
 
-export type SentrySettingsFragment = { __typename?: "SentrySettings" } & Pick<SentrySettings, "organizationSlug">;
+export type SentrySettingsFragment = { __typename: "SentrySettings" } & Pick<SentrySettings, "organizationSlug">;
 
-export type SlackPostSettingsFragment = { __typename?: "SlackPostSettings" } & Pick<
+export type SlackPostSettingsFragment = { __typename: "SlackPostSettings" } & Pick<
   SlackPostSettings,
   "channel" | "channelId" | "configurationUrl"
 >;
 
-export type IntegrationSettingsFragment = { __typename?: "IntegrationSettings" } & {
+export type IntegrationSettingsFragment = { __typename: "IntegrationSettings" } & {
   googleSheets?: Maybe<{ __typename?: "GoogleSheetsSettings" } & GoogleSheetsSettingsFragment>;
   intercom?: Maybe<{ __typename?: "IntercomSettings" } & IntercomSettingsFragment>;
   jira?: Maybe<{ __typename?: "JiraSettings" } & JiraSettingsFragment>;
@@ -7750,17 +7805,17 @@ export type IntegrationSettingsFragment = { __typename?: "IntegrationSettings" }
   zendesk?: Maybe<{ __typename?: "ZendeskSettings" } & ZendeskSettingsFragment>;
 };
 
-export type SamlConfigurationPayloadFragment = { __typename?: "SamlConfigurationPayload" } & Pick<
+export type SamlConfigurationPayloadFragment = { __typename: "SamlConfigurationPayload" } & Pick<
   SamlConfigurationPayload,
   "ssoBinding" | "allowedDomains" | "ssoEndpoint" | "ssoSignAlgo" | "issuerEntityId"
 >;
 
-export type UserSettingsFragment = { __typename?: "UserSettings" } & Pick<
+export type UserSettingsFragment = { __typename: "UserSettings" } & Pick<
   UserSettings,
   "unsubscribedFrom" | "updatedAt" | "notificationPreferences" | "archivedAt" | "createdAt" | "id"
 > & { user: { __typename?: "User" } & Pick<User, "id"> };
 
-export type SubscriptionFragment = { __typename?: "Subscription" } & Pick<
+export type SubscriptionFragment = { __typename: "Subscription" } & Pick<
   Subscription,
   | "canceledAt"
   | "nextBillingAt"
@@ -7773,12 +7828,12 @@ export type SubscriptionFragment = { __typename?: "Subscription" } & Pick<
   | "id"
 > & { creator?: Maybe<{ __typename?: "User" } & Pick<User, "id">> };
 
-export type JiraLinearMappingFragment = { __typename?: "JiraLinearMapping" } & Pick<
+export type JiraLinearMappingFragment = { __typename: "JiraLinearMapping" } & Pick<
   JiraLinearMapping,
   "jiraProjectId" | "linearTeamId"
 >;
 
-export type FavoriteFragment = { __typename?: "Favorite" } & Pick<
+export type FavoriteFragment = { __typename: "Favorite" } & Pick<
   Favorite,
   "updatedAt" | "folderName" | "sortOrder" | "archivedAt" | "createdAt" | "predefinedViewType" | "type" | "id"
 > & {
@@ -7794,22 +7849,22 @@ export type FavoriteFragment = { __typename?: "Favorite" } & Pick<
     predefinedViewTeam?: Maybe<{ __typename?: "Team" } & Pick<Team, "id">>;
   };
 
-export type ViewPreferencesFragment = { __typename?: "ViewPreferences" } & Pick<
+export type ViewPreferencesFragment = { __typename: "ViewPreferences" } & Pick<
   ViewPreferences,
   "updatedAt" | "archivedAt" | "createdAt" | "id" | "type" | "viewType"
 >;
 
-export type AuditEntryFragment = { __typename?: "AuditEntry" } & Pick<
+export type AuditEntryFragment = { __typename: "AuditEntry" } & Pick<
   AuditEntry,
   "metadata" | "countryCode" | "ip" | "actorId" | "updatedAt" | "archivedAt" | "createdAt" | "id" | "type"
 > & { actor?: Maybe<{ __typename?: "User" } & Pick<User, "id">> };
 
-export type ZendeskSettingsFragment = { __typename?: "ZendeskSettings" } & Pick<
+export type ZendeskSettingsFragment = { __typename: "ZendeskSettings" } & Pick<
   ZendeskSettings,
   "botUserId" | "url" | "subdomain"
 >;
 
-export type AttachmentFragment = { __typename?: "Attachment" } & Pick<
+export type AttachmentFragment = { __typename: "Attachment" } & Pick<
   Attachment,
   | "sourceType"
   | "subtitle"
@@ -7827,35 +7882,35 @@ export type AttachmentFragment = { __typename?: "Attachment" } & Pick<
     issue: { __typename?: "Issue" } & Pick<Issue, "id">;
   };
 
-export type ApiKeyConnectionFragment = { __typename?: "ApiKeyConnection" } & {
+export type ApiKeyConnectionFragment = { __typename: "ApiKeyConnection" } & {
   nodes: Array<{ __typename?: "ApiKey" } & ApiKeyFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type ApiKeyPayloadFragment = { __typename?: "ApiKeyPayload" } & Pick<ApiKeyPayload, "lastSyncId" | "success"> & {
+export type ApiKeyPayloadFragment = { __typename: "ApiKeyPayload" } & Pick<ApiKeyPayload, "lastSyncId" | "success"> & {
     apiKey: { __typename?: "ApiKey" } & ApiKeyFragment;
   };
 
-export type ArchivePayloadFragment = { __typename?: "ArchivePayload" } & Pick<ArchivePayload, "lastSyncId" | "success">;
+export type ArchivePayloadFragment = { __typename: "ArchivePayload" } & Pick<ArchivePayload, "lastSyncId" | "success">;
 
-export type AttachmentConnectionFragment = { __typename?: "AttachmentConnection" } & {
+export type AttachmentConnectionFragment = { __typename: "AttachmentConnection" } & {
   nodes: Array<{ __typename?: "Attachment" } & AttachmentFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type AttachmentPayloadFragment = { __typename?: "AttachmentPayload" } & Pick<
+export type AttachmentPayloadFragment = { __typename: "AttachmentPayload" } & Pick<
   AttachmentPayload,
   "lastSyncId" | "success"
 > & { attachment: { __typename?: "Attachment" } & Pick<Attachment, "id"> };
 
-export type AuditEntryConnectionFragment = { __typename?: "AuditEntryConnection" } & {
+export type AuditEntryConnectionFragment = { __typename: "AuditEntryConnection" } & {
   nodes: Array<{ __typename?: "AuditEntry" } & AuditEntryFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type AuditEntryTypeFragment = { __typename?: "AuditEntryType" } & Pick<AuditEntryType, "description" | "type">;
+export type AuditEntryTypeFragment = { __typename: "AuditEntryType" } & Pick<AuditEntryType, "description" | "type">;
 
-export type AuthResolverResponseFragment = { __typename?: "AuthResolverResponse" } & Pick<
+export type AuthResolverResponseFragment = { __typename: "AuthResolverResponse" } & Pick<
   AuthResolverResponse,
   "email" | "lastUsedOrganizationId" | "token" | "allowDomainAccess" | "id"
 > & {
@@ -7863,7 +7918,7 @@ export type AuthResolverResponseFragment = { __typename?: "AuthResolverResponse"
     users: Array<{ __typename?: "User" } & UserFragment>;
   };
 
-export type BillingDetailsPayloadFragment = { __typename?: "BillingDetailsPayload" } & Pick<
+export type BillingDetailsPayloadFragment = { __typename: "BillingDetailsPayload" } & Pick<
   BillingDetailsPayload,
   "email" | "success"
 > & {
@@ -7871,293 +7926,293 @@ export type BillingDetailsPayloadFragment = { __typename?: "BillingDetailsPayloa
     paymentMethod?: Maybe<{ __typename?: "Card" } & CardFragment>;
   };
 
-export type BillingEmailPayloadFragment = { __typename?: "BillingEmailPayload" } & Pick<
+export type BillingEmailPayloadFragment = { __typename: "BillingEmailPayload" } & Pick<
   BillingEmailPayload,
   "email" | "success"
 >;
 
-export type CardFragment = { __typename?: "Card" } & Pick<Card, "brand" | "last4">;
+export type CardFragment = { __typename: "Card" } & Pick<Card, "brand" | "last4">;
 
-export type CollaborationDocumentUpdatePayloadFragment = { __typename?: "CollaborationDocumentUpdatePayload" } & Pick<
+export type CollaborationDocumentUpdatePayloadFragment = { __typename: "CollaborationDocumentUpdatePayload" } & Pick<
   CollaborationDocumentUpdatePayload,
   "success"
 > & { steps?: Maybe<{ __typename?: "StepsResponse" } & StepsResponseFragment> };
 
-export type CommentConnectionFragment = { __typename?: "CommentConnection" } & {
+export type CommentConnectionFragment = { __typename: "CommentConnection" } & {
   nodes: Array<{ __typename?: "Comment" } & CommentFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type CommentPayloadFragment = { __typename?: "CommentPayload" } & Pick<
+export type CommentPayloadFragment = { __typename: "CommentPayload" } & Pick<
   CommentPayload,
   "lastSyncId" | "success"
 > & { comment: { __typename?: "Comment" } & Pick<Comment, "id"> };
 
-export type ContactPayloadFragment = { __typename?: "ContactPayload" } & Pick<ContactPayload, "success">;
+export type ContactPayloadFragment = { __typename: "ContactPayload" } & Pick<ContactPayload, "success">;
 
-export type CreateCsvExportReportPayloadFragment = { __typename?: "CreateCsvExportReportPayload" } & Pick<
+export type CreateCsvExportReportPayloadFragment = { __typename: "CreateCsvExportReportPayload" } & Pick<
   CreateCsvExportReportPayload,
   "success"
 >;
 
-export type CreateOrJoinOrganizationResponseFragment = { __typename?: "CreateOrJoinOrganizationResponse" } & {
+export type CreateOrJoinOrganizationResponseFragment = { __typename: "CreateOrJoinOrganizationResponse" } & {
   user: { __typename?: "User" } & Pick<User, "id">;
 };
 
-export type CustomViewConnectionFragment = { __typename?: "CustomViewConnection" } & {
+export type CustomViewConnectionFragment = { __typename: "CustomViewConnection" } & {
   nodes: Array<{ __typename?: "CustomView" } & CustomViewFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type CustomViewPayloadFragment = { __typename?: "CustomViewPayload" } & Pick<
+export type CustomViewPayloadFragment = { __typename: "CustomViewPayload" } & Pick<
   CustomViewPayload,
   "lastSyncId" | "success"
 > & { customView: { __typename?: "CustomView" } & Pick<CustomView, "id"> };
 
-export type CycleConnectionFragment = { __typename?: "CycleConnection" } & {
+export type CycleConnectionFragment = { __typename: "CycleConnection" } & {
   nodes: Array<{ __typename?: "Cycle" } & CycleFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type CyclePayloadFragment = { __typename?: "CyclePayload" } & Pick<CyclePayload, "lastSyncId" | "success"> & {
+export type CyclePayloadFragment = { __typename: "CyclePayload" } & Pick<CyclePayload, "lastSyncId" | "success"> & {
     cycle?: Maybe<{ __typename?: "Cycle" } & Pick<Cycle, "id">>;
   };
 
-export type DebugPayloadFragment = { __typename?: "DebugPayload" } & Pick<DebugPayload, "success">;
+export type DebugPayloadFragment = { __typename: "DebugPayload" } & Pick<DebugPayload, "success">;
 
-export type DocumentConnectionFragment = { __typename?: "DocumentConnection" } & {
+export type DocumentConnectionFragment = { __typename: "DocumentConnection" } & {
   nodes: Array<{ __typename?: "Document" } & DocumentFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type DocumentPayloadFragment = { __typename?: "DocumentPayload" } & Pick<
+export type DocumentPayloadFragment = { __typename: "DocumentPayload" } & Pick<
   DocumentPayload,
   "lastSyncId" | "success"
 > & { document: { __typename?: "Document" } & Pick<Document, "id"> };
 
-export type DocumentVersionConnectionFragment = { __typename?: "DocumentVersionConnection" } & {
+export type DocumentVersionConnectionFragment = { __typename: "DocumentVersionConnection" } & {
   nodes: Array<{ __typename?: "DocumentVersion" } & DocumentVersionFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type EmailSubscribePayloadFragment = { __typename?: "EmailSubscribePayload" } & Pick<
+export type EmailSubscribePayloadFragment = { __typename: "EmailSubscribePayload" } & Pick<
   EmailSubscribePayload,
   "success"
 >;
 
-export type EmailUnsubscribePayloadFragment = { __typename?: "EmailUnsubscribePayload" } & Pick<
+export type EmailUnsubscribePayloadFragment = { __typename: "EmailUnsubscribePayload" } & Pick<
   EmailUnsubscribePayload,
   "success"
 >;
 
 export type EmailUserAccountAuthChallengeResponseFragment = {
-  __typename?: "EmailUserAccountAuthChallengeResponse";
+  __typename: "EmailUserAccountAuthChallengeResponse";
 } & Pick<EmailUserAccountAuthChallengeResponse, "authType" | "success">;
 
-export type EmojiConnectionFragment = { __typename?: "EmojiConnection" } & {
+export type EmojiConnectionFragment = { __typename: "EmojiConnection" } & {
   nodes: Array<{ __typename?: "Emoji" } & EmojiFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type EmojiPayloadFragment = { __typename?: "EmojiPayload" } & Pick<EmojiPayload, "lastSyncId" | "success"> & {
+export type EmojiPayloadFragment = { __typename: "EmojiPayload" } & Pick<EmojiPayload, "lastSyncId" | "success"> & {
     emoji: { __typename?: "Emoji" } & Pick<Emoji, "id">;
   };
 
-export type EventPayloadFragment = { __typename?: "EventPayload" } & Pick<EventPayload, "success">;
+export type EventPayloadFragment = { __typename: "EventPayload" } & Pick<EventPayload, "success">;
 
-export type FavoriteConnectionFragment = { __typename?: "FavoriteConnection" } & {
+export type FavoriteConnectionFragment = { __typename: "FavoriteConnection" } & {
   nodes: Array<{ __typename?: "Favorite" } & FavoriteFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type FavoritePayloadFragment = { __typename?: "FavoritePayload" } & Pick<
+export type FavoritePayloadFragment = { __typename: "FavoritePayload" } & Pick<
   FavoritePayload,
   "lastSyncId" | "success"
 > & { favorite: { __typename?: "Favorite" } & Pick<Favorite, "id"> };
 
-export type FeedbackPayloadFragment = { __typename?: "FeedbackPayload" } & Pick<FeedbackPayload, "success">;
+export type FeedbackPayloadFragment = { __typename: "FeedbackPayload" } & Pick<FeedbackPayload, "success">;
 
-export type FigmaEmbedPayloadFragment = { __typename?: "FigmaEmbedPayload" } & Pick<FigmaEmbedPayload, "success"> & {
+export type FigmaEmbedPayloadFragment = { __typename: "FigmaEmbedPayload" } & Pick<FigmaEmbedPayload, "success"> & {
     figmaEmbed?: Maybe<{ __typename?: "FigmaEmbed" } & FigmaEmbedFragment>;
   };
 
-export type FrontAttachmentPayloadFragment = { __typename?: "FrontAttachmentPayload" } & Pick<
+export type FrontAttachmentPayloadFragment = { __typename: "FrontAttachmentPayload" } & Pick<
   FrontAttachmentPayload,
   "lastSyncId" | "success"
 >;
 
-export type GitHubCommitIntegrationPayloadFragment = { __typename?: "GitHubCommitIntegrationPayload" } & Pick<
+export type GitHubCommitIntegrationPayloadFragment = { __typename: "GitHubCommitIntegrationPayload" } & Pick<
   GitHubCommitIntegrationPayload,
   "lastSyncId" | "webhookSecret" | "success"
 > & { integration?: Maybe<{ __typename?: "Integration" } & Pick<Integration, "id">> };
 
-export type ImageUploadFromUrlPayloadFragment = { __typename?: "ImageUploadFromUrlPayload" } & Pick<
+export type ImageUploadFromUrlPayloadFragment = { __typename: "ImageUploadFromUrlPayload" } & Pick<
   ImageUploadFromUrlPayload,
   "url" | "lastSyncId" | "success"
 >;
 
-export type IntegrationConnectionFragment = { __typename?: "IntegrationConnection" } & {
+export type IntegrationConnectionFragment = { __typename: "IntegrationConnection" } & {
   nodes: Array<{ __typename?: "Integration" } & IntegrationFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type IntegrationPayloadFragment = { __typename?: "IntegrationPayload" } & Pick<
+export type IntegrationPayloadFragment = { __typename: "IntegrationPayload" } & Pick<
   IntegrationPayload,
   "lastSyncId" | "success"
 > & { integration?: Maybe<{ __typename?: "Integration" } & Pick<Integration, "id">> };
 
-export type IntegrationResourceConnectionFragment = { __typename?: "IntegrationResourceConnection" } & {
+export type IntegrationResourceConnectionFragment = { __typename: "IntegrationResourceConnection" } & {
   nodes: Array<{ __typename?: "IntegrationResource" } & IntegrationResourceFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type InvoiceFragment = { __typename?: "Invoice" } & Pick<
+export type InvoiceFragment = { __typename: "Invoice" } & Pick<
   Invoice,
   "url" | "created" | "dueDate" | "total" | "status"
 >;
 
-export type IssueBatchPayloadFragment = { __typename?: "IssueBatchPayload" } & Pick<
+export type IssueBatchPayloadFragment = { __typename: "IssueBatchPayload" } & Pick<
   IssueBatchPayload,
   "lastSyncId" | "success"
 > & { issues: Array<{ __typename?: "Issue" } & IssueFragment> };
 
-export type IssueConnectionFragment = { __typename?: "IssueConnection" } & {
+export type IssueConnectionFragment = { __typename: "IssueConnection" } & {
   nodes: Array<{ __typename?: "Issue" } & IssueFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type IssueHistoryConnectionFragment = { __typename?: "IssueHistoryConnection" } & {
+export type IssueHistoryConnectionFragment = { __typename: "IssueHistoryConnection" } & {
   nodes: Array<{ __typename?: "IssueHistory" } & IssueHistoryFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type IssueImportDeletePayloadFragment = { __typename?: "IssueImportDeletePayload" } & Pick<
+export type IssueImportDeletePayloadFragment = { __typename: "IssueImportDeletePayload" } & Pick<
   IssueImportDeletePayload,
   "lastSyncId" | "success"
 > & { issueImport?: Maybe<{ __typename?: "IssueImport" } & IssueImportFragment> };
 
-export type IssueImportPayloadFragment = { __typename?: "IssueImportPayload" } & Pick<
+export type IssueImportPayloadFragment = { __typename: "IssueImportPayload" } & Pick<
   IssueImportPayload,
   "lastSyncId" | "success"
 > & { issueImport?: Maybe<{ __typename?: "IssueImport" } & IssueImportFragment> };
 
-export type IssueLabelConnectionFragment = { __typename?: "IssueLabelConnection" } & {
+export type IssueLabelConnectionFragment = { __typename: "IssueLabelConnection" } & {
   nodes: Array<{ __typename?: "IssueLabel" } & IssueLabelFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type IssueLabelPayloadFragment = { __typename?: "IssueLabelPayload" } & Pick<
+export type IssueLabelPayloadFragment = { __typename: "IssueLabelPayload" } & Pick<
   IssueLabelPayload,
   "lastSyncId" | "success"
 > & { issueLabel: { __typename?: "IssueLabel" } & Pick<IssueLabel, "id"> };
 
-export type IssuePayloadFragment = { __typename?: "IssuePayload" } & Pick<IssuePayload, "lastSyncId" | "success"> & {
+export type IssuePayloadFragment = { __typename: "IssuePayload" } & Pick<IssuePayload, "lastSyncId" | "success"> & {
     issue?: Maybe<{ __typename?: "Issue" } & Pick<Issue, "id">>;
   };
 
-export type IssuePriorityValueFragment = { __typename?: "IssuePriorityValue" } & Pick<
+export type IssuePriorityValueFragment = { __typename: "IssuePriorityValue" } & Pick<
   IssuePriorityValue,
   "label" | "priority"
 >;
 
-export type IssueRelationConnectionFragment = { __typename?: "IssueRelationConnection" } & {
+export type IssueRelationConnectionFragment = { __typename: "IssueRelationConnection" } & {
   nodes: Array<{ __typename?: "IssueRelation" } & IssueRelationFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type IssueRelationPayloadFragment = { __typename?: "IssueRelationPayload" } & Pick<
+export type IssueRelationPayloadFragment = { __typename: "IssueRelationPayload" } & Pick<
   IssueRelationPayload,
   "lastSyncId" | "success"
 > & { issueRelation: { __typename?: "IssueRelation" } & Pick<IssueRelation, "id"> };
 
-export type MilestoneConnectionFragment = { __typename?: "MilestoneConnection" } & {
+export type MilestoneConnectionFragment = { __typename: "MilestoneConnection" } & {
   nodes: Array<{ __typename?: "Milestone" } & MilestoneFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type MilestonePayloadFragment = { __typename?: "MilestonePayload" } & Pick<
+export type MilestonePayloadFragment = { __typename: "MilestonePayload" } & Pick<
   MilestonePayload,
   "lastSyncId" | "success"
 > & { milestone?: Maybe<{ __typename?: "Milestone" } & Pick<Milestone, "id">> };
 
-type Node_ApiKey_Fragment = { __typename?: "ApiKey" } & Pick<ApiKey, "id">;
+type Node_ApiKey_Fragment = { __typename: "ApiKey" } & Pick<ApiKey, "id">;
 
-type Node_Attachment_Fragment = { __typename?: "Attachment" } & Pick<Attachment, "id">;
+type Node_Attachment_Fragment = { __typename: "Attachment" } & Pick<Attachment, "id">;
 
-type Node_AuditEntry_Fragment = { __typename?: "AuditEntry" } & Pick<AuditEntry, "id">;
+type Node_AuditEntry_Fragment = { __typename: "AuditEntry" } & Pick<AuditEntry, "id">;
 
-type Node_Comment_Fragment = { __typename?: "Comment" } & Pick<Comment, "id">;
+type Node_Comment_Fragment = { __typename: "Comment" } & Pick<Comment, "id">;
 
-type Node_CustomView_Fragment = { __typename?: "CustomView" } & Pick<CustomView, "id">;
+type Node_CustomView_Fragment = { __typename: "CustomView" } & Pick<CustomView, "id">;
 
-type Node_Cycle_Fragment = { __typename?: "Cycle" } & Pick<Cycle, "id">;
+type Node_Cycle_Fragment = { __typename: "Cycle" } & Pick<Cycle, "id">;
 
-type Node_Document_Fragment = { __typename?: "Document" } & Pick<Document, "id">;
+type Node_Document_Fragment = { __typename: "Document" } & Pick<Document, "id">;
 
-type Node_DocumentStep_Fragment = { __typename?: "DocumentStep" } & Pick<DocumentStep, "id">;
+type Node_DocumentStep_Fragment = { __typename: "DocumentStep" } & Pick<DocumentStep, "id">;
 
-type Node_DocumentVersion_Fragment = { __typename?: "DocumentVersion" } & Pick<DocumentVersion, "id">;
+type Node_DocumentVersion_Fragment = { __typename: "DocumentVersion" } & Pick<DocumentVersion, "id">;
 
-type Node_Emoji_Fragment = { __typename?: "Emoji" } & Pick<Emoji, "id">;
+type Node_Emoji_Fragment = { __typename: "Emoji" } & Pick<Emoji, "id">;
 
-type Node_Favorite_Fragment = { __typename?: "Favorite" } & Pick<Favorite, "id">;
+type Node_Favorite_Fragment = { __typename: "Favorite" } & Pick<Favorite, "id">;
 
-type Node_Integration_Fragment = { __typename?: "Integration" } & Pick<Integration, "id">;
+type Node_Integration_Fragment = { __typename: "Integration" } & Pick<Integration, "id">;
 
-type Node_IntegrationResource_Fragment = { __typename?: "IntegrationResource" } & Pick<IntegrationResource, "id">;
+type Node_IntegrationResource_Fragment = { __typename: "IntegrationResource" } & Pick<IntegrationResource, "id">;
 
-type Node_Issue_Fragment = { __typename?: "Issue" } & Pick<Issue, "id">;
+type Node_Issue_Fragment = { __typename: "Issue" } & Pick<Issue, "id">;
 
-type Node_IssueHistory_Fragment = { __typename?: "IssueHistory" } & Pick<IssueHistory, "id">;
+type Node_IssueHistory_Fragment = { __typename: "IssueHistory" } & Pick<IssueHistory, "id">;
 
-type Node_IssueImport_Fragment = { __typename?: "IssueImport" } & Pick<IssueImport, "id">;
+type Node_IssueImport_Fragment = { __typename: "IssueImport" } & Pick<IssueImport, "id">;
 
-type Node_IssueLabel_Fragment = { __typename?: "IssueLabel" } & Pick<IssueLabel, "id">;
+type Node_IssueLabel_Fragment = { __typename: "IssueLabel" } & Pick<IssueLabel, "id">;
 
-type Node_IssueRelation_Fragment = { __typename?: "IssueRelation" } & Pick<IssueRelation, "id">;
+type Node_IssueNotification_Fragment = { __typename: "IssueNotification" } & Pick<IssueNotification, "id">;
 
-type Node_Milestone_Fragment = { __typename?: "Milestone" } & Pick<Milestone, "id">;
+type Node_IssueRelation_Fragment = { __typename: "IssueRelation" } & Pick<IssueRelation, "id">;
 
-type Node_Notification_Fragment = { __typename?: "Notification" } & Pick<Notification, "id">;
+type Node_Milestone_Fragment = { __typename: "Milestone" } & Pick<Milestone, "id">;
 
-type Node_NotificationSubscription_Fragment = { __typename?: "NotificationSubscription" } & Pick<
+type Node_NotificationSubscription_Fragment = { __typename: "NotificationSubscription" } & Pick<
   NotificationSubscription,
   "id"
 >;
 
-type Node_OauthClient_Fragment = { __typename?: "OauthClient" } & Pick<OauthClient, "id">;
+type Node_OauthClient_Fragment = { __typename: "OauthClient" } & Pick<OauthClient, "id">;
 
-type Node_Organization_Fragment = { __typename?: "Organization" } & Pick<Organization, "id">;
+type Node_Organization_Fragment = { __typename: "Organization" } & Pick<Organization, "id">;
 
-type Node_OrganizationDomain_Fragment = { __typename?: "OrganizationDomain" } & Pick<OrganizationDomain, "id">;
+type Node_OrganizationDomain_Fragment = { __typename: "OrganizationDomain" } & Pick<OrganizationDomain, "id">;
 
-type Node_OrganizationInvite_Fragment = { __typename?: "OrganizationInvite" } & Pick<OrganizationInvite, "id">;
+type Node_OrganizationInvite_Fragment = { __typename: "OrganizationInvite" } & Pick<OrganizationInvite, "id">;
 
-type Node_Project_Fragment = { __typename?: "Project" } & Pick<Project, "id">;
+type Node_Project_Fragment = { __typename: "Project" } & Pick<Project, "id">;
 
-type Node_ProjectLink_Fragment = { __typename?: "ProjectLink" } & Pick<ProjectLink, "id">;
+type Node_ProjectLink_Fragment = { __typename: "ProjectLink" } & Pick<ProjectLink, "id">;
 
-type Node_PushSubscription_Fragment = { __typename?: "PushSubscription" } & Pick<PushSubscription, "id">;
+type Node_PushSubscription_Fragment = { __typename: "PushSubscription" } & Pick<PushSubscription, "id">;
 
-type Node_Reaction_Fragment = { __typename?: "Reaction" } & Pick<Reaction, "id">;
+type Node_Reaction_Fragment = { __typename: "Reaction" } & Pick<Reaction, "id">;
 
-type Node_Subscription_Fragment = { __typename?: "Subscription" } & Pick<Subscription, "id">;
+type Node_Subscription_Fragment = { __typename: "Subscription" } & Pick<Subscription, "id">;
 
-type Node_Team_Fragment = { __typename?: "Team" } & Pick<Team, "id">;
+type Node_Team_Fragment = { __typename: "Team" } & Pick<Team, "id">;
 
-type Node_TeamMembership_Fragment = { __typename?: "TeamMembership" } & Pick<TeamMembership, "id">;
+type Node_TeamMembership_Fragment = { __typename: "TeamMembership" } & Pick<TeamMembership, "id">;
 
-type Node_Template_Fragment = { __typename?: "Template" } & Pick<Template, "id">;
+type Node_Template_Fragment = { __typename: "Template" } & Pick<Template, "id">;
 
-type Node_User_Fragment = { __typename?: "User" } & Pick<User, "id">;
+type Node_User_Fragment = { __typename: "User" } & Pick<User, "id">;
 
-type Node_UserSettings_Fragment = { __typename?: "UserSettings" } & Pick<UserSettings, "id">;
+type Node_UserSettings_Fragment = { __typename: "UserSettings" } & Pick<UserSettings, "id">;
 
-type Node_ViewPreferences_Fragment = { __typename?: "ViewPreferences" } & Pick<ViewPreferences, "id">;
+type Node_ViewPreferences_Fragment = { __typename: "ViewPreferences" } & Pick<ViewPreferences, "id">;
 
-type Node_Webhook_Fragment = { __typename?: "Webhook" } & Pick<Webhook, "id">;
+type Node_Webhook_Fragment = { __typename: "Webhook" } & Pick<Webhook, "id">;
 
-type Node_WorkflowState_Fragment = { __typename?: "WorkflowState" } & Pick<WorkflowState, "id">;
+type Node_WorkflowState_Fragment = { __typename: "WorkflowState" } & Pick<WorkflowState, "id">;
 
 export type NodeFragment =
   | Node_ApiKey_Fragment
@@ -8177,9 +8232,9 @@ export type NodeFragment =
   | Node_IssueHistory_Fragment
   | Node_IssueImport_Fragment
   | Node_IssueLabel_Fragment
+  | Node_IssueNotification_Fragment
   | Node_IssueRelation_Fragment
   | Node_Milestone_Fragment
-  | Node_Notification_Fragment
   | Node_NotificationSubscription_Fragment
   | Node_OauthClient_Fragment
   | Node_Organization_Fragment
@@ -8199,82 +8254,82 @@ export type NodeFragment =
   | Node_Webhook_Fragment
   | Node_WorkflowState_Fragment;
 
-export type NotificationConnectionFragment = { __typename?: "NotificationConnection" } & {
-  nodes: Array<{ __typename?: "Notification" } & NotificationFragment>;
+export type NotificationConnectionFragment = { __typename: "NotificationConnection" } & {
+  nodes: Array<{ __typename?: "IssueNotification" } & NotificationFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type NotificationPayloadFragment = { __typename?: "NotificationPayload" } & Pick<
+export type NotificationPayloadFragment = { __typename: "NotificationPayload" } & Pick<
   NotificationPayload,
   "lastSyncId" | "success"
-> & { notification: { __typename?: "Notification" } & Pick<Notification, "id"> };
+> & { notification: { __typename?: "IssueNotification" } & NotificationFragment };
 
-export type NotificationSubscriptionConnectionFragment = { __typename?: "NotificationSubscriptionConnection" } & {
+export type NotificationSubscriptionConnectionFragment = { __typename: "NotificationSubscriptionConnection" } & {
   nodes: Array<{ __typename?: "NotificationSubscription" } & NotificationSubscriptionFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type NotificationSubscriptionPayloadFragment = { __typename?: "NotificationSubscriptionPayload" } & Pick<
+export type NotificationSubscriptionPayloadFragment = { __typename: "NotificationSubscriptionPayload" } & Pick<
   NotificationSubscriptionPayload,
   "lastSyncId" | "success"
 > & { notificationSubscription: { __typename?: "NotificationSubscription" } & Pick<NotificationSubscription, "id"> };
 
-export type OauthAuthStringAuthorizePayloadFragment = { __typename?: "OauthAuthStringAuthorizePayload" } & Pick<
+export type OauthAuthStringAuthorizePayloadFragment = { __typename: "OauthAuthStringAuthorizePayload" } & Pick<
   OauthAuthStringAuthorizePayload,
   "success"
 >;
 
-export type OauthAuthStringChallengePayloadFragment = { __typename?: "OauthAuthStringChallengePayload" } & Pick<
+export type OauthAuthStringChallengePayloadFragment = { __typename: "OauthAuthStringChallengePayload" } & Pick<
   OauthAuthStringChallengePayload,
   "authString" | "success"
 >;
 
-export type OauthAuthStringCheckPayloadFragment = { __typename?: "OauthAuthStringCheckPayload" } & Pick<
+export type OauthAuthStringCheckPayloadFragment = { __typename: "OauthAuthStringCheckPayload" } & Pick<
   OauthAuthStringCheckPayload,
   "token" | "success"
 >;
 
-export type OauthClientPayloadFragment = { __typename?: "OauthClientPayload" } & Pick<
+export type OauthClientPayloadFragment = { __typename: "OauthClientPayload" } & Pick<
   OauthClientPayload,
   "lastSyncId" | "success"
 > & { oauthClient: { __typename?: "OauthClient" } & OauthClientFragment };
 
-export type OauthTokenRevokePayloadFragment = { __typename?: "OauthTokenRevokePayload" } & Pick<
+export type OauthTokenRevokePayloadFragment = { __typename: "OauthTokenRevokePayload" } & Pick<
   OauthTokenRevokePayload,
   "success"
 >;
 
-export type OrganizationCancelDeletePayloadFragment = { __typename?: "OrganizationCancelDeletePayload" } & Pick<
+export type OrganizationCancelDeletePayloadFragment = { __typename: "OrganizationCancelDeletePayload" } & Pick<
   OrganizationCancelDeletePayload,
   "success"
 >;
 
-export type OrganizationDeletePayloadFragment = { __typename?: "OrganizationDeletePayload" } & Pick<
+export type OrganizationDeletePayloadFragment = { __typename: "OrganizationDeletePayload" } & Pick<
   OrganizationDeletePayload,
   "success"
 >;
 
-export type OrganizationDomainPayloadFragment = { __typename?: "OrganizationDomainPayload" } & Pick<
+export type OrganizationDomainPayloadFragment = { __typename: "OrganizationDomainPayload" } & Pick<
   OrganizationDomainPayload,
   "lastSyncId" | "success"
 > & { organizationDomain: { __typename?: "OrganizationDomain" } & OrganizationDomainFragment };
 
-export type OrganizationDomainSimplePayloadFragment = { __typename?: "OrganizationDomainSimplePayload" } & Pick<
+export type OrganizationDomainSimplePayloadFragment = { __typename: "OrganizationDomainSimplePayload" } & Pick<
   OrganizationDomainSimplePayload,
   "success"
 >;
 
-export type OrganizationExistsPayloadFragment = { __typename?: "OrganizationExistsPayload" } & Pick<
+export type OrganizationExistsPayloadFragment = { __typename: "OrganizationExistsPayload" } & Pick<
   OrganizationExistsPayload,
   "success" | "exists"
 >;
 
-export type OrganizationInviteConnectionFragment = { __typename?: "OrganizationInviteConnection" } & {
+export type OrganizationInviteConnectionFragment = { __typename: "OrganizationInviteConnection" } & {
   nodes: Array<{ __typename?: "OrganizationInvite" } & OrganizationInviteFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type OrganizationInviteDetailsPayloadFragment = { __typename?: "OrganizationInviteDetailsPayload" } & Pick<
+export type OrganizationInviteDetailsPayloadFragment = { __typename: "OrganizationInviteDetailsPayload" } & Pick<
   OrganizationInviteDetailsPayload,
   | "organizationId"
   | "organizationName"
@@ -8287,197 +8342,197 @@ export type OrganizationInviteDetailsPayloadFragment = { __typename?: "Organizat
   | "permission"
 >;
 
-export type OrganizationInvitePayloadFragment = { __typename?: "OrganizationInvitePayload" } & Pick<
+export type OrganizationInvitePayloadFragment = { __typename: "OrganizationInvitePayload" } & Pick<
   OrganizationInvitePayload,
   "lastSyncId" | "success"
 > & { organizationInvite: { __typename?: "OrganizationInvite" } & Pick<OrganizationInvite, "id"> };
 
-export type OrganizationPayloadFragment = { __typename?: "OrganizationPayload" } & Pick<
+export type OrganizationPayloadFragment = { __typename: "OrganizationPayload" } & Pick<
   OrganizationPayload,
   "lastSyncId" | "success"
 >;
 
-export type PageInfoFragment = { __typename?: "PageInfo" } & Pick<
+export type PageInfoFragment = { __typename: "PageInfo" } & Pick<
   PageInfo,
   "startCursor" | "endCursor" | "hasPreviousPage" | "hasNextPage"
 >;
 
-export type ProjectConnectionFragment = { __typename?: "ProjectConnection" } & {
+export type ProjectConnectionFragment = { __typename: "ProjectConnection" } & {
   nodes: Array<{ __typename?: "Project" } & ProjectFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type ProjectLinkConnectionFragment = { __typename?: "ProjectLinkConnection" } & {
+export type ProjectLinkConnectionFragment = { __typename: "ProjectLinkConnection" } & {
   nodes: Array<{ __typename?: "ProjectLink" } & ProjectLinkFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type ProjectLinkPayloadFragment = { __typename?: "ProjectLinkPayload" } & Pick<
+export type ProjectLinkPayloadFragment = { __typename: "ProjectLinkPayload" } & Pick<
   ProjectLinkPayload,
   "lastSyncId" | "success"
 > & { projectLink: { __typename?: "ProjectLink" } & Pick<ProjectLink, "id"> };
 
-export type ProjectPayloadFragment = { __typename?: "ProjectPayload" } & Pick<
+export type ProjectPayloadFragment = { __typename: "ProjectPayload" } & Pick<
   ProjectPayload,
   "lastSyncId" | "success"
 > & { project?: Maybe<{ __typename?: "Project" } & Pick<Project, "id">> };
 
-export type PushSubscriptionConnectionFragment = { __typename?: "PushSubscriptionConnection" } & {
+export type PushSubscriptionConnectionFragment = { __typename: "PushSubscriptionConnection" } & {
   nodes: Array<{ __typename?: "PushSubscription" } & PushSubscriptionFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type PushSubscriptionPayloadFragment = { __typename?: "PushSubscriptionPayload" } & Pick<
+export type PushSubscriptionPayloadFragment = { __typename: "PushSubscriptionPayload" } & Pick<
   PushSubscriptionPayload,
   "lastSyncId" | "success"
 >;
 
-export type PushSubscriptionTestPayloadFragment = { __typename?: "PushSubscriptionTestPayload" } & Pick<
+export type PushSubscriptionTestPayloadFragment = { __typename: "PushSubscriptionTestPayload" } & Pick<
   PushSubscriptionTestPayload,
   "success"
 >;
 
-export type RateLimitPayloadFragment = { __typename?: "RateLimitPayload" } & Pick<
+export type RateLimitPayloadFragment = { __typename: "RateLimitPayload" } & Pick<
   RateLimitPayload,
   "identifier" | "kind"
 > & { limits: Array<{ __typename?: "RateLimitResultPayload" } & RateLimitResultPayloadFragment> };
 
-export type RateLimitResultPayloadFragment = { __typename?: "RateLimitResultPayload" } & Pick<
+export type RateLimitResultPayloadFragment = { __typename: "RateLimitResultPayload" } & Pick<
   RateLimitResultPayload,
   "period" | "remainingAmount" | "requestedAmount" | "reset" | "allowedAmount" | "type"
 >;
 
-export type ReactionConnectionFragment = { __typename?: "ReactionConnection" } & {
+export type ReactionConnectionFragment = { __typename: "ReactionConnection" } & {
   nodes: Array<{ __typename?: "Reaction" } & ReactionFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type ReactionPayloadFragment = { __typename?: "ReactionPayload" } & Pick<
+export type ReactionPayloadFragment = { __typename: "ReactionPayload" } & Pick<
   ReactionPayload,
   "lastSyncId" | "success"
 > & { reaction: { __typename?: "Reaction" } & Pick<Reaction, "id"> };
 
-export type RotateSecretPayloadFragment = { __typename?: "RotateSecretPayload" } & Pick<
+export type RotateSecretPayloadFragment = { __typename: "RotateSecretPayload" } & Pick<
   RotateSecretPayload,
   "lastSyncId" | "success"
 >;
 
-export type SamlConfigurationFragment = { __typename?: "SamlConfiguration" } & Pick<
+export type SamlConfigurationFragment = { __typename: "SamlConfiguration" } & Pick<
   SamlConfiguration,
   "ssoBinding" | "allowedDomains" | "ssoEndpoint" | "ssoSignAlgo" | "issuerEntityId" | "ssoSigningCert"
 >;
 
-export type SsoUrlFromEmailResponseFragment = { __typename?: "SsoUrlFromEmailResponse" } & Pick<
+export type SsoUrlFromEmailResponseFragment = { __typename: "SsoUrlFromEmailResponse" } & Pick<
   SsoUrlFromEmailResponse,
   "samlSsoUrl" | "success"
 >;
 
-export type StepsResponseFragment = { __typename?: "StepsResponse" } & Pick<
+export type StepsResponseFragment = { __typename: "StepsResponse" } & Pick<
   StepsResponse,
   "version" | "clientIds" | "steps"
 >;
 
-export type SubscriptionPayloadFragment = { __typename?: "SubscriptionPayload" } & Pick<
+export type SubscriptionPayloadFragment = { __typename: "SubscriptionPayload" } & Pick<
   SubscriptionPayload,
   "canceledAt" | "lastSyncId" | "success"
 >;
 
-export type SubscriptionSessionPayloadFragment = { __typename?: "SubscriptionSessionPayload" } & Pick<
+export type SubscriptionSessionPayloadFragment = { __typename: "SubscriptionSessionPayload" } & Pick<
   SubscriptionSessionPayload,
   "session"
 >;
 
-export type SynchronizedPayloadFragment = { __typename?: "SynchronizedPayload" } & Pick<
+export type SynchronizedPayloadFragment = { __typename: "SynchronizedPayload" } & Pick<
   SynchronizedPayload,
   "lastSyncId"
 >;
 
-export type TeamConnectionFragment = { __typename?: "TeamConnection" } & {
+export type TeamConnectionFragment = { __typename: "TeamConnection" } & {
   nodes: Array<{ __typename?: "Team" } & TeamFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type TeamMembershipConnectionFragment = { __typename?: "TeamMembershipConnection" } & {
+export type TeamMembershipConnectionFragment = { __typename: "TeamMembershipConnection" } & {
   nodes: Array<{ __typename?: "TeamMembership" } & TeamMembershipFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type TeamMembershipPayloadFragment = { __typename?: "TeamMembershipPayload" } & Pick<
+export type TeamMembershipPayloadFragment = { __typename: "TeamMembershipPayload" } & Pick<
   TeamMembershipPayload,
   "lastSyncId" | "success"
 > & { teamMembership?: Maybe<{ __typename?: "TeamMembership" } & Pick<TeamMembership, "id">> };
 
-export type TeamPayloadFragment = { __typename?: "TeamPayload" } & Pick<TeamPayload, "lastSyncId" | "success"> & {
+export type TeamPayloadFragment = { __typename: "TeamPayload" } & Pick<TeamPayload, "lastSyncId" | "success"> & {
     team?: Maybe<{ __typename?: "Team" } & Pick<Team, "id">>;
   };
 
-export type TemplateConnectionFragment = { __typename?: "TemplateConnection" } & {
+export type TemplateConnectionFragment = { __typename: "TemplateConnection" } & {
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type TemplatePayloadFragment = { __typename?: "TemplatePayload" } & Pick<
+export type TemplatePayloadFragment = { __typename: "TemplatePayload" } & Pick<
   TemplatePayload,
   "lastSyncId" | "success"
 > & { template: { __typename?: "Template" } & Pick<Template, "id"> };
 
-export type UploadFileHeaderFragment = { __typename?: "UploadFileHeader" } & Pick<UploadFileHeader, "key" | "value">;
+export type UploadFileHeaderFragment = { __typename: "UploadFileHeader" } & Pick<UploadFileHeader, "key" | "value">;
 
-export type UploadPayloadFragment = { __typename?: "UploadPayload" } & Pick<UploadPayload, "lastSyncId" | "success"> & {
+export type UploadPayloadFragment = { __typename: "UploadPayload" } & Pick<UploadPayload, "lastSyncId" | "success"> & {
     uploadFile?: Maybe<{ __typename?: "UploadFile" } & UploadFileFragment>;
   };
 
-export type UserAdminPayloadFragment = { __typename?: "UserAdminPayload" } & Pick<UserAdminPayload, "success">;
+export type UserAdminPayloadFragment = { __typename: "UserAdminPayload" } & Pick<UserAdminPayload, "success">;
 
-export type UserConnectionFragment = { __typename?: "UserConnection" } & {
+export type UserConnectionFragment = { __typename: "UserConnection" } & {
   nodes: Array<{ __typename?: "User" } & UserFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type UserPayloadFragment = { __typename?: "UserPayload" } & Pick<UserPayload, "lastSyncId" | "success"> & {
+export type UserPayloadFragment = { __typename: "UserPayload" } & Pick<UserPayload, "lastSyncId" | "success"> & {
     user?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
   };
 
-export type UserSettingsFlagPayloadFragment = { __typename?: "UserSettingsFlagPayload" } & Pick<
+export type UserSettingsFlagPayloadFragment = { __typename: "UserSettingsFlagPayload" } & Pick<
   UserSettingsFlagPayload,
   "flag" | "value" | "lastSyncId" | "success"
 >;
 
-export type UserSettingsFlagsResetPayloadFragment = { __typename?: "UserSettingsFlagsResetPayload" } & Pick<
+export type UserSettingsFlagsResetPayloadFragment = { __typename: "UserSettingsFlagsResetPayload" } & Pick<
   UserSettingsFlagsResetPayload,
   "lastSyncId" | "success"
 >;
 
-export type UserSettingsPayloadFragment = { __typename?: "UserSettingsPayload" } & Pick<
+export type UserSettingsPayloadFragment = { __typename: "UserSettingsPayload" } & Pick<
   UserSettingsPayload,
   "lastSyncId" | "success"
 >;
 
-export type UserSubscribeToNewsletterPayloadFragment = { __typename?: "UserSubscribeToNewsletterPayload" } & Pick<
+export type UserSubscribeToNewsletterPayloadFragment = { __typename: "UserSubscribeToNewsletterPayload" } & Pick<
   UserSubscribeToNewsletterPayload,
   "success"
 >;
 
-export type ViewPreferencesPayloadFragment = { __typename?: "ViewPreferencesPayload" } & Pick<
+export type ViewPreferencesPayloadFragment = { __typename: "ViewPreferencesPayload" } & Pick<
   ViewPreferencesPayload,
   "lastSyncId" | "success"
 > & { viewPreferences: { __typename?: "ViewPreferences" } & ViewPreferencesFragment };
 
-export type WebhookConnectionFragment = { __typename?: "WebhookConnection" } & {
+export type WebhookConnectionFragment = { __typename: "WebhookConnection" } & {
   nodes: Array<{ __typename?: "Webhook" } & WebhookFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type WebhookPayloadFragment = { __typename?: "WebhookPayload" } & Pick<
+export type WebhookPayloadFragment = { __typename: "WebhookPayload" } & Pick<
   WebhookPayload,
   "lastSyncId" | "success"
 > & { webhook: { __typename?: "Webhook" } & Pick<Webhook, "id"> };
 
-export type WorkflowStateConnectionFragment = { __typename?: "WorkflowStateConnection" } & {
+export type WorkflowStateConnectionFragment = { __typename: "WorkflowStateConnection" } & {
   nodes: Array<{ __typename?: "WorkflowState" } & WorkflowStateFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type WorkflowStatePayloadFragment = { __typename?: "WorkflowStatePayload" } & Pick<
+export type WorkflowStatePayloadFragment = { __typename: "WorkflowStatePayload" } & Pick<
   WorkflowStatePayload,
   "lastSyncId" | "success"
 > & { workflowState: { __typename?: "WorkflowState" } & Pick<WorkflowState, "id"> };
@@ -9260,7 +9315,7 @@ export type NotificationQueryVariables = Exact<{
 }>;
 
 export type NotificationQuery = { __typename?: "Query" } & {
-  notification: { __typename?: "Notification" } & NotificationFragment;
+  notification: { __typename?: "IssueNotification" } & NotificationFragment;
 };
 
 export type NotificationSubscriptionQueryVariables = Exact<{
@@ -11327,6 +11382,26 @@ export type WorkflowStateUpdateMutation = { __typename?: "Mutation" } & {
   workflowStateUpdate: { __typename?: "WorkflowStatePayload" } & WorkflowStatePayloadFragment;
 };
 
+export const EntityFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "Entity" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Entity" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<EntityFragment, unknown>;
 export const TemplateFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -11337,6 +11412,7 @@ export const TemplateFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "templateData" } },
           { kind: "Field", name: { kind: "Name", value: "description" } },
           { kind: "Field", name: { kind: "Name", value: "type" } },
@@ -11376,6 +11452,7 @@ export const UserFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "statusUntilAt" } },
           { kind: "Field", name: { kind: "Name", value: "description" } },
           { kind: "Field", name: { kind: "Name", value: "avatarUrl" } },
@@ -11413,6 +11490,7 @@ export const UserAccountFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "service" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
@@ -11444,6 +11522,7 @@ export const DocumentStepFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "clientId" } },
           { kind: "Field", name: { kind: "Name", value: "step" } },
           { kind: "Field", name: { kind: "Name", value: "version" } },
@@ -11466,6 +11545,7 @@ export const SyncDeltaResponseFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "updates" } },
           { kind: "Field", name: { kind: "Name", value: "success" } },
           { kind: "Field", name: { kind: "Name", value: "loadMore" } },
@@ -11484,6 +11564,7 @@ export const SyncResponseFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "delta" } },
           { kind: "Field", name: { kind: "Name", value: "state" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
@@ -11504,6 +11585,7 @@ export const ArchiveResponseFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "archive" } },
           { kind: "Field", name: { kind: "Name", value: "totalCount" } },
           { kind: "Field", name: { kind: "Name", value: "databaseVersion" } },
@@ -11522,7 +11604,10 @@ export const DependencyResponseFragmentDoc = {
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "DependencyResponse" } },
       selectionSet: {
         kind: "SelectionSet",
-        selections: [{ kind: "Field", name: { kind: "Name", value: "dependencies" } }],
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "dependencies" } },
+        ],
       },
     },
   ],
@@ -11534,7 +11619,13 @@ export const SyncBatchResponseFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "SyncBatchResponse" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "SyncBatchResponse" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "models" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "models" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<SyncBatchResponseFragment, unknown>;
@@ -11548,6 +11639,7 @@ export const GithubRepoFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
         ],
@@ -11565,6 +11657,7 @@ export const GithubOrgFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
           {
             kind: "Field",
@@ -11592,6 +11685,7 @@ export const GithubOAuthTokenPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "organizations" },
@@ -11617,6 +11711,7 @@ export const AuthorizedApplicationFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
           { kind: "Field", name: { kind: "Name", value: "description" } },
@@ -11641,6 +11736,7 @@ export const UserAuthorizedApplicationFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
           { kind: "Field", name: { kind: "Name", value: "description" } },
@@ -11665,6 +11761,7 @@ export const ApplicationFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
           { kind: "Field", name: { kind: "Name", value: "description" } },
@@ -11686,6 +11783,7 @@ export const GoogleSheetsSettingsFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "sheetId" } },
           { kind: "Field", name: { kind: "Name", value: "spreadsheetId" } },
           { kind: "Field", name: { kind: "Name", value: "spreadsheetUrl" } },
@@ -11705,6 +11803,7 @@ export const IntercomSettingsFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "sendNoteOnStatusChange" } },
           { kind: "Field", name: { kind: "Name", value: "sendNoteOnComment" } },
         ],
@@ -11722,6 +11821,7 @@ export const JiraProjectDataFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "key" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
@@ -11740,6 +11840,7 @@ export const JiraLinearMappingFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "jiraProjectId" } },
           { kind: "Field", name: { kind: "Name", value: "linearTeamId" } },
         ],
@@ -11757,6 +11858,7 @@ export const JiraSettingsFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "projects" },
@@ -11789,7 +11891,10 @@ export const SentrySettingsFragmentDoc = {
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "SentrySettings" } },
       selectionSet: {
         kind: "SelectionSet",
-        selections: [{ kind: "Field", name: { kind: "Name", value: "organizationSlug" } }],
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "organizationSlug" } },
+        ],
       },
     },
   ],
@@ -11804,6 +11909,7 @@ export const SlackPostSettingsFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "channel" } },
           { kind: "Field", name: { kind: "Name", value: "channelId" } },
           { kind: "Field", name: { kind: "Name", value: "configurationUrl" } },
@@ -11822,6 +11928,7 @@ export const ZendeskSettingsFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "botUserId" } },
           { kind: "Field", name: { kind: "Name", value: "url" } },
           { kind: "Field", name: { kind: "Name", value: "subdomain" } },
@@ -11840,6 +11947,7 @@ export const IntegrationSettingsFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "googleSheets" },
@@ -11917,6 +12025,7 @@ export const SamlConfigurationPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "ssoBinding" } },
           { kind: "Field", name: { kind: "Name", value: "allowedDomains" } },
           { kind: "Field", name: { kind: "Name", value: "ssoEndpoint" } },
@@ -11937,6 +12046,7 @@ export const UserSettingsFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "unsubscribedFrom" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           { kind: "Field", name: { kind: "Name", value: "notificationPreferences" } },
@@ -11966,6 +12076,7 @@ export const SubscriptionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "creator" },
@@ -11998,6 +12109,7 @@ export const ApiKeyFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "label" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
@@ -12018,6 +12130,7 @@ export const PageInfoFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "startCursor" } },
           { kind: "Field", name: { kind: "Name", value: "endCursor" } },
           { kind: "Field", name: { kind: "Name", value: "hasPreviousPage" } },
@@ -12037,6 +12150,7 @@ export const ApiKeyConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -12070,6 +12184,7 @@ export const ApiKeyPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "apiKey" },
@@ -12096,6 +12211,7 @@ export const ArchivePayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           { kind: "Field", name: { kind: "Name", value: "success" } },
         ],
@@ -12113,6 +12229,7 @@ export const AttachmentFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "sourceType" } },
           { kind: "Field", name: { kind: "Name", value: "subtitle" } },
           { kind: "Field", name: { kind: "Name", value: "title" } },
@@ -12155,6 +12272,7 @@ export const AttachmentConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -12188,6 +12306,7 @@ export const AttachmentPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -12213,6 +12332,7 @@ export const AuditEntryFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "metadata" } },
           { kind: "Field", name: { kind: "Name", value: "countryCode" } },
           { kind: "Field", name: { kind: "Name", value: "ip" } },
@@ -12245,6 +12365,7 @@ export const AuditEntryConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -12278,6 +12399,7 @@ export const AuditEntryTypeFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "description" } },
           { kind: "Field", name: { kind: "Name", value: "type" } },
         ],
@@ -12295,6 +12417,7 @@ export const OrganizationFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "allowedAuthServices" } },
           { kind: "Field", name: { kind: "Name", value: "gitBranchFormat" } },
           { kind: "Field", name: { kind: "Name", value: "userCount" } },
@@ -12327,6 +12450,7 @@ export const AuthResolverResponseFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "email" } },
           { kind: "Field", name: { kind: "Name", value: "lastUsedOrganizationId" } },
           { kind: "Field", name: { kind: "Name", value: "token" } },
@@ -12365,6 +12489,7 @@ export const InvoiceFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "url" } },
           { kind: "Field", name: { kind: "Name", value: "created" } },
           { kind: "Field", name: { kind: "Name", value: "dueDate" } },
@@ -12385,6 +12510,7 @@ export const CardFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "brand" } },
           { kind: "Field", name: { kind: "Name", value: "last4" } },
         ],
@@ -12402,6 +12528,7 @@ export const BillingDetailsPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "invoices" },
@@ -12437,6 +12564,7 @@ export const BillingEmailPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "email" } },
           { kind: "Field", name: { kind: "Name", value: "success" } },
         ],
@@ -12454,6 +12582,7 @@ export const StepsResponseFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "version" } },
           { kind: "Field", name: { kind: "Name", value: "clientIds" } },
           { kind: "Field", name: { kind: "Name", value: "steps" } },
@@ -12472,6 +12601,7 @@ export const CollaborationDocumentUpdatePayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "steps" },
@@ -12497,6 +12627,7 @@ export const CommentFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "url" } },
           { kind: "Field", name: { kind: "Name", value: "body" } },
           {
@@ -12543,6 +12674,7 @@ export const CommentConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -12576,6 +12708,7 @@ export const CommentPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "comment" },
@@ -12598,7 +12731,13 @@ export const ContactPayloadFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "ContactPayload" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "ContactPayload" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "success" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<ContactPayloadFragment, unknown>;
@@ -12609,7 +12748,13 @@ export const CreateCsvExportReportPayloadFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "CreateCsvExportReportPayload" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "CreateCsvExportReportPayload" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "success" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<CreateCsvExportReportPayloadFragment, unknown>;
@@ -12623,6 +12768,7 @@ export const CreateOrJoinOrganizationResponseFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "user" },
@@ -12646,6 +12792,7 @@ export const CustomViewFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "color" } },
           { kind: "Field", name: { kind: "Name", value: "description" } },
           { kind: "Field", name: { kind: "Name", value: "filters" } },
@@ -12688,6 +12835,7 @@ export const CustomViewConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -12721,6 +12869,7 @@ export const CustomViewPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "customView" },
@@ -12746,6 +12895,7 @@ export const CycleFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "completedAt" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "endsAt" } },
@@ -12784,6 +12934,7 @@ export const CycleConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -12817,6 +12968,7 @@ export const CyclePayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "cycle" },
@@ -12839,7 +12991,13 @@ export const DebugPayloadFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "DebugPayload" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "DebugPayload" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "success" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<DebugPayloadFragment, unknown>;
@@ -12853,6 +13011,7 @@ export const DocumentFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "color" } },
           { kind: "Field", name: { kind: "Name", value: "contentData" } },
           { kind: "Field", name: { kind: "Name", value: "content" } },
@@ -12902,6 +13061,7 @@ export const DocumentConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -12935,6 +13095,7 @@ export const DocumentPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "document" },
@@ -12960,6 +13121,7 @@ export const DocumentVersionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "content" } },
           { kind: "Field", name: { kind: "Name", value: "title" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
@@ -12998,6 +13160,7 @@ export const DocumentVersionConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -13028,7 +13191,13 @@ export const EmailSubscribePayloadFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "EmailSubscribePayload" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "EmailSubscribePayload" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "success" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<EmailSubscribePayloadFragment, unknown>;
@@ -13039,7 +13208,13 @@ export const EmailUnsubscribePayloadFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "EmailUnsubscribePayload" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "EmailUnsubscribePayload" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "success" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<EmailUnsubscribePayloadFragment, unknown>;
@@ -13053,6 +13228,7 @@ export const EmailUserAccountAuthChallengeResponseFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "authType" } },
           { kind: "Field", name: { kind: "Name", value: "success" } },
         ],
@@ -13070,6 +13246,7 @@ export const EmojiFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "url" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
@@ -13100,6 +13277,7 @@ export const EmojiConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -13133,6 +13311,7 @@ export const EmojiPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "emoji" },
@@ -13155,7 +13334,13 @@ export const EventPayloadFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "EventPayload" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "EventPayload" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "success" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<EventPayloadFragment, unknown>;
@@ -13169,6 +13354,7 @@ export const FavoriteFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "customView" },
@@ -13272,6 +13458,7 @@ export const FavoriteConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -13305,6 +13492,7 @@ export const FavoritePayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -13327,7 +13515,13 @@ export const FeedbackPayloadFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "FeedbackPayload" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "FeedbackPayload" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "success" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<FeedbackPayloadFragment, unknown>;
@@ -13341,6 +13535,7 @@ export const FigmaEmbedFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastModified" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "url" } },
@@ -13360,6 +13555,7 @@ export const FigmaEmbedPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "figmaEmbed" },
@@ -13385,6 +13581,7 @@ export const FrontAttachmentPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           { kind: "Field", name: { kind: "Name", value: "success" } },
         ],
@@ -13402,6 +13599,7 @@ export const GitHubCommitIntegrationPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -13428,6 +13626,7 @@ export const ImageUploadFromUrlPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "url" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           { kind: "Field", name: { kind: "Name", value: "success" } },
@@ -13446,6 +13645,7 @@ export const IntegrationFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "service" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           {
@@ -13482,6 +13682,7 @@ export const IntegrationConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -13515,6 +13716,7 @@ export const IntegrationPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -13540,6 +13742,7 @@ export const CommitPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "added" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "message" } },
@@ -13562,6 +13765,7 @@ export const PullRequestPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "branch" } },
           { kind: "Field", name: { kind: "Name", value: "closedAt" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
@@ -13592,6 +13796,7 @@ export const SentryIssuePayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "issueId" } },
           { kind: "Field", name: { kind: "Name", value: "actorId" } },
           { kind: "Field", name: { kind: "Name", value: "projectId" } },
@@ -13618,6 +13823,7 @@ export const IntegrationResourceDataFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "githubCommit" },
@@ -13668,6 +13874,7 @@ export const IntegrationResourceFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "data" },
@@ -13723,6 +13930,7 @@ export const IntegrationResourceConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -13756,6 +13964,7 @@ export const IssueFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "trashed" } },
           { kind: "Field", name: { kind: "Name", value: "url" } },
           { kind: "Field", name: { kind: "Name", value: "identifier" } },
@@ -13861,6 +14070,7 @@ export const IssueBatchPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -13887,6 +14097,7 @@ export const IssueConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -13920,6 +14131,7 @@ export const IssueRelationHistoryPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "identifier" } },
           { kind: "Field", name: { kind: "Name", value: "type" } },
         ],
@@ -13937,6 +14149,7 @@ export const IssueImportFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "mapping" } },
           { kind: "Field", name: { kind: "Name", value: "creatorId" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
@@ -13961,6 +14174,7 @@ export const IssueHistoryFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "relationChanges" },
@@ -14134,6 +14348,7 @@ export const IssueHistoryConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -14167,6 +14382,7 @@ export const IssueImportDeletePayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -14193,6 +14409,7 @@ export const IssueImportPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -14219,6 +14436,7 @@ export const IssueLabelFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "color" } },
           { kind: "Field", name: { kind: "Name", value: "description" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
@@ -14257,6 +14475,7 @@ export const IssueLabelConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -14290,6 +14509,7 @@ export const IssueLabelPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -14315,6 +14535,7 @@ export const IssuePayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -14340,6 +14561,7 @@ export const IssuePriorityValueFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "label" } },
           { kind: "Field", name: { kind: "Name", value: "priority" } },
         ],
@@ -14357,6 +14579,7 @@ export const IssueRelationFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "issue" },
@@ -14393,6 +14616,7 @@ export const IssueRelationConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -14426,6 +14650,7 @@ export const IssueRelationPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -14451,6 +14676,7 @@ export const MilestoneFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "sortOrder" } },
@@ -14472,6 +14698,7 @@ export const MilestoneConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -14505,6 +14732,7 @@ export const MilestonePayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -14527,20 +14755,27 @@ export const NodeFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "Node" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Node" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<NodeFragment, unknown>;
-export const NotificationFragmentDoc = {
+export const IssueNotificationFragmentDoc = {
   kind: "Document",
   definitions: [
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "Notification" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Notification" } },
+      name: { kind: "Name", value: "IssueNotification" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "IssueNotification" } },
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "reactionEmoji" } },
           { kind: "Field", name: { kind: "Name", value: "type" } },
           {
@@ -14562,14 +14797,6 @@ export const NotificationFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           {
             kind: "Field",
-            name: { kind: "Name", value: "user" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
-            },
-          },
-          {
-            kind: "Field",
             name: { kind: "Name", value: "team" },
             selectionSet: {
               kind: "SelectionSet",
@@ -14582,9 +14809,58 @@ export const NotificationFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
           { kind: "Field", name: { kind: "Name", value: "snoozedUntilAt" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "user" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
         ],
       },
     },
+  ],
+} as unknown as DocumentNode<IssueNotificationFragment, unknown>;
+export const NotificationFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "Notification" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Notification" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "type" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "emailedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "readAt" } },
+          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "snoozedUntilAt" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "user" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+          {
+            kind: "InlineFragment",
+            typeCondition: { kind: "NamedType", name: { kind: "Name", value: "IssueNotification" } },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueNotification" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IssueNotificationFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<NotificationFragment, unknown>;
 export const NotificationConnectionFragmentDoc = {
@@ -14597,6 +14873,7 @@ export const NotificationConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -14630,19 +14907,21 @@ export const NotificationPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "notification" },
             selectionSet: {
               kind: "SelectionSet",
-              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "Notification" } }],
             },
           },
           { kind: "Field", name: { kind: "Name", value: "success" } },
         ],
       },
     },
+    ...NotificationFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<NotificationPayloadFragment, unknown>;
 export const NotificationSubscriptionFragmentDoc = {
@@ -14655,6 +14934,7 @@ export const NotificationSubscriptionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "project" },
@@ -14699,6 +14979,7 @@ export const NotificationSubscriptionConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -14732,6 +15013,7 @@ export const NotificationSubscriptionPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -14754,7 +15036,13 @@ export const OauthAuthStringAuthorizePayloadFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "OauthAuthStringAuthorizePayload" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "OauthAuthStringAuthorizePayload" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "success" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<OauthAuthStringAuthorizePayloadFragment, unknown>;
@@ -14768,6 +15056,7 @@ export const OauthAuthStringChallengePayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "authString" } },
           { kind: "Field", name: { kind: "Name", value: "success" } },
         ],
@@ -14785,6 +15074,7 @@ export const OauthAuthStringCheckPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "token" } },
           { kind: "Field", name: { kind: "Name", value: "success" } },
         ],
@@ -14802,6 +15092,7 @@ export const OauthClientFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
           { kind: "Field", name: { kind: "Name", value: "description" } },
           { kind: "Field", name: { kind: "Name", value: "redirectUris" } },
@@ -14832,6 +15123,7 @@ export const OauthClientPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "oauthClient" },
@@ -14855,7 +15147,13 @@ export const OauthTokenRevokePayloadFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "OauthTokenRevokePayload" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "OauthTokenRevokePayload" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "success" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<OauthTokenRevokePayloadFragment, unknown>;
@@ -14866,7 +15164,13 @@ export const OrganizationCancelDeletePayloadFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "OrganizationCancelDeletePayload" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "OrganizationCancelDeletePayload" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "success" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<OrganizationCancelDeletePayloadFragment, unknown>;
@@ -14877,7 +15181,13 @@ export const OrganizationDeletePayloadFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "OrganizationDeletePayload" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "OrganizationDeletePayload" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "success" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<OrganizationDeletePayloadFragment, unknown>;
@@ -14891,6 +15201,7 @@ export const OrganizationDomainFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "verificationEmail" } },
           { kind: "Field", name: { kind: "Name", value: "verified" } },
@@ -14921,6 +15232,7 @@ export const OrganizationDomainPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -14944,7 +15256,13 @@ export const OrganizationDomainSimplePayloadFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "OrganizationDomainSimplePayload" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "OrganizationDomainSimplePayload" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "success" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<OrganizationDomainSimplePayloadFragment, unknown>;
@@ -14958,6 +15276,7 @@ export const OrganizationExistsPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "success" } },
           { kind: "Field", name: { kind: "Name", value: "exists" } },
         ],
@@ -14975,6 +15294,7 @@ export const OrganizationInviteFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "external" } },
           { kind: "Field", name: { kind: "Name", value: "email" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
@@ -15015,6 +15335,7 @@ export const OrganizationInviteConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -15048,6 +15369,7 @@ export const OrganizationInviteDetailsPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "organizationId" } },
           { kind: "Field", name: { kind: "Name", value: "organizationName" } },
           { kind: "Field", name: { kind: "Name", value: "email" } },
@@ -15072,6 +15394,7 @@ export const OrganizationInvitePayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -15097,6 +15420,7 @@ export const OrganizationPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           { kind: "Field", name: { kind: "Name", value: "success" } },
         ],
@@ -15114,6 +15438,7 @@ export const ProjectFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "url" } },
           { kind: "Field", name: { kind: "Name", value: "targetDate" } },
           { kind: "Field", name: { kind: "Name", value: "icon" } },
@@ -15178,6 +15503,7 @@ export const ProjectConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -15211,6 +15537,7 @@ export const ProjectLinkFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           { kind: "Field", name: { kind: "Name", value: "url" } },
           { kind: "Field", name: { kind: "Name", value: "label" } },
@@ -15248,6 +15575,7 @@ export const ProjectLinkConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -15281,6 +15609,7 @@ export const ProjectLinkPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -15306,6 +15635,7 @@ export const ProjectPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -15331,6 +15661,7 @@ export const PushSubscriptionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
@@ -15350,6 +15681,7 @@ export const PushSubscriptionConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -15383,6 +15715,7 @@ export const PushSubscriptionPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           { kind: "Field", name: { kind: "Name", value: "success" } },
         ],
@@ -15397,7 +15730,13 @@ export const PushSubscriptionTestPayloadFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "PushSubscriptionTestPayload" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "PushSubscriptionTestPayload" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "success" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<PushSubscriptionTestPayloadFragment, unknown>;
@@ -15411,6 +15750,7 @@ export const RateLimitResultPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "period" } },
           { kind: "Field", name: { kind: "Name", value: "remainingAmount" } },
           { kind: "Field", name: { kind: "Name", value: "requestedAmount" } },
@@ -15432,6 +15772,7 @@ export const RateLimitPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "identifier" } },
           { kind: "Field", name: { kind: "Name", value: "kind" } },
           {
@@ -15458,6 +15799,7 @@ export const ReactionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "emoji" } },
           {
             kind: "Field",
@@ -15494,6 +15836,7 @@ export const ReactionConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -15527,6 +15870,7 @@ export const ReactionPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -15552,6 +15896,7 @@ export const RotateSecretPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           { kind: "Field", name: { kind: "Name", value: "success" } },
         ],
@@ -15569,6 +15914,7 @@ export const SamlConfigurationFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "ssoBinding" } },
           { kind: "Field", name: { kind: "Name", value: "allowedDomains" } },
           { kind: "Field", name: { kind: "Name", value: "ssoEndpoint" } },
@@ -15590,6 +15936,7 @@ export const SsoUrlFromEmailResponseFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "samlSsoUrl" } },
           { kind: "Field", name: { kind: "Name", value: "success" } },
         ],
@@ -15607,6 +15954,7 @@ export const SubscriptionPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "canceledAt" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           { kind: "Field", name: { kind: "Name", value: "success" } },
@@ -15622,7 +15970,13 @@ export const SubscriptionSessionPayloadFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "SubscriptionSessionPayload" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "SubscriptionSessionPayload" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "session" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "session" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<SubscriptionSessionPayloadFragment, unknown>;
@@ -15635,7 +15989,10 @@ export const SynchronizedPayloadFragmentDoc = {
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "SynchronizedPayload" } },
       selectionSet: {
         kind: "SelectionSet",
-        selections: [{ kind: "Field", name: { kind: "Name", value: "lastSyncId" } }],
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
+        ],
       },
     },
   ],
@@ -15650,6 +16007,7 @@ export const TeamFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "cycleIssueAutoAssignCompleted" } },
           { kind: "Field", name: { kind: "Name", value: "cycleIssueAutoAssignStarted" } },
           { kind: "Field", name: { kind: "Name", value: "cycleCalenderUrl" } },
@@ -15781,6 +16139,7 @@ export const TeamConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -15814,6 +16173,7 @@ export const TeamMembershipFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           {
             kind: "Field",
@@ -15850,6 +16210,7 @@ export const TeamMembershipConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -15883,6 +16244,7 @@ export const TeamMembershipPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -15908,6 +16270,7 @@ export const TeamPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -15933,6 +16296,7 @@ export const TemplateConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "pageInfo" },
@@ -15957,6 +16321,7 @@ export const TemplatePayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -15982,6 +16347,7 @@ export const UploadFileHeaderFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "key" } },
           { kind: "Field", name: { kind: "Name", value: "value" } },
         ],
@@ -15999,6 +16365,7 @@ export const UploadFileFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "assetUrl" } },
           { kind: "Field", name: { kind: "Name", value: "contentType" } },
           { kind: "Field", name: { kind: "Name", value: "filename" } },
@@ -16029,6 +16396,7 @@ export const UploadPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "uploadFile" },
@@ -16052,7 +16420,13 @@ export const UserAdminPayloadFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "UserAdminPayload" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "UserAdminPayload" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "success" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<UserAdminPayloadFragment, unknown>;
@@ -16066,6 +16440,7 @@ export const UserConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -16099,6 +16474,7 @@ export const UserPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -16124,6 +16500,7 @@ export const UserSettingsFlagPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "flag" } },
           { kind: "Field", name: { kind: "Name", value: "value" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
@@ -16143,6 +16520,7 @@ export const UserSettingsFlagsResetPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           { kind: "Field", name: { kind: "Name", value: "success" } },
         ],
@@ -16160,6 +16538,7 @@ export const UserSettingsPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           { kind: "Field", name: { kind: "Name", value: "success" } },
         ],
@@ -16174,7 +16553,13 @@ export const UserSubscribeToNewsletterPayloadFragmentDoc = {
       kind: "FragmentDefinition",
       name: { kind: "Name", value: "UserSubscribeToNewsletterPayload" },
       typeCondition: { kind: "NamedType", name: { kind: "Name", value: "UserSubscribeToNewsletterPayload" } },
-      selectionSet: { kind: "SelectionSet", selections: [{ kind: "Field", name: { kind: "Name", value: "success" } }] },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
     },
   ],
 } as unknown as DocumentNode<UserSubscribeToNewsletterPayloadFragment, unknown>;
@@ -16188,6 +16573,7 @@ export const ViewPreferencesFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
@@ -16209,6 +16595,7 @@ export const ViewPreferencesPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -16235,6 +16622,7 @@ export const WebhookFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "secret" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           { kind: "Field", name: { kind: "Name", value: "resourceTypes" } },
@@ -16276,6 +16664,7 @@ export const WebhookConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -16309,6 +16698,7 @@ export const WebhookPayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",
@@ -16334,6 +16724,7 @@ export const WorkflowStateFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "description" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           { kind: "Field", name: { kind: "Name", value: "position" } },
@@ -16366,6 +16757,7 @@ export const WorkflowStateConnectionFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "nodes" },
@@ -16399,6 +16791,7 @@ export const WorkflowStatePayloadFragmentDoc = {
       selectionSet: {
         kind: "SelectionSet",
         selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
           {
             kind: "Field",

--- a/packages/sdk/src/_tests/_generated.test.ts
+++ b/packages/sdk/src/_tests/_generated.test.ts
@@ -1630,7 +1630,7 @@ describe("generated", () => {
 
   /** Test all Notification queries */
   describe("Notifications", () => {
-    let _notification: L.Notification | undefined;
+    let _notification: L.Notification | L.IssueNotification | undefined;
     let _notification_id: string | undefined;
 
     /** Test the root connection query for the Notification */
@@ -1644,41 +1644,13 @@ describe("generated", () => {
     /** Test the root query for a single Notification */
     it("notification", async () => {
       if (_notification_id) {
-        const notification: L.Notification | undefined = await client.notification(_notification_id);
+        const notification: L.Notification | L.IssueNotification | undefined = await client.notification(
+          _notification_id
+        );
         _notification = notification;
         expect(notification instanceof L.Notification);
       } else {
         console.warn("codegen-doc:print: No first Notification found in connection - cannot test notification query");
-      }
-    });
-
-    /** Test the notification.comment query for L.Comment */
-    it("notification.comment", async () => {
-      if (_notification) {
-        const notification_comment: L.Comment | undefined = await _notification.comment;
-        expect(notification_comment instanceof L.Comment);
-      } else {
-        console.warn("codegen-doc:print: No Notification found - cannot test notification.comment query");
-      }
-    });
-
-    /** Test the notification.issue query for L.Issue */
-    it("notification.issue", async () => {
-      if (_notification) {
-        const notification_issue: L.Issue | undefined = await _notification.issue;
-        expect(notification_issue instanceof L.Issue);
-      } else {
-        console.warn("codegen-doc:print: No Notification found - cannot test notification.issue query");
-      }
-    });
-
-    /** Test the notification.team query for L.Team */
-    it("notification.team", async () => {
-      if (_notification) {
-        const notification_team: L.Team | undefined = await _notification.team;
-        expect(notification_team instanceof L.Team);
-      } else {
-        console.warn("codegen-doc:print: No Notification found - cannot test notification.team query");
       }
     });
 

--- a/packages/sdk/src/schema.graphql
+++ b/packages/sdk/src/schema.graphql
@@ -1823,6 +1823,29 @@ type EmojiPayload {
   success: Boolean!
 }
 
+"""
+A basic entity.
+"""
+interface Entity implements Node {
+  """
+  The time at which the entity was archived. Null if the entity has not been archived.
+  """
+  archivedAt: DateTime
+  """
+  The time at which the entity was created.
+  """
+  createdAt: DateTime!
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  """
+  The last time at which the entity was updated. This is the same as the creation time if the
+      entity hasn't been updated after creation.
+  """
+  updatedAt: DateTime!
+}
+
 input EventCreateInput {
   """
   The category of the event to create.
@@ -3761,6 +3784,66 @@ input IssueLabelUpdateInput {
   The name of the label.
   """
   name: String
+}
+
+"""
+An issue related notification
+"""
+type IssueNotification implements Entity & Node & Notification {
+  """
+  The time at which the entity was archived. Null if the entity has not been archived.
+  """
+  archivedAt: DateTime
+  """
+  The comment related to the notification.
+  """
+  comment: Comment
+  """
+  The time at which the entity was created.
+  """
+  createdAt: DateTime!
+  """
+  The time at when an email reminder for this notification was sent to the user. Null, if no email
+      reminder has been sent.
+  """
+  emailedAt: DateTime
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  """
+  The issue related to the notification.
+  """
+  issue: Issue!
+  """
+  Name of the reaction emoji related to the notification.
+  """
+  reactionEmoji: String
+  """
+  The time at when the user marked the notification as read. Null, if the the user hasn't read the notification
+  """
+  readAt: DateTime
+  """
+  The time until a notification will be snoozed. After that it will appear in the inbox again.
+  """
+  snoozedUntilAt: DateTime
+  """
+  The team related to the notification.
+  """
+  team: Team!
+  """
+  Notification type
+  """
+  type: String!
+  """
+  The last time at which the entity was updated. This is the same as the creation time if the
+      entity hasn't been updated after creation.
+  """
+  updatedAt: DateTime!
+  """
+  The user that received the notification.
+  """
+  user: User!
 }
 
 type IssuePayload {
@@ -6189,15 +6272,11 @@ interface Node {
 """
 A notification sent to a user.
 """
-type Notification implements Node {
+interface Notification implements Entity & Node {
   """
   The time at which the entity was archived. Null if the entity has not been archived.
   """
   archivedAt: DateTime
-  """
-  The comment which the notification is associated with.
-  """
-  comment: Comment
   """
   The time at which the entity was created.
   """
@@ -6212,14 +6291,6 @@ type Notification implements Node {
   """
   id: ID!
   """
-  The issue that the notification is associated with.
-  """
-  issue: Issue!
-  """
-  Name of the reaction emoji associated with the notification.
-  """
-  reactionEmoji: String
-  """
   The time at when the user marked the notification as read. Null, if the the user hasn't read the notification
   """
   readAt: DateTime
@@ -6227,10 +6298,6 @@ type Notification implements Node {
   The time until a notification will be snoozed. After that it will appear in the inbox again.
   """
   snoozedUntilAt: DateTime
-  """
-  The team which the notification is associated with.
-  """
-  team: Team!
   """
   Notification type
   """
@@ -6241,7 +6308,7 @@ type Notification implements Node {
   """
   updatedAt: DateTime!
   """
-  The recipient of the notification.
+  The user that received the notification.
   """
   user: User!
 }

--- a/packages/sdk/src/schema.json
+++ b/packages/sdk/src/schema.json
@@ -7080,6 +7080,89 @@
         "possibleTypes": null
       },
       {
+        "kind": "INTERFACE",
+        "name": "Entity",
+        "description": "A basic entity.",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time at which the entity was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The last time at which the entity was updated. This is the same as the creation time if the\n    entity hasn't been updated after creation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archivedAt",
+            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "IssueNotification",
+            "ofType": null
+          }
+        ]
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "EventCreateInput",
         "description": null,
@@ -14107,6 +14190,217 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "IssueNotification",
+        "description": "An issue related notification",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time at which the entity was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The last time at which the entity was updated. This is the same as the creation time if the\n    entity hasn't been updated after creation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archivedAt",
+            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "Notification type",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user",
+            "description": "The user that received the notification.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "readAt",
+            "description": "The time at when the user marked the notification as read. Null, if the the user hasn't read the notification",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "emailedAt",
+            "description": "The time at when an email reminder for this notification was sent to the user. Null, if no email\n    reminder has been sent.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "snoozedUntilAt",
+            "description": "The time until a notification will be snoozed. After that it will appear in the inbox again.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issue",
+            "description": "The issue related to the notification.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Issue",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team",
+            "description": "The team related to the notification.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Team",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "comment",
+            "description": "The comment related to the notification.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Comment",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "reactionEmoji",
+            "description": "Name of the reaction emoji related to the notification.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Notification",
+            "ofType": null
+          },
+          {
+            "kind": "INTERFACE",
+            "name": "Entity",
+            "ofType": null
+          },
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -23192,17 +23486,17 @@
           },
           {
             "kind": "OBJECT",
+            "name": "IssueNotification",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "IssueRelation",
             "ofType": null
           },
           {
             "kind": "OBJECT",
             "name": "Milestone",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "Notification",
             "ofType": null
           },
           {
@@ -23298,7 +23592,7 @@
         ]
       },
       {
-        "kind": "OBJECT",
+        "kind": "INTERFACE",
         "name": "Notification",
         "description": "A notification sent to a user.",
         "fields": [
@@ -23379,13 +23673,17 @@
             "deprecationReason": null
           },
           {
-            "name": "reactionEmoji",
-            "description": "Name of the reaction emoji associated with the notification.",
+            "name": "user",
+            "description": "The user that received the notification.",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -23425,70 +23723,15 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "user",
-            "description": "The recipient of the notification.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "User",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "issue",
-            "description": "The issue that the notification is associated with.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Issue",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "team",
-            "description": "The team which the notification is associated with.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Team",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "comment",
-            "description": "The comment which the notification is associated with.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Comment",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "inputFields": null,
         "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Entity",
+            "ofType": null
+          },
           {
             "kind": "INTERFACE",
             "name": "Node",
@@ -23496,7 +23739,13 @@
           }
         ],
         "enumValues": null,
-        "possibleTypes": null
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "IssueNotification",
+            "ofType": null
+          }
+        ]
       },
       {
         "kind": "OBJECT",
@@ -23541,7 +23790,7 @@
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "OBJECT",
+                    "kind": "INTERFACE",
                     "name": "Notification",
                     "ofType": null
                   }
@@ -23586,7 +23835,7 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
+                "kind": "INTERFACE",
                 "name": "Notification",
                 "ofType": null
               }
@@ -23645,7 +23894,7 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
+                "kind": "INTERFACE",
                 "name": "Notification",
                 "ofType": null
               }
@@ -34318,7 +34567,7 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
+                "kind": "INTERFACE",
                 "name": "Notification",
                 "ofType": null
               }


### PR DESCRIPTION
Updates:
- include `__typename` in all fragments.
- add fragments for each interface implementation to the generated graphql documents
- the sdk now returns a union type (in place of interfaces) and the objects are instantiated correctly as the implementing classes based on their `__typename`. It falls back to the "interface" class for unknown typenames.
- the tests are updated to fix types for interface return types.

It's easiest to review by looking at the updated output first and then at the implementation.