### PR TITLE
fix: update auth error message used by tests

### DIFF
--- a/.changeset/short-keys-enjoy.md
+++ b/.changeset/short-keys-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": patch
+---
+
+Fix failing test

--- a/packages/sdk/src/_tests/bundle.test.ts
+++ b/packages/sdk/src/_tests/bundle.test.ts
@@ -87,7 +87,7 @@ Object.entries(bundles).map(([bundleFormat, bundle]) =>
       expectError(
         () => client.viewer,
         LinearErrorType.AuthenticationError,
-        "Authentication required - You need to authenticate to access this operation."
+        "Authentication required, not authenticated - You need to authenticate to access this operation."
       );
     });
 


### PR DESCRIPTION
Internal change #13208 broke this test. Not sure if we need this test to be _that_ specific when it comes to the error message, will look into revamping it as part of a larger tests fixing effort (See PUB-13)