### PR TITLE
fix: pin some dependencies to fix Github dependencies workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,10 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.4",
     "tslib": "^2.1.0",
-    "typescript": "^4.0.5"
+    "typescript": "~4.7.4"
+  },
+  "devDependencies": {
+    "@types/react-transition-group": "~4.4.5"
   },
   "resolutions": {
     "graphql": "^15.4.0"

--- a/packages/codegen-doc/package.json
+++ b/packages/codegen-doc/package.json
@@ -33,7 +33,6 @@
     "graphql": "^15.4.0",
     "rollup": "^2.38.3",
     "rollup-plugin-gzip": "^2.5.0",
-    "rollup-plugin-terser": "^7.0.2",
-    "typescript": "^4.0.5"
+    "rollup-plugin-terser": "^7.0.2"
   }
 }

--- a/packages/codegen-sdk/package.json
+++ b/packages/codegen-sdk/package.json
@@ -31,7 +31,6 @@
     "graphql": "^15.4.0",
     "rollup": "^2.38.3",
     "rollup-plugin-gzip": "^2.5.0",
-    "rollup-plugin-terser": "^7.0.2",
-    "typescript": "^4.0.5"
+    "rollup-plugin-terser": "^7.0.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,8 @@
     "strict": true,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
-    "target": "es6"
+    "target": "es6",
+    "useUnknownInCatchVariables": false
   },
   "exclude": ["../**/node_modules", "../**/build", "../**/dist", "./**/jest"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2986,6 +2986,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-transition-group@~4.4.5":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.5.tgz#aae20dcf773c5aa275d5b9f7cdbca638abc5e416"
+  integrity sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "17.0.16"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.16.tgz#056f40c45645761527baeb7d89d842a6abdf285a"
@@ -12411,10 +12418,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.0.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@~4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 ua-parser-js@^0.7.18:
   version "0.7.28"


### PR DESCRIPTION
The purpose of this PR is to solve build issues that occur when trying to update dependencies as part of the `dependencies` workflow.
https://github.com/linear/linear/actions/runs/3878889472/jobs/6615503188

The `dependencies` workflow is a daily job that attempts to update the dependencies in order to consume minor and patch updates. Two main changes occur here:

### `typescript`
Typescript is declared as `^4.0.5`. When running, the job was updating typescript to 4.9.x. It turns out that plenty of graphql dependencies we use will not compile properly with typescript 4.8 and above. In order to avoid a larger update now, typescript is pinned to `~4.7.4`, the last minor version to properly compile.


### `@types/react-transition-group`
This dependency is implicitly required by `graphql-faker` and `graphql-voyager`, both of which are stale projects that haven't seen proper releases in 2+ years. It's being pinned to 4.x in order to properly compile against React types.

A larger work effort will be required if we want to upgrade above these versions in the future.
