### PR TITLE
fix: allow Github Actions to open PRs and push code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   checks: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   checks: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   release:

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   checks: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   schema:


### PR DESCRIPTION
#239 introduced granular permissions in workflows in order to fix dependabot PRs. It worked, builds are now green, but the permissions used are too restrictive: the workflows also need the ability to open/update PRs and push code as part of the release process.