### PR TITLE
fix: do not filter out [alpha] comments

### DIFF
--- a/.changeset/_generated_schema_30818366.md
+++ b/.changeset/_generated_schema_30818366.md
@@ -1,0 +1,236 @@
+---
+"@linear/sdk": minor
+---
+
+
+feat(schema): [breaking] Type 'Initiative' was removed (Initiative)
+
+feat(schema): [breaking] Type 'InitiativeConnection' was removed (InitiativeConnection)
+
+feat(schema): [breaking] Type 'InitiativeEdge' was removed (InitiativeEdge)
+
+feat(schema): [breaking] Type 'Milestone' was removed (Milestone)
+
+feat(schema): [breaking] Type 'MilestoneConnection' was removed (MilestoneConnection)
+
+feat(schema): [breaking] Type 'MilestoneCreateInput' was removed (MilestoneCreateInput)
+
+feat(schema): [breaking] Type 'MilestoneEdge' was removed (MilestoneEdge)
+
+feat(schema): [breaking] Type 'MilestoneMigrationPayload' was removed (MilestoneMigrationPayload)
+
+feat(schema): [breaking] Type 'MilestonePayload' was removed (MilestonePayload)
+
+feat(schema): [breaking] Type 'MilestoneUpdateInput' was removed (MilestoneUpdateInput)
+
+feat(schema): [breaking] Type 'MilestonesMigrateInput' was removed (MilestonesMigrateInput)
+
+feat(schema): [breaking] Type 'NestedStringComparator' was removed (NestedStringComparator)
+
+feat(schema): [breaking] Type 'UserAccountEmailChangeFindPayload' was removed (UserAccountEmailChangeFindPayload)
+
+feat(schema): [breaking] Type 'UserAccountEmailChangeVerifyCodePayload' was removed (UserAccountEmailChangeVerifyCodePayload)
+
+feat(schema): [breaking] Type 'UserAccountEmailVerificationPayload' was removed (UserAccountEmailVerificationPayload)
+
+feat(schema): [breaking] Type 'WorkflowConditions' was removed (WorkflowConditions)
+
+feat(schema): [breaking] Type 'WorkflowEntityPropertyMatcher' was removed (WorkflowEntityPropertyMatcher)
+
+feat(schema): [breaking] Input field 'AttachmentCollectionFilter.sourceType' changed type from 'NestedStringComparator' to 'SourceTypeComparator' (AttachmentCollectionFilter.sourceType)
+
+feat(schema): [breaking] Input field 'AttachmentFilter.sourceType' changed type from 'NestedStringComparator' to 'SourceTypeComparator' (AttachmentFilter.sourceType)
+
+feat(schema): [breaking] Field 'slackProjectUpdateCreatedToMilestone' was removed from object type 'IntegrationsSettings' (IntegrationsSettings.slackProjectUpdateCreatedToMilestone)
+
+feat(schema): [breaking] Input field 'slackProjectUpdateCreatedToMilestone' was removed from input object type 'IntegrationsSettingsCreateInput' (IntegrationsSettingsCreateInput.slackProjectUpdateCreatedToMilestone)
+
+feat(schema): [breaking] Input field 'slackProjectUpdateCreatedToMilestone' was removed from input object type 'IntegrationsSettingsUpdateInput' (IntegrationsSettingsUpdateInput.slackProjectUpdateCreatedToMilestone)
+
+feat(schema): [breaking] Field 'migrateMilestonesToRoadmaps' was removed from object type 'Mutation' (Mutation.migrateMilestonesToRoadmaps)
+
+feat(schema): [breaking] Field 'milestoneCreate' (deprecated) was removed from object type 'Mutation' (Mutation.milestoneCreate)
+
+feat(schema): [breaking] Field 'milestoneDelete' (deprecated) was removed from object type 'Mutation' (Mutation.milestoneDelete)
+
+feat(schema): [breaking] Field 'milestoneUpdate' (deprecated) was removed from object type 'Mutation' (Mutation.milestoneUpdate)
+
+feat(schema): [breaking] Field 'userAccountEmailChangeCancel' was removed from object type 'Mutation' (Mutation.userAccountEmailChangeCancel)
+
+feat(schema): [breaking] Field 'userAccountEmailChangeCreate' was removed from object type 'Mutation' (Mutation.userAccountEmailChangeCreate)
+
+feat(schema): [breaking] Field 'userAccountEmailChangeVerifyCode' was removed from object type 'Mutation' (Mutation.userAccountEmailChangeVerifyCode)
+
+feat(schema): [breaking] Field 'initiative' was removed from object type 'Project' (Project.initiative)
+
+feat(schema): [breaking] Field 'milestone' (deprecated) was removed from object type 'Project' (Project.milestone)
+
+feat(schema): [breaking] Input field 'milestoneId' was removed from input object type 'ProjectCreateInput' (ProjectCreateInput.milestoneId)
+
+feat(schema): [breaking] Input field 'milestoneId' was removed from input object type 'ProjectUpdateInput' (ProjectUpdateInput.milestoneId)
+
+feat(schema): [breaking] Field 'milestone' (deprecated) was removed from object type 'Query' (Query.milestone)
+
+feat(schema): [breaking] Field 'milestones' (deprecated) was removed from object type 'Query' (Query.milestones)
+
+feat(schema): [breaking] Field 'userAccountEmailChangeFind' was removed from object type 'Query' (Query.userAccountEmailChangeFind)
+
+feat(schema): [breaking] Field 'organization' was removed from object type 'WorkflowDefinition' (WorkflowDefinition.organization)
+
+feat(schema): [breaking] Field 'WorkflowDefinition.team' changed type from 'Team!' to 'Team' (WorkflowDefinition.team)
+
+feat(schema): [breaking] Field 'WorkflowDefinition.trigger' changed type from 'WorkflowTriggerType!' to 'WorkflowTrigger!' (WorkflowDefinition.trigger)
+
+feat(schema): [breaking] Enum value 'cron' was removed from enum 'WorkflowTriggerType' (WorkflowTriggerType.cron)
+
+feat(schema): [breaking] Enum value 'issueCreated' was removed from enum 'WorkflowTriggerType' (WorkflowTriggerType.issueCreated)
+
+feat(schema): [breaking] Enum value 'issueDeleted' was removed from enum 'WorkflowTriggerType' (WorkflowTriggerType.issueDeleted)
+
+feat(schema): [breaking] Enum value 'issueUpdated' was removed from enum 'WorkflowTriggerType' (WorkflowTriggerType.issueUpdated)
+
+feat(schema): [dangerous] Input field 'doNotSubscribeToIssue' was added to input object type 'CommentCreateInput' (CommentCreateInput.doNotSubscribeToIssue)
+
+feat(schema): [dangerous] Input field 'notion' was added to input object type 'IntegrationSettingsInput' (IntegrationSettingsInput.notion)
+
+feat(schema): [dangerous] Input field 'slackIssueAddedToTriage' was added to input object type 'IntegrationsSettingsCreateInput' (IntegrationsSettingsCreateInput.slackIssueAddedToTriage)
+
+feat(schema): [dangerous] Input field 'slackIssueSlaBreached' was added to input object type 'IntegrationsSettingsCreateInput' (IntegrationsSettingsCreateInput.slackIssueSlaBreached)
+
+feat(schema): [dangerous] Input field 'slackIssueSlaHighRisk' was added to input object type 'IntegrationsSettingsCreateInput' (IntegrationsSettingsCreateInput.slackIssueSlaHighRisk)
+
+feat(schema): [dangerous] Input field 'slackIssueAddedToTriage' was added to input object type 'IntegrationsSettingsUpdateInput' (IntegrationsSettingsUpdateInput.slackIssueAddedToTriage)
+
+feat(schema): [dangerous] Input field 'slackIssueSlaBreached' was added to input object type 'IntegrationsSettingsUpdateInput' (IntegrationsSettingsUpdateInput.slackIssueSlaBreached)
+
+feat(schema): [dangerous] Input field 'slackIssueSlaHighRisk' was added to input object type 'IntegrationsSettingsUpdateInput' (IntegrationsSettingsUpdateInput.slackIssueSlaHighRisk)
+
+feat(schema): [dangerous] Input field 'slaStatus' was added to input object type 'IssueCollectionFilter' (IssueCollectionFilter.slaStatus)
+
+feat(schema): [dangerous] Input field 'projectMilestoneId' was added to input object type 'IssueCreateInput' (IssueCreateInput.projectMilestoneId)
+
+feat(schema): [dangerous] Input field 'slaStatus' was added to input object type 'IssueFilter' (IssueFilter.slaStatus)
+
+feat(schema): [dangerous] Input field 'projectMilestoneId' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.projectMilestoneId)
+
+feat(schema): [dangerous] Input field 'slaBreachesAt' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.slaBreachesAt)
+
+feat(schema): [dangerous] Argument 'id: String' added to field 'Mutation.attachmentLinkURL' (Mutation.attachmentLinkURL.id)
+
+feat(schema): [dangerous] Input field 'teamNotificationSubscriptionTypes' was added to input object type 'NotificationSubscriptionCreateInput' (NotificationSubscriptionCreateInput.teamNotificationSubscriptionTypes)
+
+feat(schema): [dangerous] Input field 'teamNotificationSubscriptionTypes' was added to input object type 'NotificationSubscriptionUpdateInput' (NotificationSubscriptionUpdateInput.teamNotificationSubscriptionTypes)
+
+feat(schema): [dangerous] Input field 'slaStatus' was added to input object type 'NullableIssueFilter' (NullableIssueFilter.slaStatus)
+
+feat(schema): [dangerous] Input field 'slaEnabled' was added to input object type 'UpdateOrganizationInput' (UpdateOrganizationInput.slaEnabled)
+
+feat(schema): [dangerous] Enum value 'myIssuesActivity' was added to enum 'ViewType' (ViewType.myIssuesActivity)
+
+feat(schema): [dangerous] Enum value 'myIssuesTouchedByMe' was added to enum 'ViewType' (ViewType.myIssuesTouchedByMe)
+
+feat(schema): [dangerous] Enum value 'issue' was added to enum 'WorkflowTriggerType' (WorkflowTriggerType.issue)
+
+feat(schema): [dangerous] Enum value 'project' was added to enum 'WorkflowTriggerType' (WorkflowTriggerType.project)
+
+feat(schema): [dangerous] Enum value 'sla' was added to enum 'WorkflowType' (WorkflowType.sla)
+
+feat(schema): [non_breaking] Type 'IssueDraft' was added (IssueDraft)
+
+feat(schema): [non_breaking] Type 'NotionSettings' was added (NotionSettings)
+
+feat(schema): [non_breaking] Type 'NotionSettingsInput' was added (NotionSettingsInput)
+
+feat(schema): [non_breaking] Type 'PersonalNote' was added (PersonalNote)
+
+feat(schema): [non_breaking] Type 'ProjectMilestone' was added (ProjectMilestone)
+
+feat(schema): [non_breaking] Type 'ProjectMilestoneConnection' was added (ProjectMilestoneConnection)
+
+feat(schema): [non_breaking] Type 'ProjectMilestoneCreateInput' was added (ProjectMilestoneCreateInput)
+
+feat(schema): [non_breaking] Type 'ProjectMilestoneEdge' was added (ProjectMilestoneEdge)
+
+feat(schema): [non_breaking] Type 'ProjectMilestonePayload' was added (ProjectMilestonePayload)
+
+feat(schema): [non_breaking] Type 'ProjectMilestoneUpdateInput' was added (ProjectMilestoneUpdateInput)
+
+feat(schema): [non_breaking] Type 'SlaStatus' was added (SlaStatus)
+
+feat(schema): [non_breaking] Type 'SlaStatusComparator' was added (SlaStatusComparator)
+
+feat(schema): [non_breaking] Type 'SourceTypeComparator' was added (SourceTypeComparator)
+
+feat(schema): [non_breaking] Type 'WorkflowCondition' was added (WorkflowCondition)
+
+feat(schema): [non_breaking] Type 'WorkflowDefinitionConnection' was added (WorkflowDefinitionConnection)
+
+feat(schema): [non_breaking] Type 'WorkflowDefinitionEdge' was added (WorkflowDefinitionEdge)
+
+feat(schema): [non_breaking] Type 'WorkflowTrigger' was added (WorkflowTrigger)
+
+feat(schema): [non_breaking] Field 'organization' was added to object type 'AuditEntry' (AuditEntry.organization)
+
+feat(schema): [non_breaking] Field 'Comment.parent' description changed from 'The parent of the comment.' to 'The parent comment under which the current comment is nested.' (Comment.parent)
+
+feat(schema): [non_breaking] Input field 'CommentCreateInput.parentId' description changed from '[Internal] The parent under which to nest the comment.' to 'The parent comment under which to nest a current comment.' (CommentCreateInput.parentId)
+
+feat(schema): [non_breaking] Field 'notion' was added to object type 'IntegrationSettings' (IntegrationSettings.notion)
+
+feat(schema): [non_breaking] Field 'slackIssueAddedToTriage' was added to object type 'IntegrationsSettings' (IntegrationsSettings.slackIssueAddedToTriage)
+
+feat(schema): [non_breaking] Field 'slackIssueSlaBreached' was added to object type 'IntegrationsSettings' (IntegrationsSettings.slackIssueSlaBreached)
+
+feat(schema): [non_breaking] Field 'slackIssueSlaHighRisk' was added to object type 'IntegrationsSettings' (IntegrationsSettings.slackIssueSlaHighRisk)
+
+feat(schema): [non_breaking] Field 'projectMilestone' was added to object type 'Issue' (Issue.projectMilestone)
+
+feat(schema): [non_breaking] Field 'slaBreachesAt' was added to object type 'Issue' (Issue.slaBreachesAt)
+
+feat(schema): [non_breaking] Field 'slaStartedAt' was added to object type 'Issue' (Issue.slaStartedAt)
+
+feat(schema): [non_breaking] Field 'startedTriageAt' was added to object type 'Issue' (Issue.startedTriageAt)
+
+feat(schema): [non_breaking] Field 'changes' was added to object type 'IssueHistory' (IssueHistory.changes)
+
+feat(schema): [non_breaking] Field 'issueDescriptionUpdateFromFront' was added to object type 'Mutation' (Mutation.issueDescriptionUpdateFromFront)
+
+feat(schema): [non_breaking] Field 'projectMilestoneCreate' was added to object type 'Mutation' (Mutation.projectMilestoneCreate)
+
+feat(schema): [non_breaking] Field 'projectMilestoneDelete' was added to object type 'Mutation' (Mutation.projectMilestoneDelete)
+
+feat(schema): [non_breaking] Field 'projectMilestoneUpdate' was added to object type 'Mutation' (Mutation.projectMilestoneUpdate)
+
+feat(schema): [non_breaking] Input field 'NotificationSubscriptionUpdateInput.projectNotificationSubscriptionType' changed type from 'ProjectNotificationSubscriptionType!' to 'ProjectNotificationSubscriptionType' (NotificationSubscriptionUpdateInput.projectNotificationSubscriptionType)
+
+feat(schema): [non_breaking] Field 'PaidSubscription.seatsMaximum' description changed from 'The maximum number of seats that can be added to the subscription.' to 'The maximum number of seats that will be billed in the subscription.' (PaidSubscription.seatsMaximum)
+
+feat(schema): [non_breaking] Field 'projectMilestones' was added to object type 'Project' (Project.projectMilestones)
+
+feat(schema): [non_breaking] Field 'Project.sortOrder' description changed from 'The sort order for the project within its milestone/initiative.' to 'The sort order for the project within the organizion.' (Project.sortOrder)
+
+feat(schema): [non_breaking] Field 'ProjectMilestone' was added to object type 'Query' (Query.ProjectMilestone)
+
+feat(schema): [non_breaking] Field 'ProjectMilestones' was added to object type 'Query' (Query.ProjectMilestones)
+
+feat(schema): [non_breaking] Input field 'RoadmapToProjectCreateInput.sortOrder' description changed from 'The sort order for the project within its milestone.' to 'The sort order for the project within its organization.' (RoadmapToProjectCreateInput.sortOrder)
+
+feat(schema): [non_breaking] Input field 'RoadmapToProjectUpdateInput.sortOrder' description changed from 'The sort order for the project within its milestone.' to 'The sort order for the project within its organization.' (RoadmapToProjectUpdateInput.sortOrder)
+
+feat(schema): [non_breaking] Field 'requirePriorityToLeaveTriage' was added to object type 'Team' (Team.requirePriorityToLeaveTriage)
+
+feat(schema): [non_breaking] Field 'groupName' was added to object type 'WorkflowDefinition' (WorkflowDefinition.groupName)
+
+feat(schema): [non_breaking] Field 'sortOrder' was added to object type 'WorkflowDefinition' (WorkflowDefinition.sortOrder)
+
+feat(schema): [non_breaking] Field 'triggerType' was added to object type 'WorkflowDefinition' (WorkflowDefinition.triggerType)
+
+feat(schema): [non_breaking] Field 'WorkflowDefinition.conditions' description changed from 'One or more conditions that need to be true for workflow to be triggered.' to 'The conditions that need to be match for the workflow to be triggered.' (WorkflowDefinition.conditions)
+
+feat(schema): [non_breaking] Field 'WorkflowDefinition.description' description changed from 'The workflow description.' to 'The description of the workflow.' (WorkflowDefinition.description)
+
+feat(schema): [non_breaking] Field 'WorkflowDefinition.team' description changed from 'The team associated with the workflow.' to 'The team associated with the workflow. If not set, the workflow is associated with the entire organization.' (WorkflowDefinition.team)
+
+feat(schema): [non_breaking] Field 'WorkflowDefinition.trigger' description changed from 'The type of the trigger that kicks off the workflow.' to 'The type of the event that triggers off the workflow.' (WorkflowDefinition.trigger)
+
+feat(schema): [non_breaking] Field 'WorkflowDefinition.type' description changed from 'The type of the workflow' to 'The type of the workflow.' (WorkflowDefinition.type)

--- a/.changeset/light-readers-shop.md
+++ b/.changeset/light-readers-shop.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": patch
+---
+
+Do not filter out [alpha] comments

--- a/packages/sdk/codegen.doc.yml
+++ b/packages/sdk/codegen.doc.yml
@@ -7,7 +7,6 @@ config:
   skipComments:
     - "[Internal]"
     - "[INTERNAL]"
-    - "[ALPHA]"
   skipFields:
     - integrationResource
     - integrationResources

--- a/packages/sdk/codegen.sdk.yml
+++ b/packages/sdk/codegen.sdk.yml
@@ -9,7 +9,6 @@ config:
   skipComments:
     - "[Internal]"
     - "[INTERNAL]"
-    - "[ALPHA]"
   skipFields:
     - integrationResource
     - integrationResources

--- a/packages/sdk/src/_generated_documents.graphql
+++ b/packages/sdk/src/_generated_documents.graphql
@@ -32,7 +32,7 @@ fragment Comment on Comment {
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
   #     been updated after creation.
   updatedAt
-  # The parent of the comment.
+  # The parent comment under which the current comment is nested.
   parent {
     id
   }
@@ -151,40 +151,23 @@ fragment Document on Document {
   }
 }
 
-# A initiative that contains projects.
-fragment Initiative on Initiative {
+# A milestone for a project.
+fragment ProjectMilestone on ProjectMilestone {
   __typename
-  # The estimated completion date of the initiative.
-  targetDate
-  # The initiative's description.
+  # The description of the project milestone.
   description
   # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
   #     been updated after creation.
   updatedAt
-  # The name of the initiative.
+  # The name of the project milestone.
   name
-  # The sort order for the initiative.
-  sortOrder
-  # The time at which the entity was archived. Null if the entity has not been archived.
-  archivedAt
-  # The time at which the entity was created.
-  createdAt
-  # The unique identifier of the entity.
-  id
-}
-
-# A milestone that contains projects.
-fragment Milestone on Milestone {
-  __typename
-  # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
-  #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
-  #     been updated after creation.
-  updatedAt
-  # The name of the milestone.
-  name
-  # The sort order for the milestone.
-  sortOrder
+  # The planned completion date of the milestone.
+  targetDate
+  # The project of the milestone.
+  project {
+    id
+  }
   # The time at which the entity was archived. Null if the entity has not been archived.
   archivedAt
   # The time at which the entity was created.
@@ -236,6 +219,27 @@ fragment Notification on Notification {
 
   ... on ProjectNotification {
     ...ProjectNotification
+  }
+}
+
+# A personal note for a user
+fragment PersonalNote on PersonalNote {
+  __typename
+  # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+  #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+  #     been updated after creation.
+  updatedAt
+  # The note content as JSON.
+  contentData
+  # The time at which the entity was archived. Null if the entity has not been archived.
+  archivedAt
+  # The time at which the entity was created.
+  createdAt
+  # The unique identifier of the entity.
+  id
+  # The user that owns the note.
+  user {
+    id
   }
 }
 
@@ -323,18 +327,10 @@ fragment Project on Project {
   targetDate
   # The icon of the project.
   icon
-  # The initiative that this project is associated with.
-  initiative {
-    ...Initiative
-  }
   # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
   #     been updated after creation.
   updatedAt
-  # The milestone that this project is associated with.
-  milestone {
-    id
-  }
   # The number of completed estimation points after each week.
   completedScopeHistory
   # The number of completed issues in the project after each week.
@@ -361,7 +357,7 @@ fragment Project on Project {
   name
   # The project's unique URL slug.
   slugId
-  # The sort order for the project within its milestone/initiative.
+  # The sort order for the project within the organizion.
   sortOrder
   # The time at which the entity was archived. Null if the entity has not been archived.
   archivedAt
@@ -1183,6 +1179,8 @@ fragment Issue on Issue {
   archivedAt
   # The time at which the entity was created.
   createdAt
+  # The time at which the issue entered triage.
+  startedTriageAt
   # The time at which the issue left triage.
   triagedAt
   # The time at which the issue was automatically archived by the auto pruning process.
@@ -1213,6 +1211,10 @@ fragment Issue on Issue {
   }
   # The workflow state that the issue is associated with.
   state {
+    id
+  }
+  # [ALPHA] The projectMilestone that the issue is associated with.
+  projectMilestone {
     id
   }
 }
@@ -1407,6 +1409,8 @@ fragment Team on Team {
   inviteHash
   # What to use as an default estimate for unestimated issues.
   defaultIssueEstimate
+  # Whether an issue needs to have a priority set before leaving triage
+  requirePriorityToLeaveTriage
   # Whether issues without priority should be sorted first.
   issueOrderingNoPriorityFirst
   # Whether the team is private or not.
@@ -1800,6 +1804,15 @@ fragment NotificationSubscription on NotificationSubscription {
   }
 }
 
+# Notion specific settings.
+fragment NotionSettings on NotionSettings {
+  __typename
+  # The ID of the Notion workspace being connected.
+  workspaceId
+  # The name of the Notion workspace being connected.
+  workspaceName
+}
+
 # OAuth2 client application
 fragment OauthClient on OauthClient {
   __typename
@@ -2077,16 +2090,20 @@ fragment IntegrationsSettings on IntegrationsSettings {
   id
   # Whether to send a Slack message when a comment is created on any of the project or team's issues.
   slackIssueNewComment
+  # Whether to send a Slack message when a new issue is added to triage.
+  slackIssueAddedToTriage
   # Whether to send a Slack message when a new issue is created for the project or the team.
   slackIssueCreated
   # Whether to send a Slack message when a project update is created.
   slackProjectUpdateCreated
+  # Whether to send a Slack message when an SLA is at high risk
+  slackIssueSlaHighRisk
+  # Whether to send a Slack message when an SLA is breached
+  slackIssueSlaBreached
   # Whether to send a Slack message when any of the project or team's issues change to completed or cancelled.
   slackIssueStatusChangedDone
   # Whether to send a Slack message when any of the project or team's issues has a change in status.
   slackIssueStatusChangedAll
-  # Whether to send a new project update to milestone Slack channels.
-  slackProjectUpdateCreatedToMilestone
   # Whether to send a new project update to team Slack channels.
   slackProjectUpdateCreatedToTeam
   # Whether to send a new project update to workspace Slack channel.
@@ -2110,6 +2127,9 @@ fragment IntegrationSettings on IntegrationSettings {
   }
   jira {
     ...JiraSettings
+  }
+  notion {
+    ...NotionSettings
   }
   sentry {
     ...SentrySettings
@@ -2156,7 +2176,7 @@ fragment PaidSubscription on PaidSubscription {
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
   #     been updated after creation.
   updatedAt
-  # The maximum number of seats that can be added to the subscription.
+  # The maximum number of seats that will be billed in the subscription.
   seatsMaximum
   # The minimum number of seats that will be billed in the subscription.
   seatsMinimum
@@ -2666,16 +2686,6 @@ fragment ImageUploadFromUrlPayload on ImageUploadFromUrlPayload {
   success
 }
 
-fragment InitiativeConnection on InitiativeConnection {
-  __typename
-  nodes {
-    ...Initiative
-  }
-  pageInfo {
-    ...PageInfo
-  }
-}
-
 fragment IntegrationConnection on IntegrationConnection {
   __typename
   nodes {
@@ -2884,36 +2894,6 @@ fragment LogoutResponse on LogoutResponse {
   success
 }
 
-fragment MilestoneConnection on MilestoneConnection {
-  __typename
-  nodes {
-    ...Milestone
-  }
-  pageInfo {
-    ...PageInfo
-  }
-}
-
-fragment MilestoneMigrationPayload on MilestoneMigrationPayload {
-  __typename
-  # The identifier of the last sync operation.
-  lastSyncId
-  # Whether the operation was successful.
-  success
-}
-
-fragment MilestonePayload on MilestonePayload {
-  __typename
-  # The identifier of the last sync operation.
-  lastSyncId
-  # The milesteone that was created or updated.
-  milestone {
-    id
-  }
-  # Whether the operation was successful.
-  success
-}
-
 fragment Node on Node {
   __typename
   # The unique identifier of the entity.
@@ -3072,6 +3052,28 @@ fragment ProjectLinkPayload on ProjectLinkPayload {
   lastSyncId
   # The project that was created or updated.
   projectLink {
+    id
+  }
+  # Whether the operation was successful.
+  success
+}
+
+fragment ProjectMilestoneConnection on ProjectMilestoneConnection {
+  __typename
+  nodes {
+    ...ProjectMilestone
+  }
+  pageInfo {
+    ...PageInfo
+  }
+}
+
+fragment ProjectMilestonePayload on ProjectMilestonePayload {
+  __typename
+  # The identifier of the last sync operation.
+  lastSyncId
+  # The project milestone that was created or updated.
+  projectMilestone {
     id
   }
   # Whether the operation was successful.
@@ -3473,15 +3475,21 @@ fragment WorkflowDefinition on WorkflowDefinition {
   activities
   # Cron schedule which is used to execute the workflow. Only applicable for cron based workflows.
   schedule
-  # One or more conditions that need to be true for workflow to be triggered.
+  # The conditions that need to be match for the workflow to be triggered.
   conditions
+  # The description of the workflow.
+  description
   # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
   #     been updated after creation.
   updatedAt
+  # The name of the group that the workflow belongs to.
+  groupName
   # The name of the workflow.
   name
-  # The team associated with the workflow.
+  # The sort order of the workflow definition within its siblings.
+  sortOrder
+  # The team associated with the workflow. If not set, the workflow is associated with the entire organization.
   team {
     id
   }
@@ -3495,9 +3503,17 @@ fragment WorkflowDefinition on WorkflowDefinition {
   creator {
     id
   }
-  # The workflow description.
-  description
   enabled
+}
+
+fragment WorkflowDefinitionConnection on WorkflowDefinitionConnection {
+  __typename
+  nodes {
+    ...WorkflowDefinition
+  }
+  pageInfo {
+    ...PageInfo
+  }
 }
 
 fragment WorkflowStateConnection on WorkflowStateConnection {
@@ -3522,6 +3538,1788 @@ fragment WorkflowStatePayload on WorkflowStatePayload {
   success
 }
 
+# Creates an integration api key for Airbyte to connect with Linear
+mutation airbyteIntegrationConnect(
+  # Airbyte integration settings.
+  $input: AirbyteConfigurationInput!
+) {
+  airbyteIntegrationConnect(input: $input) {
+    ...IntegrationPayload
+  }
+}
+# Creates a new API key.
+mutation createApiKey(
+  # The api key object to create.
+  $input: ApiKeyCreateInput!
+) {
+  apiKeyCreate(input: $input) {
+    ...ApiKeyPayload
+  }
+}
+# Deletes an API key.
+mutation deleteApiKey(
+  # The identifier of the API key to delete.
+  $id: String!
+) {
+  apiKeyDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# [DEPRECATED] Archives an issue attachment.
+mutation archiveAttachment(
+  # The identifier of the attachment to archive.
+  $id: String!
+) {
+  attachmentArchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new attachment, or updates existing if the same `url` and `issueId` is used.
+mutation createAttachment(
+  # The attachment object to create.
+  $input: AttachmentCreateInput!
+) {
+  attachmentCreate(input: $input) {
+    ...AttachmentPayload
+  }
+}
+# Deletes an issue attachment.
+mutation deleteAttachment(
+  # The identifier of the attachment to delete.
+  $id: String!
+) {
+  attachmentDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Link an existing Discord message to an issue.
+mutation attachmentLinkDiscord(
+  # The Discord channel ID for the message to link.
+  $channelId: String!
+  # The issue for which to link the Discord message.
+  $issueId: String!
+  # The Discord message ID for the message to link.
+  $messageId: String!
+  # The Discord message URL for the message to link.
+  $url: String!
+) {
+  attachmentLinkDiscord(channelId: $channelId, issueId: $issueId, messageId: $messageId, url: $url) {
+    ...AttachmentPayload
+  }
+}
+# Link an existing Front conversation to an issue.
+mutation attachmentLinkFront(
+  # The Front conversation ID to link.
+  $conversationId: String!
+  # The issue for which to link the Front conversation.
+  $issueId: String!
+) {
+  attachmentLinkFront(conversationId: $conversationId, issueId: $issueId) {
+    ...FrontAttachmentPayload
+  }
+}
+# Link an existing Intercom conversation to an issue.
+mutation attachmentLinkIntercom(
+  # The Intercom conversation ID to link.
+  $conversationId: String!
+  # The issue for which to link the Intercom conversation.
+  $issueId: String!
+) {
+  attachmentLinkIntercom(conversationId: $conversationId, issueId: $issueId) {
+    ...AttachmentPayload
+  }
+}
+# Link an existing Jira issue to an issue.
+mutation attachmentLinkJiraIssue(
+  # The issue for which to link the Jira issue.
+  $issueId: String!
+  # The Jira issue key or ID to link.
+  $jiraIssueId: String!
+) {
+  attachmentLinkJiraIssue(issueId: $issueId, jiraIssueId: $jiraIssueId) {
+    ...AttachmentPayload
+  }
+}
+# Link any url to an issue.
+mutation attachmentLinkURL(
+  # The id for the attachment.
+  $id: String
+  # The issue for which to link the url.
+  $issueId: String!
+  # The title to use for the attachment.
+  $title: String
+  # The url to link.
+  $url: String!
+) {
+  attachmentLinkURL(id: $id, issueId: $issueId, title: $title, url: $url) {
+    ...AttachmentPayload
+  }
+}
+# Link an existing Zendesk ticket to an issue.
+mutation attachmentLinkZendesk(
+  # The issue for which to link the Zendesk ticket.
+  $issueId: String!
+  # The Zendesk ticket ID to link.
+  $ticketId: String!
+) {
+  attachmentLinkZendesk(issueId: $issueId, ticketId: $ticketId) {
+    ...AttachmentPayload
+  }
+}
+# Updates an existing issue attachment.
+mutation updateAttachment(
+  # The identifier of the attachment to update.
+  $id: String!
+  # A partial attachment object to update the attachment with.
+  $input: AttachmentUpdateInput!
+) {
+  attachmentUpdate(id: $id, input: $input) {
+    ...AttachmentPayload
+  }
+}
+# Creates a new comment.
+mutation createComment(
+  # The comment object to create.
+  $input: CommentCreateInput!
+) {
+  commentCreate(input: $input) {
+    ...CommentPayload
+  }
+}
+# Deletes a comment.
+mutation deleteComment(
+  # The identifier of the comment to delete.
+  $id: String!
+) {
+  commentDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a comment.
+mutation updateComment(
+  # The identifier of the comment to update.
+  $id: String!
+  # A partial comment object to update the comment with.
+  $input: CommentUpdateInput!
+) {
+  commentUpdate(id: $id, input: $input) {
+    ...CommentPayload
+  }
+}
+# Saves user message.
+mutation createContact(
+  # The contact entry to create.
+  $input: ContactCreateInput!
+) {
+  contactCreate(input: $input) {
+    ...ContactPayload
+  }
+}
+# Create CSV export report for the organization.
+mutation createCsvExportReport($includePrivateTeamIds: [String!]) {
+  createCsvExportReport(includePrivateTeamIds: $includePrivateTeamIds) {
+    ...CreateCsvExportReportPayload
+  }
+}
+# Creates an organization from onboarding.
+mutation createOrganizationFromOnboarding(
+  # Organization details for the new organization.
+  $input: CreateOrganizationInput!
+  # Onboarding survey.
+  $survey: OnboardingCustomerSurvey
+) {
+  createOrganizationFromOnboarding(input: $input, survey: $survey) {
+    ...CreateOrJoinOrganizationResponse
+  }
+}
+# Creates a new custom view.
+mutation createCustomView(
+  # The properties of the custom view to create.
+  $input: CustomViewCreateInput!
+) {
+  customViewCreate(input: $input) {
+    ...CustomViewPayload
+  }
+}
+# Deletes a custom view.
+mutation deleteCustomView(
+  # The identifier of the custom view to delete.
+  $id: String!
+) {
+  customViewDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a custom view.
+mutation updateCustomView(
+  # The identifier of the custom view to update.
+  $id: String!
+  # The properties of the custom view to update.
+  $input: CustomViewUpdateInput!
+) {
+  customViewUpdate(id: $id, input: $input) {
+    ...CustomViewPayload
+  }
+}
+# Archives a cycle.
+mutation archiveCycle(
+  # The identifier of the cycle to archive.
+  $id: String!
+) {
+  cycleArchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new cycle.
+mutation createCycle(
+  # The cycle object to create.
+  $input: CycleCreateInput!
+) {
+  cycleCreate(input: $input) {
+    ...CyclePayload
+  }
+}
+# Updates a cycle.
+mutation updateCycle(
+  # The identifier of the cycle to update.
+  $id: String!
+  # A partial cycle object to update the cycle with.
+  $input: CycleUpdateInput!
+) {
+  cycleUpdate(id: $id, input: $input) {
+    ...CyclePayload
+  }
+}
+# Creates a new document.
+mutation createDocument(
+  # The document to create.
+  $input: DocumentCreateInput!
+) {
+  documentCreate(input: $input) {
+    ...DocumentPayload
+  }
+}
+# Deletes a document.
+mutation deleteDocument(
+  # The identifier of the document to delete.
+  $id: String!
+) {
+  documentDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a document.
+mutation updateDocument(
+  # The identifier of the document to update. Also the identifier from the URL is accepted.
+  $id: String!
+  # A partial document object to update the document with.
+  $input: DocumentUpdateInput!
+) {
+  documentUpdate(id: $id, input: $input) {
+    ...DocumentPayload
+  }
+}
+# Authenticates a user account via email and authentication token.
+mutation emailTokenUserAccountAuth(
+  # The data used for token authentication.
+  $input: TokenUserAccountAuthInput!
+) {
+  emailTokenUserAccountAuth(input: $input) {
+    ...AuthResolverResponse
+  }
+}
+# Unsubscribes the user from one type of emails.
+mutation emailUnsubscribe(
+  # Unsubscription details.
+  $input: EmailUnsubscribeInput!
+) {
+  emailUnsubscribe(input: $input) {
+    ...EmailUnsubscribePayload
+  }
+}
+# Finds or creates a new user account by email and sends an email with token.
+mutation emailUserAccountAuthChallenge(
+  # The data used for email authentication.
+  $input: EmailUserAccountAuthChallengeInput!
+) {
+  emailUserAccountAuthChallenge(input: $input) {
+    ...EmailUserAccountAuthChallengeResponse
+  }
+}
+# Creates a custom emoji.
+mutation createEmoji(
+  # The emoji object to create.
+  $input: EmojiCreateInput!
+) {
+  emojiCreate(input: $input) {
+    ...EmojiPayload
+  }
+}
+# Deletes an emoji.
+mutation deleteEmoji(
+  # The identifier of the emoji to delete.
+  $id: String!
+) {
+  emojiDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# [Deprecated] Creates a new event.
+mutation createEvent(
+  # The event to create.
+  $input: EventCreateInput!
+) {
+  eventCreate(input: $input) {
+    ...EventPayload
+  }
+}
+# Creates a new favorite (project, cycle etc).
+mutation createFavorite(
+  # The favorite object to create.
+  $input: FavoriteCreateInput!
+) {
+  favoriteCreate(input: $input) {
+    ...FavoritePayload
+  }
+}
+# Deletes a favorite reference.
+mutation deleteFavorite(
+  # The identifier of the favorite reference to delete.
+  $id: String!
+) {
+  favoriteDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a favorite.
+mutation updateFavorite(
+  # The identifier of the favorite to update.
+  $id: String!
+  # A partial favorite object to update the favorite with.
+  $input: FavoriteUpdateInput!
+) {
+  favoriteUpdate(id: $id, input: $input) {
+    ...FavoritePayload
+  }
+}
+# XHR request payload to upload an images, video and other attachments directly to Linear's cloud
+# storage.
+mutation fileUpload(
+  # MIME type of the uploaded file.
+  $contentType: String!
+  # Filename of the uploaded file.
+  $filename: String!
+  # Should the file be made publicly accessible (default: false).
+  $makePublic: Boolean
+  # Optional metadata.
+  $metaData: JSON
+  # File size of the uploaded file.
+  $size: Int!
+) {
+  fileUpload(
+    contentType: $contentType
+    filename: $filename
+    makePublic: $makePublic
+    metaData: $metaData
+    size: $size
+  ) {
+    ...UploadPayload
+  }
+}
+# Authenticate user account through Google OAuth. This is the 2nd step of OAuth flow.
+mutation googleUserAccountAuth(
+  # The data used for Google authentication.
+  $input: GoogleUserAccountAuthInput!
+) {
+  googleUserAccountAuth(input: $input) {
+    ...AuthResolverResponse
+  }
+}
+# Upload an image from an URL to Linear.
+mutation imageUploadFromUrl(
+  # URL of the file to be uploaded to Linear.
+  $url: String!
+) {
+  imageUploadFromUrl(url: $url) {
+    ...ImageUploadFromUrlPayload
+  }
+}
+# Deletes an integration.
+mutation deleteIntegration(
+  # The identifier of the integration to delete.
+  $id: String!
+) {
+  integrationDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Integrates the organization with Discord.
+mutation integrationDiscord(
+  # The Discord OAuth code.
+  $code: String!
+  # The Discord OAuth redirect URI.
+  $redirectUri: String!
+) {
+  integrationDiscord(code: $code, redirectUri: $redirectUri) {
+    ...IntegrationPayload
+  }
+}
+# Integrates the organization with Figma.
+mutation integrationFigma(
+  # The Figma OAuth code.
+  $code: String!
+  # The Figma OAuth redirect URI.
+  $redirectUri: String!
+) {
+  integrationFigma(code: $code, redirectUri: $redirectUri) {
+    ...IntegrationPayload
+  }
+}
+# Integrates the organization with Front.
+mutation integrationFront(
+  # The Front OAuth code.
+  $code: String!
+  # The Front OAuth redirect URI.
+  $redirectUri: String!
+) {
+  integrationFront(code: $code, redirectUri: $redirectUri) {
+    ...IntegrationPayload
+  }
+}
+# Generates a webhook for the GitHub commit integration.
+mutation createIntegrationGithubCommit {
+  integrationGithubCommitCreate {
+    ...GitHubCommitIntegrationPayload
+  }
+}
+# Connects the organization with the GitHub App.
+mutation integrationGithubConnect(
+  # The GitHub data to connect with.
+  $installationId: String!
+) {
+  integrationGithubConnect(installationId: $installationId) {
+    ...IntegrationPayload
+  }
+}
+# Connects the organization with a GitLab Access Token.
+mutation integrationGitlabConnect(
+  # The GitLab Access Token to connect with.
+  $accessToken: String!
+  # The URL of the GitLab installation
+  $gitlabUrl: String!
+) {
+  integrationGitlabConnect(accessToken: $accessToken, gitlabUrl: $gitlabUrl) {
+    ...IntegrationPayload
+  }
+}
+# Integrates the organization with Google Sheets.
+mutation integrationGoogleSheets(
+  # The Google OAuth code.
+  $code: String!
+) {
+  integrationGoogleSheets(code: $code) {
+    ...IntegrationPayload
+  }
+}
+# Integrates the organization with Intercom.
+mutation integrationIntercom(
+  # The Intercom OAuth code.
+  $code: String!
+  # The Intercom domain URL to use for the integration. Defaults to app.intercom.com if not provided.
+  $domainUrl: String
+  # The Intercom OAuth redirect URI.
+  $redirectUri: String!
+) {
+  integrationIntercom(code: $code, domainUrl: $domainUrl, redirectUri: $redirectUri) {
+    ...IntegrationPayload
+  }
+}
+# Disconnects the organization from Intercom.
+mutation deleteIntegrationIntercom {
+  integrationIntercomDelete {
+    ...IntegrationPayload
+  }
+}
+# [DEPRECATED] Updates settings on the Intercom integration.
+mutation updateIntegrationIntercomSettings(
+  # A partial Intercom integration settings object to update the integration settings with.
+  $input: IntercomSettingsInput!
+) {
+  integrationIntercomSettingsUpdate(input: $input) {
+    ...IntegrationPayload
+  }
+}
+# Enables Loom integration for the organization.
+mutation integrationLoom {
+  integrationLoom {
+    ...IntegrationPayload
+  }
+}
+# Requests a currently unavailable integration.
+mutation integrationRequest(
+  # Integration request details.
+  $input: IntegrationRequestInput!
+) {
+  integrationRequest(input: $input) {
+    ...IntegrationRequestPayload
+  }
+}
+# Archives an integration resource.
+mutation archiveIntegrationResource(
+  # The identifier of the integration resource to archive.
+  $id: String!
+) {
+  integrationResourceArchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Integrates the organization with Sentry.
+mutation integrationSentryConnect(
+  # The Sentry grant code that's exchanged for OAuth tokens.
+  $code: String!
+  # The Sentry installationId to connect with.
+  $installationId: String!
+  # The slug of the Sentry organization being connected.
+  $organizationSlug: String!
+) {
+  integrationSentryConnect(code: $code, installationId: $installationId, organizationSlug: $organizationSlug) {
+    ...IntegrationPayload
+  }
+}
+# Integrates the organization with Slack.
+mutation integrationSlack(
+  # The Slack OAuth code.
+  $code: String!
+  # The Slack OAuth redirect URI.
+  $redirectUri: String!
+  # [DEPRECATED] Whether or not v2 of Slack OAuth should be used. No longer used.
+  $shouldUseV2Auth: Boolean
+) {
+  integrationSlack(code: $code, redirectUri: $redirectUri, shouldUseV2Auth: $shouldUseV2Auth) {
+    ...IntegrationPayload
+  }
+}
+# Imports custom emojis from your Slack workspace.
+mutation integrationSlackImportEmojis(
+  # The Slack OAuth code.
+  $code: String!
+  # The Slack OAuth redirect URI.
+  $redirectUri: String!
+) {
+  integrationSlackImportEmojis(code: $code, redirectUri: $redirectUri) {
+    ...IntegrationPayload
+  }
+}
+# Slack integration for organization level project update notifications.
+mutation integrationSlackOrgProjectUpdatesPost(
+  # The Slack OAuth code.
+  $code: String!
+  # The Slack OAuth redirect URI.
+  $redirectUri: String!
+) {
+  integrationSlackOrgProjectUpdatesPost(code: $code, redirectUri: $redirectUri) {
+    ...IntegrationPayload
+  }
+}
+# Integrates your personal notifications with Slack.
+mutation integrationSlackPersonal(
+  # The Slack OAuth code.
+  $code: String!
+  # The Slack OAuth redirect URI.
+  $redirectUri: String!
+) {
+  integrationSlackPersonal(code: $code, redirectUri: $redirectUri) {
+    ...IntegrationPayload
+  }
+}
+# Slack webhook integration.
+mutation integrationSlackPost(
+  # The Slack OAuth code.
+  $code: String!
+  # The Slack OAuth redirect URI.
+  $redirectUri: String!
+  # [DEPRECATED] Whether or not v2 of Slack OAuth should be used. No longer used.
+  $shouldUseV2Auth: Boolean
+  # Integration's associated team.
+  $teamId: String!
+) {
+  integrationSlackPost(code: $code, redirectUri: $redirectUri, shouldUseV2Auth: $shouldUseV2Auth, teamId: $teamId) {
+    ...IntegrationPayload
+  }
+}
+# Slack integration for project notifications.
+mutation integrationSlackProjectPost(
+  # The Slack OAuth code.
+  $code: String!
+  # Integration's associated project.
+  $projectId: String!
+  # The Slack OAuth redirect URI.
+  $redirectUri: String!
+  # The service to enable once connected, either 'notifications' or 'updates'.
+  $service: String!
+) {
+  integrationSlackProjectPost(code: $code, projectId: $projectId, redirectUri: $redirectUri, service: $service) {
+    ...IntegrationPayload
+  }
+}
+# Creates a new integrationTemplate join.
+mutation createIntegrationTemplate(
+  # The properties of the integrationTemplate to create.
+  $input: IntegrationTemplateCreateInput!
+) {
+  integrationTemplateCreate(input: $input) {
+    ...IntegrationTemplatePayload
+  }
+}
+# Deletes a integrationTemplate.
+mutation deleteIntegrationTemplate(
+  # The identifier of the integrationTemplate to delete.
+  $id: String!
+) {
+  integrationTemplateDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Integrates the organization with Zendesk.
+mutation integrationZendesk(
+  # The Zendesk OAuth code.
+  $code: String!
+  # The Zendesk OAuth redirect URI.
+  $redirectUri: String!
+  # The Zendesk OAuth scopes.
+  $scope: String!
+  # The Zendesk installation subdomain.
+  $subdomain: String!
+) {
+  integrationZendesk(code: $code, redirectUri: $redirectUri, scope: $scope, subdomain: $subdomain) {
+    ...IntegrationPayload
+  }
+}
+# Creates new settings for one or more integrations.
+mutation createIntegrationsSettings(
+  # The settings to create.
+  $input: IntegrationsSettingsCreateInput!
+) {
+  integrationsSettingsCreate(input: $input) {
+    ...IntegrationsSettingsPayload
+  }
+}
+# Updates settings related to integrations for a project or a team.
+mutation updateIntegrationsSettings(
+  # The identifier of the settings to update.
+  $id: String!
+  # A settings object to update the settings with.
+  $input: IntegrationsSettingsUpdateInput!
+) {
+  integrationsSettingsUpdate(id: $id, input: $input) {
+    ...IntegrationsSettingsPayload
+  }
+}
+# Archives an issue.
+mutation archiveIssue(
+  # The identifier of the issue to archive.
+  $id: String!
+  # Whether to trash the issue
+  $trash: Boolean
+) {
+  issueArchive(id: $id, trash: $trash) {
+    ...ArchivePayload
+  }
+}
+# Updates multiple issues at once.
+mutation updateIssueBatch(
+  # The id's of the issues to update. Can't be more than 50 at a time.
+  $ids: [UUID!]!
+  # A partial issue object to update the issues with.
+  $input: IssueUpdateInput!
+) {
+  issueBatchUpdate(ids: $ids, input: $input) {
+    ...IssueBatchPayload
+  }
+}
+# Creates a new issue.
+mutation createIssue(
+  # The issue object to create.
+  $input: IssueCreateInput!
+) {
+  issueCreate(input: $input) {
+    ...IssuePayload
+  }
+}
+# Deletes (trashes) an issue.
+mutation deleteIssue(
+  # The identifier of the issue to delete.
+  $id: String!
+) {
+  issueDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Kicks off an Asana import job.
+mutation issueImportCreateAsana(
+  # Asana team name to choose which issues we should import.
+  $asanaTeamName: String!
+  # Asana token to fetch information from the Asana API.
+  $asanaToken: String!
+  # ID of issue import. If not provided it will be generated.
+  $id: String
+  # Whether or not we should collect the data for closed issues.
+  $includeClosedIssues: Boolean
+  # Whether to instantly process the import with the default configuration mapping.
+  $instantProcess: Boolean
+  # ID of the organization into which to import data.
+  $organizationId: String
+  # ID of the team into which to import data.
+  $teamId: String
+  # Name of new team. When teamId is not set.
+  $teamName: String
+) {
+  issueImportCreateAsana(
+    asanaTeamName: $asanaTeamName
+    asanaToken: $asanaToken
+    id: $id
+    includeClosedIssues: $includeClosedIssues
+    instantProcess: $instantProcess
+    organizationId: $organizationId
+    teamId: $teamId
+    teamName: $teamName
+  ) {
+    ...IssueImportPayload
+  }
+}
+# Kicks off a Shortcut (formerly Clubhouse) import job.
+mutation issueImportCreateClubhouse(
+  # Shortcut (formerly Clubhouse) team name to choose which issues we should import.
+  $clubhouseTeamName: String!
+  # Shortcut (formerly Clubhouse) token to fetch information from the Clubhouse API.
+  $clubhouseToken: String!
+  # ID of issue import. If not provided it will be generated.
+  $id: String
+  # Whether or not we should collect the data for closed issues.
+  $includeClosedIssues: Boolean
+  # Whether to instantly process the import with the default configuration mapping.
+  $instantProcess: Boolean
+  # ID of the organization into which to import data.
+  $organizationId: String
+  # ID of the team into which to import data.
+  $teamId: String
+  # Name of new team. When teamId is not set.
+  $teamName: String
+) {
+  issueImportCreateClubhouse(
+    clubhouseTeamName: $clubhouseTeamName
+    clubhouseToken: $clubhouseToken
+    id: $id
+    includeClosedIssues: $includeClosedIssues
+    instantProcess: $instantProcess
+    organizationId: $organizationId
+    teamId: $teamId
+    teamName: $teamName
+  ) {
+    ...IssueImportPayload
+  }
+}
+# Kicks off a GitHub import job.
+mutation issueImportCreateGithub(
+  # GitHub repository name from which we will import data.
+  $githubRepoName: String!
+  # GitHub owner (user or org) for the repository from which we will import data.
+  $githubRepoOwner: String!
+  # Whether or not we should import GitHub organization level projects.
+  $githubShouldImportOrgProjects: Boolean
+  # GitHub token to fetch information from the GitHub API.
+  $githubToken: String!
+  # ID of issue import. If not provided it will be generated.
+  $id: String
+  # Whether or not we should collect the data for closed issues.
+  $includeClosedIssues: Boolean
+  # Whether to instantly process the import with the default configuration mapping.
+  $instantProcess: Boolean
+  # ID of the organization into which to import data.
+  $organizationId: String
+  # ID of the team into which to import data.
+  $teamId: String
+  # Name of new team. When teamId is not set.
+  $teamName: String
+) {
+  issueImportCreateGithub(
+    githubRepoName: $githubRepoName
+    githubRepoOwner: $githubRepoOwner
+    githubShouldImportOrgProjects: $githubShouldImportOrgProjects
+    githubToken: $githubToken
+    id: $id
+    includeClosedIssues: $includeClosedIssues
+    instantProcess: $instantProcess
+    organizationId: $organizationId
+    teamId: $teamId
+    teamName: $teamName
+  ) {
+    ...IssueImportPayload
+  }
+}
+# Kicks off a Jira import job.
+mutation issueImportCreateJira(
+  # ID of issue import. If not provided it will be generated.
+  $id: String
+  # Whether or not we should collect the data for closed issues.
+  $includeClosedIssues: Boolean
+  # Whether to instantly process the import with the default configuration mapping.
+  $instantProcess: Boolean
+  # Jira user account email.
+  $jiraEmail: String!
+  # Jira installation or cloud hostname.
+  $jiraHostname: String!
+  # Jira project key from which we will import data.
+  $jiraProject: String!
+  # Jira personal access token to access Jira REST API.
+  $jiraToken: String!
+  # ID of the organization into which to import data.
+  $organizationId: String
+  # ID of the team into which to import data. Empty to create new team.
+  $teamId: String
+  # Name of new team. When teamId is not set.
+  $teamName: String
+) {
+  issueImportCreateJira(
+    id: $id
+    includeClosedIssues: $includeClosedIssues
+    instantProcess: $instantProcess
+    jiraEmail: $jiraEmail
+    jiraHostname: $jiraHostname
+    jiraProject: $jiraProject
+    jiraToken: $jiraToken
+    organizationId: $organizationId
+    teamId: $teamId
+    teamName: $teamName
+  ) {
+    ...IssueImportPayload
+  }
+}
+# Deletes an import job.
+mutation deleteIssueImport(
+  # ID of the issue import to delete.
+  $issueImportId: String!
+) {
+  issueImportDelete(issueImportId: $issueImportId) {
+    ...IssueImportDeletePayload
+  }
+}
+# Kicks off import processing.
+mutation issueImportProcess(
+  # ID of the issue import which we're going to process.
+  $issueImportId: String!
+  # The mapping configuration to use for processing the import.
+  $mapping: JSONObject!
+) {
+  issueImportProcess(issueImportId: $issueImportId, mapping: $mapping) {
+    ...IssueImportPayload
+  }
+}
+# Updates the mapping for the issue import.
+mutation updateIssueImport(
+  # The identifier of the issue import.
+  $id: String!
+  # The properties of the issue import to update.
+  $input: IssueImportUpdateInput!
+) {
+  issueImportUpdate(id: $id, input: $input) {
+    ...IssueImportPayload
+  }
+}
+# Deletes an issue label.
+mutation archiveIssueLabel(
+  # The identifier of the label to archive.
+  $id: String!
+) {
+  issueLabelArchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new label.
+mutation createIssueLabel(
+  # The issue label to create.
+  $input: IssueLabelCreateInput!
+  # Whether to replace all team-specific labels with the same name with this newly created workspace label.
+  $replaceTeamLabels: Boolean
+) {
+  issueLabelCreate(input: $input, replaceTeamLabels: $replaceTeamLabels) {
+    ...IssueLabelPayload
+  }
+}
+# Deletes an issue label.
+mutation deleteIssueLabel(
+  # The identifier of the label to delete.
+  $id: String!
+) {
+  issueLabelDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates an label.
+mutation updateIssueLabel(
+  # The identifier of the label to update.
+  $id: String!
+  # A partial label object to update.
+  $input: IssueLabelUpdateInput!
+) {
+  issueLabelUpdate(id: $id, input: $input) {
+    ...IssueLabelPayload
+  }
+}
+# Creates a new issue relation.
+mutation createIssueRelation(
+  # The issue relation to create.
+  $input: IssueRelationCreateInput!
+) {
+  issueRelationCreate(input: $input) {
+    ...IssueRelationPayload
+  }
+}
+# Deletes an issue relation.
+mutation deleteIssueRelation(
+  # The identifier of the issue relation to delete.
+  $id: String!
+) {
+  issueRelationDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates an issue relation.
+mutation updateIssueRelation(
+  # The identifier of the issue relation to update.
+  $id: String!
+  # The properties of the issue relation to update.
+  $input: IssueRelationUpdateInput!
+) {
+  issueRelationUpdate(id: $id, input: $input) {
+    ...IssueRelationPayload
+  }
+}
+# Adds an issue reminder. Will cause a notification to be sent when the issue reminder time is
+# reached.
+mutation issueReminder(
+  # The identifier of the issue to add a reminder for.
+  $id: String!
+  # The time when a reminder notification will be sent.
+  $reminderAt: DateTime!
+) {
+  issueReminder(id: $id, reminderAt: $reminderAt) {
+    ...IssuePayload
+  }
+}
+# Unarchives an issue.
+mutation unarchiveIssue(
+  # The identifier of the issue to archive.
+  $id: String!
+) {
+  issueUnarchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates an issue.
+mutation updateIssue(
+  # The identifier of the issue to update.
+  $id: String!
+  # A partial issue object to update the issue with.
+  $input: IssueUpdateInput!
+) {
+  issueUpdate(id: $id, input: $input) {
+    ...IssuePayload
+  }
+}
+# Join an organization from onboarding.
+mutation joinOrganizationFromOnboarding(
+  # Organization details for the organization to join.
+  $input: JoinOrganizationInput!
+) {
+  joinOrganizationFromOnboarding(input: $input) {
+    ...CreateOrJoinOrganizationResponse
+  }
+}
+# Leave an organization.
+mutation leaveOrganization(
+  # ID of the organization to leave.
+  $organizationId: String!
+) {
+  leaveOrganization(organizationId: $organizationId) {
+    ...CreateOrJoinOrganizationResponse
+  }
+}
+# Logout of all clients.
+mutation logout {
+  logout {
+    ...LogoutResponse
+  }
+}
+# Archives a notification.
+mutation archiveNotification(
+  # The id of the notification to archive.
+  $id: String!
+) {
+  notificationArchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new notification subscription for a team or a project.
+mutation createNotificationSubscription(
+  # The subscription object to create.
+  $input: NotificationSubscriptionCreateInput!
+) {
+  notificationSubscriptionCreate(input: $input) {
+    ...NotificationSubscriptionPayload
+  }
+}
+# Deletes a notification subscription reference.
+mutation deleteNotificationSubscription(
+  # The identifier of the notification subscription reference to delete.
+  $id: String!
+) {
+  notificationSubscriptionDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a notification subscription.
+mutation updateNotificationSubscription(
+  # The identifier of the notification subscription to update.
+  $id: String!
+  # A partial notification subscription object to update the notification subscription with.
+  $input: NotificationSubscriptionUpdateInput!
+) {
+  notificationSubscriptionUpdate(id: $id, input: $input) {
+    ...NotificationSubscriptionPayload
+  }
+}
+# Unarchives a notification.
+mutation unarchiveNotification(
+  # The id of the notification to archive.
+  $id: String!
+) {
+  notificationUnarchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a notification.
+mutation updateNotification(
+  # The identifier of the notification to update.
+  $id: String!
+  # A partial notification object to update the notification with.
+  $input: NotificationUpdateInput!
+) {
+  notificationUpdate(id: $id, input: $input) {
+    ...NotificationPayload
+  }
+}
+# Cancels the deletion of an organization. Administrator privileges required.
+mutation deleteOrganizationCancel {
+  organizationCancelDelete {
+    ...OrganizationCancelDeletePayload
+  }
+}
+# Delete's an organization. Administrator privileges required.
+mutation deleteOrganization(
+  # Information required to delete an organization.
+  $input: DeleteOrganizationInput!
+) {
+  organizationDelete(input: $input) {
+    ...OrganizationDeletePayload
+  }
+}
+# Get an organization's delete confirmation token. Administrator privileges required.
+mutation organizationDeleteChallenge {
+  organizationDeleteChallenge {
+    ...OrganizationDeletePayload
+  }
+}
+# Deletes a domain.
+mutation deleteOrganizationDomain(
+  # The identifier of the domain to delete.
+  $id: String!
+) {
+  organizationDomainDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new organization invite.
+mutation createOrganizationInvite(
+  # The organization invite object to create.
+  $input: OrganizationInviteCreateInput!
+) {
+  organizationInviteCreate(input: $input) {
+    ...OrganizationInvitePayload
+  }
+}
+# Deletes an organization invite.
+mutation deleteOrganizationInvite(
+  # The identifier of the organization invite to delete.
+  $id: String!
+) {
+  organizationInviteDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates an organization invite.
+mutation updateOrganizationInvite(
+  # The identifier of the organization invite to update.
+  $id: String!
+  # The updates to make to the organization invite object.
+  $input: OrganizationInviteUpdateInput!
+) {
+  organizationInviteUpdate(id: $id, input: $input) {
+    ...OrganizationInvitePayload
+  }
+}
+# Updates the user's organization.
+mutation updateOrganization(
+  # A partial organization object to update the organization with.
+  $input: UpdateOrganizationInput!
+) {
+  organizationUpdate(input: $input) {
+    ...OrganizationPayload
+  }
+}
+# Archives a project.
+mutation archiveProject(
+  # The identifier of the project to archive. Also the identifier from the URL is accepted.
+  $id: String!
+) {
+  projectArchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new project.
+mutation createProject(
+  # The issue object to create.
+  $input: ProjectCreateInput!
+) {
+  projectCreate(input: $input) {
+    ...ProjectPayload
+  }
+}
+# Deletes a project. All issues will be disassociated from the deleted project.
+mutation deleteProject(
+  # The identifier of the project to delete. Also the identifier from the URL is accepted.
+  $id: String!
+) {
+  projectDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new project link.
+mutation createProjectLink(
+  # The project link object to create.
+  $input: ProjectLinkCreateInput!
+) {
+  projectLinkCreate(input: $input) {
+    ...ProjectLinkPayload
+  }
+}
+# Deletes a project link.
+mutation deleteProjectLink(
+  # The identifier of the project link to delete.
+  $id: String!
+) {
+  projectLinkDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a project link.
+mutation updateProjectLink(
+  # The identifier of the project link to update.
+  $id: String!
+  # The project link object to update.
+  $input: ProjectLinkUpdateInput!
+) {
+  projectLinkUpdate(id: $id, input: $input) {
+    ...ProjectLinkPayload
+  }
+}
+# Creates a new project milestone.
+mutation createProjectMilestone(
+  # The project milestone to create.
+  $input: ProjectMilestoneCreateInput!
+) {
+  projectMilestoneCreate(input: $input) {
+    ...ProjectMilestonePayload
+  }
+}
+# Deletes a project milestone.
+mutation deleteProjectMilestone(
+  # The identifier of the project milestone to delete.
+  $id: String!
+) {
+  projectMilestoneDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a project milestone.
+mutation updateProjectMilestone(
+  # The identifier of the project milestone to update. Also the identifier from the URL is accepted.
+  $id: String!
+  # A partial object to update the project milestone with.
+  $input: ProjectMilestoneUpdateInput!
+) {
+  projectMilestoneUpdate(id: $id, input: $input) {
+    ...ProjectMilestonePayload
+  }
+}
+# Unarchives a project.
+mutation unarchiveProject(
+  # The identifier of the project to restore. Also the identifier from the URL is accepted.
+  $id: String!
+) {
+  projectUnarchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a project.
+mutation updateProject(
+  # The identifier of the project to update. Also the identifier from the URL is accepted.
+  $id: String!
+  # A partial project object to update the project with.
+  $input: ProjectUpdateInput!
+) {
+  projectUpdate(id: $id, input: $input) {
+    ...ProjectPayload
+  }
+}
+# Creates a new project update.
+mutation createProjectUpdate(
+  # Data for the project update to create.
+  $input: ProjectUpdateCreateInput!
+) {
+  projectUpdateCreate(input: $input) {
+    ...ProjectUpdatePayload
+  }
+}
+# Deletes a project update.
+mutation deleteProjectUpdate(
+  # The identifier of the project update to delete.
+  $id: String!
+) {
+  projectUpdateDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new interaction on a project update.
+mutation createProjectUpdateInteraction(
+  # Data for the project update interaction to create.
+  $input: ProjectUpdateInteractionCreateInput!
+) {
+  projectUpdateInteractionCreate(input: $input) {
+    ...ProjectUpdateInteractionPayload
+  }
+}
+# Mark a project update as read.
+mutation projectUpdateMarkAsRead(
+  # The identifier of the project update.
+  $id: String!
+) {
+  projectUpdateMarkAsRead(id: $id) {
+    ...ProjectUpdateWithInteractionPayload
+  }
+}
+# Updates a project update.
+mutation updateProjectUpdate(
+  # The identifier of the project update to update.
+  $id: String!
+  # A data to update the project update with.
+  $input: ProjectUpdateUpdateInput!
+) {
+  projectUpdateUpdate(id: $id, input: $input) {
+    ...ProjectUpdatePayload
+  }
+}
+# Creates a push subscription.
+mutation createPushSubscription(
+  # The push subscription to create.
+  $input: PushSubscriptionCreateInput!
+) {
+  pushSubscriptionCreate(input: $input) {
+    ...PushSubscriptionPayload
+  }
+}
+# Deletes a push subscription.
+mutation deletePushSubscription(
+  # The identifier of the push subscription to delete.
+  $id: String!
+) {
+  pushSubscriptionDelete(id: $id) {
+    ...PushSubscriptionPayload
+  }
+}
+# Creates a new reaction.
+mutation createReaction(
+  # The reaction object to create.
+  $input: ReactionCreateInput!
+) {
+  reactionCreate(input: $input) {
+    ...ReactionPayload
+  }
+}
+# Deletes a reaction.
+mutation deleteReaction(
+  # The identifier of the reaction to delete.
+  $id: String!
+) {
+  reactionDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Manually update Google Sheets data.
+mutation refreshGoogleSheetsData(
+  # The identifier of the Google Sheets integration to update.
+  $id: String!
+) {
+  refreshGoogleSheetsData(id: $id) {
+    ...IntegrationPayload
+  }
+}
+# Re-send an organization invite.
+mutation resendOrganizationInvite(
+  # The identifier of the organization invite to be re-send.
+  $id: String!
+) {
+  resendOrganizationInvite(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new roadmap.
+mutation createRoadmap(
+  # The properties of the roadmap to create.
+  $input: RoadmapCreateInput!
+) {
+  roadmapCreate(input: $input) {
+    ...RoadmapPayload
+  }
+}
+# Deletes a roadmap.
+mutation deleteRoadmap(
+  # The identifier of the roadmap to delete.
+  $id: String!
+) {
+  roadmapDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new roadmapToProject join.
+mutation createRoadmapToProject(
+  # The properties of the roadmapToProject to create.
+  $input: RoadmapToProjectCreateInput!
+) {
+  roadmapToProjectCreate(input: $input) {
+    ...RoadmapToProjectPayload
+  }
+}
+# Deletes a roadmapToProject.
+mutation deleteRoadmapToProject(
+  # The identifier of the roadmapToProject to delete.
+  $id: String!
+) {
+  roadmapToProjectDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a roadmapToProject.
+mutation updateRoadmapToProject(
+  # The identifier of the roadmapToProject to update.
+  $id: String!
+  # The properties of the roadmapToProject to update.
+  $input: RoadmapToProjectUpdateInput!
+) {
+  roadmapToProjectUpdate(id: $id, input: $input) {
+    ...RoadmapToProjectPayload
+  }
+}
+# Updates a roadmap.
+mutation updateRoadmap(
+  # The identifier of the roadmap to update.
+  $id: String!
+  # The properties of the roadmap to update.
+  $input: RoadmapUpdateInput!
+) {
+  roadmapUpdate(id: $id, input: $input) {
+    ...RoadmapPayload
+  }
+}
+# Authenticates a user account via email and authentication token for SAML.
+mutation samlTokenUserAccountAuth(
+  # The data used for token authentication.
+  $input: TokenUserAccountAuthInput!
+) {
+  samlTokenUserAccountAuth(input: $input) {
+    ...AuthResolverResponse
+  }
+}
+# Creates a new team. The user who creates the team will automatically be added as a member to the
+# newly created team.
+mutation createTeam(
+  # The team id to copy settings from.
+  $copySettingsFromTeamId: String
+  # The team object to create.
+  $input: TeamCreateInput!
+) {
+  teamCreate(copySettingsFromTeamId: $copySettingsFromTeamId, input: $input) {
+    ...TeamPayload
+  }
+}
+# Deletes team's cycles data
+mutation deleteTeamCycles(
+  # The identifier of the team, which cycles will be deleted.
+  $id: String!
+) {
+  teamCyclesDelete(id: $id) {
+    ...TeamPayload
+  }
+}
+# Deletes a team.
+mutation deleteTeam(
+  # The identifier of the team to delete.
+  $id: String!
+) {
+  teamDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Deletes a previously used team key.
+mutation deleteTeamKey(
+  # The identifier of the team key to delete.
+  $id: String!
+) {
+  teamKeyDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new team membership.
+mutation createTeamMembership(
+  # The team membership object to create.
+  $input: TeamMembershipCreateInput!
+) {
+  teamMembershipCreate(input: $input) {
+    ...TeamMembershipPayload
+  }
+}
+# Deletes a team membership.
+mutation deleteTeamMembership(
+  # The identifier of the team membership to delete.
+  $id: String!
+) {
+  teamMembershipDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a team membership.
+mutation updateTeamMembership(
+  # The identifier of the team membership to update.
+  $id: String!
+  # A partial team membership object to update the team membership with.
+  $input: TeamMembershipUpdateInput!
+) {
+  teamMembershipUpdate(id: $id, input: $input) {
+    ...TeamMembershipPayload
+  }
+}
+# Updates a team.
+mutation updateTeam(
+  # The identifier of the team to update.
+  $id: String!
+  # A partial team object to update the team with.
+  $input: TeamUpdateInput!
+) {
+  teamUpdate(id: $id, input: $input) {
+    ...TeamPayload
+  }
+}
+# Creates a new template.
+mutation createTemplate(
+  # The template object to create.
+  $input: TemplateCreateInput!
+) {
+  templateCreate(input: $input) {
+    ...TemplatePayload
+  }
+}
+# Deletes a template.
+mutation deleteTemplate(
+  # The identifier of the template to delete.
+  $id: String!
+) {
+  templateDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates an existing template.
+mutation updateTemplate(
+  # The identifier of the template.
+  $id: String!
+  # The properties of the template to update.
+  $input: TemplateUpdateInput!
+) {
+  templateUpdate(id: $id, input: $input) {
+    ...TemplatePayload
+  }
+}
+# Makes user a regular user. Can only be called by an admin.
+mutation userDemoteAdmin(
+  # The identifier of the user to make a regular user.
+  $id: String!
+) {
+  userDemoteAdmin(id: $id) {
+    ...UserAdminPayload
+  }
+}
+# Makes user a guest. Can only be called by an admin.
+mutation userDemoteMember(
+  # The identifier of the user to make a guest.
+  $id: String!
+) {
+  userDemoteMember(id: $id) {
+    ...UserAdminPayload
+  }
+}
+# Connects the Discord user to this Linear account via OAuth2.
+mutation userDiscordConnect(
+  # The Discord OAuth code.
+  $code: String!
+  # The Discord OAuth redirect URI.
+  $redirectUri: String!
+) {
+  userDiscordConnect(code: $code, redirectUri: $redirectUri) {
+    ...UserPayload
+  }
+}
+# Disconnects the external user from this Linear account.
+mutation userExternalUserDisconnect(
+  # The external service to disconnect
+  $service: String!
+) {
+  userExternalUserDisconnect(service: $service) {
+    ...UserPayload
+  }
+}
+# Updates a user's settings flag.
+mutation updateUserFlag(
+  # Settings flag to increment.
+  $flag: UserFlagType!
+  # Flag operation to perform
+  $operation: UserFlagUpdateOperation!
+) {
+  userFlagUpdate(flag: $flag, operation: $operation) {
+    ...UserSettingsFlagPayload
+  }
+}
+# Connects the GitHub user to this Linear account via OAuth2.
+mutation userGitHubConnect(
+  # The GitHub OAuth code.
+  $code: String!
+) {
+  userGitHubConnect(code: $code) {
+    ...UserPayload
+  }
+}
+# Connects the Google Calendar to the user to this Linear account via OAuth2.
+mutation userGoogleCalendarConnect(
+  # [Internal] The Google OAuth code.
+  $code: String!
+) {
+  userGoogleCalendarConnect(code: $code) {
+    ...UserPayload
+  }
+}
+# Makes user an admin. Can only be called by an admin.
+mutation userPromoteAdmin(
+  # The identifier of the user to make an admin.
+  $id: String!
+) {
+  userPromoteAdmin(id: $id) {
+    ...UserAdminPayload
+  }
+}
+# Makes user a regular user. Can only be called by an admin.
+mutation userPromoteMember(
+  # The identifier of the user to make a regular user.
+  $id: String!
+) {
+  userPromoteMember(id: $id) {
+    ...UserAdminPayload
+  }
+}
+# [Deprecated] Updates a user's settings flag.
+mutation userSettingsFlagIncrement(
+  # Flag to increment.
+  $flag: String!
+) {
+  userSettingsFlagIncrement(flag: $flag) {
+    ...UserSettingsFlagPayload
+  }
+}
+# Resets user's setting flags.
+mutation userSettingsFlagsReset(
+  # The flags to reset. If not provided all flags will be reset.
+  $flags: [UserFlagType!]
+) {
+  userSettingsFlagsReset(flags: $flags) {
+    ...UserSettingsFlagsResetPayload
+  }
+}
+# Updates the user's settings.
+mutation updateUserSettings(
+  # The identifier of the userSettings to update.
+  $id: String!
+  # A partial notification object to update the settings with.
+  $input: UserSettingsUpdateInput!
+) {
+  userSettingsUpdate(id: $id, input: $input) {
+    ...UserSettingsPayload
+  }
+}
+# Suspends a user. Can only be called by an admin.
+mutation suspendUser(
+  # The identifier of the user to suspend.
+  $id: String!
+) {
+  userSuspend(id: $id) {
+    ...UserAdminPayload
+  }
+}
+# Un-suspends a user. Can only be called by an admin.
+mutation unsuspendUser(
+  # The identifier of the user to unsuspend.
+  $id: String!
+) {
+  userUnsuspend(id: $id) {
+    ...UserAdminPayload
+  }
+}
+# Updates a user. Only available to organization admins and the user themselves.
+mutation updateUser(
+  # The identifier of the user to update. Use `me` to reference currently authenticated user.
+  $id: String!
+  # A partial user object to update the user with.
+  $input: UpdateUserInput!
+) {
+  userUpdate(id: $id, input: $input) {
+    ...UserPayload
+  }
+}
+# Creates a new ViewPreferences object.
+mutation createViewPreferences(
+  # The ViewPreferences object to create.
+  $input: ViewPreferencesCreateInput!
+) {
+  viewPreferencesCreate(input: $input) {
+    ...ViewPreferencesPayload
+  }
+}
+# Deletes a ViewPreferences.
+mutation deleteViewPreferences(
+  # The identifier of the ViewPreferences to delete.
+  $id: String!
+) {
+  viewPreferencesDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates an existing ViewPreferences object.
+mutation updateViewPreferences(
+  # The identifier of the ViewPreferences object.
+  $id: String!
+  # The properties of the view preferences.
+  $input: ViewPreferencesUpdateInput!
+) {
+  viewPreferencesUpdate(id: $id, input: $input) {
+    ...ViewPreferencesPayload
+  }
+}
+# Creates a new webhook.
+mutation createWebhook(
+  # The webhook object to create.
+  $input: WebhookCreateInput!
+) {
+  webhookCreate(input: $input) {
+    ...WebhookPayload
+  }
+}
+# Deletes a Webhook.
+mutation deleteWebhook(
+  # The identifier of the Webhook to delete.
+  $id: String!
+) {
+  webhookDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates an existing Webhook.
+mutation updateWebhook(
+  # The identifier of the Webhook.
+  $id: String!
+  # The properties of the Webhook.
+  $input: WebhookUpdateInput!
+) {
+  webhookUpdate(id: $id, input: $input) {
+    ...WebhookPayload
+  }
+}
+# Archives a state. Only states with issues that have all been archived can be archived.
+mutation archiveWorkflowState(
+  # The identifier of the state to archive.
+  $id: String!
+) {
+  workflowStateArchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new state, adding it to the workflow of a team.
+mutation createWorkflowState(
+  # The state to create.
+  $input: WorkflowStateCreateInput!
+) {
+  workflowStateCreate(input: $input) {
+    ...WorkflowStatePayload
+  }
+}
+# Updates a state.
+mutation updateWorkflowState(
+  # The identifier of the state to update.
+  $id: String!
+  # A partial state object to update.
+  $input: WorkflowStateUpdateInput!
+) {
+  workflowStateUpdate(id: $id, input: $input) {
+    ...WorkflowStatePayload
+  }
+}
+# One specific project milestone.
+query ProjectMilestone($id: String!) {
+  ProjectMilestone(id: $id) {
+    ...ProjectMilestone
+  }
+}
+# All milestones for the project.
+query ProjectMilestones(
+  # A cursor to be used with first for forward pagination
+  $after: String
+  # A cursor to be used with last for backward pagination.
+  $before: String
+  # The number of items to forward paginate (used with after). Defaults to 50.
+  $first: Int
+  # Should archived resources be included (default: false)
+  $includeArchived: Boolean
+  # The number of items to backward paginate (used with before). Defaults to 50.
+  $last: Int
+  # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+  $orderBy: PaginationOrderBy
+) {
+  ProjectMilestones(
+    after: $after
+    before: $before
+    first: $first
+    includeArchived: $includeArchived
+    last: $last
+    orderBy: $orderBy
+  ) {
+    ...ProjectMilestoneConnection
+  }
+}
 # All teams you the user can administrate. Administrable teams are teams whose settings the user can
 # change, but to whose issues the user doesn't necessarily have access to.
 query administrableTeams(
@@ -4803,6 +6601,38 @@ query issueRelations(
     ...IssueRelationConnection
   }
 }
+# [ALPHA] Search issues. This query is experimental and is subject to change without notice.
+query issueSearch(
+  # A cursor to be used with first for forward pagination
+  $after: String
+  # A cursor to be used with last for backward pagination.
+  $before: String
+  # Filter returned issues.
+  $filter: IssueFilter
+  # The number of items to forward paginate (used with after). Defaults to 50.
+  $first: Int
+  # Should archived resources be included (default: false)
+  $includeArchived: Boolean
+  # The number of items to backward paginate (used with before). Defaults to 50.
+  $last: Int
+  # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+  $orderBy: PaginationOrderBy
+  # [Deprecated] Search string to look for.
+  $query: String!
+) {
+  issueSearch(
+    after: $after
+    before: $before
+    filter: $filter
+    first: $first
+    includeArchived: $includeArchived
+    last: $last
+    orderBy: $orderBy
+    query: $query
+  ) {
+    ...IssueConnection
+  }
+}
 # Find issue based on the VCS branch name.
 query issueVcsBranchSearch(
   # The VCS branch name to search for.
@@ -5097,70 +6927,6 @@ query issues(
     orderBy: $orderBy
   ) {
     ...IssueConnection
-  }
-}
-# One specific milestone.
-query milestone($id: String!) {
-  milestone(id: $id) {
-    ...Milestone
-  }
-}
-# Projects associated with the milestone.
-query milestone_projects(
-  $id: String!
-  # A cursor to be used with first for forward pagination
-  $after: String
-  # A cursor to be used with last for backward pagination.
-  $before: String
-  # Filter returned projects.
-  $filter: ProjectFilter
-  # The number of items to forward paginate (used with after). Defaults to 50.
-  $first: Int
-  # Should archived resources be included (default: false)
-  $includeArchived: Boolean
-  # The number of items to backward paginate (used with before). Defaults to 50.
-  $last: Int
-  # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
-  $orderBy: PaginationOrderBy
-) {
-  milestone(id: $id) {
-    projects(
-      after: $after
-      before: $before
-      filter: $filter
-      first: $first
-      includeArchived: $includeArchived
-      last: $last
-      orderBy: $orderBy
-    ) {
-      ...ProjectConnection
-    }
-  }
-}
-# All milestones.
-query milestones(
-  # A cursor to be used with first for forward pagination
-  $after: String
-  # A cursor to be used with last for backward pagination.
-  $before: String
-  # The number of items to forward paginate (used with after). Defaults to 50.
-  $first: Int
-  # Should archived resources be included (default: false)
-  $includeArchived: Boolean
-  # The number of items to backward paginate (used with before). Defaults to 50.
-  $last: Int
-  # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
-  $orderBy: PaginationOrderBy
-) {
-  milestones(
-    after: $after
-    before: $before
-    first: $first
-    includeArchived: $includeArchived
-    last: $last
-    orderBy: $orderBy
-  ) {
-    ...MilestoneConnection
   }
 }
 # One specific notification.
@@ -5469,14 +7235,6 @@ query project_documents(
     }
   }
 }
-# The initiative that this project is associated with.
-query project_initiative($id: String!) {
-  project(id: $id) {
-    initiative {
-      ...Initiative
-    }
-  }
-}
 # Issues associated with the project.
 query project_issues(
   $id: String!
@@ -5570,6 +7328,35 @@ query project_members(
       orderBy: $orderBy
     ) {
       ...UserConnection
+    }
+  }
+}
+# [ALPHA] Milestones associated with the project.
+query project_projectMilestones(
+  $id: String!
+  # A cursor to be used with first for forward pagination
+  $after: String
+  # A cursor to be used with last for backward pagination.
+  $before: String
+  # The number of items to forward paginate (used with after). Defaults to 50.
+  $first: Int
+  # Should archived resources be included (default: false)
+  $includeArchived: Boolean
+  # The number of items to backward paginate (used with before). Defaults to 50.
+  $last: Int
+  # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+  $orderBy: PaginationOrderBy
+) {
+  project(id: $id) {
+    projectMilestones(
+      after: $after
+      before: $before
+      first: $first
+      includeArchived: $includeArchived
+      last: $last
+      orderBy: $orderBy
+    ) {
+      ...ProjectMilestoneConnection
     }
   }
 }
@@ -6652,1762 +8439,5 @@ query workflowStates(
     orderBy: $orderBy
   ) {
     ...WorkflowStateConnection
-  }
-}
-# Creates an integration api key for Airbyte to connect with Linear
-mutation airbyteIntegrationConnect(
-  # Airbyte integration settings.
-  $input: AirbyteConfigurationInput!
-) {
-  airbyteIntegrationConnect(input: $input) {
-    ...IntegrationPayload
-  }
-}
-# Creates a new API key.
-mutation createApiKey(
-  # The api key object to create.
-  $input: ApiKeyCreateInput!
-) {
-  apiKeyCreate(input: $input) {
-    ...ApiKeyPayload
-  }
-}
-# Deletes an API key.
-mutation deleteApiKey(
-  # The identifier of the API key to delete.
-  $id: String!
-) {
-  apiKeyDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# [DEPRECATED] Archives an issue attachment.
-mutation archiveAttachment(
-  # The identifier of the attachment to archive.
-  $id: String!
-) {
-  attachmentArchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new attachment, or updates existing if the same `url` and `issueId` is used.
-mutation createAttachment(
-  # The attachment object to create.
-  $input: AttachmentCreateInput!
-) {
-  attachmentCreate(input: $input) {
-    ...AttachmentPayload
-  }
-}
-# Deletes an issue attachment.
-mutation deleteAttachment(
-  # The identifier of the attachment to delete.
-  $id: String!
-) {
-  attachmentDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Link an existing Discord message to an issue.
-mutation attachmentLinkDiscord(
-  # The Discord channel ID for the message to link.
-  $channelId: String!
-  # The issue for which to link the Discord message.
-  $issueId: String!
-  # The Discord message ID for the message to link.
-  $messageId: String!
-  # The Discord message URL for the message to link.
-  $url: String!
-) {
-  attachmentLinkDiscord(channelId: $channelId, issueId: $issueId, messageId: $messageId, url: $url) {
-    ...AttachmentPayload
-  }
-}
-# Link an existing Front conversation to an issue.
-mutation attachmentLinkFront(
-  # The Front conversation ID to link.
-  $conversationId: String!
-  # The issue for which to link the Front conversation.
-  $issueId: String!
-) {
-  attachmentLinkFront(conversationId: $conversationId, issueId: $issueId) {
-    ...FrontAttachmentPayload
-  }
-}
-# Link an existing Intercom conversation to an issue.
-mutation attachmentLinkIntercom(
-  # The Intercom conversation ID to link.
-  $conversationId: String!
-  # The issue for which to link the Intercom conversation.
-  $issueId: String!
-) {
-  attachmentLinkIntercom(conversationId: $conversationId, issueId: $issueId) {
-    ...AttachmentPayload
-  }
-}
-# Link an existing Jira issue to an issue.
-mutation attachmentLinkJiraIssue(
-  # The issue for which to link the Jira issue.
-  $issueId: String!
-  # The Jira issue key or ID to link.
-  $jiraIssueId: String!
-) {
-  attachmentLinkJiraIssue(issueId: $issueId, jiraIssueId: $jiraIssueId) {
-    ...AttachmentPayload
-  }
-}
-# Link any url to an issue.
-mutation attachmentLinkURL(
-  # The issue for which to link the url.
-  $issueId: String!
-  # The title to use for the attachment.
-  $title: String
-  # The url to link.
-  $url: String!
-) {
-  attachmentLinkURL(issueId: $issueId, title: $title, url: $url) {
-    ...AttachmentPayload
-  }
-}
-# Link an existing Zendesk ticket to an issue.
-mutation attachmentLinkZendesk(
-  # The issue for which to link the Zendesk ticket.
-  $issueId: String!
-  # The Zendesk ticket ID to link.
-  $ticketId: String!
-) {
-  attachmentLinkZendesk(issueId: $issueId, ticketId: $ticketId) {
-    ...AttachmentPayload
-  }
-}
-# Updates an existing issue attachment.
-mutation updateAttachment(
-  # The identifier of the attachment to update.
-  $id: String!
-  # A partial attachment object to update the attachment with.
-  $input: AttachmentUpdateInput!
-) {
-  attachmentUpdate(id: $id, input: $input) {
-    ...AttachmentPayload
-  }
-}
-# Creates a new comment.
-mutation createComment(
-  # The comment object to create.
-  $input: CommentCreateInput!
-) {
-  commentCreate(input: $input) {
-    ...CommentPayload
-  }
-}
-# Deletes a comment.
-mutation deleteComment(
-  # The identifier of the comment to delete.
-  $id: String!
-) {
-  commentDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a comment.
-mutation updateComment(
-  # The identifier of the comment to update.
-  $id: String!
-  # A partial comment object to update the comment with.
-  $input: CommentUpdateInput!
-) {
-  commentUpdate(id: $id, input: $input) {
-    ...CommentPayload
-  }
-}
-# Saves user message.
-mutation createContact(
-  # The contact entry to create.
-  $input: ContactCreateInput!
-) {
-  contactCreate(input: $input) {
-    ...ContactPayload
-  }
-}
-# Create CSV export report for the organization.
-mutation createCsvExportReport($includePrivateTeamIds: [String!]) {
-  createCsvExportReport(includePrivateTeamIds: $includePrivateTeamIds) {
-    ...CreateCsvExportReportPayload
-  }
-}
-# Creates an organization from onboarding.
-mutation createOrganizationFromOnboarding(
-  # Organization details for the new organization.
-  $input: CreateOrganizationInput!
-  # Onboarding survey.
-  $survey: OnboardingCustomerSurvey
-) {
-  createOrganizationFromOnboarding(input: $input, survey: $survey) {
-    ...CreateOrJoinOrganizationResponse
-  }
-}
-# Creates a new custom view.
-mutation createCustomView(
-  # The properties of the custom view to create.
-  $input: CustomViewCreateInput!
-) {
-  customViewCreate(input: $input) {
-    ...CustomViewPayload
-  }
-}
-# Deletes a custom view.
-mutation deleteCustomView(
-  # The identifier of the custom view to delete.
-  $id: String!
-) {
-  customViewDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a custom view.
-mutation updateCustomView(
-  # The identifier of the custom view to update.
-  $id: String!
-  # The properties of the custom view to update.
-  $input: CustomViewUpdateInput!
-) {
-  customViewUpdate(id: $id, input: $input) {
-    ...CustomViewPayload
-  }
-}
-# Archives a cycle.
-mutation archiveCycle(
-  # The identifier of the cycle to archive.
-  $id: String!
-) {
-  cycleArchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new cycle.
-mutation createCycle(
-  # The cycle object to create.
-  $input: CycleCreateInput!
-) {
-  cycleCreate(input: $input) {
-    ...CyclePayload
-  }
-}
-# Updates a cycle.
-mutation updateCycle(
-  # The identifier of the cycle to update.
-  $id: String!
-  # A partial cycle object to update the cycle with.
-  $input: CycleUpdateInput!
-) {
-  cycleUpdate(id: $id, input: $input) {
-    ...CyclePayload
-  }
-}
-# Creates a new document.
-mutation createDocument(
-  # The document to create.
-  $input: DocumentCreateInput!
-) {
-  documentCreate(input: $input) {
-    ...DocumentPayload
-  }
-}
-# Deletes a document.
-mutation deleteDocument(
-  # The identifier of the document to delete.
-  $id: String!
-) {
-  documentDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a document.
-mutation updateDocument(
-  # The identifier of the document to update. Also the identifier from the URL is accepted.
-  $id: String!
-  # A partial document object to update the document with.
-  $input: DocumentUpdateInput!
-) {
-  documentUpdate(id: $id, input: $input) {
-    ...DocumentPayload
-  }
-}
-# Authenticates a user account via email and authentication token.
-mutation emailTokenUserAccountAuth(
-  # The data used for token authentication.
-  $input: TokenUserAccountAuthInput!
-) {
-  emailTokenUserAccountAuth(input: $input) {
-    ...AuthResolverResponse
-  }
-}
-# Unsubscribes the user from one type of emails.
-mutation emailUnsubscribe(
-  # Unsubscription details.
-  $input: EmailUnsubscribeInput!
-) {
-  emailUnsubscribe(input: $input) {
-    ...EmailUnsubscribePayload
-  }
-}
-# Finds or creates a new user account by email and sends an email with token.
-mutation emailUserAccountAuthChallenge(
-  # The data used for email authentication.
-  $input: EmailUserAccountAuthChallengeInput!
-) {
-  emailUserAccountAuthChallenge(input: $input) {
-    ...EmailUserAccountAuthChallengeResponse
-  }
-}
-# Creates a custom emoji.
-mutation createEmoji(
-  # The emoji object to create.
-  $input: EmojiCreateInput!
-) {
-  emojiCreate(input: $input) {
-    ...EmojiPayload
-  }
-}
-# Deletes an emoji.
-mutation deleteEmoji(
-  # The identifier of the emoji to delete.
-  $id: String!
-) {
-  emojiDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# [Deprecated] Creates a new event.
-mutation createEvent(
-  # The event to create.
-  $input: EventCreateInput!
-) {
-  eventCreate(input: $input) {
-    ...EventPayload
-  }
-}
-# Creates a new favorite (project, cycle etc).
-mutation createFavorite(
-  # The favorite object to create.
-  $input: FavoriteCreateInput!
-) {
-  favoriteCreate(input: $input) {
-    ...FavoritePayload
-  }
-}
-# Deletes a favorite reference.
-mutation deleteFavorite(
-  # The identifier of the favorite reference to delete.
-  $id: String!
-) {
-  favoriteDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a favorite.
-mutation updateFavorite(
-  # The identifier of the favorite to update.
-  $id: String!
-  # A partial favorite object to update the favorite with.
-  $input: FavoriteUpdateInput!
-) {
-  favoriteUpdate(id: $id, input: $input) {
-    ...FavoritePayload
-  }
-}
-# XHR request payload to upload an images, video and other attachments directly to Linear's cloud
-# storage.
-mutation fileUpload(
-  # MIME type of the uploaded file.
-  $contentType: String!
-  # Filename of the uploaded file.
-  $filename: String!
-  # Should the file be made publicly accessible (default: false).
-  $makePublic: Boolean
-  # Optional metadata.
-  $metaData: JSON
-  # File size of the uploaded file.
-  $size: Int!
-) {
-  fileUpload(
-    contentType: $contentType
-    filename: $filename
-    makePublic: $makePublic
-    metaData: $metaData
-    size: $size
-  ) {
-    ...UploadPayload
-  }
-}
-# Authenticate user account through Google OAuth. This is the 2nd step of OAuth flow.
-mutation googleUserAccountAuth(
-  # The data used for Google authentication.
-  $input: GoogleUserAccountAuthInput!
-) {
-  googleUserAccountAuth(input: $input) {
-    ...AuthResolverResponse
-  }
-}
-# Upload an image from an URL to Linear.
-mutation imageUploadFromUrl(
-  # URL of the file to be uploaded to Linear.
-  $url: String!
-) {
-  imageUploadFromUrl(url: $url) {
-    ...ImageUploadFromUrlPayload
-  }
-}
-# Deletes an integration.
-mutation deleteIntegration(
-  # The identifier of the integration to delete.
-  $id: String!
-) {
-  integrationDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Integrates the organization with Discord.
-mutation integrationDiscord(
-  # The Discord OAuth code.
-  $code: String!
-  # The Discord OAuth redirect URI.
-  $redirectUri: String!
-) {
-  integrationDiscord(code: $code, redirectUri: $redirectUri) {
-    ...IntegrationPayload
-  }
-}
-# Integrates the organization with Figma.
-mutation integrationFigma(
-  # The Figma OAuth code.
-  $code: String!
-  # The Figma OAuth redirect URI.
-  $redirectUri: String!
-) {
-  integrationFigma(code: $code, redirectUri: $redirectUri) {
-    ...IntegrationPayload
-  }
-}
-# Integrates the organization with Front.
-mutation integrationFront(
-  # The Front OAuth code.
-  $code: String!
-  # The Front OAuth redirect URI.
-  $redirectUri: String!
-) {
-  integrationFront(code: $code, redirectUri: $redirectUri) {
-    ...IntegrationPayload
-  }
-}
-# Generates a webhook for the GitHub commit integration.
-mutation createIntegrationGithubCommit {
-  integrationGithubCommitCreate {
-    ...GitHubCommitIntegrationPayload
-  }
-}
-# Connects the organization with the GitHub App.
-mutation integrationGithubConnect(
-  # The GitHub data to connect with.
-  $installationId: String!
-) {
-  integrationGithubConnect(installationId: $installationId) {
-    ...IntegrationPayload
-  }
-}
-# Connects the organization with a GitLab Access Token.
-mutation integrationGitlabConnect(
-  # The GitLab Access Token to connect with.
-  $accessToken: String!
-  # The URL of the GitLab installation
-  $gitlabUrl: String!
-) {
-  integrationGitlabConnect(accessToken: $accessToken, gitlabUrl: $gitlabUrl) {
-    ...IntegrationPayload
-  }
-}
-# Integrates the organization with Google Sheets.
-mutation integrationGoogleSheets(
-  # The Google OAuth code.
-  $code: String!
-) {
-  integrationGoogleSheets(code: $code) {
-    ...IntegrationPayload
-  }
-}
-# Integrates the organization with Intercom.
-mutation integrationIntercom(
-  # The Intercom OAuth code.
-  $code: String!
-  # The Intercom domain URL to use for the integration. Defaults to app.intercom.com if not provided.
-  $domainUrl: String
-  # The Intercom OAuth redirect URI.
-  $redirectUri: String!
-) {
-  integrationIntercom(code: $code, domainUrl: $domainUrl, redirectUri: $redirectUri) {
-    ...IntegrationPayload
-  }
-}
-# Disconnects the organization from Intercom.
-mutation deleteIntegrationIntercom {
-  integrationIntercomDelete {
-    ...IntegrationPayload
-  }
-}
-# [DEPRECATED] Updates settings on the Intercom integration.
-mutation updateIntegrationIntercomSettings(
-  # A partial Intercom integration settings object to update the integration settings with.
-  $input: IntercomSettingsInput!
-) {
-  integrationIntercomSettingsUpdate(input: $input) {
-    ...IntegrationPayload
-  }
-}
-# Enables Loom integration for the organization.
-mutation integrationLoom {
-  integrationLoom {
-    ...IntegrationPayload
-  }
-}
-# Requests a currently unavailable integration.
-mutation integrationRequest(
-  # Integration request details.
-  $input: IntegrationRequestInput!
-) {
-  integrationRequest(input: $input) {
-    ...IntegrationRequestPayload
-  }
-}
-# Archives an integration resource.
-mutation archiveIntegrationResource(
-  # The identifier of the integration resource to archive.
-  $id: String!
-) {
-  integrationResourceArchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Integrates the organization with Sentry.
-mutation integrationSentryConnect(
-  # The Sentry grant code that's exchanged for OAuth tokens.
-  $code: String!
-  # The Sentry installationId to connect with.
-  $installationId: String!
-  # The slug of the Sentry organization being connected.
-  $organizationSlug: String!
-) {
-  integrationSentryConnect(code: $code, installationId: $installationId, organizationSlug: $organizationSlug) {
-    ...IntegrationPayload
-  }
-}
-# Integrates the organization with Slack.
-mutation integrationSlack(
-  # The Slack OAuth code.
-  $code: String!
-  # The Slack OAuth redirect URI.
-  $redirectUri: String!
-  # [DEPRECATED] Whether or not v2 of Slack OAuth should be used. No longer used.
-  $shouldUseV2Auth: Boolean
-) {
-  integrationSlack(code: $code, redirectUri: $redirectUri, shouldUseV2Auth: $shouldUseV2Auth) {
-    ...IntegrationPayload
-  }
-}
-# Imports custom emojis from your Slack workspace.
-mutation integrationSlackImportEmojis(
-  # The Slack OAuth code.
-  $code: String!
-  # The Slack OAuth redirect URI.
-  $redirectUri: String!
-) {
-  integrationSlackImportEmojis(code: $code, redirectUri: $redirectUri) {
-    ...IntegrationPayload
-  }
-}
-# Slack integration for organization level project update notifications.
-mutation integrationSlackOrgProjectUpdatesPost(
-  # The Slack OAuth code.
-  $code: String!
-  # The Slack OAuth redirect URI.
-  $redirectUri: String!
-) {
-  integrationSlackOrgProjectUpdatesPost(code: $code, redirectUri: $redirectUri) {
-    ...IntegrationPayload
-  }
-}
-# Integrates your personal notifications with Slack.
-mutation integrationSlackPersonal(
-  # The Slack OAuth code.
-  $code: String!
-  # The Slack OAuth redirect URI.
-  $redirectUri: String!
-) {
-  integrationSlackPersonal(code: $code, redirectUri: $redirectUri) {
-    ...IntegrationPayload
-  }
-}
-# Slack webhook integration.
-mutation integrationSlackPost(
-  # The Slack OAuth code.
-  $code: String!
-  # The Slack OAuth redirect URI.
-  $redirectUri: String!
-  # [DEPRECATED] Whether or not v2 of Slack OAuth should be used. No longer used.
-  $shouldUseV2Auth: Boolean
-  # Integration's associated team.
-  $teamId: String!
-) {
-  integrationSlackPost(code: $code, redirectUri: $redirectUri, shouldUseV2Auth: $shouldUseV2Auth, teamId: $teamId) {
-    ...IntegrationPayload
-  }
-}
-# Slack integration for project notifications.
-mutation integrationSlackProjectPost(
-  # The Slack OAuth code.
-  $code: String!
-  # Integration's associated project.
-  $projectId: String!
-  # The Slack OAuth redirect URI.
-  $redirectUri: String!
-  # The service to enable once connected, either 'notifications' or 'updates'.
-  $service: String!
-) {
-  integrationSlackProjectPost(code: $code, projectId: $projectId, redirectUri: $redirectUri, service: $service) {
-    ...IntegrationPayload
-  }
-}
-# Creates a new integrationTemplate join.
-mutation createIntegrationTemplate(
-  # The properties of the integrationTemplate to create.
-  $input: IntegrationTemplateCreateInput!
-) {
-  integrationTemplateCreate(input: $input) {
-    ...IntegrationTemplatePayload
-  }
-}
-# Deletes a integrationTemplate.
-mutation deleteIntegrationTemplate(
-  # The identifier of the integrationTemplate to delete.
-  $id: String!
-) {
-  integrationTemplateDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Integrates the organization with Zendesk.
-mutation integrationZendesk(
-  # The Zendesk OAuth code.
-  $code: String!
-  # The Zendesk OAuth redirect URI.
-  $redirectUri: String!
-  # The Zendesk OAuth scopes.
-  $scope: String!
-  # The Zendesk installation subdomain.
-  $subdomain: String!
-) {
-  integrationZendesk(code: $code, redirectUri: $redirectUri, scope: $scope, subdomain: $subdomain) {
-    ...IntegrationPayload
-  }
-}
-# Creates new settings for one or more integrations.
-mutation createIntegrationsSettings(
-  # The settings to create.
-  $input: IntegrationsSettingsCreateInput!
-) {
-  integrationsSettingsCreate(input: $input) {
-    ...IntegrationsSettingsPayload
-  }
-}
-# Updates settings related to integrations for a project or a team.
-mutation updateIntegrationsSettings(
-  # The identifier of the settings to update.
-  $id: String!
-  # A settings object to update the settings with.
-  $input: IntegrationsSettingsUpdateInput!
-) {
-  integrationsSettingsUpdate(id: $id, input: $input) {
-    ...IntegrationsSettingsPayload
-  }
-}
-# Archives an issue.
-mutation archiveIssue(
-  # The identifier of the issue to archive.
-  $id: String!
-  # Whether to trash the issue
-  $trash: Boolean
-) {
-  issueArchive(id: $id, trash: $trash) {
-    ...ArchivePayload
-  }
-}
-# Updates multiple issues at once.
-mutation updateIssueBatch(
-  # The id's of the issues to update. Can't be more than 50 at a time.
-  $ids: [UUID!]!
-  # A partial issue object to update the issues with.
-  $input: IssueUpdateInput!
-) {
-  issueBatchUpdate(ids: $ids, input: $input) {
-    ...IssueBatchPayload
-  }
-}
-# Creates a new issue.
-mutation createIssue(
-  # The issue object to create.
-  $input: IssueCreateInput!
-) {
-  issueCreate(input: $input) {
-    ...IssuePayload
-  }
-}
-# Deletes (trashes) an issue.
-mutation deleteIssue(
-  # The identifier of the issue to delete.
-  $id: String!
-) {
-  issueDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Kicks off an Asana import job.
-mutation issueImportCreateAsana(
-  # Asana team name to choose which issues we should import.
-  $asanaTeamName: String!
-  # Asana token to fetch information from the Asana API.
-  $asanaToken: String!
-  # ID of issue import. If not provided it will be generated.
-  $id: String
-  # Whether or not we should collect the data for closed issues.
-  $includeClosedIssues: Boolean
-  # Whether to instantly process the import with the default configuration mapping.
-  $instantProcess: Boolean
-  # ID of the organization into which to import data.
-  $organizationId: String
-  # ID of the team into which to import data.
-  $teamId: String
-  # Name of new team. When teamId is not set.
-  $teamName: String
-) {
-  issueImportCreateAsana(
-    asanaTeamName: $asanaTeamName
-    asanaToken: $asanaToken
-    id: $id
-    includeClosedIssues: $includeClosedIssues
-    instantProcess: $instantProcess
-    organizationId: $organizationId
-    teamId: $teamId
-    teamName: $teamName
-  ) {
-    ...IssueImportPayload
-  }
-}
-# Kicks off a Shortcut (formerly Clubhouse) import job.
-mutation issueImportCreateClubhouse(
-  # Shortcut (formerly Clubhouse) team name to choose which issues we should import.
-  $clubhouseTeamName: String!
-  # Shortcut (formerly Clubhouse) token to fetch information from the Clubhouse API.
-  $clubhouseToken: String!
-  # ID of issue import. If not provided it will be generated.
-  $id: String
-  # Whether or not we should collect the data for closed issues.
-  $includeClosedIssues: Boolean
-  # Whether to instantly process the import with the default configuration mapping.
-  $instantProcess: Boolean
-  # ID of the organization into which to import data.
-  $organizationId: String
-  # ID of the team into which to import data.
-  $teamId: String
-  # Name of new team. When teamId is not set.
-  $teamName: String
-) {
-  issueImportCreateClubhouse(
-    clubhouseTeamName: $clubhouseTeamName
-    clubhouseToken: $clubhouseToken
-    id: $id
-    includeClosedIssues: $includeClosedIssues
-    instantProcess: $instantProcess
-    organizationId: $organizationId
-    teamId: $teamId
-    teamName: $teamName
-  ) {
-    ...IssueImportPayload
-  }
-}
-# Kicks off a GitHub import job.
-mutation issueImportCreateGithub(
-  # GitHub repository name from which we will import data.
-  $githubRepoName: String!
-  # GitHub owner (user or org) for the repository from which we will import data.
-  $githubRepoOwner: String!
-  # Whether or not we should import GitHub organization level projects.
-  $githubShouldImportOrgProjects: Boolean
-  # GitHub token to fetch information from the GitHub API.
-  $githubToken: String!
-  # ID of issue import. If not provided it will be generated.
-  $id: String
-  # Whether or not we should collect the data for closed issues.
-  $includeClosedIssues: Boolean
-  # Whether to instantly process the import with the default configuration mapping.
-  $instantProcess: Boolean
-  # ID of the organization into which to import data.
-  $organizationId: String
-  # ID of the team into which to import data.
-  $teamId: String
-  # Name of new team. When teamId is not set.
-  $teamName: String
-) {
-  issueImportCreateGithub(
-    githubRepoName: $githubRepoName
-    githubRepoOwner: $githubRepoOwner
-    githubShouldImportOrgProjects: $githubShouldImportOrgProjects
-    githubToken: $githubToken
-    id: $id
-    includeClosedIssues: $includeClosedIssues
-    instantProcess: $instantProcess
-    organizationId: $organizationId
-    teamId: $teamId
-    teamName: $teamName
-  ) {
-    ...IssueImportPayload
-  }
-}
-# Kicks off a Jira import job.
-mutation issueImportCreateJira(
-  # ID of issue import. If not provided it will be generated.
-  $id: String
-  # Whether or not we should collect the data for closed issues.
-  $includeClosedIssues: Boolean
-  # Whether to instantly process the import with the default configuration mapping.
-  $instantProcess: Boolean
-  # Jira user account email.
-  $jiraEmail: String!
-  # Jira installation or cloud hostname.
-  $jiraHostname: String!
-  # Jira project key from which we will import data.
-  $jiraProject: String!
-  # Jira personal access token to access Jira REST API.
-  $jiraToken: String!
-  # ID of the organization into which to import data.
-  $organizationId: String
-  # ID of the team into which to import data. Empty to create new team.
-  $teamId: String
-  # Name of new team. When teamId is not set.
-  $teamName: String
-) {
-  issueImportCreateJira(
-    id: $id
-    includeClosedIssues: $includeClosedIssues
-    instantProcess: $instantProcess
-    jiraEmail: $jiraEmail
-    jiraHostname: $jiraHostname
-    jiraProject: $jiraProject
-    jiraToken: $jiraToken
-    organizationId: $organizationId
-    teamId: $teamId
-    teamName: $teamName
-  ) {
-    ...IssueImportPayload
-  }
-}
-# Deletes an import job.
-mutation deleteIssueImport(
-  # ID of the issue import to delete.
-  $issueImportId: String!
-) {
-  issueImportDelete(issueImportId: $issueImportId) {
-    ...IssueImportDeletePayload
-  }
-}
-# Kicks off import processing.
-mutation issueImportProcess(
-  # ID of the issue import which we're going to process.
-  $issueImportId: String!
-  # The mapping configuration to use for processing the import.
-  $mapping: JSONObject!
-) {
-  issueImportProcess(issueImportId: $issueImportId, mapping: $mapping) {
-    ...IssueImportPayload
-  }
-}
-# Updates the mapping for the issue import.
-mutation updateIssueImport(
-  # The identifier of the issue import.
-  $id: String!
-  # The properties of the issue import to update.
-  $input: IssueImportUpdateInput!
-) {
-  issueImportUpdate(id: $id, input: $input) {
-    ...IssueImportPayload
-  }
-}
-# Deletes an issue label.
-mutation archiveIssueLabel(
-  # The identifier of the label to archive.
-  $id: String!
-) {
-  issueLabelArchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new label.
-mutation createIssueLabel(
-  # The issue label to create.
-  $input: IssueLabelCreateInput!
-  # Whether to replace all team-specific labels with the same name with this newly created workspace label.
-  $replaceTeamLabels: Boolean
-) {
-  issueLabelCreate(input: $input, replaceTeamLabels: $replaceTeamLabels) {
-    ...IssueLabelPayload
-  }
-}
-# Deletes an issue label.
-mutation deleteIssueLabel(
-  # The identifier of the label to delete.
-  $id: String!
-) {
-  issueLabelDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates an label.
-mutation updateIssueLabel(
-  # The identifier of the label to update.
-  $id: String!
-  # A partial label object to update.
-  $input: IssueLabelUpdateInput!
-) {
-  issueLabelUpdate(id: $id, input: $input) {
-    ...IssueLabelPayload
-  }
-}
-# Creates a new issue relation.
-mutation createIssueRelation(
-  # The issue relation to create.
-  $input: IssueRelationCreateInput!
-) {
-  issueRelationCreate(input: $input) {
-    ...IssueRelationPayload
-  }
-}
-# Deletes an issue relation.
-mutation deleteIssueRelation(
-  # The identifier of the issue relation to delete.
-  $id: String!
-) {
-  issueRelationDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates an issue relation.
-mutation updateIssueRelation(
-  # The identifier of the issue relation to update.
-  $id: String!
-  # The properties of the issue relation to update.
-  $input: IssueRelationUpdateInput!
-) {
-  issueRelationUpdate(id: $id, input: $input) {
-    ...IssueRelationPayload
-  }
-}
-# Adds an issue reminder. Will cause a notification to be sent when the issue reminder time is
-# reached.
-mutation issueReminder(
-  # The identifier of the issue to add a reminder for.
-  $id: String!
-  # The time when a reminder notification will be sent.
-  $reminderAt: DateTime!
-) {
-  issueReminder(id: $id, reminderAt: $reminderAt) {
-    ...IssuePayload
-  }
-}
-# Unarchives an issue.
-mutation unarchiveIssue(
-  # The identifier of the issue to archive.
-  $id: String!
-) {
-  issueUnarchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates an issue.
-mutation updateIssue(
-  # The identifier of the issue to update.
-  $id: String!
-  # A partial issue object to update the issue with.
-  $input: IssueUpdateInput!
-) {
-  issueUpdate(id: $id, input: $input) {
-    ...IssuePayload
-  }
-}
-# Join an organization from onboarding.
-mutation joinOrganizationFromOnboarding(
-  # Organization details for the organization to join.
-  $input: JoinOrganizationInput!
-) {
-  joinOrganizationFromOnboarding(input: $input) {
-    ...CreateOrJoinOrganizationResponse
-  }
-}
-# Leave an organization.
-mutation leaveOrganization(
-  # ID of the organization to leave.
-  $organizationId: String!
-) {
-  leaveOrganization(organizationId: $organizationId) {
-    ...CreateOrJoinOrganizationResponse
-  }
-}
-# Logout of all clients.
-mutation logout {
-  logout {
-    ...LogoutResponse
-  }
-}
-# Migrates milestones to roadmaps
-mutation migrateMilestonesToRoadmaps(
-  # Ids for milestones to migrate and milestones to delete
-  $input: MilestonesMigrateInput!
-) {
-  migrateMilestonesToRoadmaps(input: $input) {
-    ...MilestoneMigrationPayload
-  }
-}
-# Creates a new milestone.
-mutation createMilestone(
-  # The issue object to create.
-  $input: MilestoneCreateInput!
-) {
-  milestoneCreate(input: $input) {
-    ...MilestonePayload
-  }
-}
-# Deletes a milestone.
-mutation deleteMilestone(
-  # The identifier of the milestone to delete.
-  $id: String!
-) {
-  milestoneDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a milestone.
-mutation updateMilestone(
-  # The identifier of the milestone to update.
-  $id: String!
-  # A partial milestone object to update the milestone with.
-  $input: MilestoneUpdateInput!
-) {
-  milestoneUpdate(id: $id, input: $input) {
-    ...MilestonePayload
-  }
-}
-# Archives a notification.
-mutation archiveNotification(
-  # The id of the notification to archive.
-  $id: String!
-) {
-  notificationArchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new notification subscription for a team or a project.
-mutation createNotificationSubscription(
-  # The subscription object to create.
-  $input: NotificationSubscriptionCreateInput!
-) {
-  notificationSubscriptionCreate(input: $input) {
-    ...NotificationSubscriptionPayload
-  }
-}
-# Deletes a notification subscription reference.
-mutation deleteNotificationSubscription(
-  # The identifier of the notification subscription reference to delete.
-  $id: String!
-) {
-  notificationSubscriptionDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a notification subscription.
-mutation updateNotificationSubscription(
-  # The identifier of the notification subscription to update.
-  $id: String!
-  # A partial notification subscription object to update the notification subscription with.
-  $input: NotificationSubscriptionUpdateInput!
-) {
-  notificationSubscriptionUpdate(id: $id, input: $input) {
-    ...NotificationSubscriptionPayload
-  }
-}
-# Unarchives a notification.
-mutation unarchiveNotification(
-  # The id of the notification to archive.
-  $id: String!
-) {
-  notificationUnarchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a notification.
-mutation updateNotification(
-  # The identifier of the notification to update.
-  $id: String!
-  # A partial notification object to update the notification with.
-  $input: NotificationUpdateInput!
-) {
-  notificationUpdate(id: $id, input: $input) {
-    ...NotificationPayload
-  }
-}
-# Cancels the deletion of an organization. Administrator privileges required.
-mutation deleteOrganizationCancel {
-  organizationCancelDelete {
-    ...OrganizationCancelDeletePayload
-  }
-}
-# Delete's an organization. Administrator privileges required.
-mutation deleteOrganization(
-  # Information required to delete an organization.
-  $input: DeleteOrganizationInput!
-) {
-  organizationDelete(input: $input) {
-    ...OrganizationDeletePayload
-  }
-}
-# Get an organization's delete confirmation token. Administrator privileges required.
-mutation organizationDeleteChallenge {
-  organizationDeleteChallenge {
-    ...OrganizationDeletePayload
-  }
-}
-# Deletes a domain.
-mutation deleteOrganizationDomain(
-  # The identifier of the domain to delete.
-  $id: String!
-) {
-  organizationDomainDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new organization invite.
-mutation createOrganizationInvite(
-  # The organization invite object to create.
-  $input: OrganizationInviteCreateInput!
-) {
-  organizationInviteCreate(input: $input) {
-    ...OrganizationInvitePayload
-  }
-}
-# Deletes an organization invite.
-mutation deleteOrganizationInvite(
-  # The identifier of the organization invite to delete.
-  $id: String!
-) {
-  organizationInviteDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates an organization invite.
-mutation updateOrganizationInvite(
-  # The identifier of the organization invite to update.
-  $id: String!
-  # The updates to make to the organization invite object.
-  $input: OrganizationInviteUpdateInput!
-) {
-  organizationInviteUpdate(id: $id, input: $input) {
-    ...OrganizationInvitePayload
-  }
-}
-# Updates the user's organization.
-mutation updateOrganization(
-  # A partial organization object to update the organization with.
-  $input: UpdateOrganizationInput!
-) {
-  organizationUpdate(input: $input) {
-    ...OrganizationPayload
-  }
-}
-# Archives a project.
-mutation archiveProject(
-  # The identifier of the project to archive. Also the identifier from the URL is accepted.
-  $id: String!
-) {
-  projectArchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new project.
-mutation createProject(
-  # The issue object to create.
-  $input: ProjectCreateInput!
-) {
-  projectCreate(input: $input) {
-    ...ProjectPayload
-  }
-}
-# Deletes a project. All issues will be disassociated from the deleted project.
-mutation deleteProject(
-  # The identifier of the project to delete. Also the identifier from the URL is accepted.
-  $id: String!
-) {
-  projectDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new project link.
-mutation createProjectLink(
-  # The project link object to create.
-  $input: ProjectLinkCreateInput!
-) {
-  projectLinkCreate(input: $input) {
-    ...ProjectLinkPayload
-  }
-}
-# Deletes a project link.
-mutation deleteProjectLink(
-  # The identifier of the project link to delete.
-  $id: String!
-) {
-  projectLinkDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a project link.
-mutation updateProjectLink(
-  # The identifier of the project link to update.
-  $id: String!
-  # The project link object to update.
-  $input: ProjectLinkUpdateInput!
-) {
-  projectLinkUpdate(id: $id, input: $input) {
-    ...ProjectLinkPayload
-  }
-}
-# Unarchives a project.
-mutation unarchiveProject(
-  # The identifier of the project to restore. Also the identifier from the URL is accepted.
-  $id: String!
-) {
-  projectUnarchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a project.
-mutation updateProject(
-  # The identifier of the project to update. Also the identifier from the URL is accepted.
-  $id: String!
-  # A partial project object to update the project with.
-  $input: ProjectUpdateInput!
-) {
-  projectUpdate(id: $id, input: $input) {
-    ...ProjectPayload
-  }
-}
-# Creates a new project update.
-mutation createProjectUpdate(
-  # Data for the project update to create.
-  $input: ProjectUpdateCreateInput!
-) {
-  projectUpdateCreate(input: $input) {
-    ...ProjectUpdatePayload
-  }
-}
-# Deletes a project update.
-mutation deleteProjectUpdate(
-  # The identifier of the project update to delete.
-  $id: String!
-) {
-  projectUpdateDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new interaction on a project update.
-mutation createProjectUpdateInteraction(
-  # Data for the project update interaction to create.
-  $input: ProjectUpdateInteractionCreateInput!
-) {
-  projectUpdateInteractionCreate(input: $input) {
-    ...ProjectUpdateInteractionPayload
-  }
-}
-# Mark a project update as read.
-mutation projectUpdateMarkAsRead(
-  # The identifier of the project update.
-  $id: String!
-) {
-  projectUpdateMarkAsRead(id: $id) {
-    ...ProjectUpdateWithInteractionPayload
-  }
-}
-# Updates a project update.
-mutation updateProjectUpdate(
-  # The identifier of the project update to update.
-  $id: String!
-  # A data to update the project update with.
-  $input: ProjectUpdateUpdateInput!
-) {
-  projectUpdateUpdate(id: $id, input: $input) {
-    ...ProjectUpdatePayload
-  }
-}
-# Creates a push subscription.
-mutation createPushSubscription(
-  # The push subscription to create.
-  $input: PushSubscriptionCreateInput!
-) {
-  pushSubscriptionCreate(input: $input) {
-    ...PushSubscriptionPayload
-  }
-}
-# Deletes a push subscription.
-mutation deletePushSubscription(
-  # The identifier of the push subscription to delete.
-  $id: String!
-) {
-  pushSubscriptionDelete(id: $id) {
-    ...PushSubscriptionPayload
-  }
-}
-# Creates a new reaction.
-mutation createReaction(
-  # The reaction object to create.
-  $input: ReactionCreateInput!
-) {
-  reactionCreate(input: $input) {
-    ...ReactionPayload
-  }
-}
-# Deletes a reaction.
-mutation deleteReaction(
-  # The identifier of the reaction to delete.
-  $id: String!
-) {
-  reactionDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Manually update Google Sheets data.
-mutation refreshGoogleSheetsData(
-  # The identifier of the Google Sheets integration to update.
-  $id: String!
-) {
-  refreshGoogleSheetsData(id: $id) {
-    ...IntegrationPayload
-  }
-}
-# Re-send an organization invite.
-mutation resendOrganizationInvite(
-  # The identifier of the organization invite to be re-send.
-  $id: String!
-) {
-  resendOrganizationInvite(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new roadmap.
-mutation createRoadmap(
-  # The properties of the roadmap to create.
-  $input: RoadmapCreateInput!
-) {
-  roadmapCreate(input: $input) {
-    ...RoadmapPayload
-  }
-}
-# Deletes a roadmap.
-mutation deleteRoadmap(
-  # The identifier of the roadmap to delete.
-  $id: String!
-) {
-  roadmapDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new roadmapToProject join.
-mutation createRoadmapToProject(
-  # The properties of the roadmapToProject to create.
-  $input: RoadmapToProjectCreateInput!
-) {
-  roadmapToProjectCreate(input: $input) {
-    ...RoadmapToProjectPayload
-  }
-}
-# Deletes a roadmapToProject.
-mutation deleteRoadmapToProject(
-  # The identifier of the roadmapToProject to delete.
-  $id: String!
-) {
-  roadmapToProjectDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a roadmapToProject.
-mutation updateRoadmapToProject(
-  # The identifier of the roadmapToProject to update.
-  $id: String!
-  # The properties of the roadmapToProject to update.
-  $input: RoadmapToProjectUpdateInput!
-) {
-  roadmapToProjectUpdate(id: $id, input: $input) {
-    ...RoadmapToProjectPayload
-  }
-}
-# Updates a roadmap.
-mutation updateRoadmap(
-  # The identifier of the roadmap to update.
-  $id: String!
-  # The properties of the roadmap to update.
-  $input: RoadmapUpdateInput!
-) {
-  roadmapUpdate(id: $id, input: $input) {
-    ...RoadmapPayload
-  }
-}
-# Authenticates a user account via email and authentication token for SAML.
-mutation samlTokenUserAccountAuth(
-  # The data used for token authentication.
-  $input: TokenUserAccountAuthInput!
-) {
-  samlTokenUserAccountAuth(input: $input) {
-    ...AuthResolverResponse
-  }
-}
-# Creates a new team. The user who creates the team will automatically be added as a member to the
-# newly created team.
-mutation createTeam(
-  # The team id to copy settings from.
-  $copySettingsFromTeamId: String
-  # The team object to create.
-  $input: TeamCreateInput!
-) {
-  teamCreate(copySettingsFromTeamId: $copySettingsFromTeamId, input: $input) {
-    ...TeamPayload
-  }
-}
-# Deletes team's cycles data
-mutation deleteTeamCycles(
-  # The identifier of the team, which cycles will be deleted.
-  $id: String!
-) {
-  teamCyclesDelete(id: $id) {
-    ...TeamPayload
-  }
-}
-# Deletes a team.
-mutation deleteTeam(
-  # The identifier of the team to delete.
-  $id: String!
-) {
-  teamDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Deletes a previously used team key.
-mutation deleteTeamKey(
-  # The identifier of the team key to delete.
-  $id: String!
-) {
-  teamKeyDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new team membership.
-mutation createTeamMembership(
-  # The team membership object to create.
-  $input: TeamMembershipCreateInput!
-) {
-  teamMembershipCreate(input: $input) {
-    ...TeamMembershipPayload
-  }
-}
-# Deletes a team membership.
-mutation deleteTeamMembership(
-  # The identifier of the team membership to delete.
-  $id: String!
-) {
-  teamMembershipDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a team membership.
-mutation updateTeamMembership(
-  # The identifier of the team membership to update.
-  $id: String!
-  # A partial team membership object to update the team membership with.
-  $input: TeamMembershipUpdateInput!
-) {
-  teamMembershipUpdate(id: $id, input: $input) {
-    ...TeamMembershipPayload
-  }
-}
-# Updates a team.
-mutation updateTeam(
-  # The identifier of the team to update.
-  $id: String!
-  # A partial team object to update the team with.
-  $input: TeamUpdateInput!
-) {
-  teamUpdate(id: $id, input: $input) {
-    ...TeamPayload
-  }
-}
-# Creates a new template.
-mutation createTemplate(
-  # The template object to create.
-  $input: TemplateCreateInput!
-) {
-  templateCreate(input: $input) {
-    ...TemplatePayload
-  }
-}
-# Deletes a template.
-mutation deleteTemplate(
-  # The identifier of the template to delete.
-  $id: String!
-) {
-  templateDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates an existing template.
-mutation updateTemplate(
-  # The identifier of the template.
-  $id: String!
-  # The properties of the template to update.
-  $input: TemplateUpdateInput!
-) {
-  templateUpdate(id: $id, input: $input) {
-    ...TemplatePayload
-  }
-}
-# Makes user a regular user. Can only be called by an admin.
-mutation userDemoteAdmin(
-  # The identifier of the user to make a regular user.
-  $id: String!
-) {
-  userDemoteAdmin(id: $id) {
-    ...UserAdminPayload
-  }
-}
-# Makes user a guest. Can only be called by an admin.
-mutation userDemoteMember(
-  # The identifier of the user to make a guest.
-  $id: String!
-) {
-  userDemoteMember(id: $id) {
-    ...UserAdminPayload
-  }
-}
-# Connects the Discord user to this Linear account via OAuth2.
-mutation userDiscordConnect(
-  # The Discord OAuth code.
-  $code: String!
-  # The Discord OAuth redirect URI.
-  $redirectUri: String!
-) {
-  userDiscordConnect(code: $code, redirectUri: $redirectUri) {
-    ...UserPayload
-  }
-}
-# Disconnects the external user from this Linear account.
-mutation userExternalUserDisconnect(
-  # The external service to disconnect
-  $service: String!
-) {
-  userExternalUserDisconnect(service: $service) {
-    ...UserPayload
-  }
-}
-# Updates a user's settings flag.
-mutation updateUserFlag(
-  # Settings flag to increment.
-  $flag: UserFlagType!
-  # Flag operation to perform
-  $operation: UserFlagUpdateOperation!
-) {
-  userFlagUpdate(flag: $flag, operation: $operation) {
-    ...UserSettingsFlagPayload
-  }
-}
-# Connects the GitHub user to this Linear account via OAuth2.
-mutation userGitHubConnect(
-  # The GitHub OAuth code.
-  $code: String!
-) {
-  userGitHubConnect(code: $code) {
-    ...UserPayload
-  }
-}
-# Connects the Google Calendar to the user to this Linear account via OAuth2.
-mutation userGoogleCalendarConnect(
-  # [Internal] The Google OAuth code.
-  $code: String!
-) {
-  userGoogleCalendarConnect(code: $code) {
-    ...UserPayload
-  }
-}
-# Makes user an admin. Can only be called by an admin.
-mutation userPromoteAdmin(
-  # The identifier of the user to make an admin.
-  $id: String!
-) {
-  userPromoteAdmin(id: $id) {
-    ...UserAdminPayload
-  }
-}
-# Makes user a regular user. Can only be called by an admin.
-mutation userPromoteMember(
-  # The identifier of the user to make a regular user.
-  $id: String!
-) {
-  userPromoteMember(id: $id) {
-    ...UserAdminPayload
-  }
-}
-# [Deprecated] Updates a user's settings flag.
-mutation userSettingsFlagIncrement(
-  # Flag to increment.
-  $flag: String!
-) {
-  userSettingsFlagIncrement(flag: $flag) {
-    ...UserSettingsFlagPayload
-  }
-}
-# Resets user's setting flags.
-mutation userSettingsFlagsReset(
-  # The flags to reset. If not provided all flags will be reset.
-  $flags: [UserFlagType!]
-) {
-  userSettingsFlagsReset(flags: $flags) {
-    ...UserSettingsFlagsResetPayload
-  }
-}
-# Updates the user's settings.
-mutation updateUserSettings(
-  # The identifier of the userSettings to update.
-  $id: String!
-  # A partial notification object to update the settings with.
-  $input: UserSettingsUpdateInput!
-) {
-  userSettingsUpdate(id: $id, input: $input) {
-    ...UserSettingsPayload
-  }
-}
-# Suspends a user. Can only be called by an admin.
-mutation suspendUser(
-  # The identifier of the user to suspend.
-  $id: String!
-) {
-  userSuspend(id: $id) {
-    ...UserAdminPayload
-  }
-}
-# Un-suspends a user. Can only be called by an admin.
-mutation unsuspendUser(
-  # The identifier of the user to unsuspend.
-  $id: String!
-) {
-  userUnsuspend(id: $id) {
-    ...UserAdminPayload
-  }
-}
-# Updates a user. Only available to organization admins and the user themselves.
-mutation updateUser(
-  # The identifier of the user to update. Use `me` to reference currently authenticated user.
-  $id: String!
-  # A partial user object to update the user with.
-  $input: UpdateUserInput!
-) {
-  userUpdate(id: $id, input: $input) {
-    ...UserPayload
-  }
-}
-# Creates a new ViewPreferences object.
-mutation createViewPreferences(
-  # The ViewPreferences object to create.
-  $input: ViewPreferencesCreateInput!
-) {
-  viewPreferencesCreate(input: $input) {
-    ...ViewPreferencesPayload
-  }
-}
-# Deletes a ViewPreferences.
-mutation deleteViewPreferences(
-  # The identifier of the ViewPreferences to delete.
-  $id: String!
-) {
-  viewPreferencesDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates an existing ViewPreferences object.
-mutation updateViewPreferences(
-  # The identifier of the ViewPreferences object.
-  $id: String!
-  # The properties of the view preferences.
-  $input: ViewPreferencesUpdateInput!
-) {
-  viewPreferencesUpdate(id: $id, input: $input) {
-    ...ViewPreferencesPayload
-  }
-}
-# Creates a new webhook.
-mutation createWebhook(
-  # The webhook object to create.
-  $input: WebhookCreateInput!
-) {
-  webhookCreate(input: $input) {
-    ...WebhookPayload
-  }
-}
-# Deletes a Webhook.
-mutation deleteWebhook(
-  # The identifier of the Webhook to delete.
-  $id: String!
-) {
-  webhookDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates an existing Webhook.
-mutation updateWebhook(
-  # The identifier of the Webhook.
-  $id: String!
-  # The properties of the Webhook.
-  $input: WebhookUpdateInput!
-) {
-  webhookUpdate(id: $id, input: $input) {
-    ...WebhookPayload
-  }
-}
-# Archives a state. Only states with issues that have all been archived can be archived.
-mutation archiveWorkflowState(
-  # The identifier of the state to archive.
-  $id: String!
-) {
-  workflowStateArchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new state, adding it to the workflow of a team.
-mutation createWorkflowState(
-  # The state to create.
-  $input: WorkflowStateCreateInput!
-) {
-  workflowStateCreate(input: $input) {
-    ...WorkflowStatePayload
-  }
-}
-# Updates a state.
-mutation updateWorkflowState(
-  # The identifier of the state to update.
-  $id: String!
-  # A partial state object to update.
-  $input: WorkflowStateUpdateInput!
-) {
-  workflowStateUpdate(id: $id, input: $input) {
-    ...WorkflowStatePayload
   }
 }

--- a/packages/sdk/src/_tests/_generated.test.ts
+++ b/packages/sdk/src/_tests/_generated.test.ts
@@ -19,6 +19,43 @@ describe("generated", () => {
     stopClient();
   });
 
+  /** Test all ProjectMilestone queries */
+  describe("ProjectMilestones", () => {
+    let _ProjectMilestone: L.ProjectMilestone | undefined;
+    let _ProjectMilestone_id: string | undefined;
+
+    /** Test the root connection query for the ProjectMilestone */
+    it("ProjectMilestones", async () => {
+      const ProjectMilestones: L.ProjectMilestoneConnection | undefined = await client.ProjectMilestones();
+      const ProjectMilestone = ProjectMilestones?.nodes?.[0];
+      _ProjectMilestone_id = ProjectMilestone?.id;
+      expect(ProjectMilestones instanceof L.ProjectMilestoneConnection);
+    });
+
+    /** Test the root query for a single ProjectMilestone */
+    it("ProjectMilestone", async () => {
+      if (_ProjectMilestone_id) {
+        const ProjectMilestone: L.ProjectMilestone | undefined = await client.ProjectMilestone(_ProjectMilestone_id);
+        _ProjectMilestone = ProjectMilestone;
+        expect(ProjectMilestone instanceof L.ProjectMilestone);
+      } else {
+        console.warn(
+          "codegen-doc:print: No first ProjectMilestone found in connection - cannot test ProjectMilestone query"
+        );
+      }
+    });
+
+    /** Test the ProjectMilestone.project query for L.Project */
+    it("ProjectMilestone.project", async () => {
+      if (_ProjectMilestone) {
+        const ProjectMilestone_project: L.Project | undefined = await _ProjectMilestone.project;
+        expect(ProjectMilestone_project instanceof L.Project);
+      } else {
+        console.warn("codegen-doc:print: No ProjectMilestone found - cannot test ProjectMilestone.project query");
+      }
+    });
+  });
+
   /** Test all Team queries */
   describe("AdministrableTeams", () => {
     let _team: L.Team | undefined;
@@ -1202,6 +1239,201 @@ describe("generated", () => {
     });
   });
 
+  /** Test all Issue queries */
+  describe("IssueSearch", () => {
+    let _issue: L.Issue | undefined;
+    let _issue_id: string | undefined;
+
+    /** Test the root connection query for the Issue */
+    it("issueSearch", async () => {
+      const issueSearch: L.IssueConnection | undefined = await client.issueSearch("mock-query");
+      const issue = issueSearch?.nodes?.[0];
+      _issue_id = issue?.id;
+      expect(issueSearch instanceof L.IssueConnection);
+    });
+
+    /** Test the root query for a single Issue */
+    it("issue", async () => {
+      if (_issue_id) {
+        const issue: L.Issue | undefined = await client.issue(_issue_id);
+        _issue = issue;
+        expect(issue instanceof L.Issue);
+      } else {
+        console.warn("codegen-doc:print: No first Issue found in connection - cannot test issue query");
+      }
+    });
+
+    /** Test the issue connection query for the Attachment */
+    it("issue.attachments", async () => {
+      if (_issue) {
+        const attachments: L.AttachmentConnection | undefined = await _issue.attachments();
+        expect(attachments instanceof L.AttachmentConnection);
+      } else {
+        console.warn("codegen-doc:print: No issue found - cannot test _issue.attachments query");
+      }
+    });
+
+    /** Test the issue connection query for the Issue */
+    it("issue.children", async () => {
+      if (_issue) {
+        const children: L.IssueConnection | undefined = await _issue.children();
+        expect(children instanceof L.IssueConnection);
+      } else {
+        console.warn("codegen-doc:print: No issue found - cannot test _issue.children query");
+      }
+    });
+
+    /** Test the issue connection query for the Comment */
+    it("issue.comments", async () => {
+      if (_issue) {
+        const comments: L.CommentConnection | undefined = await _issue.comments();
+        expect(comments instanceof L.CommentConnection);
+      } else {
+        console.warn("codegen-doc:print: No issue found - cannot test _issue.comments query");
+      }
+    });
+
+    /** Test the issue connection query for the IssueHistory */
+    it("issue.history", async () => {
+      if (_issue) {
+        const history: L.IssueHistoryConnection | undefined = await _issue.history();
+        expect(history instanceof L.IssueHistoryConnection);
+      } else {
+        console.warn("codegen-doc:print: No issue found - cannot test _issue.history query");
+      }
+    });
+
+    /** Test the issue connection query for the IssueRelation */
+    it("issue.inverseRelations", async () => {
+      if (_issue) {
+        const inverseRelations: L.IssueRelationConnection | undefined = await _issue.inverseRelations();
+        expect(inverseRelations instanceof L.IssueRelationConnection);
+      } else {
+        console.warn("codegen-doc:print: No issue found - cannot test _issue.inverseRelations query");
+      }
+    });
+
+    /** Test the issue connection query for the IssueLabel */
+    it("issue.labels", async () => {
+      if (_issue) {
+        const labels: L.IssueLabelConnection | undefined = await _issue.labels();
+        expect(labels instanceof L.IssueLabelConnection);
+      } else {
+        console.warn("codegen-doc:print: No issue found - cannot test _issue.labels query");
+      }
+    });
+
+    /** Test the issue connection query for the IssueRelation */
+    it("issue.relations", async () => {
+      if (_issue) {
+        const relations: L.IssueRelationConnection | undefined = await _issue.relations();
+        expect(relations instanceof L.IssueRelationConnection);
+      } else {
+        console.warn("codegen-doc:print: No issue found - cannot test _issue.relations query");
+      }
+    });
+
+    /** Test the issue connection query for the User */
+    it("issue.subscribers", async () => {
+      if (_issue) {
+        const subscribers: L.UserConnection | undefined = await _issue.subscribers();
+        expect(subscribers instanceof L.UserConnection);
+      } else {
+        console.warn("codegen-doc:print: No issue found - cannot test _issue.subscribers query");
+      }
+    });
+
+    /** Test the issue.assignee query for L.User */
+    it("issue.assignee", async () => {
+      if (_issue) {
+        const issue_assignee: L.User | undefined = await _issue.assignee;
+        expect(issue_assignee instanceof L.User);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.assignee query");
+      }
+    });
+
+    /** Test the issue.creator query for L.User */
+    it("issue.creator", async () => {
+      if (_issue) {
+        const issue_creator: L.User | undefined = await _issue.creator;
+        expect(issue_creator instanceof L.User);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.creator query");
+      }
+    });
+
+    /** Test the issue.cycle query for L.Cycle */
+    it("issue.cycle", async () => {
+      if (_issue) {
+        const issue_cycle: L.Cycle | undefined = await _issue.cycle;
+        expect(issue_cycle instanceof L.Cycle);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.cycle query");
+      }
+    });
+
+    /** Test the issue.parent query for L.Issue */
+    it("issue.parent", async () => {
+      if (_issue) {
+        const issue_parent: L.Issue | undefined = await _issue.parent;
+        expect(issue_parent instanceof L.Issue);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.parent query");
+      }
+    });
+
+    /** Test the issue.project query for L.Project */
+    it("issue.project", async () => {
+      if (_issue) {
+        const issue_project: L.Project | undefined = await _issue.project;
+        expect(issue_project instanceof L.Project);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.project query");
+      }
+    });
+
+    /** Test the issue.projectMilestone query for L.ProjectMilestone */
+    it("issue.projectMilestone", async () => {
+      if (_issue) {
+        const issue_projectMilestone: L.ProjectMilestone | undefined = await _issue.projectMilestone;
+        expect(issue_projectMilestone instanceof L.ProjectMilestone);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.projectMilestone query");
+      }
+    });
+
+    /** Test the issue.snoozedBy query for L.User */
+    it("issue.snoozedBy", async () => {
+      if (_issue) {
+        const issue_snoozedBy: L.User | undefined = await _issue.snoozedBy;
+        expect(issue_snoozedBy instanceof L.User);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.snoozedBy query");
+      }
+    });
+
+    /** Test the issue.state query for L.WorkflowState */
+    it("issue.state", async () => {
+      if (_issue) {
+        const issue_state: L.WorkflowState | undefined = await _issue.state;
+        expect(issue_state instanceof L.WorkflowState);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.state query");
+      }
+    });
+
+    /** Test the issue.team query for L.Team */
+    it("issue.team", async () => {
+      if (_issue) {
+        const issue_team: L.Team | undefined = await _issue.team;
+        expect(issue_team instanceof L.Team);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.team query");
+      }
+    });
+  });
+
   /** Test IssueVcsBranchSearch query */
   describe("IssueVcsBranchSearch", () => {
     let _issueVcsBranchSearch: L.Issue | undefined;
@@ -1464,6 +1696,16 @@ describe("generated", () => {
       }
     });
 
+    /** Test the issue.projectMilestone query for L.ProjectMilestone */
+    it("issue.projectMilestone", async () => {
+      if (_issue) {
+        const issue_projectMilestone: L.ProjectMilestone | undefined = await _issue.projectMilestone;
+        expect(issue_projectMilestone instanceof L.ProjectMilestone);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.projectMilestone query");
+      }
+    });
+
     /** Test the issue.snoozedBy query for L.User */
     it("issue.snoozedBy", async () => {
       if (_issue) {
@@ -1491,51 +1733,6 @@ describe("generated", () => {
         expect(issue_team instanceof L.Team);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.team query");
-      }
-    });
-  });
-
-  /** Test all Milestone queries */
-  describe("Milestones", () => {
-    let _milestone: L.Milestone | undefined;
-    let _milestone_id: string | undefined;
-
-    /** Test the root connection query for the Milestone */
-    it("milestones", async () => {
-      const milestones: L.MilestoneConnection | undefined = await client.milestones();
-      const milestone = milestones?.nodes?.[0];
-      _milestone_id = milestone?.id;
-      expect(milestones instanceof L.MilestoneConnection);
-    });
-
-    /** Test the root query for a single Milestone */
-    it("milestone", async () => {
-      if (_milestone_id) {
-        const milestone: L.Milestone | undefined = await client.milestone(_milestone_id);
-        _milestone = milestone;
-        expect(milestone instanceof L.Milestone);
-      } else {
-        console.warn("codegen-doc:print: No first Milestone found in connection - cannot test milestone query");
-      }
-    });
-
-    /** Test the milestone connection query for the Project */
-    it("milestone.projects", async () => {
-      if (_milestone) {
-        const projects: L.ProjectConnection | undefined = await _milestone.projects();
-        expect(projects instanceof L.ProjectConnection);
-      } else {
-        console.warn("codegen-doc:print: No milestone found - cannot test _milestone.projects query");
-      }
-    });
-
-    /** Test the milestone.organization query for L.Organization */
-    it("milestone.organization", async () => {
-      if (_milestone) {
-        const milestone_organization: L.Organization | undefined = await _milestone.organization;
-        expect(milestone_organization instanceof L.Organization);
-      } else {
-        console.warn("codegen-doc:print: No Milestone found - cannot test milestone.organization query");
       }
     });
   });
@@ -2000,16 +2197,6 @@ describe("generated", () => {
       }
     });
 
-    /** Test the project model query for Project_Initiative */
-    it("project.initiative", async () => {
-      if (_project) {
-        const initiative: L.Initiative | undefined = _project.initiative;
-        expect(initiative instanceof L.Initiative);
-      } else {
-        console.warn("codegen-doc:print: No project found - cannot test _project.initiative query");
-      }
-    });
-
     /** Test the project connection query for the Issue */
     it("project.issues", async () => {
       if (_project) {
@@ -2037,6 +2224,16 @@ describe("generated", () => {
         expect(members instanceof L.UserConnection);
       } else {
         console.warn("codegen-doc:print: No project found - cannot test _project.members query");
+      }
+    });
+
+    /** Test the project connection query for the ProjectMilestone */
+    it("project.projectMilestones", async () => {
+      if (_project) {
+        const projectMilestones: L.ProjectMilestoneConnection | undefined = await _project.projectMilestones();
+        expect(projectMilestones instanceof L.ProjectMilestoneConnection);
+      } else {
+        console.warn("codegen-doc:print: No project found - cannot test _project.projectMilestones query");
       }
     });
 
@@ -2097,16 +2294,6 @@ describe("generated", () => {
         expect(project_lead instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Project found - cannot test project.lead query");
-      }
-    });
-
-    /** Test the project.milestone query for L.Milestone */
-    it("project.milestone", async () => {
-      if (_project) {
-        const project_milestone: L.Milestone | undefined = await _project.milestone;
-        expect(project_milestone instanceof L.Milestone);
-      } else {
-        console.warn("codegen-doc:print: No Project found - cannot test project.milestone query");
       }
     });
   });

--- a/packages/sdk/src/schema.graphql
+++ b/packages/sdk/src/schema.graphql
@@ -247,7 +247,7 @@ input AttachmentCollectionFilter {
   """
   Comparator for the source type.
   """
-  sourceType: NestedStringComparator
+  sourceType: SourceTypeComparator
   """
   Comparator for the subtitle.
   """
@@ -354,7 +354,7 @@ input AttachmentFilter {
   """
   Comparator for the source type.
   """
-  sourceType: NestedStringComparator
+  sourceType: SourceTypeComparator
   """
   Comparator for the subtitle.
   """
@@ -443,6 +443,10 @@ type AuditEntry implements Node {
   Additional metadata related to the audit entry.
   """
   metadata: JSONObject
+  """
+  The organization the audit log belongs to.
+  """
+  organization: Organization
   """
   Additional information related to the request which performed the action.
   """
@@ -670,7 +674,7 @@ type Comment implements Node {
   """
   issue: Issue!
   """
-  The parent of the comment.
+  The parent comment under which the current comment is nested.
   """
   parent: Comment
   """
@@ -771,6 +775,10 @@ input CommentCreateInput {
   """
   displayIconUrl: String
   """
+  Flag to prevent auto subscription to the issue the comment is created on.
+  """
+  doNotSubscribeToIssue: Boolean
+  """
   The identifier in UUID v4 format. If none is provided, the backend will generate one.
   """
   id: String
@@ -779,7 +787,7 @@ input CommentCreateInput {
   """
   issueId: String!
   """
-  [Internal] The parent under which to nest the comment.
+  The parent comment under which to nest a current comment.
   """
   parentId: String
 }
@@ -2397,64 +2405,6 @@ type ImageUploadFromUrlPayload {
 }
 
 """
-A initiative that contains projects.
-"""
-type Initiative implements Node {
-  """
-  The time at which the entity was archived. Null if the entity has not been archived.
-  """
-  archivedAt: DateTime
-  """
-  The time at which the entity was created.
-  """
-  createdAt: DateTime!
-  """
-  The initiative's description.
-  """
-  description: String
-  """
-  The unique identifier of the entity.
-  """
-  id: ID!
-  """
-  The name of the initiative.
-  """
-  name: String!
-  """
-  The organization that the initiative belongs to.
-  """
-  organization: Organization!
-  """
-  The sort order for the initiative.
-  """
-  sortOrder: Float!
-  """
-  The estimated completion date of the initiative.
-  """
-  targetDate: TimelessDate
-  """
-  The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
-      for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
-      been updated after creation.
-  """
-  updatedAt: DateTime!
-}
-
-type InitiativeConnection {
-  edges: [InitiativeEdge!]!
-  nodes: [Initiative!]!
-  pageInfo: PageInfo!
-}
-
-type InitiativeEdge {
-  """
-  Used in `before` and `after` args
-  """
-  cursor: String!
-  node: Initiative!
-}
-
-"""
 An integration with an external service.
 """
 type Integration implements Node {
@@ -2634,6 +2584,7 @@ type IntegrationSettings {
   googleSheets: GoogleSheetsSettings
   intercom: IntercomSettings
   jira: JiraSettings
+  notion: NotionSettings
   sentry: SentrySettings
   slackOrgProjectUpdatesPost: SlackPostSettings
   slackPost: SlackPostSettings
@@ -2647,6 +2598,7 @@ input IntegrationSettingsInput {
   googleSheets: GoogleSheetsSettingsInput
   intercom: IntercomSettingsInput
   jira: JiraSettingsInput
+  notion: NotionSettingsInput
   sentry: SentrySettingsInput
   slackOrgProjectUpdatesPost: SlackPostSettingsInput
   slackPost: SlackPostSettingsInput
@@ -2751,6 +2703,10 @@ type IntegrationsSettings implements Node {
   """
   project: Project
   """
+  Whether to send a Slack message when a new issue is added to triage.
+  """
+  slackIssueAddedToTriage: Boolean
+  """
   Whether to send a Slack message when a new issue is created for the project or the team.
   """
   slackIssueCreated: Boolean
@@ -2758,6 +2714,14 @@ type IntegrationsSettings implements Node {
   Whether to send a Slack message when a comment is created on any of the project or team's issues.
   """
   slackIssueNewComment: Boolean
+  """
+  Whether to send a Slack message when an SLA is breached
+  """
+  slackIssueSlaBreached: Boolean
+  """
+  Whether to send a Slack message when an SLA is at high risk
+  """
+  slackIssueSlaHighRisk: Boolean
   """
   Whether to send a Slack message when any of the project or team's issues has a change in status.
   """
@@ -2770,10 +2734,6 @@ type IntegrationsSettings implements Node {
   Whether to send a Slack message when a project update is created.
   """
   slackProjectUpdateCreated: Boolean
-  """
-  Whether to send a new project update to milestone Slack channels.
-  """
-  slackProjectUpdateCreatedToMilestone: Boolean
   """
   Whether to send a new project update to team Slack channels.
   """
@@ -2810,6 +2770,10 @@ input IntegrationsSettingsCreateInput {
   """
   projectId: String
   """
+  Whether to send a Slack message when a new issue is added to triage.
+  """
+  slackIssueAddedToTriage: Boolean
+  """
   Whether to send a Slack message when a new issue is created for the project or the team.
   """
   slackIssueCreated: Boolean
@@ -2817,6 +2781,14 @@ input IntegrationsSettingsCreateInput {
   Whether to send a Slack message when a comment is created on any of the project or team's issues.
   """
   slackIssueNewComment: Boolean
+  """
+  Whether to receive notification when an SLA has breached on Slack.
+  """
+  slackIssueSlaBreached: Boolean
+  """
+  Whether to send a Slack message when an SLA is at high risk
+  """
+  slackIssueSlaHighRisk: Boolean
   """
   Whether to send a Slack message when any of the project or team's issues has a change in status.
   """
@@ -2829,10 +2801,6 @@ input IntegrationsSettingsCreateInput {
   Whether to send a Slack message when a project update is created.
   """
   slackProjectUpdateCreated: Boolean
-  """
-  Whether to send a Slack message when a project update is created to milestone channels.
-  """
-  slackProjectUpdateCreatedToMilestone: Boolean
   """
   Whether to send a Slack message when a project update is created to team channels.
   """
@@ -2872,6 +2840,10 @@ type IntegrationsSettingsPayload {
 
 input IntegrationsSettingsUpdateInput {
   """
+  Whether to send a Slack message when a new issue is added to triage.
+  """
+  slackIssueAddedToTriage: Boolean
+  """
   Whether to send a Slack message when a new issue is created for the project or the team.
   """
   slackIssueCreated: Boolean
@@ -2879,6 +2851,14 @@ input IntegrationsSettingsUpdateInput {
   Whether to send a Slack message when a comment is created on any of the project or team's issues.
   """
   slackIssueNewComment: Boolean
+  """
+  Whether to receive notification when an SLA has breached on Slack.
+  """
+  slackIssueSlaBreached: Boolean
+  """
+  Whether to send a Slack message when an SLA is at high risk
+  """
+  slackIssueSlaHighRisk: Boolean
   """
   Whether to send a Slack message when any of the project or team's issues has a change in status.
   """
@@ -2891,10 +2871,6 @@ input IntegrationsSettingsUpdateInput {
   Whether to send a Slack message when a project update is created.
   """
   slackProjectUpdateCreated: Boolean
-  """
-  Whether to send a Slack message when a project update is created to milestone channels.
-  """
-  slackProjectUpdateCreatedToMilestone: Boolean
   """
   Whether to send a Slack message when a project update is created to team channels.
   """
@@ -3275,6 +3251,10 @@ type Issue implements Node {
   """
   project: Project
   """
+  [ALPHA] The projectMilestone that the issue is associated with.
+  """
+  projectMilestone: ProjectMilestone
+  """
   Relations associated with this issue.
   """
   relations(
@@ -3304,6 +3284,14 @@ type Issue implements Node {
     orderBy: PaginationOrderBy
   ): IssueRelationConnection!
   """
+  [Internal] The time at which the issue's SLA will breach.
+  """
+  slaBreachesAt: DateTime
+  """
+  [Internal] The time at which the issue's SLA began.
+  """
+  slaStartedAt: DateTime
+  """
   The user who snoozed the issue.
   """
   snoozedBy: User
@@ -3319,6 +3307,10 @@ type Issue implements Node {
   The time at which the issue was moved into started state.
   """
   startedAt: DateTime
+  """
+  The time at which the issue entered triage.
+  """
+  startedTriageAt: DateTime
   """
   The workflow state that the issue is associated with.
   """
@@ -3528,6 +3520,10 @@ input IssueCollectionFilter {
   """
   searchableContent: ContentComparator
   """
+  Comparator for the issues sla status.
+  """
+  slaStatus: SlaStatusComparator
+  """
   Filters that the issues snoozer must satisfy.
   """
   snoozedBy: NullableUserFilter
@@ -3633,6 +3629,10 @@ input IssueCreateInput {
   """
   projectId: String
   """
+  [ALPHA] The project milestone associated with the issue.
+  """
+  projectMilestoneId: String
+  """
   The comment the issue is referencing.
   """
   referenceCommentId: String
@@ -3660,6 +3660,98 @@ input IssueCreateInput {
   The title of the issue.
   """
   title: String!
+}
+
+"""
+[Internal] A draft issue.
+"""
+type IssueDraft implements Node {
+  """
+  The time at which the entity was archived. Null if the entity has not been archived.
+  """
+  archivedAt: DateTime
+  """
+  The user assigned to the draft.
+  """
+  assigneeId: String
+  """
+  Serialized array of JSONs representing attachments.
+  """
+  attachments: JSONObject!
+  """
+  The time at which the entity was created.
+  """
+  createdAt: DateTime!
+  """
+  The user who created the draft.
+  """
+  creator: User!
+  """
+  The cycle associated with the draft.
+  """
+  cycleId: String
+  """
+  The draft's description in markdown format.
+  """
+  description: String
+  """
+  [Internal] The draft's description as a Prosemirror document.
+  """
+  descriptionData: JSON
+  """
+  The date at which the issue would be due.
+  """
+  dueDate: TimelessDate
+  """
+  The estimate of the complexity of the draft.
+  """
+  estimate: Float
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  """
+  The parent draft of the draft.
+  """
+  parent: IssueDraft
+  """
+  The parent issue of the draft.
+  """
+  parentIssue: Issue
+  """
+  The priority of the draft.
+  """
+  priority: Float!
+  """
+  Label for the priority.
+  """
+  priorityLabel: String!
+  """
+  The project associated with the draft.
+  """
+  projectId: String
+  """
+  The workflow state associated with the draft.
+  """
+  stateId: String!
+  """
+  The order of items in the sub-draft list. Only set if the draft has `parent` set.
+  """
+  subIssueSortOrder: Float
+  """
+  The team associated with the draft.
+  """
+  teamId: String!
+  """
+  The draft's title.
+  """
+  title: String!
+  """
+  The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+      for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+      been updated after creation.
+  """
+  updatedAt: DateTime!
 }
 
 type IssueEdge {
@@ -3783,6 +3875,10 @@ input IssueFilter {
   """
   searchableContent: ContentComparator
   """
+  Comparator for the issues sla status.
+  """
+  slaStatus: SlaStatusComparator
+  """
   Filters that the issues snoozer must satisfy.
   """
   snoozedBy: NullableUserFilter
@@ -3856,6 +3952,10 @@ type IssueHistory implements Node {
   Whether the issue was auto-closed.
   """
   autoClosed: Boolean
+  """
+  [Internal] Serialized JSON representing changes for certain non-relational properties.
+  """
+  changes: JSONObject
   """
   The time at which the entity was created.
   """
@@ -4702,6 +4802,14 @@ input IssueUpdateInput {
   """
   projectId: String
   """
+  [ALPHA] The project milestone associated with the issue.
+  """
+  projectMilestoneId: String
+  """
+  [Internal] The timestamp at which an issue will be considered in breach of SLA.
+  """
+  slaBreachesAt: DateTime
+  """
   The identifier of the user who snoozed the issue.
   """
   snoozedById: String
@@ -4865,184 +4973,6 @@ type LogoutResponse {
   success: Boolean!
 }
 
-"""
-A milestone that contains projects.
-"""
-type Milestone implements Node {
-  """
-  The time at which the entity was archived. Null if the entity has not been archived.
-  """
-  archivedAt: DateTime
-  """
-  The time at which the entity was created.
-  """
-  createdAt: DateTime!
-  """
-  [ALPHA] The milestone's description.
-  """
-  description: String
-  """
-  The unique identifier of the entity.
-  """
-  id: ID!
-  """
-  The name of the milestone.
-  """
-  name: String!
-  """
-  The organization that the milestone belongs to.
-  """
-  organization: Organization!
-  """
-  Projects associated with the milestone.
-  """
-  projects(
-    """
-    A cursor to be used with first for forward pagination
-    """
-    after: String
-    """
-    A cursor to be used with last for backward pagination.
-    """
-    before: String
-    """
-    Filter returned projects.
-    """
-    filter: ProjectFilter
-    """
-    The number of items to forward paginate (used with after). Defaults to 50.
-    """
-    first: Int
-    """
-    Should archived resources be included (default: false)
-    """
-    includeArchived: Boolean
-    """
-    The number of items to backward paginate (used with before). Defaults to 50.
-    """
-    last: Int
-    """
-    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
-    """
-    orderBy: PaginationOrderBy
-  ): ProjectConnection! @deprecated(reason: "Milestones will be removed. Use roadmaps instead.")
-  """
-  The sort order for the milestone.
-  """
-  sortOrder: Float!
-  """
-  [ALPHA] The estimated completion date of the initiative.
-  """
-  targetDate: TimelessDate
-  """
-  The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
-      for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
-      been updated after creation.
-  """
-  updatedAt: DateTime!
-}
-
-type MilestoneConnection {
-  edges: [MilestoneEdge!]!
-  nodes: [Milestone!]!
-  pageInfo: PageInfo!
-}
-
-input MilestoneCreateInput {
-  """
-  [ALPHA] The description for the milestone.
-  """
-  description: String
-  """
-  The identifier in UUID v4 format. If none is provided, the backend will generate one.
-  """
-  id: String
-  """
-  The name of the milestone.
-  """
-  name: String!
-  """
-  The sort order of the milestone.
-  """
-  sortOrder: Float
-  """
-  [ALPHA] The planned target date of the milestone.
-  """
-  targetDate: TimelessDate
-  """
-  [ALPHA] The identifiers of the teams this milestone is associated with.
-  """
-  teamIds: [String!]
-}
-
-type MilestoneEdge {
-  """
-  Used in `before` and `after` args
-  """
-  cursor: String!
-  node: Milestone!
-}
-
-type MilestoneMigrationPayload {
-  """
-  The identifier of the last sync operation.
-  """
-  lastSyncId: Float!
-  """
-  Whether the operation was successful.
-  """
-  success: Boolean!
-}
-
-type MilestonePayload {
-  """
-  The identifier of the last sync operation.
-  """
-  lastSyncId: Float!
-  """
-  The milesteone that was created or updated.
-  """
-  milestone: Milestone
-  """
-  Whether the operation was successful.
-  """
-  success: Boolean!
-}
-
-input MilestoneUpdateInput {
-  """
-  [ALPHA] The description for the milestone.
-  """
-  description: String
-  """
-  The name of the milestone.
-  """
-  name: String
-  """
-  The sort order of the milestone.
-  """
-  sortOrder: Float
-  """
-  [ALPHA] The planned target date of the milestone.
-  """
-  targetDate: TimelessDate
-  """
-  [ALPHA] The identifiers of the teams this milestone is associated with.
-  """
-  teamIds: [String!]
-}
-
-input MilestonesMigrateInput {
-  """
-  IDs of the milestones to delete.
-  """
-  milestonesToDelete: [String!]
-  """
-  IDs of the milestones to migrate.
-  """
-  milestonesToMigrate: [String!]
-}
-
 type Mutation {
   """
   Creates an integration api key for Airbyte to connect with Linear
@@ -5162,6 +5092,10 @@ type Mutation {
   Link any url to an issue.
   """
   attachmentLinkURL(
+    """
+    The id for the attachment.
+    """
+    id: String
     """
     The issue for which to link the url.
     """
@@ -5867,6 +5801,19 @@ type Mutation {
     id: String!
   ): ArchivePayload!
   """
+  [INTERNAL] Updates an issue description from the Front app to handle Front attachments correctly.
+  """
+  issueDescriptionUpdateFromFront(
+    """
+    Description to update the issue with.
+    """
+    description: String!
+    """
+    The identifier of the issue to update.
+    """
+    id: String!
+  ): IssuePayload!
+  """
   Kicks off an Asana import job.
   """
   issueImportCreateAsana(
@@ -6207,46 +6154,6 @@ type Mutation {
   """
   logout: LogoutResponse!
   """
-  Migrates milestones to roadmaps
-  """
-  migrateMilestonesToRoadmaps(
-    """
-    Ids for milestones to migrate and milestones to delete
-    """
-    input: MilestonesMigrateInput!
-  ): MilestoneMigrationPayload!
-  """
-  Creates a new milestone.
-  """
-  milestoneCreate(
-    """
-    The issue object to create.
-    """
-    input: MilestoneCreateInput!
-  ): MilestonePayload! @deprecated(reason: "Milestones will be removed. Use roadmaps instead.")
-  """
-  Deletes a milestone.
-  """
-  milestoneDelete(
-    """
-    The identifier of the milestone to delete.
-    """
-    id: String!
-  ): ArchivePayload! @deprecated(reason: "Milestones will be removed. Use roadmaps instead.")
-  """
-  Updates a milestone.
-  """
-  milestoneUpdate(
-    """
-    The identifier of the milestone to update.
-    """
-    id: String!
-    """
-    A partial milestone object to update the milestone with.
-    """
-    input: MilestoneUpdateInput!
-  ): MilestonePayload! @deprecated(reason: "Milestones will be removed. Use roadmaps instead.")
-  """
   Archives a notification.
   """
   notificationArchive(
@@ -6463,6 +6370,37 @@ type Mutation {
     """
     input: ProjectLinkUpdateInput!
   ): ProjectLinkPayload!
+  """
+  Creates a new project milestone.
+  """
+  projectMilestoneCreate(
+    """
+    The project milestone to create.
+    """
+    input: ProjectMilestoneCreateInput!
+  ): ProjectMilestonePayload!
+  """
+  Deletes a project milestone.
+  """
+  projectMilestoneDelete(
+    """
+    The identifier of the project milestone to delete.
+    """
+    id: String!
+  ): ArchivePayload!
+  """
+  Updates a project milestone.
+  """
+  projectMilestoneUpdate(
+    """
+    The identifier of the project milestone to update. Also the identifier from the URL is accepted.
+    """
+    id: String!
+    """
+    A partial object to update the project milestone with.
+    """
+    input: ProjectMilestoneUpdateInput!
+  ): ProjectMilestonePayload!
   """
   Unarchives a project.
   """
@@ -6775,45 +6713,6 @@ type Mutation {
     input: TemplateUpdateInput!
   ): TemplatePayload!
   """
-  [INTERNAL] Cancels an ongoing email change for the user account
-  """
-  userAccountEmailChangeCancel(
-    """
-    The id of the user account to cancel the change for.
-    """
-    id: String!
-  ): UserAccountEmailVerificationPayload!
-  """
-  [INTERNAL] Creates an email verification challenge from the app for a user account that wants to change email.
-  """
-  userAccountEmailChangeCreate(
-    """
-    [INTERNAL] Whether an existing account exists for the new email address.
-    """
-    hasExistingAccount: Boolean!
-    """
-    [INTERNAL] The identifier of the user account that wants to change email.
-    """
-    id: String!
-    """
-    [INTERNAL] The new email address the user wants to use.
-    """
-    newEmail: String!
-  ): UserAccountEmailVerificationPayload!
-  """
-  [INTERNAL] Verifies the email address and code for a user account that wants to change email.
-  """
-  userAccountEmailChangeVerifyCode(
-    """
-    [INTERNAL] The code to verify.
-    """
-    code: String!
-    """
-    [INTERNAL] The email to verify.
-    """
-    email: String!
-  ): UserAccountEmailChangeVerifyCodePayload!
-  """
   Makes user a regular user. Can only be called by an admin.
   """
   userDemoteAdmin(
@@ -7059,68 +6958,6 @@ type Mutation {
   ): WorkflowStatePayload!
 }
 
-"""
-Comparator for strings.
-"""
-input NestedStringComparator {
-  """
-  Contains constraint. Matches any values that contain the given string.
-  """
-  contains: String
-  """
-  Contains case insensitive constraint. Matches any values that contain the given string case insensitive.
-  """
-  containsIgnoreCase: String
-  """
-  Ends with constraint. Matches any values that end with the given string.
-  """
-  endsWith: String
-  """
-  Equals constraint.
-  """
-  eq: String
-  """
-  Equals case insensitive. Matches any values that matches the given string case insensitive.
-  """
-  eqIgnoreCase: String
-  """
-  In-array constraint.
-  """
-  in: [String!]
-  """
-  Not-equals constraint.
-  """
-  neq: String
-  """
-  Not-equals case insensitive. Matches any values that don't match the given string case insensitive.
-  """
-  neqIgnoreCase: String
-  """
-  Not-in-array constraint.
-  """
-  nin: [String!]
-  """
-  Doesn't contain constraint. Matches any values that don't contain the given string.
-  """
-  notContains: String
-  """
-  Doesn't contain case insensitive constraint. Matches any values that don't contain the given string case insensitive.
-  """
-  notContainsIgnoreCase: String
-  """
-  Doesn't end with constraint. Matches any values that don't end with the given string.
-  """
-  notEndsWith: String
-  """
-  Doesn't start with constraint. Matches any values that don't start with the given string.
-  """
-  notStartsWith: String
-  """
-  Starts with constraint. Matches any values that start with the given string.
-  """
-  startsWith: String
-}
-
 interface Node {
   """
   The unique identifier of the entity.
@@ -7273,6 +7110,10 @@ input NotificationSubscriptionCreateInput {
   The identifier of the team to subscribe to.
   """
   teamId: String
+  """
+  The types of notifications of the team subscription.
+  """
+  teamNotificationSubscriptionTypes: [String!]
 }
 
 type NotificationSubscriptionEdge {
@@ -7302,7 +7143,11 @@ input NotificationSubscriptionUpdateInput {
   """
   The type of the project subscription.
   """
-  projectNotificationSubscriptionType: ProjectNotificationSubscriptionType!
+  projectNotificationSubscriptionType: ProjectNotificationSubscriptionType
+  """
+  The types of notifications of the team subscription.
+  """
+  teamNotificationSubscriptionTypes: [String!]
 }
 
 input NotificationUpdateInput {
@@ -7318,6 +7163,31 @@ input NotificationUpdateInput {
   The time until a notification will be snoozed. After that it will appear in the inbox again.
   """
   snoozedUntilAt: DateTime
+}
+
+"""
+Notion specific settings.
+"""
+type NotionSettings {
+  """
+  The ID of the Notion workspace being connected.
+  """
+  workspaceId: String!
+  """
+  The name of the Notion workspace being connected.
+  """
+  workspaceName: String!
+}
+
+input NotionSettingsInput {
+  """
+  The ID of the Notion workspace being connected.
+  """
+  workspaceId: String!
+  """
+  The name of the Notion workspace being connected.
+  """
+  workspaceName: String!
 }
 
 """
@@ -7556,6 +7426,10 @@ input NullableIssueFilter {
   [Internal] Comparator for the issues content.
   """
   searchableContent: ContentComparator
+  """
+  Comparator for the issues sla status.
+  """
+  slaStatus: SlaStatusComparator
   """
   Filters that the issues snoozer must satisfy.
   """
@@ -8745,7 +8619,7 @@ type PaidSubscription implements Node {
   """
   seats: Float!
   """
-  The maximum number of seats that can be added to the subscription.
+  The maximum number of seats that will be billed in the subscription.
   """
   seatsMaximum: Float
   """
@@ -8762,6 +8636,38 @@ type PaidSubscription implements Node {
       been updated after creation.
   """
   updatedAt: DateTime!
+}
+
+"""
+A personal note for a user
+"""
+type PersonalNote implements Node {
+  """
+  The time at which the entity was archived. Null if the entity has not been archived.
+  """
+  archivedAt: DateTime
+  """
+  The note content as JSON.
+  """
+  contentData: JSONObject
+  """
+  The time at which the entity was created.
+  """
+  createdAt: DateTime!
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  """
+  The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+      for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+      been updated after creation.
+  """
+  updatedAt: DateTime!
+  """
+  The user that owns the note.
+  """
+  user: User!
 }
 
 """
@@ -8853,10 +8759,6 @@ type Project implements Node {
   The number of in progress estimation points after each week.
   """
   inProgressScopeHistory: [Float!]!
-  """
-  The initiative that this project is associated with.
-  """
-  initiative: Initiative
   """
   Settings for all integrations associated with that project.
   """
@@ -8969,10 +8871,6 @@ type Project implements Node {
     orderBy: PaginationOrderBy
   ): UserConnection!
   """
-  The milestone that this project is associated with.
-  """
-  milestone: Milestone @deprecated(reason: "Milestones will be removed. Use roadmaps instead.")
-  """
   The project's name.
   """
   name: String!
@@ -8980,6 +8878,35 @@ type Project implements Node {
   The overall progress of the project. This is the (completed estimate points + 0.25 * in progress estimate points) / total estimate points.
   """
   progress: Float!
+  """
+  [ALPHA] Milestones associated with the project.
+  """
+  projectMilestones(
+    """
+    A cursor to be used with first for forward pagination
+    """
+    after: String
+    """
+    A cursor to be used with last for backward pagination.
+    """
+    before: String
+    """
+    The number of items to forward paginate (used with after). Defaults to 50.
+    """
+    first: Int
+    """
+    Should archived resources be included (default: false)
+    """
+    includeArchived: Boolean
+    """
+    The number of items to backward paginate (used with before). Defaults to 50.
+    """
+    last: Int
+    """
+    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+    """
+    orderBy: PaginationOrderBy
+  ): ProjectMilestoneConnection!
   """
   The time until which project update reminders are paused.
   """
@@ -9038,7 +8965,7 @@ type Project implements Node {
   """
   slugId: String!
   """
-  The sort order for the project within its milestone/initiative.
+  The sort order for the project within the organizion.
   """
   sortOrder: Float!
   """
@@ -9215,10 +9142,6 @@ input ProjectCreateInput {
   The identifiers of the members of this project.
   """
   memberIds: [String!]
-  """
-  The identifier of the milestone to associate the project with.
-  """
-  milestoneId: String
   """
   The name of the project.
   """
@@ -9416,6 +9339,117 @@ input ProjectLinkUpdateInput {
   The URL of the link.
   """
   url: String
+}
+
+"""
+A milestone for a project.
+"""
+type ProjectMilestone implements Node {
+  """
+  The time at which the entity was archived. Null if the entity has not been archived.
+  """
+  archivedAt: DateTime
+  """
+  The time at which the entity was created.
+  """
+  createdAt: DateTime!
+  """
+  The description of the project milestone.
+  """
+  description: String
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  """
+  The name of the project milestone.
+  """
+  name: String!
+  """
+  The project of the milestone.
+  """
+  project: Project!
+  """
+  The planned completion date of the milestone.
+  """
+  targetDate: TimelessDate
+  """
+  The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+      for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+      been updated after creation.
+  """
+  updatedAt: DateTime!
+}
+
+type ProjectMilestoneConnection {
+  edges: [ProjectMilestoneEdge!]!
+  nodes: [ProjectMilestone!]!
+  pageInfo: PageInfo!
+}
+
+input ProjectMilestoneCreateInput {
+  """
+  The description of the project milestone.
+  """
+  description: String
+  """
+  The identifier in UUID v4 format. If none is provided, the backend will generate one.
+  """
+  id: String
+  """
+  The name of the project milestone.
+  """
+  name: String!
+  """
+  Related project for the project milestone.
+  """
+  projectId: String!
+  """
+  The planned target date of the project milestone.
+  """
+  targetDate: TimelessDate
+}
+
+type ProjectMilestoneEdge {
+  """
+  Used in `before` and `after` args
+  """
+  cursor: String!
+  node: ProjectMilestone!
+}
+
+type ProjectMilestonePayload {
+  """
+  The identifier of the last sync operation.
+  """
+  lastSyncId: Float!
+  """
+  The project milestone that was created or updated.
+  """
+  projectMilestone: ProjectMilestone!
+  """
+  Whether the operation was successful.
+  """
+  success: Boolean!
+}
+
+input ProjectMilestoneUpdateInput {
+  """
+  The description of the project milestone.
+  """
+  description: String
+  """
+  The name of the project milestone.
+  """
+  name: String
+  """
+  Related project for the project milestone.
+  """
+  projectId: String
+  """
+  The planned target date of the project milestone.
+  """
+  targetDate: TimelessDate
 }
 
 """
@@ -9674,10 +9708,6 @@ input ProjectUpdateInput {
   The identifiers of the members of this project.
   """
   memberIds: [String!]
-  """
-  The identifier of the milestone to associate the project with.
-  """
-  milestoneId: String
   """
   The name of the project.
   """
@@ -9995,6 +10025,39 @@ enum PushSubscriptionType {
 }
 
 type Query {
+  """
+  One specific project milestone.
+  """
+  ProjectMilestone(id: String!): ProjectMilestone!
+  """
+  All milestones for the project.
+  """
+  ProjectMilestones(
+    """
+    A cursor to be used with first for forward pagination
+    """
+    after: String
+    """
+    A cursor to be used with last for backward pagination.
+    """
+    before: String
+    """
+    The number of items to forward paginate (used with after). Defaults to 50.
+    """
+    first: Int
+    """
+    Should archived resources be included (default: false)
+    """
+    includeArchived: Boolean
+    """
+    The number of items to backward paginate (used with before). Defaults to 50.
+    """
+    last: Int
+    """
+    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+    """
+    orderBy: PaginationOrderBy
+  ): ProjectMilestoneConnection!
   """
   All teams you the user can administrate. Administrable teams are teams whose settings the user can change, but to whose issues the user doesn't necessarily have access to.
   """
@@ -10727,39 +10790,6 @@ type Query {
     orderBy: PaginationOrderBy
   ): IssueConnection!
   """
-  One specific milestone.
-  """
-  milestone(id: String!): Milestone! @deprecated(reason: "Milestones will be removed. Use roadmaps instead.")
-  """
-  All milestones.
-  """
-  milestones(
-    """
-    A cursor to be used with first for forward pagination
-    """
-    after: String
-    """
-    A cursor to be used with last for backward pagination.
-    """
-    before: String
-    """
-    The number of items to forward paginate (used with after). Defaults to 50.
-    """
-    first: Int
-    """
-    Should archived resources be included (default: false)
-    """
-    includeArchived: Boolean
-    """
-    The number of items to backward paginate (used with before). Defaults to 50.
-    """
-    last: Int
-    """
-    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
-    """
-    orderBy: PaginationOrderBy
-  ): MilestoneConnection! @deprecated(reason: "Milestones will be removed. Use roadmaps instead.")
-  """
   One specific notification.
   """
   notification(id: String!): Notification!
@@ -11204,15 +11234,6 @@ type Query {
     """
     id: String!
   ): User!
-  """
-  [INTERNAL] Checks if there's a currently active email verification challenge for a user account.
-  """
-  userAccountEmailChangeFind(
-    """
-    [INTERNAL] The email of the user account.
-    """
-    email: String!
-  ): UserAccountEmailChangeFindPayload!
   """
   Finds a user account by email.
   """
@@ -11751,7 +11772,7 @@ input RoadmapToProjectCreateInput {
   """
   roadmapId: String!
   """
-  The sort order for the project within its milestone.
+  The sort order for the project within its organization.
   """
   sortOrder: Float
 }
@@ -11781,7 +11802,7 @@ type RoadmapToProjectPayload {
 
 input RoadmapToProjectUpdateInput {
   """
-  The sort order for the project within its milestone.
+  The sort order for the project within its organization.
   """
   sortOrder: Float
 }
@@ -11936,6 +11957,40 @@ input SentrySettingsInput {
   organizationSlug: String!
 }
 
+enum SlaStatus {
+  Breached
+  Completed
+  HighRisk
+  LowRisk
+  MediumRisk
+}
+
+"""
+Comparator for sla status.
+"""
+input SlaStatusComparator {
+  """
+  Equals constraint.
+  """
+  eq: SlaStatus
+  """
+  In-array constraint.
+  """
+  in: [SlaStatus!]
+  """
+  Not-equals constraint.
+  """
+  neq: SlaStatus
+  """
+  Not-in-array constraint.
+  """
+  nin: [SlaStatus!]
+  """
+  Null constraint. Matches any non-null values if the given value is false, otherwise it matches null values.
+  """
+  null: Boolean
+}
+
 """
 Slack notification specific settings.
 """
@@ -11949,6 +12004,68 @@ input SlackPostSettingsInput {
   channel: String!
   channelId: String!
   configurationUrl: String!
+}
+
+"""
+Comparator for `sourceType` field.
+"""
+input SourceTypeComparator {
+  """
+  Contains constraint. Matches any values that contain the given string.
+  """
+  contains: String
+  """
+  Contains case insensitive constraint. Matches any values that contain the given string case insensitive.
+  """
+  containsIgnoreCase: String
+  """
+  Ends with constraint. Matches any values that end with the given string.
+  """
+  endsWith: String
+  """
+  Equals constraint.
+  """
+  eq: String
+  """
+  Equals case insensitive. Matches any values that matches the given string case insensitive.
+  """
+  eqIgnoreCase: String
+  """
+  In-array constraint.
+  """
+  in: [String!]
+  """
+  Not-equals constraint.
+  """
+  neq: String
+  """
+  Not-equals case insensitive. Matches any values that don't match the given string case insensitive.
+  """
+  neqIgnoreCase: String
+  """
+  Not-in-array constraint.
+  """
+  nin: [String!]
+  """
+  Doesn't contain constraint. Matches any values that don't contain the given string.
+  """
+  notContains: String
+  """
+  Doesn't contain case insensitive constraint. Matches any values that don't contain the given string case insensitive.
+  """
+  notContainsIgnoreCase: String
+  """
+  Doesn't end with constraint. Matches any values that don't end with the given string.
+  """
+  notEndsWith: String
+  """
+  Doesn't start with constraint. Matches any values that don't start with the given string.
+  """
+  notStartsWith: String
+  """
+  Starts with constraint. Matches any values that start with the given string.
+  """
+  startsWith: String
 }
 
 type SsoUrlFromEmailResponse {
@@ -12418,6 +12535,10 @@ type Team implements Node {
     """
     orderBy: PaginationOrderBy
   ): ProjectConnection!
+  """
+  Whether an issue needs to have a priority set before leaving triage
+  """
+  requirePriorityToLeaveTriage: Boolean!
   """
   The workflow state into which issues are moved when a review has been requested for the PR.
   """
@@ -13301,6 +13422,10 @@ input UpdateOrganizationInput {
   """
   roadmapEnabled: Boolean
   """
+  Internal. Whether SLA's have been enabled for the organization.
+  """
+  slaEnabled: Boolean
+  """
   The URL key of the organization.
   """
   urlKey: String
@@ -13717,52 +13842,6 @@ type UserAccountEmailChange {
   The time at which the model was updated.
   """
   updatedAt: DateTime!
-}
-
-"""
-[INTERNAL] Result of searching for a verification challenge for a user account.
-"""
-type UserAccountEmailChangeFindPayload {
-  """
-  [INTERNAL] Whether there is a currently active change.
-  """
-  hasChangeActive: Boolean!
-  """
-  The identifier of the last sync operation.
-  """
-  lastSyncId: Float!
-}
-
-"""
-[INTERNAL] Result of verifying an email and code.
-"""
-type UserAccountEmailChangeVerifyCodePayload {
-  """
-  [INTERNAL] Reason why the operation was not successful.
-  """
-  failureReason: Float
-  """
-  [INTERNAL] Whether the operation was successful.
-  """
-  success: Boolean!
-}
-
-"""
-[INTERNAL] Result of creating or cancelling a verification challenge for email change.
-"""
-type UserAccountEmailVerificationPayload {
-  """
-  [INTERNAL] Reason why the operation was not successful.
-  """
-  failureReason: Float
-  """
-  The identifier of the last sync operation.
-  """
-  lastSyncId: Float!
-  """
-  [INTERNAL] Whether the operation was successful.
-  """
-  success: Boolean!
 }
 
 """
@@ -14256,8 +14335,10 @@ enum ViewType {
   inbox
   label
   myIssues
+  myIssuesActivity
   myIssuesCreatedByMe
   myIssuesSubscribedTo
+  myIssuesTouchedByMe
   project
   projects
   projectsAll
@@ -14418,13 +14499,17 @@ input WebhookUpdateInput {
 }
 
 """
-The conditions to match different events, which need to be true for workflow to be started.
+A condition to match for the workflow to be triggered.
 """
-input WorkflowConditions {
+input WorkflowCondition {
   """
-  The conditions to match triggers based on issue (creation, update, deletion).
+  Trigger the workflow when an issue matches the filter. Can only be used when the trigger type is `Issue`.
   """
-  issue: WorkflowEntityPropertyMatcher!
+  issueFilter: IssueFilter
+  """
+  Triggers the workflow when a project matches the filter. Can only be used when the trigger type is `Project`.
+  """
+  projectFilter: ProjectFilter
 }
 
 type WorkflowDefinition implements Node {
@@ -14437,7 +14522,7 @@ type WorkflowDefinition implements Node {
   """
   archivedAt: DateTime
   """
-  One or more conditions that need to be true for workflow to be triggered.
+  The conditions that need to be match for the workflow to be triggered.
   """
   conditions: JSONObject!
   """
@@ -14449,10 +14534,14 @@ type WorkflowDefinition implements Node {
   """
   creator: User!
   """
-  The workflow description.
+  The description of the workflow.
   """
   description: String
   enabled: Boolean!
+  """
+  The name of the group that the workflow belongs to.
+  """
+  groupName: String
   """
   The unique identifier of the entity.
   """
@@ -14462,23 +14551,27 @@ type WorkflowDefinition implements Node {
   """
   name: String!
   """
-  The organization where workflow was created.
-  """
-  organization: Organization!
-  """
   Cron schedule which is used to execute the workflow. Only applicable for cron based workflows.
   """
   schedule: JSONObject!
   """
-  The team associated with the workflow.
+  The sort order of the workflow definition within its siblings.
   """
-  team: Team!
+  sortOrder: String!
   """
-  The type of the trigger that kicks off the workflow.
+  The team associated with the workflow. If not set, the workflow is associated with the entire organization.
   """
-  trigger: WorkflowTriggerType!
+  team: Team
   """
-  The type of the workflow
+  The type of the event that triggers off the workflow.
+  """
+  trigger: WorkflowTrigger!
+  """
+  The object type (e.g. Issue) that triggers this workflow.
+  """
+  triggerType: WorkflowTriggerType!
+  """
+  The type of the workflow.
   """
   type: WorkflowType!
   """
@@ -14489,30 +14582,18 @@ type WorkflowDefinition implements Node {
   updatedAt: DateTime!
 }
 
-"""
-Object to provide conditions to match an entity change.
-"""
-input WorkflowEntityPropertyMatcher {
+type WorkflowDefinitionConnection {
+  edges: [WorkflowDefinitionEdge!]!
+  nodes: [WorkflowDefinition!]!
+  pageInfo: PageInfo!
+}
+
+type WorkflowDefinitionEdge {
   """
-  The optional list of property matchers that all have to match.
+  Used in `before` and `after` args
   """
-  and: [WorkflowEntityPropertyMatcher!]
-  """
-  The initial value of the property to match.
-  """
-  fromValue: String
-  """
-  The optional list of property matchers where at least one have to match.
-  """
-  or: [WorkflowEntityPropertyMatcher!]
-  """
-  The property to check for matching.
-  """
-  property: String!
-  """
-  The new value of the property to match.
-  """
-  toValue: String
+  cursor: String!
+  node: WorkflowDefinition!
 }
 
 """
@@ -14725,16 +14806,24 @@ input WorkflowStateUpdateInput {
   position: Float
 }
 
-enum WorkflowTriggerType {
+enum WorkflowTrigger {
   cron
-  issueCreated
-  issueDeleted
-  issueUpdated
+  entityCreated
+  entityCreatedOrUpdated
+  entityRemoved
+  entityUnarchived
+  entityUpdated
+}
+
+enum WorkflowTriggerType {
+  issue
+  project
 }
 
 enum WorkflowType {
   custom
   recurringIssue
+  sla
 }
 
 """

--- a/packages/sdk/src/schema.json
+++ b/packages/sdk/src/schema.json
@@ -1063,7 +1063,7 @@
             "description": "Comparator for the source type.",
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "NestedStringComparator",
+              "name": "SourceTypeComparator",
               "ofType": null
             },
             "defaultValue": null,
@@ -1519,7 +1519,7 @@
             "description": "Comparator for the source type.",
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "NestedStringComparator",
+              "name": "SourceTypeComparator",
               "ofType": null
             },
             "defaultValue": null,
@@ -1770,6 +1770,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organization",
+            "description": "The organization the audit log belongs to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Organization",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -2521,7 +2533,7 @@
           },
           {
             "name": "parent",
-            "description": "The parent of the comment.",
+            "description": "The parent comment under which the current comment is nested.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -3020,7 +3032,7 @@
           },
           {
             "name": "parentId",
-            "description": "[Internal] The parent under which to nest the comment.",
+            "description": "The parent comment under which to nest a current comment.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -3060,6 +3072,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "doNotSubscribeToIssue",
+            "description": "Flag to prevent auto subscription to the issue the comment is created on.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "defaultValue": null,
@@ -9143,273 +9167,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "Initiative",
-        "description": "A initiative that contains projects.",
-        "fields": [
-          {
-            "name": "id",
-            "description": "The unique identifier of the entity.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "createdAt",
-            "description": "The time at which the entity was created.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatedAt",
-            "description": "The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those\n    for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't\n    been updated after creation.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "archivedAt",
-            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": "The name of the initiative.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "organization",
-            "description": "The organization that the initiative belongs to.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Organization",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sortOrder",
-            "description": "The sort order for the initiative.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": "The initiative's description.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "targetDate",
-            "description": "The estimated completion date of the initiative.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "TimelessDate",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "Node",
-            "ofType": null
-          }
-        ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "InitiativeConnection",
-        "description": null,
-        "fields": [
-          {
-            "name": "edges",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "InitiativeEdge",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "nodes",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Initiative",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pageInfo",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PageInfo",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "InitiativeEdge",
-        "description": null,
-        "fields": [
-          {
-            "name": "node",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Initiative",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cursor",
-            "description": "Used in `before` and `after` args",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "Integration",
         "description": "An integration with an external service.",
         "fields": [
@@ -10254,6 +10011,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "notion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "NotionSettings",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -10381,6 +10150,18 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "JiraSettingsInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notion",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "NotionSettingsInput",
               "ofType": null
             },
             "defaultValue": null,
@@ -10871,8 +10652,8 @@
             "deprecationReason": null
           },
           {
-            "name": "slackProjectUpdateCreatedToMilestone",
-            "description": "Whether to send a new project update to milestone Slack channels.",
+            "name": "slackProjectUpdateCreatedToWorkspace",
+            "description": "Whether to send a new project update to workspace Slack channel.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -10883,8 +10664,32 @@
             "deprecationReason": null
           },
           {
-            "name": "slackProjectUpdateCreatedToWorkspace",
-            "description": "Whether to send a new project update to workspace Slack channel.",
+            "name": "slackIssueAddedToTriage",
+            "description": "Whether to send a Slack message when a new issue is added to triage.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slackIssueSlaHighRisk",
+            "description": "Whether to send a Slack message when an SLA is at high risk",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slackIssueSlaBreached",
+            "description": "Whether to send a Slack message when an SLA is breached",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -11084,8 +10889,8 @@
             "deprecationReason": null
           },
           {
-            "name": "slackProjectUpdateCreatedToMilestone",
-            "description": "Whether to send a Slack message when a project update is created to milestone channels.",
+            "name": "slackProjectUpdateCreatedToWorkspace",
+            "description": "Whether to send a Slack message when a project update is created to workspace channel.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -11096,8 +10901,32 @@
             "deprecationReason": null
           },
           {
-            "name": "slackProjectUpdateCreatedToWorkspace",
-            "description": "Whether to send a Slack message when a project update is created to workspace channel.",
+            "name": "slackIssueAddedToTriage",
+            "description": "Whether to send a Slack message when a new issue is added to triage.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slackIssueSlaHighRisk",
+            "description": "Whether to send a Slack message when an SLA is at high risk",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slackIssueSlaBreached",
+            "description": "Whether to receive notification when an SLA has breached on Slack.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -11329,8 +11158,8 @@
             "deprecationReason": null
           },
           {
-            "name": "slackProjectUpdateCreatedToMilestone",
-            "description": "Whether to send a Slack message when a project update is created to milestone channels.",
+            "name": "slackProjectUpdateCreatedToWorkspace",
+            "description": "Whether to send a Slack message when a project update is created to workspace channel.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -11341,8 +11170,32 @@
             "deprecationReason": null
           },
           {
-            "name": "slackProjectUpdateCreatedToWorkspace",
-            "description": "Whether to send a Slack message when a project update is created to workspace channel.",
+            "name": "slackIssueAddedToTriage",
+            "description": "Whether to send a Slack message when a new issue is added to triage.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slackIssueSlaHighRisk",
+            "description": "Whether to send a Slack message when an SLA is at high risk",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slackIssueSlaBreached",
+            "description": "Whether to receive notification when an SLA has breached on Slack.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -11693,6 +11546,18 @@
             "deprecationReason": null
           },
           {
+            "name": "startedTriageAt",
+            "description": "The time at which the issue entered triage.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "triagedAt",
             "description": "The time at which the issue left triage.",
             "args": [],
@@ -11747,6 +11612,30 @@
             "type": {
               "kind": "SCALAR",
               "name": "TimelessDate",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slaStartedAt",
+            "description": "[Internal] The time at which the issue's SLA began.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slaBreachesAt",
+            "description": "[Internal] The time at which the issue's SLA will breach.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
               "ofType": null
             },
             "isDeprecated": false,
@@ -11811,6 +11700,18 @@
             "type": {
               "kind": "OBJECT",
               "name": "Project",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectMilestone",
+            "description": "[ALPHA] The projectMilestone that the issue is associated with.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ProjectMilestone",
               "ofType": null
             },
             "isDeprecated": false,
@@ -13363,6 +13264,18 @@
             "deprecationReason": null
           },
           {
+            "name": "slaStatus",
+            "description": "Comparator for the issues sla status.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "SlaStatusComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "and",
             "description": "Compound filters, all of which need to be matched by the issue.",
             "type": {
@@ -13705,6 +13618,18 @@
             "deprecationReason": null
           },
           {
+            "name": "projectMilestoneId",
+            "description": "[ALPHA] The project milestone associated with the issue.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "stateId",
             "description": "The team state of the issue.",
             "type": {
@@ -13814,6 +13739,315 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "IssueDraft",
+        "description": "[Internal] A draft issue.",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time at which the entity was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those\n    for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't\n    been updated after creation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archivedAt",
+            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": "The draft's title.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "The draft's description in markdown format.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "priority",
+            "description": "The priority of the draft.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "estimate",
+            "description": "The estimate of the complexity of the draft.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dueDate",
+            "description": "The date at which the issue would be due.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "TimelessDate",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "teamId",
+            "description": "The team associated with the draft.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cycleId",
+            "description": "The cycle associated with the draft.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectId",
+            "description": "The project associated with the draft.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "creator",
+            "description": "The user who created the draft.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "assigneeId",
+            "description": "The user assigned to the draft.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stateId",
+            "description": "The workflow state associated with the draft.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "parent",
+            "description": "The parent draft of the draft.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "IssueDraft",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "parentIssue",
+            "description": "The parent issue of the draft.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Issue",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subIssueSortOrder",
+            "description": "The order of items in the sub-draft list. Only set if the draft has `parent` set.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "priorityLabel",
+            "description": "Label for the priority.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "descriptionData",
+            "description": "[Internal] The draft's description as a Prosemirror document.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSON",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "attachments",
+            "description": "Serialized array of JSONs representing attachments.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSONObject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -14256,6 +14490,18 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "RelationExistsComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slaStatus",
+            "description": "Comparator for the issues sla status.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "SlaStatusComparator",
               "ofType": null
             },
             "defaultValue": null,
@@ -14971,6 +15217,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "TimelessDate",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "changes",
+            "description": "[Internal] Serialized JSON representing changes for certain non-relational properties.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
               "ofType": null
             },
             "isDeprecated": false,
@@ -17459,6 +17717,18 @@
             "deprecationReason": null
           },
           {
+            "name": "projectMilestoneId",
+            "description": "[ALPHA] The project milestone associated with the issue.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "stateId",
             "description": "The team state of the issue.",
             "type": {
@@ -17524,6 +17794,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slaBreachesAt",
+            "description": "[Internal] The timestamp at which an issue will be considered in breach of SLA.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
               "ofType": null
             },
             "defaultValue": null,
@@ -18020,697 +18302,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "Milestone",
-        "description": "A milestone that contains projects.",
-        "fields": [
-          {
-            "name": "id",
-            "description": "The unique identifier of the entity.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "createdAt",
-            "description": "The time at which the entity was created.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatedAt",
-            "description": "The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those\n    for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't\n    been updated after creation.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "archivedAt",
-            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": "The name of the milestone.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "organization",
-            "description": "The organization that the milestone belongs to.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Organization",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sortOrder",
-            "description": "The sort order for the milestone.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": "[ALPHA] The milestone's description.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "targetDate",
-            "description": "[ALPHA] The estimated completion date of the initiative.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "TimelessDate",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projects",
-            "description": "Projects associated with the milestone.",
-            "args": [
-              {
-                "name": "filter",
-                "description": "Filter returned projects.",
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "ProjectFilter",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "before",
-                "description": "A cursor to be used with last for backward pagination.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "after",
-                "description": "A cursor to be used with first for forward pagination",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "first",
-                "description": "The number of items to forward paginate (used with after). Defaults to 50.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "last",
-                "description": "The number of items to backward paginate (used with before). Defaults to 50.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "includeArchived",
-                "description": "Should archived resources be included (default: false)",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "orderBy",
-                "description": "By which field should the pagination order by. Available options are createdAt (default) and updatedAt.",
-                "type": {
-                  "kind": "ENUM",
-                  "name": "PaginationOrderBy",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ProjectConnection",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Milestones will be removed. Use roadmaps instead."
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "Node",
-            "ofType": null
-          }
-        ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "MilestoneConnection",
-        "description": null,
-        "fields": [
-          {
-            "name": "edges",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "MilestoneEdge",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "nodes",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Milestone",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pageInfo",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PageInfo",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "MilestoneCreateInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "id",
-            "description": "The identifier in UUID v4 format. If none is provided, the backend will generate one.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": "The name of the milestone.",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sortOrder",
-            "description": "The sort order of the milestone.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": "[ALPHA] The description for the milestone.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "targetDate",
-            "description": "[ALPHA] The planned target date of the milestone.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "TimelessDate",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "teamIds",
-            "description": "[ALPHA] The identifiers of the teams this milestone is associated with.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "MilestoneEdge",
-        "description": null,
-        "fields": [
-          {
-            "name": "node",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Milestone",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cursor",
-            "description": "Used in `before` and `after` args",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "MilestoneMigrationPayload",
-        "description": null,
-        "fields": [
-          {
-            "name": "lastSyncId",
-            "description": "The identifier of the last sync operation.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": "Whether the operation was successful.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "MilestonePayload",
-        "description": null,
-        "fields": [
-          {
-            "name": "lastSyncId",
-            "description": "The identifier of the last sync operation.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "milestone",
-            "description": "The milesteone that was created or updated.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Milestone",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": "Whether the operation was successful.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "MilestoneUpdateInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "name",
-            "description": "The name of the milestone.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sortOrder",
-            "description": "The sort order of the milestone.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": "[ALPHA] The description for the milestone.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "targetDate",
-            "description": "[ALPHA] The planned target date of the milestone.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "TimelessDate",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "teamIds",
-            "description": "[ALPHA] The identifiers of the teams this milestone is associated with.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "MilestonesMigrateInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "milestonesToMigrate",
-            "description": "IDs of the milestones to migrate.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "milestonesToDelete",
-            "description": "IDs of the milestones to delete.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "Mutation",
         "description": null,
         "fields": [
@@ -18902,6 +18493,18 @@
               {
                 "name": "title",
                 "description": "The title to use for the attachment.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "id",
+                "description": "The id for the attachment.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -21458,24 +21061,8 @@
             "description": "Integrates the organization with Zendesk.",
             "args": [
               {
-                "name": "redirectUri",
-                "description": "The Zendesk OAuth redirect URI.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "scope",
-                "description": "The Zendesk OAuth scopes.",
+                "name": "subdomain",
+                "description": "The Zendesk installation subdomain.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21506,8 +21093,24 @@
                 "deprecationReason": null
               },
               {
-                "name": "subdomain",
-                "description": "The Zendesk installation subdomain.",
+                "name": "scope",
+                "description": "The Zendesk OAuth scopes.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "redirectUri",
+                "description": "The Zendesk OAuth redirect URI.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -23014,51 +22617,18 @@
             "deprecationReason": null
           },
           {
-            "name": "milestoneCreate",
-            "description": "Creates a new milestone.",
+            "name": "issueDescriptionUpdateFromFront",
+            "description": "[INTERNAL] Updates an issue description from the Front app to handle Front attachments correctly.",
             "args": [
               {
-                "name": "input",
-                "description": "The issue object to create.",
+                "name": "description",
+                "description": "Description to update the issue with. ",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "MilestoneCreateInput",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "MilestonePayload",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Milestones will be removed. Use roadmaps instead."
-          },
-          {
-            "name": "milestoneUpdate",
-            "description": "Updates a milestone.",
-            "args": [
-              {
-                "name": "input",
-                "description": "A partial milestone object to update the milestone with.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "MilestoneUpdateInput",
+                    "kind": "SCALAR",
+                    "name": "String",
                     "ofType": null
                   }
                 },
@@ -23068,7 +22638,7 @@
               },
               {
                 "name": "id",
-                "description": "The identifier of the milestone to update.",
+                "description": "The identifier of the issue to update.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -23088,73 +22658,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "MilestonePayload",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Milestones will be removed. Use roadmaps instead."
-          },
-          {
-            "name": "milestoneDelete",
-            "description": "Deletes a milestone.",
-            "args": [
-              {
-                "name": "id",
-                "description": "The identifier of the milestone to delete.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ArchivePayload",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Milestones will be removed. Use roadmaps instead."
-          },
-          {
-            "name": "migrateMilestonesToRoadmaps",
-            "description": "Migrates milestones to roadmaps",
-            "args": [
-              {
-                "name": "input",
-                "description": "Ids for milestones to migrate and milestones to delete",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "MilestonesMigrateInput",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "MilestoneMigrationPayload",
+                "name": "IssuePayload",
                 "ofType": null
               }
             },
@@ -23870,6 +23374,121 @@
               {
                 "name": "id",
                 "description": "The identifier of the project link to delete.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ArchivePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectMilestoneCreate",
+            "description": "Creates a new project milestone.",
+            "args": [
+              {
+                "name": "input",
+                "description": "The project milestone to create.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectMilestoneCreateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProjectMilestonePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectMilestoneUpdate",
+            "description": "Updates a project milestone.",
+            "args": [
+              {
+                "name": "input",
+                "description": "A partial object to update the project milestone with.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectMilestoneUpdateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "id",
+                "description": "The identifier of the project milestone to update. Also the identifier from the URL is accepted.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProjectMilestonePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectMilestoneDelete",
+            "description": "Deletes a project milestone.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The identifier of the project milestone to delete.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -25081,153 +24700,6 @@
             "deprecationReason": null
           },
           {
-            "name": "userAccountEmailChangeVerifyCode",
-            "description": "[INTERNAL] Verifies the email address and code for a user account that wants to change email.",
-            "args": [
-              {
-                "name": "code",
-                "description": "[INTERNAL] The code to verify.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "email",
-                "description": "[INTERNAL] The email to verify.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "UserAccountEmailChangeVerifyCodePayload",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "userAccountEmailChangeCreate",
-            "description": "[INTERNAL] Creates an email verification challenge from the app for a user account that wants to change email.",
-            "args": [
-              {
-                "name": "hasExistingAccount",
-                "description": "[INTERNAL] Whether an existing account exists for the new email address.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "newEmail",
-                "description": "[INTERNAL] The new email address the user wants to use.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "id",
-                "description": "[INTERNAL] The identifier of the user account that wants to change email.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "UserAccountEmailVerificationPayload",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "userAccountEmailChangeCancel",
-            "description": "[INTERNAL] Cancels an ongoing email change for the user account",
-            "args": [
-              {
-                "name": "id",
-                "description": "The id of the user account to cancel the change for.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "UserAccountEmailVerificationPayload",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "userUpdate",
             "description": "Updates a user. Only available to organization admins and the user themselves.",
             "args": [
@@ -26142,201 +25614,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "NestedStringComparator",
-        "description": "Comparator for strings.",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "eq",
-            "description": "Equals constraint.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "neq",
-            "description": "Not-equals constraint.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "in",
-            "description": "In-array constraint.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "nin",
-            "description": "Not-in-array constraint.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "eqIgnoreCase",
-            "description": "Equals case insensitive. Matches any values that matches the given string case insensitive.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "neqIgnoreCase",
-            "description": "Not-equals case insensitive. Matches any values that don't match the given string case insensitive.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "startsWith",
-            "description": "Starts with constraint. Matches any values that start with the given string.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "notStartsWith",
-            "description": "Doesn't start with constraint. Matches any values that don't start with the given string.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "endsWith",
-            "description": "Ends with constraint. Matches any values that end with the given string.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "notEndsWith",
-            "description": "Doesn't end with constraint. Matches any values that don't end with the given string.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "contains",
-            "description": "Contains constraint. Matches any values that contain the given string.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "containsIgnoreCase",
-            "description": "Contains case insensitive constraint. Matches any values that contain the given string case insensitive.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "notContains",
-            "description": "Doesn't contain constraint. Matches any values that don't contain the given string.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "notContainsIgnoreCase",
-            "description": "Doesn't contain case insensitive constraint. Matches any values that don't contain the given string case insensitive.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "INTERFACE",
         "name": "Node",
         "description": null,
@@ -26409,11 +25686,6 @@
           },
           {
             "kind": "OBJECT",
-            "name": "Initiative",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
             "name": "Integration",
             "ofType": null
           },
@@ -26439,6 +25711,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "IssueDraft",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "IssueHistory",
             "ofType": null
           },
@@ -26460,11 +25737,6 @@
           {
             "kind": "OBJECT",
             "name": "IssueRelation",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "Milestone",
             "ofType": null
           },
           {
@@ -26504,12 +25776,22 @@
           },
           {
             "kind": "OBJECT",
+            "name": "PersonalNote",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "Project",
             "ofType": null
           },
           {
             "kind": "OBJECT",
             "name": "ProjectLink",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ProjectMilestone",
             "ofType": null
           },
           {
@@ -27248,6 +26530,26 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "teamNotificationSubscriptionTypes",
+            "description": "The types of notifications of the team subscription.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -27366,12 +26668,28 @@
             "name": "projectNotificationSubscriptionType",
             "description": "The type of the project subscription.",
             "type": {
-              "kind": "NON_NULL",
+              "kind": "ENUM",
+              "name": "ProjectNotificationSubscriptionType",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "teamNotificationSubscriptionTypes",
+            "description": "The types of notifications of the team subscription.",
+            "type": {
+              "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "ENUM",
-                "name": "ProjectNotificationSubscriptionType",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               }
             },
             "defaultValue": null,
@@ -27420,6 +26738,92 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "NotionSettings",
+        "description": "Notion specific settings.",
+        "fields": [
+          {
+            "name": "workspaceId",
+            "description": "The ID of the Notion workspace being connected.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workspaceName",
+            "description": "The name of the Notion workspace being connected.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "NotionSettingsInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "workspaceId",
+            "description": "The ID of the Notion workspace being connected.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workspaceName",
+            "description": "The name of the Notion workspace being connected.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -28204,6 +27608,18 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "RelationExistsComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slaStatus",
+            "description": "Comparator for the issues sla status.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "SlaStatusComparator",
               "ofType": null
             },
             "defaultValue": null,
@@ -32259,7 +31675,7 @@
           },
           {
             "name": "seatsMaximum",
-            "description": "The maximum number of seats that can be added to the subscription.",
+            "description": "The maximum number of seats that will be billed in the subscription.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32328,6 +31744,111 @@
             "type": {
               "kind": "SCALAR",
               "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PersonalNote",
+        "description": "A personal note for a user",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time at which the entity was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those\n    for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't\n    been updated after creation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archivedAt",
+            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user",
+            "description": "The user that owns the note.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contentData",
+            "description": "The note content as JSON.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
               "ofType": null
             },
             "isDeprecated": false,
@@ -32531,30 +32052,6 @@
             "deprecationReason": null
           },
           {
-            "name": "milestone",
-            "description": "The milestone that this project is associated with.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Milestone",
-              "ofType": null
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Milestones will be removed. Use roadmaps instead."
-          },
-          {
-            "name": "initiative",
-            "description": "The initiative that this project is associated with.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Initiative",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "projectUpdateRemindersPausedUntilAt",
             "description": "The time until which project update reminders are paused.",
             "args": [],
@@ -32640,7 +32137,7 @@
           },
           {
             "name": "sortOrder",
-            "description": "The sort order for the project within its milestone/initiative.",
+            "description": "The sort order for the project within the organizion.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33236,6 +32733,95 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "DocumentConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectMilestones",
+            "description": "[ALPHA] Milestones associated with the project.",
+            "args": [
+              {
+                "name": "before",
+                "description": "A cursor to be used with last for backward pagination.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "after",
+                "description": "A cursor to be used with first for forward pagination",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": "The number of items to forward paginate (used with after). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "The number of items to backward paginate (used with before). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "includeArchived",
+                "description": "Should archived resources be included (default: false)",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "By which field should the pagination order by. Available options are createdAt (default) and updatedAt.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "PaginationOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProjectMilestoneConnection",
                 "ofType": null
               }
             },
@@ -33879,18 +33465,6 @@
           {
             "name": "description",
             "description": "The description for the project.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "milestoneId",
-            "description": "The identifier of the milestone to associate the project with.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -34669,6 +34243,454 @@
           {
             "name": "label",
             "description": "The label for the link.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProjectMilestone",
+        "description": "A milestone for a project.",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time at which the entity was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those\n    for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't\n    been updated after creation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archivedAt",
+            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "The name of the project milestone.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "The description of the project milestone.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "targetDate",
+            "description": "The planned completion date of the milestone.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "TimelessDate",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project",
+            "description": "The project of the milestone.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Project",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProjectMilestoneConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProjectMilestoneEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProjectMilestone",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProjectMilestoneCreateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": "The identifier in UUID v4 format. If none is provided, the backend will generate one.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "The name of the project milestone.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "The description of the project milestone.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "targetDate",
+            "description": "The planned target date of the project milestone.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "TimelessDate",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectId",
+            "description": "Related project for the project milestone.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProjectMilestoneEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProjectMilestone",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cursor",
+            "description": "Used in `before` and `after` args",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProjectMilestonePayload",
+        "description": null,
+        "fields": [
+          {
+            "name": "lastSyncId",
+            "description": "The identifier of the last sync operation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectMilestone",
+            "description": "The project milestone that was created or updated.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProjectMilestone",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "success",
+            "description": "Whether the operation was successful.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProjectMilestoneUpdateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "name",
+            "description": "The name of the project milestone.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "The description of the project milestone.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "targetDate",
+            "description": "The planned target date of the project milestone.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "TimelessDate",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectId",
+            "description": "Related project for the project milestone.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -35561,18 +35583,6 @@
           {
             "name": "description",
             "description": "The description for the project.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "milestoneId",
-            "description": "The identifier of the milestone to associate the project with.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -39745,128 +39755,6 @@
             "deprecationReason": null
           },
           {
-            "name": "milestones",
-            "description": "All milestones.",
-            "args": [
-              {
-                "name": "before",
-                "description": "A cursor to be used with last for backward pagination.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "after",
-                "description": "A cursor to be used with first for forward pagination",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "first",
-                "description": "The number of items to forward paginate (used with after). Defaults to 50.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "last",
-                "description": "The number of items to backward paginate (used with before). Defaults to 50.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "includeArchived",
-                "description": "Should archived resources be included (default: false)",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "orderBy",
-                "description": "By which field should the pagination order by. Available options are createdAt (default) and updatedAt.",
-                "type": {
-                  "kind": "ENUM",
-                  "name": "PaginationOrderBy",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "MilestoneConnection",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Milestones will be removed. Use roadmaps instead."
-          },
-          {
-            "name": "milestone",
-            "description": "One specific milestone.",
-            "args": [
-              {
-                "name": "id",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Milestone",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Milestones will be removed. Use roadmaps instead."
-          },
-          {
             "name": "notifications",
             "description": "All notifications.",
             "args": [
@@ -40463,6 +40351,128 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "ProjectLink",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ProjectMilestones",
+            "description": "All milestones for the project.",
+            "args": [
+              {
+                "name": "before",
+                "description": "A cursor to be used with last for backward pagination.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "after",
+                "description": "A cursor to be used with first for forward pagination",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": "The number of items to forward paginate (used with after). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "The number of items to backward paginate (used with before). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "includeArchived",
+                "description": "Should archived resources be included (default: false)",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "By which field should the pagination order by. Available options are createdAt (default) and updatedAt.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "PaginationOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProjectMilestoneConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ProjectMilestone",
+            "description": "One specific project milestone.",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProjectMilestone",
                 "ofType": null
               }
             },
@@ -41442,39 +41452,6 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "Template",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "userAccountEmailChangeFind",
-            "description": "[INTERNAL] Checks if there's a currently active email verification challenge for a user account.",
-            "args": [
-              {
-                "name": "email",
-                "description": "[INTERNAL] The email of the user account.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "UserAccountEmailChangeFindPayload",
                 "ofType": null
               }
             },
@@ -43544,7 +43521,7 @@
           },
           {
             "name": "sortOrder",
-            "description": "The sort order for the project within its milestone.",
+            "description": "The sort order for the project within its organization.",
             "type": {
               "kind": "SCALAR",
               "name": "Float",
@@ -43669,7 +43646,7 @@
         "inputFields": [
           {
             "name": "sortOrder",
-            "description": "The sort order for the project within its milestone.",
+            "description": "The sort order for the project within its organization.",
             "type": {
               "kind": "SCALAR",
               "name": "Float",
@@ -44170,6 +44147,134 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "SlaStatus",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "Breached",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "HighRisk",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MediumRisk",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "LowRisk",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "Completed",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SlaStatusComparator",
+        "description": "Comparator for sla status.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "eq",
+            "description": "Equals constraint.",
+            "type": {
+              "kind": "ENUM",
+              "name": "SlaStatus",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "neq",
+            "description": "Not-equals constraint.",
+            "type": {
+              "kind": "ENUM",
+              "name": "SlaStatus",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "in",
+            "description": "In-array constraint.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SlaStatus",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nin",
+            "description": "Not-in-array constraint.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SlaStatus",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "null",
+            "description": "Null constraint. Matches any non-null values if the given value is false, otherwise it matches null values.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "SlackPostSettings",
         "description": "Slack notification specific settings.",
@@ -44277,6 +44382,201 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SourceTypeComparator",
+        "description": "Comparator for `sourceType` field.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "eq",
+            "description": "Equals constraint.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "neq",
+            "description": "Not-equals constraint.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "in",
+            "description": "In-array constraint.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nin",
+            "description": "Not-in-array constraint.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eqIgnoreCase",
+            "description": "Equals case insensitive. Matches any values that matches the given string case insensitive.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "neqIgnoreCase",
+            "description": "Not-equals case insensitive. Matches any values that don't match the given string case insensitive.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startsWith",
+            "description": "Starts with constraint. Matches any values that start with the given string.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notStartsWith",
+            "description": "Doesn't start with constraint. Matches any values that don't start with the given string.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endsWith",
+            "description": "Ends with constraint. Matches any values that end with the given string.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notEndsWith",
+            "description": "Doesn't end with constraint. Matches any values that don't end with the given string.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contains",
+            "description": "Contains constraint. Matches any values that contain the given string.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "containsIgnoreCase",
+            "description": "Contains case insensitive constraint. Matches any values that contain the given string case insensitive.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notContains",
+            "description": "Doesn't contain constraint. Matches any values that don't contain the given string.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notContainsIgnoreCase",
+            "description": "Doesn't contain case insensitive constraint. Matches any values that don't contain the given string case insensitive.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -45051,6 +45351,22 @@
           {
             "name": "triageEnabled",
             "description": "Whether triage mode is enabled for the team or not.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requirePriorityToLeaveTriage",
+            "description": "Whether an issue needs to have a priority set before leaving triage",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -48905,6 +49221,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "slaEnabled",
+            "description": "Internal. Whether SLA's have been enabled for the organization.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -50299,143 +50627,6 @@
             "type": {
               "kind": "SCALAR",
               "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "UserAccountEmailChangeFindPayload",
-        "description": "[INTERNAL] Result of searching for a verification challenge for a user account.",
-        "fields": [
-          {
-            "name": "lastSyncId",
-            "description": "The identifier of the last sync operation.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasChangeActive",
-            "description": "[INTERNAL] Whether there is a currently active change.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "UserAccountEmailChangeVerifyCodePayload",
-        "description": "[INTERNAL] Result of verifying an email and code.",
-        "fields": [
-          {
-            "name": "success",
-            "description": "[INTERNAL] Whether the operation was successful.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "failureReason",
-            "description": "[INTERNAL] Reason why the operation was not successful.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "UserAccountEmailVerificationPayload",
-        "description": "[INTERNAL] Result of creating or cancelling a verification challenge for email change.",
-        "fields": [
-          {
-            "name": "lastSyncId",
-            "description": "The identifier of the last sync operation.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": "[INTERNAL] Whether the operation was successful.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "failureReason",
-            "description": "[INTERNAL] Reason why the operation was not successful.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
               "ofType": null
             },
             "isDeprecated": false,
@@ -52247,6 +52438,18 @@
             "deprecationReason": null
           },
           {
+            "name": "myIssuesTouchedByMe",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "myIssuesActivity",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "userProfile",
             "description": null,
             "isDeprecated": false,
@@ -52967,21 +53170,29 @@
       },
       {
         "kind": "INPUT_OBJECT",
-        "name": "WorkflowConditions",
-        "description": "The conditions to match different events, which need to be true for workflow to be started.",
+        "name": "WorkflowCondition",
+        "description": "A condition to match for the workflow to be triggered.",
         "fields": null,
         "inputFields": [
           {
-            "name": "issue",
-            "description": "The conditions to match triggers based on issue (creation, update, deletion).",
+            "name": "issueFilter",
+            "description": "Trigger the workflow when an issue matches the filter. Can only be used when the trigger type is `Issue`.",
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "INPUT_OBJECT",
-                "name": "WorkflowEntityPropertyMatcher",
-                "ofType": null
-              }
+              "kind": "INPUT_OBJECT",
+              "name": "IssueFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectFilter",
+            "description": "Triggers the workflow when a project matches the filter. Can only be used when the trigger type is `Project`.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ProjectFilter",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -53074,8 +53285,20 @@
             "deprecationReason": null
           },
           {
+            "name": "groupName",
+            "description": "The name of the group that the workflow belongs to.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "description",
-            "description": "The workflow description.",
+            "description": "The description of the workflow.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -53087,7 +53310,7 @@
           },
           {
             "name": "type",
-            "description": "The type of the workflow",
+            "description": "The type of the workflow.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -53103,7 +53326,23 @@
           },
           {
             "name": "trigger",
-            "description": "The type of the trigger that kicks off the workflow.",
+            "description": "The type of the event that triggers off the workflow.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "WorkflowTrigger",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "triggerType",
+            "description": "The object type (e.g. Issue) that triggers this workflow.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -53111,6 +53350,22 @@
               "ofType": {
                 "kind": "ENUM",
                 "name": "WorkflowTriggerType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "conditions",
+            "description": "The conditions that need to be match for the workflow to be triggered.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSONObject",
                 "ofType": null
               }
             },
@@ -53134,33 +53389,13 @@
             "deprecationReason": null
           },
           {
-            "name": "organization",
-            "description": "The organization where workflow was created.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Organization",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "team",
-            "description": "The team associated with the workflow.",
+            "description": "The team associated with the workflow. If not set, the workflow is associated with the entire organization.",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Team",
-                "ofType": null
-              }
+              "kind": "OBJECT",
+              "name": "Team",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -53175,22 +53410,6 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "User",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "conditions",
-            "description": "One or more conditions that need to be true for workflow to be triggered.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "JSONObject",
                 "ofType": null
               }
             },
@@ -53228,6 +53447,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "sortOrder",
+            "description": "The sort order of the workflow definition within its siblings.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -53242,14 +53477,105 @@
         "possibleTypes": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "WorkflowEntityPropertyMatcher",
-        "description": "Object to provide conditions to match an entity change.",
-        "fields": null,
-        "inputFields": [
+        "kind": "OBJECT",
+        "name": "WorkflowDefinitionConnection",
+        "description": null,
+        "fields": [
           {
-            "name": "property",
-            "description": "The property to check for matching.",
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkflowDefinitionEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkflowDefinition",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowDefinitionEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDefinition",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cursor",
+            "description": "Used in `before` and `after` args",
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -53259,76 +53585,12 @@
                 "ofType": null
               }
             },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "fromValue",
-            "description": "The initial value of the property to match.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "toValue",
-            "description": "The new value of the property to match.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "and",
-            "description": "The optional list of property matchers that all have to match.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "WorkflowEntityPropertyMatcher",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "or",
-            "description": "The optional list of property matchers where at least one have to match.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "WorkflowEntityPropertyMatcher",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
         ],
-        "interfaces": null,
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -54110,7 +54372,7 @@
       },
       {
         "kind": "ENUM",
-        "name": "WorkflowTriggerType",
+        "name": "WorkflowTrigger",
         "description": null,
         "fields": null,
         "inputFields": null,
@@ -54123,19 +54385,54 @@
             "deprecationReason": null
           },
           {
-            "name": "issueCreated",
+            "name": "entityCreated",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "issueUpdated",
+            "name": "entityUpdated",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "issueDeleted",
+            "name": "entityCreatedOrUpdated",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "entityRemoved",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "entityUnarchived",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "WorkflowTriggerType",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "issue",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -54153,6 +54450,12 @@
         "enumValues": [
           {
             "name": "recurringIssue",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sla",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null


### PR DESCRIPTION
We're using [Internal] and [Alpha] comments to try to "hide" things from the public SDK because they either are not available through the public API or are considered not ready for primetime. 

But the code generator is not smart enough to follow dependencies and improperly placed comments can easily prevent something from being generated. 

We don't really need to hide [Alpha] features (they were not until recently) as it might prevent some features from being public as we sometimes don't update the [alpha] comment for a long time. In addition, the features are clearly labeled as alpha and consumers know that the API might change when they make use of an alpha feature.