### PR TITLE
fix: declare Github Action permissions in workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,11 @@ on:
       - master
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,11 @@ on:
       - master
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: read
+
 jobs:
   release:
     name: Release

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -5,6 +5,11 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: read
+
 jobs:
   schema:
     name: Schema


### PR DESCRIPTION
The purpose of this PR is to fix Github Actions failures on workflows when started by dependabot. 
https://github.com/linear/linear/actions/runs/3866812606/jobs/6614089466

The step `Compare schema for changes` which relies on `kamilkisiela/graphql-inspector@master` fails with:
```
Error: Resource not accessible by integration
```

The rationale behind the write permission on `checks` scope is that this integration will update the checks of the PR its running on.