### PR TITLE
feat: support skipComment for objects

### DIFF
--- a/.changeset/_generated_schema_29592340.md
+++ b/.changeset/_generated_schema_29592340.md
@@ -1,0 +1,50 @@
+---
+"@linear/sdk": minor
+---
+
+
+feat(schema): [breaking] Type 'Aggregation' was removed (Aggregation)
+
+feat(schema): [breaking] Type 'ChartType' was removed (ChartType)
+
+feat(schema): [breaking] Type 'DateAggregation' was removed (DateAggregation)
+
+feat(schema): [breaking] Type 'Dimension' was removed (Dimension)
+
+feat(schema): [breaking] Type 'DimensionName' was removed (DimensionName)
+
+feat(schema): [breaking] Type 'FactsTable' was removed (FactsTable)
+
+feat(schema): [breaking] Type 'InsightPayload' was removed (InsightPayload)
+
+feat(schema): [breaking] Type 'Measure' was removed (Measure)
+
+feat(schema): [breaking] Type 'MeasureName' was removed (MeasureName)
+
+feat(schema): [breaking] Type 'UserSubscribeToNewsletterPayload' was removed (UserSubscribeToNewsletterPayload)
+
+feat(schema): [breaking] Field 'userSubscribeToNewsletter' was removed from object type 'Mutation' (Mutation.userSubscribeToNewsletter)
+
+feat(schema): [dangerous] Enum value 'threadedCommentsNudgeIsSeen' was added to enum 'UserFlagType' (UserFlagType.threadedCommentsNudgeIsSeen)
+
+feat(schema): [non_breaking] Type 'UserAccountEmailChangeFindPayload' was added (UserAccountEmailChangeFindPayload)
+
+feat(schema): [non_breaking] Type 'UserAccountEmailVerificationPayload' was added (UserAccountEmailVerificationPayload)
+
+feat(schema): [non_breaking] Type 'UserAccountExistsPayload' was added (UserAccountExistsPayload)
+
+feat(schema): [non_breaking] Field 'requestInformation' was added to object type 'AuditEntry' (AuditEntry.requestInformation)
+
+feat(schema): [non_breaking] Input field 'EmailSubscribeInput.email' description changed from 'Email to subscribe.' to '[INTERNAL] Email to subscribe.' (EmailSubscribeInput.email)
+
+feat(schema): [non_breaking] Field 'EmailSubscribePayload.success' description changed from 'Whether the operation was successful.' to '[INTERNAL] Whether the operation was successful.' (EmailSubscribePayload.success)
+
+feat(schema): [non_breaking] Field 'userAccountEmailChangeCancel' was added to object type 'Mutation' (Mutation.userAccountEmailChangeCancel)
+
+feat(schema): [non_breaking] Field 'userAccountEmailChangeCreate' was added to object type 'Mutation' (Mutation.userAccountEmailChangeCreate)
+
+feat(schema): [non_breaking] Field 'Mutation.emailSubscribe' description changed from 'Subscribes the email to the newsletter.' to '[INTERNAL] Subscribes the email to the newsletter.' (Mutation.emailSubscribe)
+
+feat(schema): [non_breaking] Field 'userAccountEmailChangeFind' was added to object type 'Query' (Query.userAccountEmailChangeFind)
+
+feat(schema): [non_breaking] Field 'userAccountExists' was added to object type 'Query' (Query.userAccountExists)

--- a/.changeset/_generated_schema_97502883.md
+++ b/.changeset/_generated_schema_97502883.md
@@ -1,0 +1,50 @@
+---
+"@linear/sdk": minor
+---
+
+
+feat(schema): [breaking] Type 'Aggregation' was removed (Aggregation)
+
+feat(schema): [breaking] Type 'ChartType' was removed (ChartType)
+
+feat(schema): [breaking] Type 'DateAggregation' was removed (DateAggregation)
+
+feat(schema): [breaking] Type 'Dimension' was removed (Dimension)
+
+feat(schema): [breaking] Type 'DimensionName' was removed (DimensionName)
+
+feat(schema): [breaking] Type 'FactsTable' was removed (FactsTable)
+
+feat(schema): [breaking] Type 'InsightPayload' was removed (InsightPayload)
+
+feat(schema): [breaking] Type 'Measure' was removed (Measure)
+
+feat(schema): [breaking] Type 'MeasureName' was removed (MeasureName)
+
+feat(schema): [breaking] Type 'UserSubscribeToNewsletterPayload' was removed (UserSubscribeToNewsletterPayload)
+
+feat(schema): [breaking] Field 'userSubscribeToNewsletter' was removed from object type 'Mutation' (Mutation.userSubscribeToNewsletter)
+
+feat(schema): [dangerous] Enum value 'threadedCommentsNudgeIsSeen' was added to enum 'UserFlagType' (UserFlagType.threadedCommentsNudgeIsSeen)
+
+feat(schema): [non_breaking] Type 'UserAccountEmailChangeFindPayload' was added (UserAccountEmailChangeFindPayload)
+
+feat(schema): [non_breaking] Type 'UserAccountEmailVerificationPayload' was added (UserAccountEmailVerificationPayload)
+
+feat(schema): [non_breaking] Type 'UserAccountExistsPayload' was added (UserAccountExistsPayload)
+
+feat(schema): [non_breaking] Field 'requestInformation' was added to object type 'AuditEntry' (AuditEntry.requestInformation)
+
+feat(schema): [non_breaking] Input field 'EmailSubscribeInput.email' description changed from 'Email to subscribe.' to '[INTERNAL] Email to subscribe.' (EmailSubscribeInput.email)
+
+feat(schema): [non_breaking] Field 'EmailSubscribePayload.success' description changed from 'Whether the operation was successful.' to '[INTERNAL] Whether the operation was successful.' (EmailSubscribePayload.success)
+
+feat(schema): [non_breaking] Field 'userAccountEmailChangeCancel' was added to object type 'Mutation' (Mutation.userAccountEmailChangeCancel)
+
+feat(schema): [non_breaking] Field 'userAccountEmailChangeCreate' was added to object type 'Mutation' (Mutation.userAccountEmailChangeCreate)
+
+feat(schema): [non_breaking] Field 'Mutation.emailSubscribe' description changed from 'Subscribes the email to the newsletter.' to '[INTERNAL] Subscribes the email to the newsletter.' (Mutation.emailSubscribe)
+
+feat(schema): [non_breaking] Field 'userAccountEmailChangeFind' was added to object type 'Query' (Query.userAccountEmailChangeFind)
+
+feat(schema): [non_breaking] Field 'userAccountExists' was added to object type 'Query' (Query.userAccountExists)

--- a/.changeset/stale-zebras-brush.md
+++ b/.changeset/stale-zebras-brush.md
@@ -1,0 +1,5 @@
+---
+"@linear/codegen-doc": minor
+---
+
+Support skipComment on objects

--- a/packages/codegen-doc/src/fragment.ts
+++ b/packages/codegen-doc/src/fragment.ts
@@ -23,9 +23,10 @@ export function findFragment(
 }
 
 /**
- * Check whether this object has valid content and is not a connection, edge or root
+ * Check whether this object has valid content and is not a connection, edge, root or has a skip comment.
  */
 export function isValidObject(context: PluginContext, fragment: NamedFields<ObjectTypeDefinitionNode>): boolean {
   const hasFields = (fragment.fields ?? []).filter(Boolean).length;
-  return Boolean(hasFields && !isEdge(fragment) && !isOperationRoot(context, fragment));
+  const skipComment = context.config.skipComments?.some(comment => fragment.description?.value.includes(comment));
+  return Boolean(hasFields && !isEdge(fragment) && !isOperationRoot(context, fragment) && !skipComment);
 }

--- a/packages/codegen-sdk/src/model-visitor.ts
+++ b/packages/codegen-sdk/src/model-visitor.ts
@@ -37,10 +37,15 @@ import {
 } from "./types";
 
 /**
- * Ensure the models is not a root operation or edge
+ * Ensure the models is not a root operation, a edge, or has a skip comment.
  */
-function isValidModel(model: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode) {
-  return !Object.keys(OperationType).includes(lowerFirst(model.name.value)) && !model.name.value.endsWith("Edge");
+function isValidModel(model: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode, context: PluginContext) {
+  const skipComment = context.config.skipComments?.some(comment => model.description?.value.includes(comment));
+  return (
+    !Object.keys(OperationType).includes(lowerFirst(model.name.value)) &&
+    !model.name.value.endsWith("Edge") &&
+    !skipComment
+  );
 }
 
 /**
@@ -172,7 +177,7 @@ export class ModelVisitor {
 }
 
 function leaveObjectOrInterface(_node: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode): SdkModel | undefined {
-  if (isValidModel(_node) && _node.fields?.length) {
+  if (isValidModel(_node, this._context) && _node.fields?.length) {
     const node = _node as SdkModelNode;
     const name = node.name.value;
     const fields = node.fields;

--- a/packages/sdk/src/_generated_documents.graphql
+++ b/packages/sdk/src/_generated_documents.graphql
@@ -2295,6 +2295,8 @@ fragment ViewPreferences on ViewPreferences {
 # Workspace audit log entry object.
 fragment AuditEntry on AuditEntry {
   __typename
+  # Additional information related to the request which performed the action.
+  requestInformation
   # Additional metadata related to the audit entry.
   metadata
   # Country code of request resulting to audit entry.
@@ -2339,105 +2341,6 @@ fragment ZendeskSettings on ZendeskSettings {
   sendNoteOnStatusChange
   # Whether an internal message should be added when someone comments on an issue.
   sendNoteOnComment
-}
-
-# [INTERNAL] An OAuth userId/createdDate tuple
-fragment AuthMembership on AuthMembership {
-  __typename
-  # The authorizing userId
-  userId
-  # The date of the authorization
-  createdAt
-}
-
-# [INTERNAL] An email change verification challenge.
-fragment UserAccountEmailChange on UserAccountEmailChange {
-  __typename
-  # The model's identifier.
-  id
-  # The new email the user account wants to change to.
-  newEmail
-  # The time at which the model was archived.
-  archivedAt
-  # The time at which the model was updated.
-  updatedAt
-  # The timestamp the new email was verified at.
-  newEmailVerifiedAt
-  # The timestamp the old email was verified at.
-  oldEmailVerifiedAt
-  # The timestamp the verification codes expire at.
-  expiresAt
-  # The timestamp this verification challenge was canceled at.
-  canceledAt
-  # The user account's current email.
-  oldEmail
-}
-
-# [INTERNAL] Domain claim request response.
-fragment OrganizationDomainClaimPayload on OrganizationDomainClaimPayload {
-  __typename
-  # String to put into DNS for verification.
-  verificationString
-}
-
-# [INTERNAL] Organization domain operation response.
-fragment OrganizationDomainPayload on OrganizationDomainPayload {
-  __typename
-  # The identifier of the last sync operation.
-  lastSyncId
-  # The organization domain that was created or updated.
-  organizationDomain {
-    ...OrganizationDomain
-  }
-  # Whether the operation was successful.
-  success
-}
-
-# [INTERNAL] Organization domain operation response.
-fragment OrganizationDomainSimplePayload on OrganizationDomainSimplePayload {
-  __typename
-  # Whether the operation was successful.
-  success
-}
-
-# [INTERNAL] Public information of the OAuth application, plus the authorized scopes for a given user.
-fragment AuthorizedApplication on AuthorizedApplication {
-  __typename
-  # Application name.
-  name
-  # Image of the application.
-  imageUrl
-  # OAuth application's ID.
-  appId
-  # OAuth application's client ID.
-  clientId
-  # Scopes that are authorized for this application for a given user.
-  scope
-  # Whether or not webhooks are enabled for the application.
-  webhooksEnabled
-}
-
-# [INTERNAL] Public information of the OAuth application, plus the userIds and scopes for those users.
-fragment WorkspaceAuthorizedApplication on WorkspaceAuthorizedApplication {
-  __typename
-  # Application name.
-  name
-  # Image of the application.
-  imageUrl
-  # OAuth application's ID.
-  appId
-  # OAuth application's client ID.
-  clientId
-  # Scopes that are authorized for this application for a given user.
-  scope
-  # Total number of members that authorized the application
-  totalMembers
-  # UserIds and membership dates of everyone who has authorized the application with the set of scopes
-  memberships {
-    ...AuthMembership
-  }
-  # Whether or not webhooks are enabled for the application.
-  webhooksEnabled
 }
 
 fragment AdminJobConfigurationPayload on AdminJobConfigurationPayload {
@@ -2653,12 +2556,6 @@ fragment DocumentPayload on DocumentPayload {
   }
   # The identifier of the last sync operation.
   lastSyncId
-  # Whether the operation was successful.
-  success
-}
-
-fragment EmailSubscribePayload on EmailSubscribePayload {
-  __typename
   # Whether the operation was successful.
   success
 }
@@ -3532,12 +3429,6 @@ fragment UserSettingsPayload on UserSettingsPayload {
   __typename
   # The identifier of the last sync operation.
   lastSyncId
-  # Whether the operation was successful.
-  success
-}
-
-fragment UserSubscribeToNewsletterPayload on UserSubscribeToNewsletterPayload {
-  __typename
   # Whether the operation was successful.
   success
 }
@@ -7042,15 +6933,6 @@ mutation updateDocument(
     ...DocumentPayload
   }
 }
-# Subscribes the email to the newsletter.
-mutation emailSubscribe(
-  # Subscription details.
-  $input: EmailSubscribeInput!
-) {
-  emailSubscribe(input: $input) {
-    ...EmailSubscribePayload
-  }
-}
 # Authenticates a user account via email and authentication token.
 mutation emailTokenUserAccountAuth(
   # The data used for token authentication.
@@ -8411,12 +8293,6 @@ mutation updateUserSettings(
 ) {
   userSettingsUpdate(id: $id, input: $input) {
     ...UserSettingsPayload
-  }
-}
-# Subscribes user to changelog newsletter.
-mutation userSubscribeToNewsletter {
-  userSubscribeToNewsletter {
-    ...UserSubscribeToNewsletterPayload
   }
 }
 # Suspends a user. Can only be called by an admin.

--- a/packages/sdk/src/_generated_documents.ts
+++ b/packages/sdk/src/_generated_documents.ts
@@ -45,19 +45,6 @@ export type AdminJobStatusPayload = {
   startedAt?: Maybe<Scalars["DateTime"]>;
 };
 
-/** Different aggregation functions for analytical queries. */
-export enum Aggregation {
-  Avg = "avg",
-  Count = "count",
-  Max = "max",
-  Median = "median",
-  Min = "min",
-  P90 = "p90",
-  P95 = "p95",
-  P99 = "p99",
-  Sum = "sum",
-}
-
 export type AirbyteConfigurationInput = {
   /** Linear export API key. */
   apiKey: Scalars["String"];
@@ -310,6 +297,8 @@ export type AuditEntry = Node & {
   ip?: Maybe<Scalars["String"]>;
   /** Additional metadata related to the audit entry. */
   metadata?: Maybe<Scalars["JSONObject"]>;
+  /** Additional information related to the request which performed the action. */
+  requestInformation?: Maybe<Scalars["JSONObject"]>;
   type: Scalars["String"];
   /**
    * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
@@ -410,12 +399,6 @@ export type BooleanComparator = {
   /** Not equals constraint. */
   neq?: Maybe<Scalars["Boolean"]>;
 };
-
-/** All possible chart types. */
-export enum ChartType {
-  NivoBar = "nivoBar",
-  NivoScatterPlot = "nivoScatterPlot",
-}
 
 /** A comment associated with an issue. */
 export type Comment = Node & {
@@ -904,15 +887,6 @@ export type CycleUpdateInput = {
   startsAt?: Maybe<Scalars["DateTime"]>;
 };
 
-/** Different date aggregation functions for date dimension. */
-export enum DateAggregation {
-  Day = "day",
-  Month = "month",
-  ThirtyMinutes = "thirtyMinutes",
-  Week = "week",
-  Year = "year",
-}
-
 /** Comparator for dates. */
 export type DateComparator = {
   /** Equals constraint. */
@@ -948,33 +922,6 @@ export type DeleteOrganizationInput = {
   /** The deletion code to confirm operation. */
   deletionCode: Scalars["String"];
 };
-
-/** Object describing a dimension in analytical query, value to group by. */
-export type Dimension = {
-  /** aggregation function to be applied on date dimensions */
-  dateAggregation?: Maybe<DateAggregation>;
-  /** name of the dimension column */
-  name: DimensionName;
-};
-
-/** All possible dimensions that can be applied to analytical queries. */
-export enum DimensionName {
-  Assignee = "assignee",
-  CompletedAt = "completedAt",
-  CreatedAt = "createdAt",
-  Creator = "creator",
-  Cycle = "cycle",
-  DueDate = "dueDate",
-  Estimate = "estimate",
-  Label = "label",
-  Priority = "priority",
-  Project = "project",
-  Roadmap = "roadmap",
-  SnapshotAt = "snapshotAt",
-  StateName = "stateName",
-  StateType = "stateType",
-  Team = "team",
-}
 
 /** A document for a project. */
 export type Document = Node & {
@@ -1068,13 +1015,13 @@ export type DocumentUpdateInput = {
 };
 
 export type EmailSubscribeInput = {
-  /** Email to subscribe. */
+  /** [INTERNAL] Email to subscribe. */
   email: Scalars["String"];
 };
 
 export type EmailSubscribePayload = {
   __typename?: "EmailSubscribePayload";
-  /** Whether the operation was successful. */
+  /** [INTERNAL] Whether the operation was successful. */
   success: Scalars["Boolean"];
 };
 
@@ -1232,12 +1179,6 @@ export type EventPayload = {
   /** Whether the operation was successful. */
   success: Scalars["Boolean"];
 };
-
-/** Different facts tables to run analytical queries against. */
-export enum FactsTable {
-  Issue = "issue",
-  IssueSnapshot = "issueSnapshot",
-}
 
 /** User favorites presented in the sidebar. */
 export type Favorite = Node & {
@@ -1570,21 +1511,6 @@ export type InitiativeEdge = {
   /** Used in `before` and `after` args */
   cursor: Scalars["String"];
   node: Initiative;
-};
-
-export type InsightPayload = {
-  /** Chart type of the visualization. */
-  chartType: ChartType;
-  dimensions: Array<Dimension>;
-  /** If set to true, analytics data will include archived data */
-  includeArchived?: Maybe<Scalars["Boolean"]>;
-  /** Insight id where to send data to. */
-  insightId: Scalars["String"];
-  /** Filters that needs to be matched by some issues. */
-  issueFilter: IssueFilter;
-  measures: Array<Measure>;
-  /** Table to run analytical query against. */
-  table: FactsTable;
 };
 
 /** An integration with an external service. */
@@ -2958,23 +2884,6 @@ export type LogoutResponse = {
   success: Scalars["Boolean"];
 };
 
-/** Object describing a measure in analytical query. */
-export type Measure = {
-  /** aggregation function to be applied on the measure column */
-  aggregation: Aggregation;
-  /** name of the measure */
-  name: MeasureName;
-};
-
-/** All possible measures that can be applied to analytical queries. */
-export enum MeasureName {
-  CycleTime = "cycleTime",
-  Effort = "effort",
-  Id = "id",
-  TimeToStart = "timeToStart",
-  TimeToTriage = "timeToTriage",
-}
-
 /** A milestone that contains projects. */
 export type Milestone = Node & {
   __typename?: "Milestone";
@@ -3148,7 +3057,7 @@ export type Mutation = {
   documentDelete: ArchivePayload;
   /** Updates a document. */
   documentUpdate: DocumentPayload;
-  /** Subscribes the email to the newsletter. */
+  /** [INTERNAL] Subscribes the email to the newsletter. */
   emailSubscribe: EmailSubscribePayload;
   /** Authenticates a user account via email and authentication token. */
   emailTokenUserAccountAuth: AuthResolverResponse;
@@ -3418,6 +3327,10 @@ export type Mutation = {
   templateDelete: ArchivePayload;
   /** Updates an existing template. */
   templateUpdate: TemplatePayload;
+  /** [INTERNAL] Cancels an ongoing email change for the user account */
+  userAccountEmailChangeCancel: UserAccountEmailVerificationPayload;
+  /** [INTERNAL] Creates an email verification challenge from the app for a user account that wants to change email. */
+  userAccountEmailChangeCreate: UserAccountEmailVerificationPayload;
   /** [INTERNAL] Verifies the email address and code for a user account that wants to change email. */
   userAccountEmailChangeVerifyCode: UserAccountEmailChangeVerifyCodePayload;
   /** Makes user a regular user. Can only be called by an admin. */
@@ -3444,8 +3357,6 @@ export type Mutation = {
   userSettingsFlagsReset: UserSettingsFlagsResetPayload;
   /** Updates the user's settings. */
   userSettingsUpdate: UserSettingsPayload;
-  /** Subscribes user to changelog newsletter. */
-  userSubscribeToNewsletter: UserSubscribeToNewsletterPayload;
   /** Suspends a user. Can only be called by an admin. */
   userSuspend: UserAdminPayload;
   /** Un-suspends a user. Can only be called by an admin. */
@@ -4153,6 +4064,16 @@ export type MutationTemplateDeleteArgs = {
 export type MutationTemplateUpdateArgs = {
   id: Scalars["String"];
   input: TemplateUpdateInput;
+};
+
+export type MutationUserAccountEmailChangeCancelArgs = {
+  id: Scalars["String"];
+};
+
+export type MutationUserAccountEmailChangeCreateArgs = {
+  hasExistingAccount: Scalars["Boolean"];
+  id: Scalars["String"];
+  newEmail: Scalars["String"];
 };
 
 export type MutationUserAccountEmailChangeVerifyCodeArgs = {
@@ -6138,6 +6059,10 @@ export type Query = {
   templates: Array<Template>;
   /** One specific user. */
   user: User;
+  /** [INTERNAL] Checks if there's a currently active email verification challenge for a user account. */
+  userAccountEmailChangeFind: UserAccountEmailChangeFindPayload;
+  /** Finds a user account by email. */
+  userAccountExists?: Maybe<UserAccountExistsPayload>;
   /** The user's settings. */
   userSettings: UserSettings;
   /** All users for the organization. */
@@ -6597,6 +6522,14 @@ export type QueryTemplateArgs = {
 
 export type QueryUserArgs = {
   id: Scalars["String"];
+};
+
+export type QueryUserAccountEmailChangeFindArgs = {
+  email: Scalars["String"];
+};
+
+export type QueryUserAccountExistsArgs = {
+  email: Scalars["String"];
 };
 
 export type QueryUsersArgs = {
@@ -7954,11 +7887,36 @@ export type UserAccountEmailChange = {
   updatedAt: Scalars["DateTime"];
 };
 
+/** [INTERNAL] Result of searching for a verification challenge for a user account. */
+export type UserAccountEmailChangeFindPayload = {
+  __typename?: "UserAccountEmailChangeFindPayload";
+  /** [INTERNAL] Whether there is a currently active change. */
+  hasChangeActive: Scalars["Boolean"];
+  /** The identifier of the last sync operation. */
+  lastSyncId: Scalars["Float"];
+};
+
 /** [INTERNAL] Result of verifying an email and code. */
 export type UserAccountEmailChangeVerifyCodePayload = {
   __typename?: "UserAccountEmailChangeVerifyCodePayload";
   /** [INTERNAL] Reason why the operation was not successful. */
   failureReason?: Maybe<Scalars["Float"]>;
+  /** [INTERNAL] Whether the operation was successful. */
+  success: Scalars["Boolean"];
+};
+
+/** [INTERNAL] Result of creating or cancelling a verification challenge for email change. */
+export type UserAccountEmailVerificationPayload = {
+  __typename?: "UserAccountEmailVerificationPayload";
+  /** The identifier of the last sync operation. */
+  lastSyncId: Scalars["Float"];
+  /** [INTERNAL] Whether the operation was successful. */
+  success: Scalars["Boolean"];
+};
+
+/** [INTERNAL] Result of looking up a user account by email. */
+export type UserAccountExistsPayload = {
+  __typename?: "UserAccountExistsPayload";
   /** [INTERNAL] Whether the operation was successful. */
   success: Scalars["Boolean"];
 };
@@ -8101,6 +8059,7 @@ export enum UserFlagType {
   RewindBannerDismissed = "rewindBannerDismissed",
   SlackCommentReactionTipShown = "slackCommentReactionTipShown",
   TeamsPageIntroductionDismissed = "teamsPageIntroductionDismissed",
+  ThreadedCommentsNudgeIsSeen = "threadedCommentsNudgeIsSeen",
   TriageWelcomeDismissed = "triageWelcomeDismissed",
 }
 
@@ -8189,12 +8148,6 @@ export type UserSettingsUpdateInput = {
   settings?: Maybe<Scalars["JSONObject"]>;
   /** The types of emails the user has unsubscribed from. */
   unsubscribedFrom?: Maybe<Array<Scalars["String"]>>;
-};
-
-export type UserSubscribeToNewsletterPayload = {
-  __typename?: "UserSubscribeToNewsletterPayload";
-  /** Whether the operation was successful. */
-  success: Scalars["Boolean"];
 };
 
 /** View preferences. */
@@ -9519,7 +9472,16 @@ export type ViewPreferencesFragment = { __typename: "ViewPreferences" } & Pick<
 
 export type AuditEntryFragment = { __typename: "AuditEntry" } & Pick<
   AuditEntry,
-  "metadata" | "countryCode" | "ip" | "actorId" | "updatedAt" | "archivedAt" | "createdAt" | "id" | "type"
+  | "requestInformation"
+  | "metadata"
+  | "countryCode"
+  | "ip"
+  | "actorId"
+  | "updatedAt"
+  | "archivedAt"
+  | "createdAt"
+  | "id"
+  | "type"
 > & { actor?: Maybe<{ __typename?: "User" } & Pick<User, "id">> };
 
 export type ZendeskSettingsFragment = { __typename: "ZendeskSettings" } & Pick<
@@ -9533,46 +9495,6 @@ export type ZendeskSettingsFragment = { __typename: "ZendeskSettings" } & Pick<
   | "sendNoteOnStatusChange"
   | "sendNoteOnComment"
 >;
-
-export type AuthMembershipFragment = { __typename: "AuthMembership" } & Pick<AuthMembership, "userId" | "createdAt">;
-
-export type UserAccountEmailChangeFragment = { __typename: "UserAccountEmailChange" } & Pick<
-  UserAccountEmailChange,
-  | "id"
-  | "newEmail"
-  | "archivedAt"
-  | "updatedAt"
-  | "newEmailVerifiedAt"
-  | "oldEmailVerifiedAt"
-  | "expiresAt"
-  | "canceledAt"
-  | "oldEmail"
->;
-
-export type OrganizationDomainClaimPayloadFragment = { __typename: "OrganizationDomainClaimPayload" } & Pick<
-  OrganizationDomainClaimPayload,
-  "verificationString"
->;
-
-export type OrganizationDomainPayloadFragment = { __typename: "OrganizationDomainPayload" } & Pick<
-  OrganizationDomainPayload,
-  "lastSyncId" | "success"
-> & { organizationDomain: { __typename?: "OrganizationDomain" } & OrganizationDomainFragment };
-
-export type OrganizationDomainSimplePayloadFragment = { __typename: "OrganizationDomainSimplePayload" } & Pick<
-  OrganizationDomainSimplePayload,
-  "success"
->;
-
-export type AuthorizedApplicationFragment = { __typename: "AuthorizedApplication" } & Pick<
-  AuthorizedApplication,
-  "name" | "imageUrl" | "appId" | "clientId" | "scope" | "webhooksEnabled"
->;
-
-export type WorkspaceAuthorizedApplicationFragment = { __typename: "WorkspaceAuthorizedApplication" } & Pick<
-  WorkspaceAuthorizedApplication,
-  "name" | "imageUrl" | "appId" | "clientId" | "scope" | "totalMembers" | "webhooksEnabled"
-> & { memberships: Array<{ __typename?: "AuthMembership" } & AuthMembershipFragment> };
 
 export type AdminJobConfigurationPayloadFragment = { __typename: "AdminJobConfigurationPayload" } & Pick<
   AdminJobConfigurationPayload,
@@ -9669,11 +9591,6 @@ export type DocumentPayloadFragment = { __typename: "DocumentPayload" } & Pick<
   DocumentPayload,
   "lastSyncId" | "success"
 > & { document: { __typename?: "Document" } & Pick<Document, "id"> };
-
-export type EmailSubscribePayloadFragment = { __typename: "EmailSubscribePayload" } & Pick<
-  EmailSubscribePayload,
-  "success"
->;
 
 export type EmailUnsubscribePayloadFragment = { __typename: "EmailUnsubscribePayload" } & Pick<
   EmailUnsubscribePayload,
@@ -10263,11 +10180,6 @@ export type UserSettingsFlagsResetPayloadFragment = { __typename: "UserSettingsF
 export type UserSettingsPayloadFragment = { __typename: "UserSettingsPayload" } & Pick<
   UserSettingsPayload,
   "lastSyncId" | "success"
->;
-
-export type UserSubscribeToNewsletterPayloadFragment = { __typename: "UserSubscribeToNewsletterPayload" } & Pick<
-  UserSubscribeToNewsletterPayload,
-  "success"
 >;
 
 export type ViewPreferencesPayloadFragment = { __typename: "ViewPreferencesPayload" } & Pick<
@@ -12308,14 +12220,6 @@ export type UpdateDocumentMutation = { __typename?: "Mutation" } & {
   documentUpdate: { __typename?: "DocumentPayload" } & DocumentPayloadFragment;
 };
 
-export type EmailSubscribeMutationVariables = Exact<{
-  input: EmailSubscribeInput;
-}>;
-
-export type EmailSubscribeMutation = { __typename?: "Mutation" } & {
-  emailSubscribe: { __typename?: "EmailSubscribePayload" } & EmailSubscribePayloadFragment;
-};
-
 export type EmailTokenUserAccountAuthMutationVariables = Exact<{
   input: TokenUserAccountAuthInput;
 }>;
@@ -13437,14 +13341,6 @@ export type UpdateUserSettingsMutation = { __typename?: "Mutation" } & {
   userSettingsUpdate: { __typename?: "UserSettingsPayload" } & UserSettingsPayloadFragment;
 };
 
-export type UserSubscribeToNewsletterMutationVariables = Exact<{ [key: string]: never }>;
-
-export type UserSubscribeToNewsletterMutation = { __typename?: "Mutation" } & {
-  userSubscribeToNewsletter: {
-    __typename?: "UserSubscribeToNewsletterPayload";
-  } & UserSubscribeToNewsletterPayloadFragment;
-};
-
 export type SuspendUserMutationVariables = Exact<{
   id: Scalars["String"];
 }>;
@@ -13795,6 +13691,38 @@ export const SyncResponseFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<SyncResponseFragment, unknown>;
+export const OrganizationDomainFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "OrganizationDomain" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "OrganizationDomain" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "verificationEmail" } },
+          { kind: "Field", name: { kind: "Name", value: "verified" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "creator" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "claimed" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<OrganizationDomainFragment, unknown>;
 export const GithubRepoFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -14322,196 +14250,6 @@ export const UserSettingsFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<UserSettingsFragment, unknown>;
-export const UserAccountEmailChangeFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "UserAccountEmailChange" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "UserAccountEmailChange" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "id" } },
-          { kind: "Field", name: { kind: "Name", value: "newEmail" } },
-          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
-          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
-          { kind: "Field", name: { kind: "Name", value: "newEmailVerifiedAt" } },
-          { kind: "Field", name: { kind: "Name", value: "oldEmailVerifiedAt" } },
-          { kind: "Field", name: { kind: "Name", value: "expiresAt" } },
-          { kind: "Field", name: { kind: "Name", value: "canceledAt" } },
-          { kind: "Field", name: { kind: "Name", value: "oldEmail" } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<UserAccountEmailChangeFragment, unknown>;
-export const OrganizationDomainClaimPayloadFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "OrganizationDomainClaimPayload" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "OrganizationDomainClaimPayload" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "verificationString" } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<OrganizationDomainClaimPayloadFragment, unknown>;
-export const OrganizationDomainFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "OrganizationDomain" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "OrganizationDomain" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "name" } },
-          { kind: "Field", name: { kind: "Name", value: "verificationEmail" } },
-          { kind: "Field", name: { kind: "Name", value: "verified" } },
-          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
-          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
-          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
-          { kind: "Field", name: { kind: "Name", value: "id" } },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "creator" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
-            },
-          },
-          { kind: "Field", name: { kind: "Name", value: "claimed" } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<OrganizationDomainFragment, unknown>;
-export const OrganizationDomainPayloadFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "OrganizationDomainPayload" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "OrganizationDomainPayload" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "organizationDomain" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "OrganizationDomain" } }],
-            },
-          },
-          { kind: "Field", name: { kind: "Name", value: "success" } },
-        ],
-      },
-    },
-    ...OrganizationDomainFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<OrganizationDomainPayloadFragment, unknown>;
-export const OrganizationDomainSimplePayloadFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "OrganizationDomainSimplePayload" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "OrganizationDomainSimplePayload" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "success" } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<OrganizationDomainSimplePayloadFragment, unknown>;
-export const AuthorizedApplicationFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "AuthorizedApplication" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "AuthorizedApplication" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "name" } },
-          { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
-          { kind: "Field", name: { kind: "Name", value: "appId" } },
-          { kind: "Field", name: { kind: "Name", value: "clientId" } },
-          { kind: "Field", name: { kind: "Name", value: "scope" } },
-          { kind: "Field", name: { kind: "Name", value: "webhooksEnabled" } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<AuthorizedApplicationFragment, unknown>;
-export const AuthMembershipFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "AuthMembership" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "AuthMembership" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "userId" } },
-          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<AuthMembershipFragment, unknown>;
-export const WorkspaceAuthorizedApplicationFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "WorkspaceAuthorizedApplication" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "WorkspaceAuthorizedApplication" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "name" } },
-          { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
-          { kind: "Field", name: { kind: "Name", value: "appId" } },
-          { kind: "Field", name: { kind: "Name", value: "clientId" } },
-          { kind: "Field", name: { kind: "Name", value: "scope" } },
-          { kind: "Field", name: { kind: "Name", value: "totalMembers" } },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "memberships" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AuthMembership" } }],
-            },
-          },
-          { kind: "Field", name: { kind: "Name", value: "webhooksEnabled" } },
-        ],
-      },
-    },
-    ...AuthMembershipFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<WorkspaceAuthorizedApplicationFragment, unknown>;
 export const AdminJobConfigurationPayloadFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -14794,6 +14532,7 @@ export const AuditEntryFragmentDoc = {
         kind: "SelectionSet",
         selections: [
           { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "requestInformation" } },
           { kind: "Field", name: { kind: "Name", value: "metadata" } },
           { kind: "Field", name: { kind: "Name", value: "countryCode" } },
           { kind: "Field", name: { kind: "Name", value: "ip" } },
@@ -15468,23 +15207,6 @@ export const DocumentPayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<DocumentPayloadFragment, unknown>;
-export const EmailSubscribePayloadFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "EmailSubscribePayload" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "EmailSubscribePayload" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "success" } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<EmailSubscribePayloadFragment, unknown>;
 export const EmailUnsubscribePayloadFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -19564,23 +19286,6 @@ export const UserSettingsPayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<UserSettingsPayloadFragment, unknown>;
-export const UserSubscribeToNewsletterPayloadFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "UserSubscribeToNewsletterPayload" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "UserSubscribeToNewsletterPayload" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "success" } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<UserSubscribeToNewsletterPayloadFragment, unknown>;
 export const ViewPreferencesFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -32846,47 +32551,6 @@ export const UpdateDocumentDocument = {
     ...DocumentPayloadFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<UpdateDocumentMutation, UpdateDocumentMutationVariables>;
-export const EmailSubscribeDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "emailSubscribe" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "EmailSubscribeInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "emailSubscribe" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "EmailSubscribePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...EmailSubscribePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<EmailSubscribeMutation, EmailSubscribeMutationVariables>;
 export const EmailTokenUserAccountAuthDocument = {
   kind: "Document",
   definitions: [
@@ -38727,32 +38391,6 @@ export const UpdateUserSettingsDocument = {
     ...UserSettingsPayloadFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<UpdateUserSettingsMutation, UpdateUserSettingsMutationVariables>;
-export const UserSubscribeToNewsletterDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "userSubscribeToNewsletter" },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "userSubscribeToNewsletter" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [
-                { kind: "FragmentSpread", name: { kind: "Name", value: "UserSubscribeToNewsletterPayload" } },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    ...UserSubscribeToNewsletterPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UserSubscribeToNewsletterMutation, UserSubscribeToNewsletterMutationVariables>;
 export const SuspendUserDocument = {
   kind: "Document",
   definitions: [

--- a/packages/sdk/src/_generated_sdk.ts
+++ b/packages/sdk/src/_generated_sdk.ts
@@ -478,6 +478,7 @@ export class AuditEntry extends Request {
     this.id = data.id;
     this.ip = data.ip ?? undefined;
     this.metadata = parseJson(data.metadata) ?? undefined;
+    this.requestInformation = parseJson(data.requestInformation) ?? undefined;
     this.type = data.type;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
     this._actor = data.actor ?? undefined;
@@ -497,6 +498,8 @@ export class AuditEntry extends Request {
   public ip?: string;
   /** Additional metadata related to the audit entry. */
   public metadata?: Record<string, unknown>;
+  /** Additional information related to the request which performed the action. */
+  public requestInformation?: Record<string, unknown>;
   public type: string;
   /**
    * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
@@ -549,24 +552,6 @@ export class AuditEntryType extends Request {
   public type: string;
 }
 /**
- * [INTERNAL] An OAuth userId/createdDate tuple
- *
- * @param request - function to call the graphql client
- * @param data - L.AuthMembershipFragment response data
- */
-export class AuthMembership extends Request {
-  public constructor(request: LinearRequest, data: L.AuthMembershipFragment) {
-    super(request);
-    this.createdAt = parseDate(data.createdAt) ?? new Date();
-    this.userId = data.userId;
-  }
-
-  /** The date of the authorization */
-  public createdAt: Date;
-  /** The authorizing userId */
-  public userId: string;
-}
-/**
  * AuthResolverResponse model
  *
  * @param request - function to call the graphql client
@@ -600,36 +585,6 @@ export class AuthResolverResponse extends Request {
   public availableOrganizations?: Organization[];
   /** Users belonging to this account. */
   public users: User[];
-}
-/**
- * [INTERNAL] Public information of the OAuth application, plus the authorized scopes for a given user.
- *
- * @param request - function to call the graphql client
- * @param data - L.AuthorizedApplicationFragment response data
- */
-export class AuthorizedApplication extends Request {
-  public constructor(request: LinearRequest, data: L.AuthorizedApplicationFragment) {
-    super(request);
-    this.appId = data.appId;
-    this.clientId = data.clientId;
-    this.imageUrl = data.imageUrl ?? undefined;
-    this.name = data.name;
-    this.scope = data.scope;
-    this.webhooksEnabled = data.webhooksEnabled;
-  }
-
-  /** OAuth application's ID. */
-  public appId: string;
-  /** OAuth application's client ID. */
-  public clientId: string;
-  /** Image of the application. */
-  public imageUrl?: string;
-  /** Application name. */
-  public name: string;
-  /** Scopes that are authorized for this application for a given user. */
-  public scope: string[];
-  /** Whether or not webhooks are enabled for the application. */
-  public webhooksEnabled: boolean;
 }
 /**
  * A comment associated with an issue.
@@ -1220,21 +1175,6 @@ export class DocumentPayload extends Request {
   public get document(): LinearFetch<Document> | undefined {
     return new DocumentQuery(this._request).fetch(this._document.id);
   }
-}
-/**
- * EmailSubscribePayload model
- *
- * @param request - function to call the graphql client
- * @param data - L.EmailSubscribePayloadFragment response data
- */
-export class EmailSubscribePayload extends Request {
-  public constructor(request: LinearRequest, data: L.EmailSubscribePayloadFragment) {
-    super(request);
-    this.success = data.success;
-  }
-
-  /** Whether the operation was successful. */
-  public success: boolean;
 }
 /**
  * EmailUnsubscribePayload model
@@ -4170,57 +4110,6 @@ export class OrganizationDomain extends Request {
   }
 }
 /**
- * [INTERNAL] Domain claim request response.
- *
- * @param request - function to call the graphql client
- * @param data - L.OrganizationDomainClaimPayloadFragment response data
- */
-export class OrganizationDomainClaimPayload extends Request {
-  public constructor(request: LinearRequest, data: L.OrganizationDomainClaimPayloadFragment) {
-    super(request);
-    this.verificationString = data.verificationString;
-  }
-
-  /** String to put into DNS for verification. */
-  public verificationString: string;
-}
-/**
- * [INTERNAL] Organization domain operation response.
- *
- * @param request - function to call the graphql client
- * @param data - L.OrganizationDomainPayloadFragment response data
- */
-export class OrganizationDomainPayload extends Request {
-  public constructor(request: LinearRequest, data: L.OrganizationDomainPayloadFragment) {
-    super(request);
-    this.lastSyncId = data.lastSyncId;
-    this.success = data.success;
-    this.organizationDomain = new OrganizationDomain(request, data.organizationDomain);
-  }
-
-  /** The identifier of the last sync operation. */
-  public lastSyncId: number;
-  /** Whether the operation was successful. */
-  public success: boolean;
-  /** The organization domain that was created or updated. */
-  public organizationDomain: OrganizationDomain;
-}
-/**
- * [INTERNAL] Organization domain operation response.
- *
- * @param request - function to call the graphql client
- * @param data - L.OrganizationDomainSimplePayloadFragment response data
- */
-export class OrganizationDomainSimplePayload extends Request {
-  public constructor(request: LinearRequest, data: L.OrganizationDomainSimplePayloadFragment) {
-    super(request);
-    this.success = data.success;
-  }
-
-  /** Whether the operation was successful. */
-  public success: boolean;
-}
-/**
  * OrganizationExistsPayload model
  *
  * @param request - function to call the graphql client
@@ -6715,45 +6604,6 @@ export class UserAccount extends Request {
   public users: User[];
 }
 /**
- * [INTERNAL] An email change verification challenge.
- *
- * @param request - function to call the graphql client
- * @param data - L.UserAccountEmailChangeFragment response data
- */
-export class UserAccountEmailChange extends Request {
-  public constructor(request: LinearRequest, data: L.UserAccountEmailChangeFragment) {
-    super(request);
-    this.archivedAt = parseDate(data.archivedAt) ?? undefined;
-    this.canceledAt = parseDate(data.canceledAt) ?? undefined;
-    this.expiresAt = parseDate(data.expiresAt) ?? new Date();
-    this.id = data.id;
-    this.newEmail = data.newEmail;
-    this.newEmailVerifiedAt = parseDate(data.newEmailVerifiedAt) ?? undefined;
-    this.oldEmail = data.oldEmail;
-    this.oldEmailVerifiedAt = parseDate(data.oldEmailVerifiedAt) ?? undefined;
-    this.updatedAt = parseDate(data.updatedAt) ?? new Date();
-  }
-
-  /** The time at which the model was archived. */
-  public archivedAt?: Date;
-  /** The timestamp this verification challenge was canceled at. */
-  public canceledAt?: Date;
-  /** The timestamp the verification codes expire at. */
-  public expiresAt: Date;
-  /** The model's identifier. */
-  public id: string;
-  /** The new email the user account wants to change to. */
-  public newEmail: string;
-  /** The timestamp the new email was verified at. */
-  public newEmailVerifiedAt?: Date;
-  /** The user account's current email. */
-  public oldEmail: string;
-  /** The timestamp the old email was verified at. */
-  public oldEmailVerifiedAt?: Date;
-  /** The time at which the model was updated. */
-  public updatedAt: Date;
-}
-/**
  * UserAdminPayload model
  *
  * @param request - function to call the graphql client
@@ -6968,21 +6818,6 @@ export class UserSettingsPayload extends Request {
   public get userSettings(): LinearFetch<UserSettings> {
     return new UserSettingsQuery(this._request).fetch();
   }
-}
-/**
- * UserSubscribeToNewsletterPayload model
- *
- * @param request - function to call the graphql client
- * @param data - L.UserSubscribeToNewsletterPayloadFragment response data
- */
-export class UserSubscribeToNewsletterPayload extends Request {
-  public constructor(request: LinearRequest, data: L.UserSubscribeToNewsletterPayloadFragment) {
-    super(request);
-    this.success = data.success;
-  }
-
-  /** Whether the operation was successful. */
-  public success: boolean;
 }
 /**
  * View preferences.
@@ -7343,42 +7178,6 @@ export class WorkflowStatePayload extends Request {
   public get workflowState(): LinearFetch<WorkflowState> | undefined {
     return new WorkflowStateQuery(this._request).fetch(this._workflowState.id);
   }
-}
-/**
- * [INTERNAL] Public information of the OAuth application, plus the userIds and scopes for those users.
- *
- * @param request - function to call the graphql client
- * @param data - L.WorkspaceAuthorizedApplicationFragment response data
- */
-export class WorkspaceAuthorizedApplication extends Request {
-  public constructor(request: LinearRequest, data: L.WorkspaceAuthorizedApplicationFragment) {
-    super(request);
-    this.appId = data.appId;
-    this.clientId = data.clientId;
-    this.imageUrl = data.imageUrl ?? undefined;
-    this.name = data.name;
-    this.scope = data.scope;
-    this.totalMembers = data.totalMembers;
-    this.webhooksEnabled = data.webhooksEnabled;
-    this.memberships = data.memberships.map(node => new AuthMembership(request, node));
-  }
-
-  /** OAuth application's ID. */
-  public appId: string;
-  /** OAuth application's client ID. */
-  public clientId: string;
-  /** Image of the application. */
-  public imageUrl?: string;
-  /** Application name. */
-  public name: string;
-  /** Scopes that are authorized for this application for a given user. */
-  public scope: string[];
-  /** Total number of members that authorized the application */
-  public totalMembers: number;
-  /** Whether or not webhooks are enabled for the application. */
-  public webhooksEnabled: boolean;
-  /** UserIds and membership dates of everyone who has authorized the application with the set of scopes */
-  public memberships: AuthMembership[];
 }
 /**
  * Zendesk specific settings.
@@ -10686,35 +10485,6 @@ export class UpdateDocumentMutation extends Request {
     const data = response.documentUpdate;
 
     return new DocumentPayload(this._request, data);
-  }
-}
-
-/**
- * A fetchable EmailSubscribe Mutation
- *
- * @param request - function to call the graphql client
- */
-export class EmailSubscribeMutation extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the EmailSubscribe mutation and return a EmailSubscribePayload
-   *
-   * @param input - required input to pass to emailSubscribe
-   * @returns parsed response from EmailSubscribeMutation
-   */
-  public async fetch(input: L.EmailSubscribeInput): LinearFetch<EmailSubscribePayload> {
-    const response = await this._request<L.EmailSubscribeMutation, L.EmailSubscribeMutationVariables>(
-      L.EmailSubscribeDocument,
-      {
-        input,
-      }
-    );
-    const data = response.emailSubscribe;
-
-    return new EmailSubscribePayload(this._request, data);
   }
 }
 
@@ -14590,32 +14360,6 @@ export class UpdateUserSettingsMutation extends Request {
     const data = response.userSettingsUpdate;
 
     return new UserSettingsPayload(this._request, data);
-  }
-}
-
-/**
- * A fetchable UserSubscribeToNewsletter Mutation
- *
- * @param request - function to call the graphql client
- */
-export class UserSubscribeToNewsletterMutation extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the UserSubscribeToNewsletter mutation and return a UserSubscribeToNewsletterPayload
-   *
-   * @returns parsed response from UserSubscribeToNewsletterMutation
-   */
-  public async fetch(): LinearFetch<UserSubscribeToNewsletterPayload> {
-    const response = await this._request<
-      L.UserSubscribeToNewsletterMutation,
-      L.UserSubscribeToNewsletterMutationVariables
-    >(L.UserSubscribeToNewsletterDocument, {});
-    const data = response.userSubscribeToNewsletter;
-
-    return new UserSubscribeToNewsletterPayload(this._request, data);
   }
 }
 
@@ -19097,15 +18841,6 @@ export class LinearSdk extends Request {
     return new UpdateDocumentMutation(this._request).fetch(id, input);
   }
   /**
-   * Subscribes the email to the newsletter.
-   *
-   * @param input - required input to pass to emailSubscribe
-   * @returns EmailSubscribePayload
-   */
-  public emailSubscribe(input: L.EmailSubscribeInput): LinearFetch<EmailSubscribePayload> {
-    return new EmailSubscribeMutation(this._request).fetch(input);
-  }
-  /**
    * Authenticates a user account via email and authentication token.
    *
    * @param input - required input to pass to emailTokenUserAccountAuth
@@ -20421,14 +20156,6 @@ export class LinearSdk extends Request {
    */
   public updateUserSettings(id: string, input: L.UserSettingsUpdateInput): LinearFetch<UserSettingsPayload> {
     return new UpdateUserSettingsMutation(this._request).fetch(id, input);
-  }
-  /**
-   * Subscribes user to changelog newsletter.
-   *
-   * @returns UserSubscribeToNewsletterPayload
-   */
-  public get userSubscribeToNewsletter(): LinearFetch<UserSubscribeToNewsletterPayload> {
-    return new UserSubscribeToNewsletterMutation(this._request).fetch();
   }
   /**
    * Suspends a user. Can only be called by an admin.

--- a/packages/sdk/src/schema.graphql
+++ b/packages/sdk/src/schema.graphql
@@ -24,21 +24,6 @@ type AdminJobStatusPayload {
   startedAt: DateTime
 }
 
-"""
-Different aggregation functions for analytical queries.
-"""
-enum Aggregation {
-  avg
-  count
-  max
-  median
-  min
-  p90
-  p95
-  p99
-  sum
-}
-
 input AirbyteConfigurationInput {
   """
   Linear export API key.
@@ -458,6 +443,10 @@ type AuditEntry implements Node {
   Additional metadata related to the audit entry.
   """
   metadata: JSONObject
+  """
+  Additional information related to the request which performed the action.
+  """
+  requestInformation: JSONObject
   type: String!
   """
   The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
@@ -613,14 +602,6 @@ input BooleanComparator {
   Not equals constraint.
   """
   neq: Boolean
-}
-
-"""
-All possible chart types.
-"""
-enum ChartType {
-  nivoBar
-  nivoScatterPlot
 }
 
 """
@@ -1464,17 +1445,6 @@ input CycleUpdateInput {
 }
 
 """
-Different date aggregation functions for date dimension.
-"""
-enum DateAggregation {
-  day
-  month
-  thirtyMinutes
-  week
-  year
-}
-
-"""
 Comparator for dates.
 """
 input DateComparator {
@@ -1535,41 +1505,6 @@ input DeleteOrganizationInput {
   The deletion code to confirm operation.
   """
   deletionCode: String!
-}
-
-"""
-Object describing a dimension in analytical query, value to group by.
-"""
-input Dimension {
-  """
-  aggregation function to be applied on date dimensions
-  """
-  dateAggregation: DateAggregation
-  """
-  name of the dimension column
-  """
-  name: DimensionName!
-}
-
-"""
-All possible dimensions that can be applied to analytical queries.
-"""
-enum DimensionName {
-  assignee
-  completedAt
-  createdAt
-  creator
-  cycle
-  dueDate
-  estimate
-  label
-  priority
-  project
-  roadmap
-  snapshotAt
-  stateName
-  stateType
-  team
 }
 
 """
@@ -1721,14 +1656,14 @@ input DocumentUpdateInput {
 
 input EmailSubscribeInput {
   """
-  Email to subscribe.
+  [INTERNAL] Email to subscribe.
   """
   email: String!
 }
 
 type EmailSubscribePayload {
   """
-  Whether the operation was successful.
+  [INTERNAL] Whether the operation was successful.
   """
   success: Boolean!
 }
@@ -1975,14 +1910,6 @@ type EventPayload {
   Whether the operation was successful.
   """
   success: Boolean!
-}
-
-"""
-Different facts tables to run analytical queries against.
-"""
-enum FactsTable {
-  issue
-  issueSnapshot
 }
 
 """
@@ -2525,31 +2452,6 @@ type InitiativeEdge {
   """
   cursor: String!
   node: Initiative!
-}
-
-input InsightPayload {
-  """
-  Chart type of the visualization.
-  """
-  chartType: ChartType!
-  dimensions: [Dimension!]!
-  """
-  If set to true, analytics data will include archived data
-  """
-  includeArchived: Boolean
-  """
-  Insight id where to send data to.
-  """
-  insightId: String!
-  """
-  Filters that needs to be matched by some issues.
-  """
-  issueFilter: IssueFilter!
-  measures: [Measure!]!
-  """
-  Table to run analytical query against.
-  """
-  table: FactsTable!
 }
 
 """
@@ -4964,31 +4866,6 @@ type LogoutResponse {
 }
 
 """
-Object describing a measure in analytical query.
-"""
-input Measure {
-  """
-  aggregation function to be applied on the measure column
-  """
-  aggregation: Aggregation!
-  """
-  name of the measure
-  """
-  name: MeasureName!
-}
-
-"""
-All possible measures that can be applied to analytical queries.
-"""
-enum MeasureName {
-  cycleTime
-  effort
-  id
-  timeToStart
-  timeToTriage
-}
-
-"""
 A milestone that contains projects.
 """
 type Milestone implements Node {
@@ -5484,7 +5361,7 @@ type Mutation {
     input: DocumentUpdateInput!
   ): DocumentPayload!
   """
-  Subscribes the email to the newsletter.
+  [INTERNAL] Subscribes the email to the newsletter.
   """
   emailSubscribe(
     """
@@ -6898,6 +6775,32 @@ type Mutation {
     input: TemplateUpdateInput!
   ): TemplatePayload!
   """
+  [INTERNAL] Cancels an ongoing email change for the user account
+  """
+  userAccountEmailChangeCancel(
+    """
+    The id of the user account to cancel the change for.
+    """
+    id: String!
+  ): UserAccountEmailVerificationPayload!
+  """
+  [INTERNAL] Creates an email verification challenge from the app for a user account that wants to change email.
+  """
+  userAccountEmailChangeCreate(
+    """
+    [INTERNAL] Whether an existing account exists for the new email address.
+    """
+    hasExistingAccount: Boolean!
+    """
+    [INTERNAL] The identifier of the user account that wants to change email.
+    """
+    id: String!
+    """
+    [INTERNAL] The new email address the user wants to use.
+    """
+    newEmail: String!
+  ): UserAccountEmailVerificationPayload!
+  """
   [INTERNAL] Verifies the email address and code for a user account that wants to change email.
   """
   userAccountEmailChangeVerifyCode(
@@ -7030,10 +6933,6 @@ type Mutation {
     """
     input: UserSettingsUpdateInput!
   ): UserSettingsPayload!
-  """
-  Subscribes user to changelog newsletter.
-  """
-  userSubscribeToNewsletter: UserSubscribeToNewsletterPayload!
   """
   Suspends a user. Can only be called by an admin.
   """
@@ -11306,6 +11205,24 @@ type Query {
     id: String!
   ): User!
   """
+  [INTERNAL] Checks if there's a currently active email verification challenge for a user account.
+  """
+  userAccountEmailChangeFind(
+    """
+    [INTERNAL] The email of the user account.
+    """
+    email: String!
+  ): UserAccountEmailChangeFindPayload!
+  """
+  Finds a user account by email.
+  """
+  userAccountExists(
+    """
+    The email to find the user account by.
+    """
+    email: String!
+  ): UserAccountExistsPayload
+  """
   The user's settings.
   """
   userSettings: UserSettings!
@@ -13803,6 +13720,20 @@ type UserAccountEmailChange {
 }
 
 """
+[INTERNAL] Result of searching for a verification challenge for a user account.
+"""
+type UserAccountEmailChangeFindPayload {
+  """
+  [INTERNAL] Whether there is a currently active change.
+  """
+  hasChangeActive: Boolean!
+  """
+  The identifier of the last sync operation.
+  """
+  lastSyncId: Float!
+}
+
+"""
 [INTERNAL] Result of verifying an email and code.
 """
 type UserAccountEmailChangeVerifyCodePayload {
@@ -13810,6 +13741,30 @@ type UserAccountEmailChangeVerifyCodePayload {
   [INTERNAL] Reason why the operation was not successful.
   """
   failureReason: Float
+  """
+  [INTERNAL] Whether the operation was successful.
+  """
+  success: Boolean!
+}
+
+"""
+[INTERNAL] Result of creating or cancelling a verification challenge for email change.
+"""
+type UserAccountEmailVerificationPayload {
+  """
+  The identifier of the last sync operation.
+  """
+  lastSyncId: Float!
+  """
+  [INTERNAL] Whether the operation was successful.
+  """
+  success: Boolean!
+}
+
+"""
+[INTERNAL] Result of looking up a user account by email.
+"""
+type UserAccountExistsPayload {
   """
   [INTERNAL] Whether the operation was successful.
   """
@@ -14038,6 +13993,7 @@ enum UserFlagType {
   rewindBannerDismissed
   slackCommentReactionTipShown
   teamsPageIntroductionDismissed
+  threadedCommentsNudgeIsSeen
   triageWelcomeDismissed
 }
 
@@ -14169,13 +14125,6 @@ input UserSettingsUpdateInput {
   The types of emails the user has unsubscribed from.
   """
   unsubscribedFrom: [String!]
-}
-
-type UserSubscribeToNewsletterPayload {
-  """
-  Whether the operation was successful.
-  """
-  success: Boolean!
 }
 
 """

--- a/packages/sdk/src/schema.json
+++ b/packages/sdk/src/schema.json
@@ -244,71 +244,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "ENUM",
-        "name": "Aggregation",
-        "description": "Different aggregation functions for analytical queries.",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "count",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "avg",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "max",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "min",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sum",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "median",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "p90",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "p95",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "p99",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
         "kind": "INPUT_OBJECT",
         "name": "AirbyteConfigurationInput",
         "description": null,
@@ -1898,6 +1833,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "requestInformation",
+            "description": "Additional information related to the request which performed the action.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -2473,29 +2420,6 @@
         ],
         "interfaces": null,
         "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "ChartType",
-        "description": "All possible chart types.",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "nivoBar",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "nivoScatterPlot",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
         "possibleTypes": null
       },
       {
@@ -5661,47 +5585,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "ENUM",
-        "name": "DateAggregation",
-        "description": "Different date aggregation functions for date dimension.",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "day",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "week",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "month",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "year",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "thirtyMinutes",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
         "kind": "INPUT_OBJECT",
         "name": "DateComparator",
         "description": "Comparator for dates.",
@@ -5912,146 +5795,6 @@
         ],
         "interfaces": null,
         "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "Dimension",
-        "description": "Object describing a dimension in analytical query, value to group by.",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "name",
-            "description": "name of the dimension column",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "DimensionName",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dateAggregation",
-            "description": "aggregation function to be applied on date dimensions",
-            "type": {
-              "kind": "ENUM",
-              "name": "DateAggregation",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "DimensionName",
-        "description": "All possible dimensions that can be applied to analytical queries.",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "stateName",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "priority",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "estimate",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cycle",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "label",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "stateType",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "creator",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "assignee",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "snapshotAt",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "completedAt",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dueDate",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "createdAt",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "project",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "team",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "roadmap",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
         "possibleTypes": null
       },
       {
@@ -6630,7 +6373,7 @@
         "inputFields": [
           {
             "name": "email",
-            "description": "Email to subscribe.",
+            "description": "[INTERNAL] Email to subscribe.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -6656,7 +6399,7 @@
         "fields": [
           {
             "name": "success",
-            "description": "Whether the operation was successful.",
+            "description": "[INTERNAL] Whether the operation was successful.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7639,29 +7382,6 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "FactsTable",
-        "description": "Different facts tables to run analytical queries against.",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "issueSnapshot",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "issue",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
         "possibleTypes": null
       },
       {
@@ -9685,141 +9405,6 @@
         ],
         "inputFields": null,
         "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "InsightPayload",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "insightId",
-            "description": "Insight id where to send data to.",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "table",
-            "description": "Table to run analytical query against.",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "FactsTable",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "chartType",
-            "description": "Chart type of the visualization.",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "ChartType",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "issueFilter",
-            "description": "Filters that needs to be matched by some issues.",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "INPUT_OBJECT",
-                "name": "IssueFilter",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "measures",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "Measure",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dimensions",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "Dimension",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "includeArchived",
-            "description": "If set to true, analytics data will include archived data",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -18434,90 +18019,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "Measure",
-        "description": "Object describing a measure in analytical query.",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "name",
-            "description": "name of the measure",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "MeasureName",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "aggregation",
-            "description": "aggregation function to be applied on the measure column",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "Aggregation",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "MeasureName",
-        "description": "All possible measures that can be applied to analytical queries.",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "id",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "effort",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cycleTime",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "timeToTriage",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "timeToStart",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
         "kind": "OBJECT",
         "name": "Milestone",
         "description": "A milestone that contains projects.",
@@ -20585,7 +20086,7 @@
           },
           {
             "name": "emailSubscribe",
-            "description": "Subscribes the email to the newsletter.",
+            "description": "[INTERNAL] Subscribes the email to the newsletter.",
             "args": [
               {
                 "name": "input",
@@ -25629,6 +25130,104 @@
             "deprecationReason": null
           },
           {
+            "name": "userAccountEmailChangeCreate",
+            "description": "[INTERNAL] Creates an email verification challenge from the app for a user account that wants to change email.",
+            "args": [
+              {
+                "name": "hasExistingAccount",
+                "description": "[INTERNAL] Whether an existing account exists for the new email address.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "newEmail",
+                "description": "[INTERNAL] The new email address the user wants to use.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "id",
+                "description": "[INTERNAL] The identifier of the user account that wants to change email.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UserAccountEmailVerificationPayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userAccountEmailChangeCancel",
+            "description": "[INTERNAL] Cancels an ongoing email change for the user account",
+            "args": [
+              {
+                "name": "id",
+                "description": "The id of the user account to cancel the change for.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UserAccountEmailVerificationPayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "userUpdate",
             "description": "Updates a user. Only available to organization admins and the user themselves.",
             "args": [
@@ -26185,22 +25784,6 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "UserSettingsFlagPayload",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "userSubscribeToNewsletter",
-            "description": "Subscribes user to changelog newsletter.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "UserSubscribeToNewsletterPayload",
                 "ofType": null
               }
             },
@@ -41866,6 +41449,68 @@
             "deprecationReason": null
           },
           {
+            "name": "userAccountEmailChangeFind",
+            "description": "[INTERNAL] Checks if there's a currently active email verification challenge for a user account.",
+            "args": [
+              {
+                "name": "email",
+                "description": "[INTERNAL] The email of the user account.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UserAccountEmailChangeFindPayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userAccountExists",
+            "description": "Finds a user account by email.",
+            "args": [
+              {
+                "name": "email",
+                "description": "The email to find the user account by.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "UserAccountExistsPayload",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "users",
             "description": "All users for the organization.",
             "args": [
@@ -50667,6 +50312,49 @@
       },
       {
         "kind": "OBJECT",
+        "name": "UserAccountEmailChangeFindPayload",
+        "description": "[INTERNAL] Result of searching for a verification challenge for a user account.",
+        "fields": [
+          {
+            "name": "lastSyncId",
+            "description": "The identifier of the last sync operation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasChangeActive",
+            "description": "[INTERNAL] Whether there is a currently active change.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "UserAccountEmailChangeVerifyCodePayload",
         "description": "[INTERNAL] Result of verifying an email and code.",
         "fields": [
@@ -50694,6 +50382,76 @@
               "kind": "SCALAR",
               "name": "Float",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UserAccountEmailVerificationPayload",
+        "description": "[INTERNAL] Result of creating or cancelling a verification challenge for email change.",
+        "fields": [
+          {
+            "name": "lastSyncId",
+            "description": "The identifier of the last sync operation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "success",
+            "description": "[INTERNAL] Whether the operation was successful.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UserAccountExistsPayload",
+        "description": "[INTERNAL] Result of looking up a user account by email.",
+        "fields": [
+          {
+            "name": "success",
+            "description": "[INTERNAL] Whether the operation was successful.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -51573,6 +51331,12 @@
             "deprecationReason": null
           },
           {
+            "name": "threadedCommentsNudgeIsSeen",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "all",
             "description": null,
             "isDeprecated": false,
@@ -52062,33 +51826,6 @@
           }
         ],
         "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "UserSubscribeToNewsletterPayload",
-        "description": null,
-        "fields": [
-          {
-            "name": "success",
-            "description": "Whether the operation was successful.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },


### PR DESCRIPTION
The skip comments, designated by `[Internal]` or `[Alpha]` were only meant to skip specific fields. But it turns out we have taken the habit to use on whole objects as well.

This PR adds support for skip comments on objects in additions to fields