### PR TITLE
fix: improve import cli message

### DIFF
--- a/.changeset/dry-poets-promise.md
+++ b/.changeset/dry-poets-promise.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": patch
+---
+
+fix: improve import cli success message

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -283,8 +283,8 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
     });
   }
 
-  console.error(
-    chalk.green(`${importer.name} issues imported to your backlog: https://linear.app/team/${teamKey}/backlog`)
+  console.info(
+    chalk.green(`${importer.name} issues imported to your team: https://linear.app/team/${teamKey}/all`)
   );
 };
 


### PR DESCRIPTION
Issues are not always imported to team's backlog but to corresponding workflow statuses, so the current message and the link are misleading. 