### PR TITLE
feat: do not minify plugins in dev mode

### DIFF
--- a/.changeset/wicked-cups-report.md
+++ b/.changeset/wicked-cups-report.md
@@ -1,0 +1,9 @@
+---
+"@linear/codegen-test": patch
+"@linear/codegen-doc": patch
+"@linear/codegen-sdk": patch
+"@linear/import": patch
+"@linear/sdk": patch
+---
+
+Edit rollup config for dev

--- a/packages/codegen-doc/rollup.config.js
+++ b/packages/codegen-doc/rollup.config.js
@@ -3,6 +3,18 @@ import gzip from "rollup-plugin-gzip";
 import { terser } from "rollup-plugin-terser";
 import { brotliCompressSync } from "zlib";
 
+const minPlugins =
+  process.env.NODE_ENV === "development"
+    ? []
+    : [
+        terser(),
+        gzip(),
+        gzip({
+          customCompression: content => brotliCompressSync(Buffer.from(content)),
+          fileName: ".br",
+        }),
+      ];
+
 export default [
   {
     input: "src/index.ts",
@@ -20,15 +32,7 @@ export default [
         sourcemap: true,
       },
     ],
-    plugins: [
-      typescript(),
-      terser(),
-      gzip(),
-      gzip({
-        customCompression: content => brotliCompressSync(Buffer.from(content)),
-        fileName: ".br",
-      }),
-    ],
+    plugins: [typescript(), ...minPlugins],
   },
   {
     input: "src/index.ts",

--- a/packages/codegen-sdk/rollup.config.js
+++ b/packages/codegen-sdk/rollup.config.js
@@ -3,6 +3,18 @@ import gzip from "rollup-plugin-gzip";
 import { terser } from "rollup-plugin-terser";
 import { brotliCompressSync } from "zlib";
 
+const minPlugins =
+  process.env.NODE_ENV === "development"
+    ? []
+    : [
+        terser(),
+        gzip(),
+        gzip({
+          customCompression: content => brotliCompressSync(Buffer.from(content)),
+          fileName: ".br",
+        }),
+      ];
+
 export default [
   {
     input: "src/index.ts",
@@ -20,15 +32,7 @@ export default [
         sourcemap: true,
       },
     ],
-    plugins: [
-      typescript(),
-      terser(),
-      gzip(),
-      gzip({
-        customCompression: content => brotliCompressSync(Buffer.from(content)),
-        fileName: ".br",
-      }),
-    ],
+    plugins: [typescript(), ...minPlugins],
   },
   {
     input: "src/index.ts",

--- a/packages/codegen-test/rollup.config.js
+++ b/packages/codegen-test/rollup.config.js
@@ -3,6 +3,18 @@ import gzip from "rollup-plugin-gzip";
 import { terser } from "rollup-plugin-terser";
 import { brotliCompressSync } from "zlib";
 
+const minPlugins =
+  process.env.NODE_ENV === "development"
+    ? []
+    : [
+        terser(),
+        gzip(),
+        gzip({
+          customCompression: content => brotliCompressSync(Buffer.from(content)),
+          fileName: ".br",
+        }),
+      ];
+
 export default [
   {
     input: "src/index.ts",
@@ -20,15 +32,7 @@ export default [
         sourcemap: true,
       },
     ],
-    plugins: [
-      typescript(),
-      terser(),
-      gzip(),
-      gzip({
-        customCompression: content => brotliCompressSync(Buffer.from(content)),
-        fileName: ".br",
-      }),
-    ],
+    plugins: [typescript(), ...minPlugins],
   },
   {
     input: "src/index.ts",

--- a/packages/import/rollup.config.js
+++ b/packages/import/rollup.config.js
@@ -6,6 +6,18 @@ import gzip from "rollup-plugin-gzip";
 import { terser } from "rollup-plugin-terser";
 import { brotliCompressSync } from "zlib";
 
+const minPlugins =
+  process.env.NODE_ENV === "development"
+    ? []
+    : [
+        terser(),
+        gzip(),
+        gzip({
+          customCompression: content => brotliCompressSync(Buffer.from(content)),
+          fileName: ".br",
+        }),
+      ];
+
 export default [
   {
     input: "src/cli.ts",
@@ -35,18 +47,7 @@ export default [
         sourcemap: true,
       },
     ],
-    plugins: [
-      typescript(),
-      resolve(),
-      commonjs(),
-      json(),
-      terser(),
-      gzip(),
-      gzip({
-        customCompression: content => brotliCompressSync(Buffer.from(content)),
-        fileName: ".br",
-      }),
-    ],
+    plugins: [typescript(), resolve(), commonjs(), json(), ...minPlugins],
   },
   {
     input: "src/index.ts",

--- a/packages/sdk/rollup.config.js
+++ b/packages/sdk/rollup.config.js
@@ -22,14 +22,17 @@ const browserPlugins = [
   }),
 ];
 
-const minPlugins = [
-  terser(),
-  gzip(),
-  gzip({
-    customCompression: content => brotliCompressSync(Buffer.from(content)),
-    fileName: ".br",
-  }),
-];
+const minPlugins =
+  process.env.NODE_ENV === "development"
+    ? []
+    : [
+        terser(),
+        gzip(),
+        gzip({
+          customCompression: content => brotliCompressSync(Buffer.from(content)),
+          fileName: ".br",
+        }),
+      ];
 
 export default [
   {


### PR DESCRIPTION
This PR disables all minify plugins (terser and gzip) in dev mode as they make it hard to work with a debugger.