### PR TITLE
Fix: deprecated -g in npm cli

### DIFF
--- a/packages/import/README.md
+++ b/packages/import/README.md
@@ -9,7 +9,7 @@ yarn global add @linear/import
 or
 
 ```
-npm i -g @linear/import
+npm i --location=global @linear/import
 ```
 
 Run interactive importer:


### PR DESCRIPTION
Change `-g` by `--location=global` in readme file