### PR TITLE
fix: do not generate tests for skip comments

### DIFF
--- a/.changeset/_generated_schema_10584077.md
+++ b/.changeset/_generated_schema_10584077.md
@@ -1,0 +1,240 @@
+---
+"@linear/sdk": minor
+---
+
+
+feat(schema): [breaking] Type 'Initiative' was removed (Initiative)
+
+feat(schema): [breaking] Type 'InitiativeConnection' was removed (InitiativeConnection)
+
+feat(schema): [breaking] Type 'InitiativeEdge' was removed (InitiativeEdge)
+
+feat(schema): [breaking] Type 'Milestone' was removed (Milestone)
+
+feat(schema): [breaking] Type 'MilestoneConnection' was removed (MilestoneConnection)
+
+feat(schema): [breaking] Type 'MilestoneCreateInput' was removed (MilestoneCreateInput)
+
+feat(schema): [breaking] Type 'MilestoneEdge' was removed (MilestoneEdge)
+
+feat(schema): [breaking] Type 'MilestoneMigrationPayload' was removed (MilestoneMigrationPayload)
+
+feat(schema): [breaking] Type 'MilestonePayload' was removed (MilestonePayload)
+
+feat(schema): [breaking] Type 'MilestoneUpdateInput' was removed (MilestoneUpdateInput)
+
+feat(schema): [breaking] Type 'MilestonesMigrateInput' was removed (MilestonesMigrateInput)
+
+feat(schema): [breaking] Type 'NestedStringComparator' was removed (NestedStringComparator)
+
+feat(schema): [breaking] Type 'UserAccountEmailChangeFindPayload' was removed (UserAccountEmailChangeFindPayload)
+
+feat(schema): [breaking] Type 'UserAccountEmailChangeVerifyCodePayload' was removed (UserAccountEmailChangeVerifyCodePayload)
+
+feat(schema): [breaking] Type 'UserAccountEmailVerificationPayload' was removed (UserAccountEmailVerificationPayload)
+
+feat(schema): [breaking] Type 'WorkflowConditions' was removed (WorkflowConditions)
+
+feat(schema): [breaking] Type 'WorkflowEntityPropertyMatcher' was removed (WorkflowEntityPropertyMatcher)
+
+feat(schema): [breaking] Input field 'AttachmentCollectionFilter.sourceType' changed type from 'NestedStringComparator' to 'SourceTypeComparator' (AttachmentCollectionFilter.sourceType)
+
+feat(schema): [breaking] Input field 'AttachmentFilter.sourceType' changed type from 'NestedStringComparator' to 'SourceTypeComparator' (AttachmentFilter.sourceType)
+
+feat(schema): [breaking] Field 'slackProjectUpdateCreatedToMilestone' was removed from object type 'IntegrationsSettings' (IntegrationsSettings.slackProjectUpdateCreatedToMilestone)
+
+feat(schema): [breaking] Input field 'slackProjectUpdateCreatedToMilestone' was removed from input object type 'IntegrationsSettingsCreateInput' (IntegrationsSettingsCreateInput.slackProjectUpdateCreatedToMilestone)
+
+feat(schema): [breaking] Input field 'slackProjectUpdateCreatedToMilestone' was removed from input object type 'IntegrationsSettingsUpdateInput' (IntegrationsSettingsUpdateInput.slackProjectUpdateCreatedToMilestone)
+
+feat(schema): [breaking] Field 'migrateMilestonesToRoadmaps' was removed from object type 'Mutation' (Mutation.migrateMilestonesToRoadmaps)
+
+feat(schema): [breaking] Field 'milestoneCreate' (deprecated) was removed from object type 'Mutation' (Mutation.milestoneCreate)
+
+feat(schema): [breaking] Field 'milestoneDelete' (deprecated) was removed from object type 'Mutation' (Mutation.milestoneDelete)
+
+feat(schema): [breaking] Field 'milestoneUpdate' (deprecated) was removed from object type 'Mutation' (Mutation.milestoneUpdate)
+
+feat(schema): [breaking] Field 'userAccountEmailChangeCancel' was removed from object type 'Mutation' (Mutation.userAccountEmailChangeCancel)
+
+feat(schema): [breaking] Field 'userAccountEmailChangeCreate' was removed from object type 'Mutation' (Mutation.userAccountEmailChangeCreate)
+
+feat(schema): [breaking] Field 'userAccountEmailChangeVerifyCode' was removed from object type 'Mutation' (Mutation.userAccountEmailChangeVerifyCode)
+
+feat(schema): [breaking] Field 'initiative' was removed from object type 'Project' (Project.initiative)
+
+feat(schema): [breaking] Field 'milestone' (deprecated) was removed from object type 'Project' (Project.milestone)
+
+feat(schema): [breaking] Input field 'milestoneId' was removed from input object type 'ProjectCreateInput' (ProjectCreateInput.milestoneId)
+
+feat(schema): [breaking] Input field 'milestoneId' was removed from input object type 'ProjectUpdateInput' (ProjectUpdateInput.milestoneId)
+
+feat(schema): [breaking] Field 'milestone' (deprecated) was removed from object type 'Query' (Query.milestone)
+
+feat(schema): [breaking] Field 'milestones' (deprecated) was removed from object type 'Query' (Query.milestones)
+
+feat(schema): [breaking] Field 'userAccountEmailChangeFind' was removed from object type 'Query' (Query.userAccountEmailChangeFind)
+
+feat(schema): [breaking] Field 'organization' was removed from object type 'WorkflowDefinition' (WorkflowDefinition.organization)
+
+feat(schema): [breaking] Field 'WorkflowDefinition.team' changed type from 'Team!' to 'Team' (WorkflowDefinition.team)
+
+feat(schema): [breaking] Field 'WorkflowDefinition.trigger' changed type from 'WorkflowTriggerType!' to 'WorkflowTrigger!' (WorkflowDefinition.trigger)
+
+feat(schema): [breaking] Enum value 'cron' was removed from enum 'WorkflowTriggerType' (WorkflowTriggerType.cron)
+
+feat(schema): [breaking] Enum value 'issueCreated' was removed from enum 'WorkflowTriggerType' (WorkflowTriggerType.issueCreated)
+
+feat(schema): [breaking] Enum value 'issueDeleted' was removed from enum 'WorkflowTriggerType' (WorkflowTriggerType.issueDeleted)
+
+feat(schema): [breaking] Enum value 'issueUpdated' was removed from enum 'WorkflowTriggerType' (WorkflowTriggerType.issueUpdated)
+
+feat(schema): [dangerous] Input field 'doNotSubscribeToIssue' was added to input object type 'CommentCreateInput' (CommentCreateInput.doNotSubscribeToIssue)
+
+feat(schema): [dangerous] Input field 'notion' was added to input object type 'IntegrationSettingsInput' (IntegrationSettingsInput.notion)
+
+feat(schema): [dangerous] Input field 'slackIssueAddedToTriage' was added to input object type 'IntegrationsSettingsCreateInput' (IntegrationsSettingsCreateInput.slackIssueAddedToTriage)
+
+feat(schema): [dangerous] Input field 'slackIssueSlaBreached' was added to input object type 'IntegrationsSettingsCreateInput' (IntegrationsSettingsCreateInput.slackIssueSlaBreached)
+
+feat(schema): [dangerous] Input field 'slackIssueSlaHighRisk' was added to input object type 'IntegrationsSettingsCreateInput' (IntegrationsSettingsCreateInput.slackIssueSlaHighRisk)
+
+feat(schema): [dangerous] Input field 'slackIssueAddedToTriage' was added to input object type 'IntegrationsSettingsUpdateInput' (IntegrationsSettingsUpdateInput.slackIssueAddedToTriage)
+
+feat(schema): [dangerous] Input field 'slackIssueSlaBreached' was added to input object type 'IntegrationsSettingsUpdateInput' (IntegrationsSettingsUpdateInput.slackIssueSlaBreached)
+
+feat(schema): [dangerous] Input field 'slackIssueSlaHighRisk' was added to input object type 'IntegrationsSettingsUpdateInput' (IntegrationsSettingsUpdateInput.slackIssueSlaHighRisk)
+
+feat(schema): [dangerous] Input field 'slaStatus' was added to input object type 'IssueCollectionFilter' (IssueCollectionFilter.slaStatus)
+
+feat(schema): [dangerous] Input field 'projectMilestoneId' was added to input object type 'IssueCreateInput' (IssueCreateInput.projectMilestoneId)
+
+feat(schema): [dangerous] Input field 'slaStatus' was added to input object type 'IssueFilter' (IssueFilter.slaStatus)
+
+feat(schema): [dangerous] Input field 'projectMilestoneId' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.projectMilestoneId)
+
+feat(schema): [dangerous] Input field 'slaBreachesAt' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.slaBreachesAt)
+
+feat(schema): [dangerous] Argument 'id: String' added to field 'Mutation.attachmentLinkURL' (Mutation.attachmentLinkURL.id)
+
+feat(schema): [dangerous] Input field 'teamNotificationSubscriptionTypes' was added to input object type 'NotificationSubscriptionCreateInput' (NotificationSubscriptionCreateInput.teamNotificationSubscriptionTypes)
+
+feat(schema): [dangerous] Input field 'teamNotificationSubscriptionTypes' was added to input object type 'NotificationSubscriptionUpdateInput' (NotificationSubscriptionUpdateInput.teamNotificationSubscriptionTypes)
+
+feat(schema): [dangerous] Input field 'slaStatus' was added to input object type 'NullableIssueFilter' (NullableIssueFilter.slaStatus)
+
+feat(schema): [dangerous] Input field 'requirePriorityToLeaveTriage' was added to input object type 'TeamCreateInput' (TeamCreateInput.requirePriorityToLeaveTriage)
+
+feat(schema): [dangerous] Input field 'requirePriorityToLeaveTriage' was added to input object type 'TeamUpdateInput' (TeamUpdateInput.requirePriorityToLeaveTriage)
+
+feat(schema): [dangerous] Input field 'slaEnabled' was added to input object type 'UpdateOrganizationInput' (UpdateOrganizationInput.slaEnabled)
+
+feat(schema): [dangerous] Enum value 'myIssuesActivity' was added to enum 'ViewType' (ViewType.myIssuesActivity)
+
+feat(schema): [dangerous] Enum value 'myIssuesTouchedByMe' was added to enum 'ViewType' (ViewType.myIssuesTouchedByMe)
+
+feat(schema): [dangerous] Enum value 'issue' was added to enum 'WorkflowTriggerType' (WorkflowTriggerType.issue)
+
+feat(schema): [dangerous] Enum value 'project' was added to enum 'WorkflowTriggerType' (WorkflowTriggerType.project)
+
+feat(schema): [dangerous] Enum value 'sla' was added to enum 'WorkflowType' (WorkflowType.sla)
+
+feat(schema): [non_breaking] Type 'IssueDraft' was added (IssueDraft)
+
+feat(schema): [non_breaking] Type 'NotionSettings' was added (NotionSettings)
+
+feat(schema): [non_breaking] Type 'NotionSettingsInput' was added (NotionSettingsInput)
+
+feat(schema): [non_breaking] Type 'PersonalNote' was added (PersonalNote)
+
+feat(schema): [non_breaking] Type 'ProjectMilestone' was added (ProjectMilestone)
+
+feat(schema): [non_breaking] Type 'ProjectMilestoneConnection' was added (ProjectMilestoneConnection)
+
+feat(schema): [non_breaking] Type 'ProjectMilestoneCreateInput' was added (ProjectMilestoneCreateInput)
+
+feat(schema): [non_breaking] Type 'ProjectMilestoneEdge' was added (ProjectMilestoneEdge)
+
+feat(schema): [non_breaking] Type 'ProjectMilestonePayload' was added (ProjectMilestonePayload)
+
+feat(schema): [non_breaking] Type 'ProjectMilestoneUpdateInput' was added (ProjectMilestoneUpdateInput)
+
+feat(schema): [non_breaking] Type 'SlaStatus' was added (SlaStatus)
+
+feat(schema): [non_breaking] Type 'SlaStatusComparator' was added (SlaStatusComparator)
+
+feat(schema): [non_breaking] Type 'SourceTypeComparator' was added (SourceTypeComparator)
+
+feat(schema): [non_breaking] Type 'WorkflowCondition' was added (WorkflowCondition)
+
+feat(schema): [non_breaking] Type 'WorkflowDefinitionConnection' was added (WorkflowDefinitionConnection)
+
+feat(schema): [non_breaking] Type 'WorkflowDefinitionEdge' was added (WorkflowDefinitionEdge)
+
+feat(schema): [non_breaking] Type 'WorkflowTrigger' was added (WorkflowTrigger)
+
+feat(schema): [non_breaking] Field 'organization' was added to object type 'AuditEntry' (AuditEntry.organization)
+
+feat(schema): [non_breaking] Field 'Comment.parent' description changed from 'The parent of the comment.' to 'The parent comment under which the current comment is nested.' (Comment.parent)
+
+feat(schema): [non_breaking] Input field 'CommentCreateInput.parentId' description changed from '[Internal] The parent under which to nest the comment.' to 'The parent comment under which to nest a current comment.' (CommentCreateInput.parentId)
+
+feat(schema): [non_breaking] Field 'notion' was added to object type 'IntegrationSettings' (IntegrationSettings.notion)
+
+feat(schema): [non_breaking] Field 'slackIssueAddedToTriage' was added to object type 'IntegrationsSettings' (IntegrationsSettings.slackIssueAddedToTriage)
+
+feat(schema): [non_breaking] Field 'slackIssueSlaBreached' was added to object type 'IntegrationsSettings' (IntegrationsSettings.slackIssueSlaBreached)
+
+feat(schema): [non_breaking] Field 'slackIssueSlaHighRisk' was added to object type 'IntegrationsSettings' (IntegrationsSettings.slackIssueSlaHighRisk)
+
+feat(schema): [non_breaking] Field 'projectMilestone' was added to object type 'Issue' (Issue.projectMilestone)
+
+feat(schema): [non_breaking] Field 'slaBreachesAt' was added to object type 'Issue' (Issue.slaBreachesAt)
+
+feat(schema): [non_breaking] Field 'slaStartedAt' was added to object type 'Issue' (Issue.slaStartedAt)
+
+feat(schema): [non_breaking] Field 'startedTriageAt' was added to object type 'Issue' (Issue.startedTriageAt)
+
+feat(schema): [non_breaking] Field 'changes' was added to object type 'IssueHistory' (IssueHistory.changes)
+
+feat(schema): [non_breaking] Field 'issueDescriptionUpdateFromFront' was added to object type 'Mutation' (Mutation.issueDescriptionUpdateFromFront)
+
+feat(schema): [non_breaking] Field 'projectMilestoneCreate' was added to object type 'Mutation' (Mutation.projectMilestoneCreate)
+
+feat(schema): [non_breaking] Field 'projectMilestoneDelete' was added to object type 'Mutation' (Mutation.projectMilestoneDelete)
+
+feat(schema): [non_breaking] Field 'projectMilestoneUpdate' was added to object type 'Mutation' (Mutation.projectMilestoneUpdate)
+
+feat(schema): [non_breaking] Input field 'NotificationSubscriptionUpdateInput.projectNotificationSubscriptionType' changed type from 'ProjectNotificationSubscriptionType!' to 'ProjectNotificationSubscriptionType' (NotificationSubscriptionUpdateInput.projectNotificationSubscriptionType)
+
+feat(schema): [non_breaking] Field 'PaidSubscription.seatsMaximum' description changed from 'The maximum number of seats that can be added to the subscription.' to 'The maximum number of seats that will be billed in the subscription.' (PaidSubscription.seatsMaximum)
+
+feat(schema): [non_breaking] Field 'projectMilestones' was added to object type 'Project' (Project.projectMilestones)
+
+feat(schema): [non_breaking] Field 'Project.sortOrder' description changed from 'The sort order for the project within its milestone/initiative.' to 'The sort order for the project within the organizion.' (Project.sortOrder)
+
+feat(schema): [non_breaking] Field 'ProjectMilestone' was added to object type 'Query' (Query.ProjectMilestone)
+
+feat(schema): [non_breaking] Field 'ProjectMilestones' was added to object type 'Query' (Query.ProjectMilestones)
+
+feat(schema): [non_breaking] Input field 'RoadmapToProjectCreateInput.sortOrder' description changed from 'The sort order for the project within its milestone.' to 'The sort order for the project within its organization.' (RoadmapToProjectCreateInput.sortOrder)
+
+feat(schema): [non_breaking] Input field 'RoadmapToProjectUpdateInput.sortOrder' description changed from 'The sort order for the project within its milestone.' to 'The sort order for the project within its organization.' (RoadmapToProjectUpdateInput.sortOrder)
+
+feat(schema): [non_breaking] Field 'requirePriorityToLeaveTriage' was added to object type 'Team' (Team.requirePriorityToLeaveTriage)
+
+feat(schema): [non_breaking] Field 'groupName' was added to object type 'WorkflowDefinition' (WorkflowDefinition.groupName)
+
+feat(schema): [non_breaking] Field 'sortOrder' was added to object type 'WorkflowDefinition' (WorkflowDefinition.sortOrder)
+
+feat(schema): [non_breaking] Field 'triggerType' was added to object type 'WorkflowDefinition' (WorkflowDefinition.triggerType)
+
+feat(schema): [non_breaking] Field 'WorkflowDefinition.conditions' description changed from 'One or more conditions that need to be true for workflow to be triggered.' to 'The conditions that need to be match for the workflow to be triggered.' (WorkflowDefinition.conditions)
+
+feat(schema): [non_breaking] Field 'WorkflowDefinition.description' description changed from 'The workflow description.' to 'The description of the workflow.' (WorkflowDefinition.description)
+
+feat(schema): [non_breaking] Field 'WorkflowDefinition.team' description changed from 'The team associated with the workflow.' to 'The team associated with the workflow. If not set, the workflow is associated with the entire organization.' (WorkflowDefinition.team)
+
+feat(schema): [non_breaking] Field 'WorkflowDefinition.trigger' description changed from 'The type of the trigger that kicks off the workflow.' to 'The type of the event that triggers off the workflow.' (WorkflowDefinition.trigger)
+
+feat(schema): [non_breaking] Field 'WorkflowDefinition.type' description changed from 'The type of the workflow' to 'The type of the workflow.' (WorkflowDefinition.type)

--- a/.changeset/_generated_schema_77603279.md
+++ b/.changeset/_generated_schema_77603279.md
@@ -1,0 +1,240 @@
+---
+"@linear/sdk": minor
+---
+
+
+feat(schema): [breaking] Type 'Initiative' was removed (Initiative)
+
+feat(schema): [breaking] Type 'InitiativeConnection' was removed (InitiativeConnection)
+
+feat(schema): [breaking] Type 'InitiativeEdge' was removed (InitiativeEdge)
+
+feat(schema): [breaking] Type 'Milestone' was removed (Milestone)
+
+feat(schema): [breaking] Type 'MilestoneConnection' was removed (MilestoneConnection)
+
+feat(schema): [breaking] Type 'MilestoneCreateInput' was removed (MilestoneCreateInput)
+
+feat(schema): [breaking] Type 'MilestoneEdge' was removed (MilestoneEdge)
+
+feat(schema): [breaking] Type 'MilestoneMigrationPayload' was removed (MilestoneMigrationPayload)
+
+feat(schema): [breaking] Type 'MilestonePayload' was removed (MilestonePayload)
+
+feat(schema): [breaking] Type 'MilestoneUpdateInput' was removed (MilestoneUpdateInput)
+
+feat(schema): [breaking] Type 'MilestonesMigrateInput' was removed (MilestonesMigrateInput)
+
+feat(schema): [breaking] Type 'NestedStringComparator' was removed (NestedStringComparator)
+
+feat(schema): [breaking] Type 'UserAccountEmailChangeFindPayload' was removed (UserAccountEmailChangeFindPayload)
+
+feat(schema): [breaking] Type 'UserAccountEmailChangeVerifyCodePayload' was removed (UserAccountEmailChangeVerifyCodePayload)
+
+feat(schema): [breaking] Type 'UserAccountEmailVerificationPayload' was removed (UserAccountEmailVerificationPayload)
+
+feat(schema): [breaking] Type 'WorkflowConditions' was removed (WorkflowConditions)
+
+feat(schema): [breaking] Type 'WorkflowEntityPropertyMatcher' was removed (WorkflowEntityPropertyMatcher)
+
+feat(schema): [breaking] Input field 'AttachmentCollectionFilter.sourceType' changed type from 'NestedStringComparator' to 'SourceTypeComparator' (AttachmentCollectionFilter.sourceType)
+
+feat(schema): [breaking] Input field 'AttachmentFilter.sourceType' changed type from 'NestedStringComparator' to 'SourceTypeComparator' (AttachmentFilter.sourceType)
+
+feat(schema): [breaking] Field 'slackProjectUpdateCreatedToMilestone' was removed from object type 'IntegrationsSettings' (IntegrationsSettings.slackProjectUpdateCreatedToMilestone)
+
+feat(schema): [breaking] Input field 'slackProjectUpdateCreatedToMilestone' was removed from input object type 'IntegrationsSettingsCreateInput' (IntegrationsSettingsCreateInput.slackProjectUpdateCreatedToMilestone)
+
+feat(schema): [breaking] Input field 'slackProjectUpdateCreatedToMilestone' was removed from input object type 'IntegrationsSettingsUpdateInput' (IntegrationsSettingsUpdateInput.slackProjectUpdateCreatedToMilestone)
+
+feat(schema): [breaking] Field 'migrateMilestonesToRoadmaps' was removed from object type 'Mutation' (Mutation.migrateMilestonesToRoadmaps)
+
+feat(schema): [breaking] Field 'milestoneCreate' (deprecated) was removed from object type 'Mutation' (Mutation.milestoneCreate)
+
+feat(schema): [breaking] Field 'milestoneDelete' (deprecated) was removed from object type 'Mutation' (Mutation.milestoneDelete)
+
+feat(schema): [breaking] Field 'milestoneUpdate' (deprecated) was removed from object type 'Mutation' (Mutation.milestoneUpdate)
+
+feat(schema): [breaking] Field 'userAccountEmailChangeCancel' was removed from object type 'Mutation' (Mutation.userAccountEmailChangeCancel)
+
+feat(schema): [breaking] Field 'userAccountEmailChangeCreate' was removed from object type 'Mutation' (Mutation.userAccountEmailChangeCreate)
+
+feat(schema): [breaking] Field 'userAccountEmailChangeVerifyCode' was removed from object type 'Mutation' (Mutation.userAccountEmailChangeVerifyCode)
+
+feat(schema): [breaking] Field 'initiative' was removed from object type 'Project' (Project.initiative)
+
+feat(schema): [breaking] Field 'milestone' (deprecated) was removed from object type 'Project' (Project.milestone)
+
+feat(schema): [breaking] Input field 'milestoneId' was removed from input object type 'ProjectCreateInput' (ProjectCreateInput.milestoneId)
+
+feat(schema): [breaking] Input field 'milestoneId' was removed from input object type 'ProjectUpdateInput' (ProjectUpdateInput.milestoneId)
+
+feat(schema): [breaking] Field 'milestone' (deprecated) was removed from object type 'Query' (Query.milestone)
+
+feat(schema): [breaking] Field 'milestones' (deprecated) was removed from object type 'Query' (Query.milestones)
+
+feat(schema): [breaking] Field 'userAccountEmailChangeFind' was removed from object type 'Query' (Query.userAccountEmailChangeFind)
+
+feat(schema): [breaking] Field 'organization' was removed from object type 'WorkflowDefinition' (WorkflowDefinition.organization)
+
+feat(schema): [breaking] Field 'WorkflowDefinition.team' changed type from 'Team!' to 'Team' (WorkflowDefinition.team)
+
+feat(schema): [breaking] Field 'WorkflowDefinition.trigger' changed type from 'WorkflowTriggerType!' to 'WorkflowTrigger!' (WorkflowDefinition.trigger)
+
+feat(schema): [breaking] Enum value 'cron' was removed from enum 'WorkflowTriggerType' (WorkflowTriggerType.cron)
+
+feat(schema): [breaking] Enum value 'issueCreated' was removed from enum 'WorkflowTriggerType' (WorkflowTriggerType.issueCreated)
+
+feat(schema): [breaking] Enum value 'issueDeleted' was removed from enum 'WorkflowTriggerType' (WorkflowTriggerType.issueDeleted)
+
+feat(schema): [breaking] Enum value 'issueUpdated' was removed from enum 'WorkflowTriggerType' (WorkflowTriggerType.issueUpdated)
+
+feat(schema): [dangerous] Input field 'doNotSubscribeToIssue' was added to input object type 'CommentCreateInput' (CommentCreateInput.doNotSubscribeToIssue)
+
+feat(schema): [dangerous] Input field 'notion' was added to input object type 'IntegrationSettingsInput' (IntegrationSettingsInput.notion)
+
+feat(schema): [dangerous] Input field 'slackIssueAddedToTriage' was added to input object type 'IntegrationsSettingsCreateInput' (IntegrationsSettingsCreateInput.slackIssueAddedToTriage)
+
+feat(schema): [dangerous] Input field 'slackIssueSlaBreached' was added to input object type 'IntegrationsSettingsCreateInput' (IntegrationsSettingsCreateInput.slackIssueSlaBreached)
+
+feat(schema): [dangerous] Input field 'slackIssueSlaHighRisk' was added to input object type 'IntegrationsSettingsCreateInput' (IntegrationsSettingsCreateInput.slackIssueSlaHighRisk)
+
+feat(schema): [dangerous] Input field 'slackIssueAddedToTriage' was added to input object type 'IntegrationsSettingsUpdateInput' (IntegrationsSettingsUpdateInput.slackIssueAddedToTriage)
+
+feat(schema): [dangerous] Input field 'slackIssueSlaBreached' was added to input object type 'IntegrationsSettingsUpdateInput' (IntegrationsSettingsUpdateInput.slackIssueSlaBreached)
+
+feat(schema): [dangerous] Input field 'slackIssueSlaHighRisk' was added to input object type 'IntegrationsSettingsUpdateInput' (IntegrationsSettingsUpdateInput.slackIssueSlaHighRisk)
+
+feat(schema): [dangerous] Input field 'slaStatus' was added to input object type 'IssueCollectionFilter' (IssueCollectionFilter.slaStatus)
+
+feat(schema): [dangerous] Input field 'projectMilestoneId' was added to input object type 'IssueCreateInput' (IssueCreateInput.projectMilestoneId)
+
+feat(schema): [dangerous] Input field 'slaStatus' was added to input object type 'IssueFilter' (IssueFilter.slaStatus)
+
+feat(schema): [dangerous] Input field 'projectMilestoneId' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.projectMilestoneId)
+
+feat(schema): [dangerous] Input field 'slaBreachesAt' was added to input object type 'IssueUpdateInput' (IssueUpdateInput.slaBreachesAt)
+
+feat(schema): [dangerous] Argument 'id: String' added to field 'Mutation.attachmentLinkURL' (Mutation.attachmentLinkURL.id)
+
+feat(schema): [dangerous] Input field 'teamNotificationSubscriptionTypes' was added to input object type 'NotificationSubscriptionCreateInput' (NotificationSubscriptionCreateInput.teamNotificationSubscriptionTypes)
+
+feat(schema): [dangerous] Input field 'teamNotificationSubscriptionTypes' was added to input object type 'NotificationSubscriptionUpdateInput' (NotificationSubscriptionUpdateInput.teamNotificationSubscriptionTypes)
+
+feat(schema): [dangerous] Input field 'slaStatus' was added to input object type 'NullableIssueFilter' (NullableIssueFilter.slaStatus)
+
+feat(schema): [dangerous] Input field 'requirePriorityToLeaveTriage' was added to input object type 'TeamCreateInput' (TeamCreateInput.requirePriorityToLeaveTriage)
+
+feat(schema): [dangerous] Input field 'requirePriorityToLeaveTriage' was added to input object type 'TeamUpdateInput' (TeamUpdateInput.requirePriorityToLeaveTriage)
+
+feat(schema): [dangerous] Input field 'slaEnabled' was added to input object type 'UpdateOrganizationInput' (UpdateOrganizationInput.slaEnabled)
+
+feat(schema): [dangerous] Enum value 'myIssuesActivity' was added to enum 'ViewType' (ViewType.myIssuesActivity)
+
+feat(schema): [dangerous] Enum value 'myIssuesTouchedByMe' was added to enum 'ViewType' (ViewType.myIssuesTouchedByMe)
+
+feat(schema): [dangerous] Enum value 'issue' was added to enum 'WorkflowTriggerType' (WorkflowTriggerType.issue)
+
+feat(schema): [dangerous] Enum value 'project' was added to enum 'WorkflowTriggerType' (WorkflowTriggerType.project)
+
+feat(schema): [dangerous] Enum value 'sla' was added to enum 'WorkflowType' (WorkflowType.sla)
+
+feat(schema): [non_breaking] Type 'IssueDraft' was added (IssueDraft)
+
+feat(schema): [non_breaking] Type 'NotionSettings' was added (NotionSettings)
+
+feat(schema): [non_breaking] Type 'NotionSettingsInput' was added (NotionSettingsInput)
+
+feat(schema): [non_breaking] Type 'PersonalNote' was added (PersonalNote)
+
+feat(schema): [non_breaking] Type 'ProjectMilestone' was added (ProjectMilestone)
+
+feat(schema): [non_breaking] Type 'ProjectMilestoneConnection' was added (ProjectMilestoneConnection)
+
+feat(schema): [non_breaking] Type 'ProjectMilestoneCreateInput' was added (ProjectMilestoneCreateInput)
+
+feat(schema): [non_breaking] Type 'ProjectMilestoneEdge' was added (ProjectMilestoneEdge)
+
+feat(schema): [non_breaking] Type 'ProjectMilestonePayload' was added (ProjectMilestonePayload)
+
+feat(schema): [non_breaking] Type 'ProjectMilestoneUpdateInput' was added (ProjectMilestoneUpdateInput)
+
+feat(schema): [non_breaking] Type 'SlaStatus' was added (SlaStatus)
+
+feat(schema): [non_breaking] Type 'SlaStatusComparator' was added (SlaStatusComparator)
+
+feat(schema): [non_breaking] Type 'SourceTypeComparator' was added (SourceTypeComparator)
+
+feat(schema): [non_breaking] Type 'WorkflowCondition' was added (WorkflowCondition)
+
+feat(schema): [non_breaking] Type 'WorkflowDefinitionConnection' was added (WorkflowDefinitionConnection)
+
+feat(schema): [non_breaking] Type 'WorkflowDefinitionEdge' was added (WorkflowDefinitionEdge)
+
+feat(schema): [non_breaking] Type 'WorkflowTrigger' was added (WorkflowTrigger)
+
+feat(schema): [non_breaking] Field 'organization' was added to object type 'AuditEntry' (AuditEntry.organization)
+
+feat(schema): [non_breaking] Field 'Comment.parent' description changed from 'The parent of the comment.' to 'The parent comment under which the current comment is nested.' (Comment.parent)
+
+feat(schema): [non_breaking] Input field 'CommentCreateInput.parentId' description changed from '[Internal] The parent under which to nest the comment.' to 'The parent comment under which to nest a current comment.' (CommentCreateInput.parentId)
+
+feat(schema): [non_breaking] Field 'notion' was added to object type 'IntegrationSettings' (IntegrationSettings.notion)
+
+feat(schema): [non_breaking] Field 'slackIssueAddedToTriage' was added to object type 'IntegrationsSettings' (IntegrationsSettings.slackIssueAddedToTriage)
+
+feat(schema): [non_breaking] Field 'slackIssueSlaBreached' was added to object type 'IntegrationsSettings' (IntegrationsSettings.slackIssueSlaBreached)
+
+feat(schema): [non_breaking] Field 'slackIssueSlaHighRisk' was added to object type 'IntegrationsSettings' (IntegrationsSettings.slackIssueSlaHighRisk)
+
+feat(schema): [non_breaking] Field 'projectMilestone' was added to object type 'Issue' (Issue.projectMilestone)
+
+feat(schema): [non_breaking] Field 'slaBreachesAt' was added to object type 'Issue' (Issue.slaBreachesAt)
+
+feat(schema): [non_breaking] Field 'slaStartedAt' was added to object type 'Issue' (Issue.slaStartedAt)
+
+feat(schema): [non_breaking] Field 'startedTriageAt' was added to object type 'Issue' (Issue.startedTriageAt)
+
+feat(schema): [non_breaking] Field 'changes' was added to object type 'IssueHistory' (IssueHistory.changes)
+
+feat(schema): [non_breaking] Field 'issueDescriptionUpdateFromFront' was added to object type 'Mutation' (Mutation.issueDescriptionUpdateFromFront)
+
+feat(schema): [non_breaking] Field 'projectMilestoneCreate' was added to object type 'Mutation' (Mutation.projectMilestoneCreate)
+
+feat(schema): [non_breaking] Field 'projectMilestoneDelete' was added to object type 'Mutation' (Mutation.projectMilestoneDelete)
+
+feat(schema): [non_breaking] Field 'projectMilestoneUpdate' was added to object type 'Mutation' (Mutation.projectMilestoneUpdate)
+
+feat(schema): [non_breaking] Input field 'NotificationSubscriptionUpdateInput.projectNotificationSubscriptionType' changed type from 'ProjectNotificationSubscriptionType!' to 'ProjectNotificationSubscriptionType' (NotificationSubscriptionUpdateInput.projectNotificationSubscriptionType)
+
+feat(schema): [non_breaking] Field 'PaidSubscription.seatsMaximum' description changed from 'The maximum number of seats that can be added to the subscription.' to 'The maximum number of seats that will be billed in the subscription.' (PaidSubscription.seatsMaximum)
+
+feat(schema): [non_breaking] Field 'projectMilestones' was added to object type 'Project' (Project.projectMilestones)
+
+feat(schema): [non_breaking] Field 'Project.sortOrder' description changed from 'The sort order for the project within its milestone/initiative.' to 'The sort order for the project within the organizion.' (Project.sortOrder)
+
+feat(schema): [non_breaking] Field 'ProjectMilestone' was added to object type 'Query' (Query.ProjectMilestone)
+
+feat(schema): [non_breaking] Field 'ProjectMilestones' was added to object type 'Query' (Query.ProjectMilestones)
+
+feat(schema): [non_breaking] Input field 'RoadmapToProjectCreateInput.sortOrder' description changed from 'The sort order for the project within its milestone.' to 'The sort order for the project within its organization.' (RoadmapToProjectCreateInput.sortOrder)
+
+feat(schema): [non_breaking] Input field 'RoadmapToProjectUpdateInput.sortOrder' description changed from 'The sort order for the project within its milestone.' to 'The sort order for the project within its organization.' (RoadmapToProjectUpdateInput.sortOrder)
+
+feat(schema): [non_breaking] Field 'requirePriorityToLeaveTriage' was added to object type 'Team' (Team.requirePriorityToLeaveTriage)
+
+feat(schema): [non_breaking] Field 'groupName' was added to object type 'WorkflowDefinition' (WorkflowDefinition.groupName)
+
+feat(schema): [non_breaking] Field 'sortOrder' was added to object type 'WorkflowDefinition' (WorkflowDefinition.sortOrder)
+
+feat(schema): [non_breaking] Field 'triggerType' was added to object type 'WorkflowDefinition' (WorkflowDefinition.triggerType)
+
+feat(schema): [non_breaking] Field 'WorkflowDefinition.conditions' description changed from 'One or more conditions that need to be true for workflow to be triggered.' to 'The conditions that need to be match for the workflow to be triggered.' (WorkflowDefinition.conditions)
+
+feat(schema): [non_breaking] Field 'WorkflowDefinition.description' description changed from 'The workflow description.' to 'The description of the workflow.' (WorkflowDefinition.description)
+
+feat(schema): [non_breaking] Field 'WorkflowDefinition.team' description changed from 'The team associated with the workflow.' to 'The team associated with the workflow. If not set, the workflow is associated with the entire organization.' (WorkflowDefinition.team)
+
+feat(schema): [non_breaking] Field 'WorkflowDefinition.trigger' description changed from 'The type of the trigger that kicks off the workflow.' to 'The type of the event that triggers off the workflow.' (WorkflowDefinition.trigger)
+
+feat(schema): [non_breaking] Field 'WorkflowDefinition.type' description changed from 'The type of the workflow' to 'The type of the workflow.' (WorkflowDefinition.type)

--- a/.changeset/old-moons-tie.md
+++ b/.changeset/old-moons-tie.md
@@ -1,0 +1,6 @@
+---
+"@linear/sdk": minor
+"@linear/codegen-test": minor
+---
+
+Do not generate tests for skip comments

--- a/packages/sdk/codegen.test.yml
+++ b/packages/sdk/codegen.test.yml
@@ -4,6 +4,11 @@ documents: ./src/_generated_documents.graphql
 hooks:
   afterOneFileWrite:
     - prettier --write
+config:
+  skipComments:
+    - "[Internal]"
+    - "[INTERNAL]"
+    - "[ALPHA]"
 generates:
   src/_tests/_generated.test.ts:
     plugins:

--- a/packages/sdk/src/_generated_documents.graphql
+++ b/packages/sdk/src/_generated_documents.graphql
@@ -32,7 +32,7 @@ fragment Comment on Comment {
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
   #     been updated after creation.
   updatedAt
-  # The parent of the comment.
+  # The parent comment under which the current comment is nested.
   parent {
     id
   }
@@ -151,40 +151,23 @@ fragment Document on Document {
   }
 }
 
-# A initiative that contains projects.
-fragment Initiative on Initiative {
+# A milestone for a project.
+fragment ProjectMilestone on ProjectMilestone {
   __typename
-  # The estimated completion date of the initiative.
-  targetDate
-  # The initiative's description.
+  # The description of the project milestone.
   description
   # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
   #     been updated after creation.
   updatedAt
-  # The name of the initiative.
+  # The name of the project milestone.
   name
-  # The sort order for the initiative.
-  sortOrder
-  # The time at which the entity was archived. Null if the entity has not been archived.
-  archivedAt
-  # The time at which the entity was created.
-  createdAt
-  # The unique identifier of the entity.
-  id
-}
-
-# A milestone that contains projects.
-fragment Milestone on Milestone {
-  __typename
-  # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
-  #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
-  #     been updated after creation.
-  updatedAt
-  # The name of the milestone.
-  name
-  # The sort order for the milestone.
-  sortOrder
+  # The planned completion date of the milestone.
+  targetDate
+  # The project of the milestone.
+  project {
+    id
+  }
   # The time at which the entity was archived. Null if the entity has not been archived.
   archivedAt
   # The time at which the entity was created.
@@ -236,6 +219,27 @@ fragment Notification on Notification {
 
   ... on ProjectNotification {
     ...ProjectNotification
+  }
+}
+
+# A personal note for a user
+fragment PersonalNote on PersonalNote {
+  __typename
+  # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+  #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+  #     been updated after creation.
+  updatedAt
+  # The note content as JSON.
+  contentData
+  # The time at which the entity was archived. Null if the entity has not been archived.
+  archivedAt
+  # The time at which the entity was created.
+  createdAt
+  # The unique identifier of the entity.
+  id
+  # The user that owns the note.
+  user {
+    id
   }
 }
 
@@ -323,18 +327,10 @@ fragment Project on Project {
   targetDate
   # The icon of the project.
   icon
-  # The initiative that this project is associated with.
-  initiative {
-    ...Initiative
-  }
   # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
   #     been updated after creation.
   updatedAt
-  # The milestone that this project is associated with.
-  milestone {
-    id
-  }
   # The number of completed estimation points after each week.
   completedScopeHistory
   # The number of completed issues in the project after each week.
@@ -361,7 +357,7 @@ fragment Project on Project {
   name
   # The project's unique URL slug.
   slugId
-  # The sort order for the project within its milestone/initiative.
+  # The sort order for the project within the organizion.
   sortOrder
   # The time at which the entity was archived. Null if the entity has not been archived.
   archivedAt
@@ -1183,6 +1179,8 @@ fragment Issue on Issue {
   archivedAt
   # The time at which the entity was created.
   createdAt
+  # The time at which the issue entered triage.
+  startedTriageAt
   # The time at which the issue left triage.
   triagedAt
   # The time at which the issue was automatically archived by the auto pruning process.
@@ -1407,6 +1405,8 @@ fragment Team on Team {
   inviteHash
   # What to use as an default estimate for unestimated issues.
   defaultIssueEstimate
+  # Whether an issue needs to have a priority set before leaving triage
+  requirePriorityToLeaveTriage
   # Whether issues without priority should be sorted first.
   issueOrderingNoPriorityFirst
   # Whether the team is private or not.
@@ -1800,6 +1800,15 @@ fragment NotificationSubscription on NotificationSubscription {
   }
 }
 
+# Notion specific settings.
+fragment NotionSettings on NotionSettings {
+  __typename
+  # The ID of the Notion workspace being connected.
+  workspaceId
+  # The name of the Notion workspace being connected.
+  workspaceName
+}
+
 # OAuth2 client application
 fragment OauthClient on OauthClient {
   __typename
@@ -2077,16 +2086,20 @@ fragment IntegrationsSettings on IntegrationsSettings {
   id
   # Whether to send a Slack message when a comment is created on any of the project or team's issues.
   slackIssueNewComment
+  # Whether to send a Slack message when a new issue is added to triage.
+  slackIssueAddedToTriage
   # Whether to send a Slack message when a new issue is created for the project or the team.
   slackIssueCreated
   # Whether to send a Slack message when a project update is created.
   slackProjectUpdateCreated
+  # Whether to send a Slack message when an SLA is at high risk
+  slackIssueSlaHighRisk
+  # Whether to send a Slack message when an SLA is breached
+  slackIssueSlaBreached
   # Whether to send a Slack message when any of the project or team's issues change to completed or cancelled.
   slackIssueStatusChangedDone
   # Whether to send a Slack message when any of the project or team's issues has a change in status.
   slackIssueStatusChangedAll
-  # Whether to send a new project update to milestone Slack channels.
-  slackProjectUpdateCreatedToMilestone
   # Whether to send a new project update to team Slack channels.
   slackProjectUpdateCreatedToTeam
   # Whether to send a new project update to workspace Slack channel.
@@ -2110,6 +2123,9 @@ fragment IntegrationSettings on IntegrationSettings {
   }
   jira {
     ...JiraSettings
+  }
+  notion {
+    ...NotionSettings
   }
   sentry {
     ...SentrySettings
@@ -2156,7 +2172,7 @@ fragment PaidSubscription on PaidSubscription {
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
   #     been updated after creation.
   updatedAt
-  # The maximum number of seats that can be added to the subscription.
+  # The maximum number of seats that will be billed in the subscription.
   seatsMaximum
   # The minimum number of seats that will be billed in the subscription.
   seatsMinimum
@@ -2666,16 +2682,6 @@ fragment ImageUploadFromUrlPayload on ImageUploadFromUrlPayload {
   success
 }
 
-fragment InitiativeConnection on InitiativeConnection {
-  __typename
-  nodes {
-    ...Initiative
-  }
-  pageInfo {
-    ...PageInfo
-  }
-}
-
 fragment IntegrationConnection on IntegrationConnection {
   __typename
   nodes {
@@ -2884,36 +2890,6 @@ fragment LogoutResponse on LogoutResponse {
   success
 }
 
-fragment MilestoneConnection on MilestoneConnection {
-  __typename
-  nodes {
-    ...Milestone
-  }
-  pageInfo {
-    ...PageInfo
-  }
-}
-
-fragment MilestoneMigrationPayload on MilestoneMigrationPayload {
-  __typename
-  # The identifier of the last sync operation.
-  lastSyncId
-  # Whether the operation was successful.
-  success
-}
-
-fragment MilestonePayload on MilestonePayload {
-  __typename
-  # The identifier of the last sync operation.
-  lastSyncId
-  # The milesteone that was created or updated.
-  milestone {
-    id
-  }
-  # Whether the operation was successful.
-  success
-}
-
 fragment Node on Node {
   __typename
   # The unique identifier of the entity.
@@ -3072,6 +3048,28 @@ fragment ProjectLinkPayload on ProjectLinkPayload {
   lastSyncId
   # The project that was created or updated.
   projectLink {
+    id
+  }
+  # Whether the operation was successful.
+  success
+}
+
+fragment ProjectMilestoneConnection on ProjectMilestoneConnection {
+  __typename
+  nodes {
+    ...ProjectMilestone
+  }
+  pageInfo {
+    ...PageInfo
+  }
+}
+
+fragment ProjectMilestonePayload on ProjectMilestonePayload {
+  __typename
+  # The identifier of the last sync operation.
+  lastSyncId
+  # The project milestone that was created or updated.
+  projectMilestone {
     id
   }
   # Whether the operation was successful.
@@ -3473,15 +3471,21 @@ fragment WorkflowDefinition on WorkflowDefinition {
   activities
   # Cron schedule which is used to execute the workflow. Only applicable for cron based workflows.
   schedule
-  # One or more conditions that need to be true for workflow to be triggered.
+  # The conditions that need to be match for the workflow to be triggered.
   conditions
+  # The description of the workflow.
+  description
   # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
   #     been updated after creation.
   updatedAt
+  # The name of the group that the workflow belongs to.
+  groupName
   # The name of the workflow.
   name
-  # The team associated with the workflow.
+  # The sort order of the workflow definition within its siblings.
+  sortOrder
+  # The team associated with the workflow. If not set, the workflow is associated with the entire organization.
   team {
     id
   }
@@ -3495,9 +3499,17 @@ fragment WorkflowDefinition on WorkflowDefinition {
   creator {
     id
   }
-  # The workflow description.
-  description
   enabled
+}
+
+fragment WorkflowDefinitionConnection on WorkflowDefinitionConnection {
+  __typename
+  nodes {
+    ...WorkflowDefinition
+  }
+  pageInfo {
+    ...PageInfo
+  }
 }
 
 fragment WorkflowStateConnection on WorkflowStateConnection {
@@ -3522,6 +3534,1788 @@ fragment WorkflowStatePayload on WorkflowStatePayload {
   success
 }
 
+# Creates an integration api key for Airbyte to connect with Linear
+mutation airbyteIntegrationConnect(
+  # Airbyte integration settings.
+  $input: AirbyteConfigurationInput!
+) {
+  airbyteIntegrationConnect(input: $input) {
+    ...IntegrationPayload
+  }
+}
+# Creates a new API key.
+mutation createApiKey(
+  # The api key object to create.
+  $input: ApiKeyCreateInput!
+) {
+  apiKeyCreate(input: $input) {
+    ...ApiKeyPayload
+  }
+}
+# Deletes an API key.
+mutation deleteApiKey(
+  # The identifier of the API key to delete.
+  $id: String!
+) {
+  apiKeyDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# [DEPRECATED] Archives an issue attachment.
+mutation archiveAttachment(
+  # The identifier of the attachment to archive.
+  $id: String!
+) {
+  attachmentArchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new attachment, or updates existing if the same `url` and `issueId` is used.
+mutation createAttachment(
+  # The attachment object to create.
+  $input: AttachmentCreateInput!
+) {
+  attachmentCreate(input: $input) {
+    ...AttachmentPayload
+  }
+}
+# Deletes an issue attachment.
+mutation deleteAttachment(
+  # The identifier of the attachment to delete.
+  $id: String!
+) {
+  attachmentDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Link an existing Discord message to an issue.
+mutation attachmentLinkDiscord(
+  # The Discord channel ID for the message to link.
+  $channelId: String!
+  # The issue for which to link the Discord message.
+  $issueId: String!
+  # The Discord message ID for the message to link.
+  $messageId: String!
+  # The Discord message URL for the message to link.
+  $url: String!
+) {
+  attachmentLinkDiscord(channelId: $channelId, issueId: $issueId, messageId: $messageId, url: $url) {
+    ...AttachmentPayload
+  }
+}
+# Link an existing Front conversation to an issue.
+mutation attachmentLinkFront(
+  # The Front conversation ID to link.
+  $conversationId: String!
+  # The issue for which to link the Front conversation.
+  $issueId: String!
+) {
+  attachmentLinkFront(conversationId: $conversationId, issueId: $issueId) {
+    ...FrontAttachmentPayload
+  }
+}
+# Link an existing Intercom conversation to an issue.
+mutation attachmentLinkIntercom(
+  # The Intercom conversation ID to link.
+  $conversationId: String!
+  # The issue for which to link the Intercom conversation.
+  $issueId: String!
+) {
+  attachmentLinkIntercom(conversationId: $conversationId, issueId: $issueId) {
+    ...AttachmentPayload
+  }
+}
+# Link an existing Jira issue to an issue.
+mutation attachmentLinkJiraIssue(
+  # The issue for which to link the Jira issue.
+  $issueId: String!
+  # The Jira issue key or ID to link.
+  $jiraIssueId: String!
+) {
+  attachmentLinkJiraIssue(issueId: $issueId, jiraIssueId: $jiraIssueId) {
+    ...AttachmentPayload
+  }
+}
+# Link any url to an issue.
+mutation attachmentLinkURL(
+  # The id for the attachment.
+  $id: String
+  # The issue for which to link the url.
+  $issueId: String!
+  # The title to use for the attachment.
+  $title: String
+  # The url to link.
+  $url: String!
+) {
+  attachmentLinkURL(id: $id, issueId: $issueId, title: $title, url: $url) {
+    ...AttachmentPayload
+  }
+}
+# Link an existing Zendesk ticket to an issue.
+mutation attachmentLinkZendesk(
+  # The issue for which to link the Zendesk ticket.
+  $issueId: String!
+  # The Zendesk ticket ID to link.
+  $ticketId: String!
+) {
+  attachmentLinkZendesk(issueId: $issueId, ticketId: $ticketId) {
+    ...AttachmentPayload
+  }
+}
+# Updates an existing issue attachment.
+mutation updateAttachment(
+  # The identifier of the attachment to update.
+  $id: String!
+  # A partial attachment object to update the attachment with.
+  $input: AttachmentUpdateInput!
+) {
+  attachmentUpdate(id: $id, input: $input) {
+    ...AttachmentPayload
+  }
+}
+# Creates a new comment.
+mutation createComment(
+  # The comment object to create.
+  $input: CommentCreateInput!
+) {
+  commentCreate(input: $input) {
+    ...CommentPayload
+  }
+}
+# Deletes a comment.
+mutation deleteComment(
+  # The identifier of the comment to delete.
+  $id: String!
+) {
+  commentDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a comment.
+mutation updateComment(
+  # The identifier of the comment to update.
+  $id: String!
+  # A partial comment object to update the comment with.
+  $input: CommentUpdateInput!
+) {
+  commentUpdate(id: $id, input: $input) {
+    ...CommentPayload
+  }
+}
+# Saves user message.
+mutation createContact(
+  # The contact entry to create.
+  $input: ContactCreateInput!
+) {
+  contactCreate(input: $input) {
+    ...ContactPayload
+  }
+}
+# Create CSV export report for the organization.
+mutation createCsvExportReport($includePrivateTeamIds: [String!]) {
+  createCsvExportReport(includePrivateTeamIds: $includePrivateTeamIds) {
+    ...CreateCsvExportReportPayload
+  }
+}
+# Creates an organization from onboarding.
+mutation createOrganizationFromOnboarding(
+  # Organization details for the new organization.
+  $input: CreateOrganizationInput!
+  # Onboarding survey.
+  $survey: OnboardingCustomerSurvey
+) {
+  createOrganizationFromOnboarding(input: $input, survey: $survey) {
+    ...CreateOrJoinOrganizationResponse
+  }
+}
+# Creates a new custom view.
+mutation createCustomView(
+  # The properties of the custom view to create.
+  $input: CustomViewCreateInput!
+) {
+  customViewCreate(input: $input) {
+    ...CustomViewPayload
+  }
+}
+# Deletes a custom view.
+mutation deleteCustomView(
+  # The identifier of the custom view to delete.
+  $id: String!
+) {
+  customViewDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a custom view.
+mutation updateCustomView(
+  # The identifier of the custom view to update.
+  $id: String!
+  # The properties of the custom view to update.
+  $input: CustomViewUpdateInput!
+) {
+  customViewUpdate(id: $id, input: $input) {
+    ...CustomViewPayload
+  }
+}
+# Archives a cycle.
+mutation archiveCycle(
+  # The identifier of the cycle to archive.
+  $id: String!
+) {
+  cycleArchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new cycle.
+mutation createCycle(
+  # The cycle object to create.
+  $input: CycleCreateInput!
+) {
+  cycleCreate(input: $input) {
+    ...CyclePayload
+  }
+}
+# Updates a cycle.
+mutation updateCycle(
+  # The identifier of the cycle to update.
+  $id: String!
+  # A partial cycle object to update the cycle with.
+  $input: CycleUpdateInput!
+) {
+  cycleUpdate(id: $id, input: $input) {
+    ...CyclePayload
+  }
+}
+# Creates a new document.
+mutation createDocument(
+  # The document to create.
+  $input: DocumentCreateInput!
+) {
+  documentCreate(input: $input) {
+    ...DocumentPayload
+  }
+}
+# Deletes a document.
+mutation deleteDocument(
+  # The identifier of the document to delete.
+  $id: String!
+) {
+  documentDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a document.
+mutation updateDocument(
+  # The identifier of the document to update. Also the identifier from the URL is accepted.
+  $id: String!
+  # A partial document object to update the document with.
+  $input: DocumentUpdateInput!
+) {
+  documentUpdate(id: $id, input: $input) {
+    ...DocumentPayload
+  }
+}
+# Authenticates a user account via email and authentication token.
+mutation emailTokenUserAccountAuth(
+  # The data used for token authentication.
+  $input: TokenUserAccountAuthInput!
+) {
+  emailTokenUserAccountAuth(input: $input) {
+    ...AuthResolverResponse
+  }
+}
+# Unsubscribes the user from one type of emails.
+mutation emailUnsubscribe(
+  # Unsubscription details.
+  $input: EmailUnsubscribeInput!
+) {
+  emailUnsubscribe(input: $input) {
+    ...EmailUnsubscribePayload
+  }
+}
+# Finds or creates a new user account by email and sends an email with token.
+mutation emailUserAccountAuthChallenge(
+  # The data used for email authentication.
+  $input: EmailUserAccountAuthChallengeInput!
+) {
+  emailUserAccountAuthChallenge(input: $input) {
+    ...EmailUserAccountAuthChallengeResponse
+  }
+}
+# Creates a custom emoji.
+mutation createEmoji(
+  # The emoji object to create.
+  $input: EmojiCreateInput!
+) {
+  emojiCreate(input: $input) {
+    ...EmojiPayload
+  }
+}
+# Deletes an emoji.
+mutation deleteEmoji(
+  # The identifier of the emoji to delete.
+  $id: String!
+) {
+  emojiDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# [Deprecated] Creates a new event.
+mutation createEvent(
+  # The event to create.
+  $input: EventCreateInput!
+) {
+  eventCreate(input: $input) {
+    ...EventPayload
+  }
+}
+# Creates a new favorite (project, cycle etc).
+mutation createFavorite(
+  # The favorite object to create.
+  $input: FavoriteCreateInput!
+) {
+  favoriteCreate(input: $input) {
+    ...FavoritePayload
+  }
+}
+# Deletes a favorite reference.
+mutation deleteFavorite(
+  # The identifier of the favorite reference to delete.
+  $id: String!
+) {
+  favoriteDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a favorite.
+mutation updateFavorite(
+  # The identifier of the favorite to update.
+  $id: String!
+  # A partial favorite object to update the favorite with.
+  $input: FavoriteUpdateInput!
+) {
+  favoriteUpdate(id: $id, input: $input) {
+    ...FavoritePayload
+  }
+}
+# XHR request payload to upload an images, video and other attachments directly to Linear's cloud
+# storage.
+mutation fileUpload(
+  # MIME type of the uploaded file.
+  $contentType: String!
+  # Filename of the uploaded file.
+  $filename: String!
+  # Should the file be made publicly accessible (default: false).
+  $makePublic: Boolean
+  # Optional metadata.
+  $metaData: JSON
+  # File size of the uploaded file.
+  $size: Int!
+) {
+  fileUpload(
+    contentType: $contentType
+    filename: $filename
+    makePublic: $makePublic
+    metaData: $metaData
+    size: $size
+  ) {
+    ...UploadPayload
+  }
+}
+# Authenticate user account through Google OAuth. This is the 2nd step of OAuth flow.
+mutation googleUserAccountAuth(
+  # The data used for Google authentication.
+  $input: GoogleUserAccountAuthInput!
+) {
+  googleUserAccountAuth(input: $input) {
+    ...AuthResolverResponse
+  }
+}
+# Upload an image from an URL to Linear.
+mutation imageUploadFromUrl(
+  # URL of the file to be uploaded to Linear.
+  $url: String!
+) {
+  imageUploadFromUrl(url: $url) {
+    ...ImageUploadFromUrlPayload
+  }
+}
+# Deletes an integration.
+mutation deleteIntegration(
+  # The identifier of the integration to delete.
+  $id: String!
+) {
+  integrationDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Integrates the organization with Discord.
+mutation integrationDiscord(
+  # The Discord OAuth code.
+  $code: String!
+  # The Discord OAuth redirect URI.
+  $redirectUri: String!
+) {
+  integrationDiscord(code: $code, redirectUri: $redirectUri) {
+    ...IntegrationPayload
+  }
+}
+# Integrates the organization with Figma.
+mutation integrationFigma(
+  # The Figma OAuth code.
+  $code: String!
+  # The Figma OAuth redirect URI.
+  $redirectUri: String!
+) {
+  integrationFigma(code: $code, redirectUri: $redirectUri) {
+    ...IntegrationPayload
+  }
+}
+# Integrates the organization with Front.
+mutation integrationFront(
+  # The Front OAuth code.
+  $code: String!
+  # The Front OAuth redirect URI.
+  $redirectUri: String!
+) {
+  integrationFront(code: $code, redirectUri: $redirectUri) {
+    ...IntegrationPayload
+  }
+}
+# Generates a webhook for the GitHub commit integration.
+mutation createIntegrationGithubCommit {
+  integrationGithubCommitCreate {
+    ...GitHubCommitIntegrationPayload
+  }
+}
+# Connects the organization with the GitHub App.
+mutation integrationGithubConnect(
+  # The GitHub data to connect with.
+  $installationId: String!
+) {
+  integrationGithubConnect(installationId: $installationId) {
+    ...IntegrationPayload
+  }
+}
+# Connects the organization with a GitLab Access Token.
+mutation integrationGitlabConnect(
+  # The GitLab Access Token to connect with.
+  $accessToken: String!
+  # The URL of the GitLab installation
+  $gitlabUrl: String!
+) {
+  integrationGitlabConnect(accessToken: $accessToken, gitlabUrl: $gitlabUrl) {
+    ...IntegrationPayload
+  }
+}
+# Integrates the organization with Google Sheets.
+mutation integrationGoogleSheets(
+  # The Google OAuth code.
+  $code: String!
+) {
+  integrationGoogleSheets(code: $code) {
+    ...IntegrationPayload
+  }
+}
+# Integrates the organization with Intercom.
+mutation integrationIntercom(
+  # The Intercom OAuth code.
+  $code: String!
+  # The Intercom domain URL to use for the integration. Defaults to app.intercom.com if not provided.
+  $domainUrl: String
+  # The Intercom OAuth redirect URI.
+  $redirectUri: String!
+) {
+  integrationIntercom(code: $code, domainUrl: $domainUrl, redirectUri: $redirectUri) {
+    ...IntegrationPayload
+  }
+}
+# Disconnects the organization from Intercom.
+mutation deleteIntegrationIntercom {
+  integrationIntercomDelete {
+    ...IntegrationPayload
+  }
+}
+# [DEPRECATED] Updates settings on the Intercom integration.
+mutation updateIntegrationIntercomSettings(
+  # A partial Intercom integration settings object to update the integration settings with.
+  $input: IntercomSettingsInput!
+) {
+  integrationIntercomSettingsUpdate(input: $input) {
+    ...IntegrationPayload
+  }
+}
+# Enables Loom integration for the organization.
+mutation integrationLoom {
+  integrationLoom {
+    ...IntegrationPayload
+  }
+}
+# Requests a currently unavailable integration.
+mutation integrationRequest(
+  # Integration request details.
+  $input: IntegrationRequestInput!
+) {
+  integrationRequest(input: $input) {
+    ...IntegrationRequestPayload
+  }
+}
+# Archives an integration resource.
+mutation archiveIntegrationResource(
+  # The identifier of the integration resource to archive.
+  $id: String!
+) {
+  integrationResourceArchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Integrates the organization with Sentry.
+mutation integrationSentryConnect(
+  # The Sentry grant code that's exchanged for OAuth tokens.
+  $code: String!
+  # The Sentry installationId to connect with.
+  $installationId: String!
+  # The slug of the Sentry organization being connected.
+  $organizationSlug: String!
+) {
+  integrationSentryConnect(code: $code, installationId: $installationId, organizationSlug: $organizationSlug) {
+    ...IntegrationPayload
+  }
+}
+# Integrates the organization with Slack.
+mutation integrationSlack(
+  # The Slack OAuth code.
+  $code: String!
+  # The Slack OAuth redirect URI.
+  $redirectUri: String!
+  # [DEPRECATED] Whether or not v2 of Slack OAuth should be used. No longer used.
+  $shouldUseV2Auth: Boolean
+) {
+  integrationSlack(code: $code, redirectUri: $redirectUri, shouldUseV2Auth: $shouldUseV2Auth) {
+    ...IntegrationPayload
+  }
+}
+# Imports custom emojis from your Slack workspace.
+mutation integrationSlackImportEmojis(
+  # The Slack OAuth code.
+  $code: String!
+  # The Slack OAuth redirect URI.
+  $redirectUri: String!
+) {
+  integrationSlackImportEmojis(code: $code, redirectUri: $redirectUri) {
+    ...IntegrationPayload
+  }
+}
+# Slack integration for organization level project update notifications.
+mutation integrationSlackOrgProjectUpdatesPost(
+  # The Slack OAuth code.
+  $code: String!
+  # The Slack OAuth redirect URI.
+  $redirectUri: String!
+) {
+  integrationSlackOrgProjectUpdatesPost(code: $code, redirectUri: $redirectUri) {
+    ...IntegrationPayload
+  }
+}
+# Integrates your personal notifications with Slack.
+mutation integrationSlackPersonal(
+  # The Slack OAuth code.
+  $code: String!
+  # The Slack OAuth redirect URI.
+  $redirectUri: String!
+) {
+  integrationSlackPersonal(code: $code, redirectUri: $redirectUri) {
+    ...IntegrationPayload
+  }
+}
+# Slack webhook integration.
+mutation integrationSlackPost(
+  # The Slack OAuth code.
+  $code: String!
+  # The Slack OAuth redirect URI.
+  $redirectUri: String!
+  # [DEPRECATED] Whether or not v2 of Slack OAuth should be used. No longer used.
+  $shouldUseV2Auth: Boolean
+  # Integration's associated team.
+  $teamId: String!
+) {
+  integrationSlackPost(code: $code, redirectUri: $redirectUri, shouldUseV2Auth: $shouldUseV2Auth, teamId: $teamId) {
+    ...IntegrationPayload
+  }
+}
+# Slack integration for project notifications.
+mutation integrationSlackProjectPost(
+  # The Slack OAuth code.
+  $code: String!
+  # Integration's associated project.
+  $projectId: String!
+  # The Slack OAuth redirect URI.
+  $redirectUri: String!
+  # The service to enable once connected, either 'notifications' or 'updates'.
+  $service: String!
+) {
+  integrationSlackProjectPost(code: $code, projectId: $projectId, redirectUri: $redirectUri, service: $service) {
+    ...IntegrationPayload
+  }
+}
+# Creates a new integrationTemplate join.
+mutation createIntegrationTemplate(
+  # The properties of the integrationTemplate to create.
+  $input: IntegrationTemplateCreateInput!
+) {
+  integrationTemplateCreate(input: $input) {
+    ...IntegrationTemplatePayload
+  }
+}
+# Deletes a integrationTemplate.
+mutation deleteIntegrationTemplate(
+  # The identifier of the integrationTemplate to delete.
+  $id: String!
+) {
+  integrationTemplateDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Integrates the organization with Zendesk.
+mutation integrationZendesk(
+  # The Zendesk OAuth code.
+  $code: String!
+  # The Zendesk OAuth redirect URI.
+  $redirectUri: String!
+  # The Zendesk OAuth scopes.
+  $scope: String!
+  # The Zendesk installation subdomain.
+  $subdomain: String!
+) {
+  integrationZendesk(code: $code, redirectUri: $redirectUri, scope: $scope, subdomain: $subdomain) {
+    ...IntegrationPayload
+  }
+}
+# Creates new settings for one or more integrations.
+mutation createIntegrationsSettings(
+  # The settings to create.
+  $input: IntegrationsSettingsCreateInput!
+) {
+  integrationsSettingsCreate(input: $input) {
+    ...IntegrationsSettingsPayload
+  }
+}
+# Updates settings related to integrations for a project or a team.
+mutation updateIntegrationsSettings(
+  # The identifier of the settings to update.
+  $id: String!
+  # A settings object to update the settings with.
+  $input: IntegrationsSettingsUpdateInput!
+) {
+  integrationsSettingsUpdate(id: $id, input: $input) {
+    ...IntegrationsSettingsPayload
+  }
+}
+# Archives an issue.
+mutation archiveIssue(
+  # The identifier of the issue to archive.
+  $id: String!
+  # Whether to trash the issue
+  $trash: Boolean
+) {
+  issueArchive(id: $id, trash: $trash) {
+    ...ArchivePayload
+  }
+}
+# Updates multiple issues at once.
+mutation updateIssueBatch(
+  # The id's of the issues to update. Can't be more than 50 at a time.
+  $ids: [UUID!]!
+  # A partial issue object to update the issues with.
+  $input: IssueUpdateInput!
+) {
+  issueBatchUpdate(ids: $ids, input: $input) {
+    ...IssueBatchPayload
+  }
+}
+# Creates a new issue.
+mutation createIssue(
+  # The issue object to create.
+  $input: IssueCreateInput!
+) {
+  issueCreate(input: $input) {
+    ...IssuePayload
+  }
+}
+# Deletes (trashes) an issue.
+mutation deleteIssue(
+  # The identifier of the issue to delete.
+  $id: String!
+) {
+  issueDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Kicks off an Asana import job.
+mutation issueImportCreateAsana(
+  # Asana team name to choose which issues we should import.
+  $asanaTeamName: String!
+  # Asana token to fetch information from the Asana API.
+  $asanaToken: String!
+  # ID of issue import. If not provided it will be generated.
+  $id: String
+  # Whether or not we should collect the data for closed issues.
+  $includeClosedIssues: Boolean
+  # Whether to instantly process the import with the default configuration mapping.
+  $instantProcess: Boolean
+  # ID of the organization into which to import data.
+  $organizationId: String
+  # ID of the team into which to import data.
+  $teamId: String
+  # Name of new team. When teamId is not set.
+  $teamName: String
+) {
+  issueImportCreateAsana(
+    asanaTeamName: $asanaTeamName
+    asanaToken: $asanaToken
+    id: $id
+    includeClosedIssues: $includeClosedIssues
+    instantProcess: $instantProcess
+    organizationId: $organizationId
+    teamId: $teamId
+    teamName: $teamName
+  ) {
+    ...IssueImportPayload
+  }
+}
+# Kicks off a Shortcut (formerly Clubhouse) import job.
+mutation issueImportCreateClubhouse(
+  # Shortcut (formerly Clubhouse) team name to choose which issues we should import.
+  $clubhouseTeamName: String!
+  # Shortcut (formerly Clubhouse) token to fetch information from the Clubhouse API.
+  $clubhouseToken: String!
+  # ID of issue import. If not provided it will be generated.
+  $id: String
+  # Whether or not we should collect the data for closed issues.
+  $includeClosedIssues: Boolean
+  # Whether to instantly process the import with the default configuration mapping.
+  $instantProcess: Boolean
+  # ID of the organization into which to import data.
+  $organizationId: String
+  # ID of the team into which to import data.
+  $teamId: String
+  # Name of new team. When teamId is not set.
+  $teamName: String
+) {
+  issueImportCreateClubhouse(
+    clubhouseTeamName: $clubhouseTeamName
+    clubhouseToken: $clubhouseToken
+    id: $id
+    includeClosedIssues: $includeClosedIssues
+    instantProcess: $instantProcess
+    organizationId: $organizationId
+    teamId: $teamId
+    teamName: $teamName
+  ) {
+    ...IssueImportPayload
+  }
+}
+# Kicks off a GitHub import job.
+mutation issueImportCreateGithub(
+  # GitHub repository name from which we will import data.
+  $githubRepoName: String!
+  # GitHub owner (user or org) for the repository from which we will import data.
+  $githubRepoOwner: String!
+  # Whether or not we should import GitHub organization level projects.
+  $githubShouldImportOrgProjects: Boolean
+  # GitHub token to fetch information from the GitHub API.
+  $githubToken: String!
+  # ID of issue import. If not provided it will be generated.
+  $id: String
+  # Whether or not we should collect the data for closed issues.
+  $includeClosedIssues: Boolean
+  # Whether to instantly process the import with the default configuration mapping.
+  $instantProcess: Boolean
+  # ID of the organization into which to import data.
+  $organizationId: String
+  # ID of the team into which to import data.
+  $teamId: String
+  # Name of new team. When teamId is not set.
+  $teamName: String
+) {
+  issueImportCreateGithub(
+    githubRepoName: $githubRepoName
+    githubRepoOwner: $githubRepoOwner
+    githubShouldImportOrgProjects: $githubShouldImportOrgProjects
+    githubToken: $githubToken
+    id: $id
+    includeClosedIssues: $includeClosedIssues
+    instantProcess: $instantProcess
+    organizationId: $organizationId
+    teamId: $teamId
+    teamName: $teamName
+  ) {
+    ...IssueImportPayload
+  }
+}
+# Kicks off a Jira import job.
+mutation issueImportCreateJira(
+  # ID of issue import. If not provided it will be generated.
+  $id: String
+  # Whether or not we should collect the data for closed issues.
+  $includeClosedIssues: Boolean
+  # Whether to instantly process the import with the default configuration mapping.
+  $instantProcess: Boolean
+  # Jira user account email.
+  $jiraEmail: String!
+  # Jira installation or cloud hostname.
+  $jiraHostname: String!
+  # Jira project key from which we will import data.
+  $jiraProject: String!
+  # Jira personal access token to access Jira REST API.
+  $jiraToken: String!
+  # ID of the organization into which to import data.
+  $organizationId: String
+  # ID of the team into which to import data. Empty to create new team.
+  $teamId: String
+  # Name of new team. When teamId is not set.
+  $teamName: String
+) {
+  issueImportCreateJira(
+    id: $id
+    includeClosedIssues: $includeClosedIssues
+    instantProcess: $instantProcess
+    jiraEmail: $jiraEmail
+    jiraHostname: $jiraHostname
+    jiraProject: $jiraProject
+    jiraToken: $jiraToken
+    organizationId: $organizationId
+    teamId: $teamId
+    teamName: $teamName
+  ) {
+    ...IssueImportPayload
+  }
+}
+# Deletes an import job.
+mutation deleteIssueImport(
+  # ID of the issue import to delete.
+  $issueImportId: String!
+) {
+  issueImportDelete(issueImportId: $issueImportId) {
+    ...IssueImportDeletePayload
+  }
+}
+# Kicks off import processing.
+mutation issueImportProcess(
+  # ID of the issue import which we're going to process.
+  $issueImportId: String!
+  # The mapping configuration to use for processing the import.
+  $mapping: JSONObject!
+) {
+  issueImportProcess(issueImportId: $issueImportId, mapping: $mapping) {
+    ...IssueImportPayload
+  }
+}
+# Updates the mapping for the issue import.
+mutation updateIssueImport(
+  # The identifier of the issue import.
+  $id: String!
+  # The properties of the issue import to update.
+  $input: IssueImportUpdateInput!
+) {
+  issueImportUpdate(id: $id, input: $input) {
+    ...IssueImportPayload
+  }
+}
+# Deletes an issue label.
+mutation archiveIssueLabel(
+  # The identifier of the label to archive.
+  $id: String!
+) {
+  issueLabelArchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new label.
+mutation createIssueLabel(
+  # The issue label to create.
+  $input: IssueLabelCreateInput!
+  # Whether to replace all team-specific labels with the same name with this newly created workspace label.
+  $replaceTeamLabels: Boolean
+) {
+  issueLabelCreate(input: $input, replaceTeamLabels: $replaceTeamLabels) {
+    ...IssueLabelPayload
+  }
+}
+# Deletes an issue label.
+mutation deleteIssueLabel(
+  # The identifier of the label to delete.
+  $id: String!
+) {
+  issueLabelDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates an label.
+mutation updateIssueLabel(
+  # The identifier of the label to update.
+  $id: String!
+  # A partial label object to update.
+  $input: IssueLabelUpdateInput!
+) {
+  issueLabelUpdate(id: $id, input: $input) {
+    ...IssueLabelPayload
+  }
+}
+# Creates a new issue relation.
+mutation createIssueRelation(
+  # The issue relation to create.
+  $input: IssueRelationCreateInput!
+) {
+  issueRelationCreate(input: $input) {
+    ...IssueRelationPayload
+  }
+}
+# Deletes an issue relation.
+mutation deleteIssueRelation(
+  # The identifier of the issue relation to delete.
+  $id: String!
+) {
+  issueRelationDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates an issue relation.
+mutation updateIssueRelation(
+  # The identifier of the issue relation to update.
+  $id: String!
+  # The properties of the issue relation to update.
+  $input: IssueRelationUpdateInput!
+) {
+  issueRelationUpdate(id: $id, input: $input) {
+    ...IssueRelationPayload
+  }
+}
+# Adds an issue reminder. Will cause a notification to be sent when the issue reminder time is
+# reached.
+mutation issueReminder(
+  # The identifier of the issue to add a reminder for.
+  $id: String!
+  # The time when a reminder notification will be sent.
+  $reminderAt: DateTime!
+) {
+  issueReminder(id: $id, reminderAt: $reminderAt) {
+    ...IssuePayload
+  }
+}
+# Unarchives an issue.
+mutation unarchiveIssue(
+  # The identifier of the issue to archive.
+  $id: String!
+) {
+  issueUnarchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates an issue.
+mutation updateIssue(
+  # The identifier of the issue to update.
+  $id: String!
+  # A partial issue object to update the issue with.
+  $input: IssueUpdateInput!
+) {
+  issueUpdate(id: $id, input: $input) {
+    ...IssuePayload
+  }
+}
+# Join an organization from onboarding.
+mutation joinOrganizationFromOnboarding(
+  # Organization details for the organization to join.
+  $input: JoinOrganizationInput!
+) {
+  joinOrganizationFromOnboarding(input: $input) {
+    ...CreateOrJoinOrganizationResponse
+  }
+}
+# Leave an organization.
+mutation leaveOrganization(
+  # ID of the organization to leave.
+  $organizationId: String!
+) {
+  leaveOrganization(organizationId: $organizationId) {
+    ...CreateOrJoinOrganizationResponse
+  }
+}
+# Logout of all clients.
+mutation logout {
+  logout {
+    ...LogoutResponse
+  }
+}
+# Archives a notification.
+mutation archiveNotification(
+  # The id of the notification to archive.
+  $id: String!
+) {
+  notificationArchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new notification subscription for a team or a project.
+mutation createNotificationSubscription(
+  # The subscription object to create.
+  $input: NotificationSubscriptionCreateInput!
+) {
+  notificationSubscriptionCreate(input: $input) {
+    ...NotificationSubscriptionPayload
+  }
+}
+# Deletes a notification subscription reference.
+mutation deleteNotificationSubscription(
+  # The identifier of the notification subscription reference to delete.
+  $id: String!
+) {
+  notificationSubscriptionDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a notification subscription.
+mutation updateNotificationSubscription(
+  # The identifier of the notification subscription to update.
+  $id: String!
+  # A partial notification subscription object to update the notification subscription with.
+  $input: NotificationSubscriptionUpdateInput!
+) {
+  notificationSubscriptionUpdate(id: $id, input: $input) {
+    ...NotificationSubscriptionPayload
+  }
+}
+# Unarchives a notification.
+mutation unarchiveNotification(
+  # The id of the notification to archive.
+  $id: String!
+) {
+  notificationUnarchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a notification.
+mutation updateNotification(
+  # The identifier of the notification to update.
+  $id: String!
+  # A partial notification object to update the notification with.
+  $input: NotificationUpdateInput!
+) {
+  notificationUpdate(id: $id, input: $input) {
+    ...NotificationPayload
+  }
+}
+# Cancels the deletion of an organization. Administrator privileges required.
+mutation deleteOrganizationCancel {
+  organizationCancelDelete {
+    ...OrganizationCancelDeletePayload
+  }
+}
+# Delete's an organization. Administrator privileges required.
+mutation deleteOrganization(
+  # Information required to delete an organization.
+  $input: DeleteOrganizationInput!
+) {
+  organizationDelete(input: $input) {
+    ...OrganizationDeletePayload
+  }
+}
+# Get an organization's delete confirmation token. Administrator privileges required.
+mutation organizationDeleteChallenge {
+  organizationDeleteChallenge {
+    ...OrganizationDeletePayload
+  }
+}
+# Deletes a domain.
+mutation deleteOrganizationDomain(
+  # The identifier of the domain to delete.
+  $id: String!
+) {
+  organizationDomainDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new organization invite.
+mutation createOrganizationInvite(
+  # The organization invite object to create.
+  $input: OrganizationInviteCreateInput!
+) {
+  organizationInviteCreate(input: $input) {
+    ...OrganizationInvitePayload
+  }
+}
+# Deletes an organization invite.
+mutation deleteOrganizationInvite(
+  # The identifier of the organization invite to delete.
+  $id: String!
+) {
+  organizationInviteDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates an organization invite.
+mutation updateOrganizationInvite(
+  # The identifier of the organization invite to update.
+  $id: String!
+  # The updates to make to the organization invite object.
+  $input: OrganizationInviteUpdateInput!
+) {
+  organizationInviteUpdate(id: $id, input: $input) {
+    ...OrganizationInvitePayload
+  }
+}
+# Updates the user's organization.
+mutation updateOrganization(
+  # A partial organization object to update the organization with.
+  $input: UpdateOrganizationInput!
+) {
+  organizationUpdate(input: $input) {
+    ...OrganizationPayload
+  }
+}
+# Archives a project.
+mutation archiveProject(
+  # The identifier of the project to archive. Also the identifier from the URL is accepted.
+  $id: String!
+) {
+  projectArchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new project.
+mutation createProject(
+  # The issue object to create.
+  $input: ProjectCreateInput!
+) {
+  projectCreate(input: $input) {
+    ...ProjectPayload
+  }
+}
+# Deletes a project. All issues will be disassociated from the deleted project.
+mutation deleteProject(
+  # The identifier of the project to delete. Also the identifier from the URL is accepted.
+  $id: String!
+) {
+  projectDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new project link.
+mutation createProjectLink(
+  # The project link object to create.
+  $input: ProjectLinkCreateInput!
+) {
+  projectLinkCreate(input: $input) {
+    ...ProjectLinkPayload
+  }
+}
+# Deletes a project link.
+mutation deleteProjectLink(
+  # The identifier of the project link to delete.
+  $id: String!
+) {
+  projectLinkDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a project link.
+mutation updateProjectLink(
+  # The identifier of the project link to update.
+  $id: String!
+  # The project link object to update.
+  $input: ProjectLinkUpdateInput!
+) {
+  projectLinkUpdate(id: $id, input: $input) {
+    ...ProjectLinkPayload
+  }
+}
+# Creates a new project milestone.
+mutation createProjectMilestone(
+  # The project milestone to create.
+  $input: ProjectMilestoneCreateInput!
+) {
+  projectMilestoneCreate(input: $input) {
+    ...ProjectMilestonePayload
+  }
+}
+# Deletes a project milestone.
+mutation deleteProjectMilestone(
+  # The identifier of the project milestone to delete.
+  $id: String!
+) {
+  projectMilestoneDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a project milestone.
+mutation updateProjectMilestone(
+  # The identifier of the project milestone to update. Also the identifier from the URL is accepted.
+  $id: String!
+  # A partial object to update the project milestone with.
+  $input: ProjectMilestoneUpdateInput!
+) {
+  projectMilestoneUpdate(id: $id, input: $input) {
+    ...ProjectMilestonePayload
+  }
+}
+# Unarchives a project.
+mutation unarchiveProject(
+  # The identifier of the project to restore. Also the identifier from the URL is accepted.
+  $id: String!
+) {
+  projectUnarchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a project.
+mutation updateProject(
+  # The identifier of the project to update. Also the identifier from the URL is accepted.
+  $id: String!
+  # A partial project object to update the project with.
+  $input: ProjectUpdateInput!
+) {
+  projectUpdate(id: $id, input: $input) {
+    ...ProjectPayload
+  }
+}
+# Creates a new project update.
+mutation createProjectUpdate(
+  # Data for the project update to create.
+  $input: ProjectUpdateCreateInput!
+) {
+  projectUpdateCreate(input: $input) {
+    ...ProjectUpdatePayload
+  }
+}
+# Deletes a project update.
+mutation deleteProjectUpdate(
+  # The identifier of the project update to delete.
+  $id: String!
+) {
+  projectUpdateDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new interaction on a project update.
+mutation createProjectUpdateInteraction(
+  # Data for the project update interaction to create.
+  $input: ProjectUpdateInteractionCreateInput!
+) {
+  projectUpdateInteractionCreate(input: $input) {
+    ...ProjectUpdateInteractionPayload
+  }
+}
+# Mark a project update as read.
+mutation projectUpdateMarkAsRead(
+  # The identifier of the project update.
+  $id: String!
+) {
+  projectUpdateMarkAsRead(id: $id) {
+    ...ProjectUpdateWithInteractionPayload
+  }
+}
+# Updates a project update.
+mutation updateProjectUpdate(
+  # The identifier of the project update to update.
+  $id: String!
+  # A data to update the project update with.
+  $input: ProjectUpdateUpdateInput!
+) {
+  projectUpdateUpdate(id: $id, input: $input) {
+    ...ProjectUpdatePayload
+  }
+}
+# Creates a push subscription.
+mutation createPushSubscription(
+  # The push subscription to create.
+  $input: PushSubscriptionCreateInput!
+) {
+  pushSubscriptionCreate(input: $input) {
+    ...PushSubscriptionPayload
+  }
+}
+# Deletes a push subscription.
+mutation deletePushSubscription(
+  # The identifier of the push subscription to delete.
+  $id: String!
+) {
+  pushSubscriptionDelete(id: $id) {
+    ...PushSubscriptionPayload
+  }
+}
+# Creates a new reaction.
+mutation createReaction(
+  # The reaction object to create.
+  $input: ReactionCreateInput!
+) {
+  reactionCreate(input: $input) {
+    ...ReactionPayload
+  }
+}
+# Deletes a reaction.
+mutation deleteReaction(
+  # The identifier of the reaction to delete.
+  $id: String!
+) {
+  reactionDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Manually update Google Sheets data.
+mutation refreshGoogleSheetsData(
+  # The identifier of the Google Sheets integration to update.
+  $id: String!
+) {
+  refreshGoogleSheetsData(id: $id) {
+    ...IntegrationPayload
+  }
+}
+# Re-send an organization invite.
+mutation resendOrganizationInvite(
+  # The identifier of the organization invite to be re-send.
+  $id: String!
+) {
+  resendOrganizationInvite(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new roadmap.
+mutation createRoadmap(
+  # The properties of the roadmap to create.
+  $input: RoadmapCreateInput!
+) {
+  roadmapCreate(input: $input) {
+    ...RoadmapPayload
+  }
+}
+# Deletes a roadmap.
+mutation deleteRoadmap(
+  # The identifier of the roadmap to delete.
+  $id: String!
+) {
+  roadmapDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new roadmapToProject join.
+mutation createRoadmapToProject(
+  # The properties of the roadmapToProject to create.
+  $input: RoadmapToProjectCreateInput!
+) {
+  roadmapToProjectCreate(input: $input) {
+    ...RoadmapToProjectPayload
+  }
+}
+# Deletes a roadmapToProject.
+mutation deleteRoadmapToProject(
+  # The identifier of the roadmapToProject to delete.
+  $id: String!
+) {
+  roadmapToProjectDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a roadmapToProject.
+mutation updateRoadmapToProject(
+  # The identifier of the roadmapToProject to update.
+  $id: String!
+  # The properties of the roadmapToProject to update.
+  $input: RoadmapToProjectUpdateInput!
+) {
+  roadmapToProjectUpdate(id: $id, input: $input) {
+    ...RoadmapToProjectPayload
+  }
+}
+# Updates a roadmap.
+mutation updateRoadmap(
+  # The identifier of the roadmap to update.
+  $id: String!
+  # The properties of the roadmap to update.
+  $input: RoadmapUpdateInput!
+) {
+  roadmapUpdate(id: $id, input: $input) {
+    ...RoadmapPayload
+  }
+}
+# Authenticates a user account via email and authentication token for SAML.
+mutation samlTokenUserAccountAuth(
+  # The data used for token authentication.
+  $input: TokenUserAccountAuthInput!
+) {
+  samlTokenUserAccountAuth(input: $input) {
+    ...AuthResolverResponse
+  }
+}
+# Creates a new team. The user who creates the team will automatically be added as a member to the
+# newly created team.
+mutation createTeam(
+  # The team id to copy settings from.
+  $copySettingsFromTeamId: String
+  # The team object to create.
+  $input: TeamCreateInput!
+) {
+  teamCreate(copySettingsFromTeamId: $copySettingsFromTeamId, input: $input) {
+    ...TeamPayload
+  }
+}
+# Deletes team's cycles data
+mutation deleteTeamCycles(
+  # The identifier of the team, which cycles will be deleted.
+  $id: String!
+) {
+  teamCyclesDelete(id: $id) {
+    ...TeamPayload
+  }
+}
+# Deletes a team.
+mutation deleteTeam(
+  # The identifier of the team to delete.
+  $id: String!
+) {
+  teamDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Deletes a previously used team key.
+mutation deleteTeamKey(
+  # The identifier of the team key to delete.
+  $id: String!
+) {
+  teamKeyDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new team membership.
+mutation createTeamMembership(
+  # The team membership object to create.
+  $input: TeamMembershipCreateInput!
+) {
+  teamMembershipCreate(input: $input) {
+    ...TeamMembershipPayload
+  }
+}
+# Deletes a team membership.
+mutation deleteTeamMembership(
+  # The identifier of the team membership to delete.
+  $id: String!
+) {
+  teamMembershipDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates a team membership.
+mutation updateTeamMembership(
+  # The identifier of the team membership to update.
+  $id: String!
+  # A partial team membership object to update the team membership with.
+  $input: TeamMembershipUpdateInput!
+) {
+  teamMembershipUpdate(id: $id, input: $input) {
+    ...TeamMembershipPayload
+  }
+}
+# Updates a team.
+mutation updateTeam(
+  # The identifier of the team to update.
+  $id: String!
+  # A partial team object to update the team with.
+  $input: TeamUpdateInput!
+) {
+  teamUpdate(id: $id, input: $input) {
+    ...TeamPayload
+  }
+}
+# Creates a new template.
+mutation createTemplate(
+  # The template object to create.
+  $input: TemplateCreateInput!
+) {
+  templateCreate(input: $input) {
+    ...TemplatePayload
+  }
+}
+# Deletes a template.
+mutation deleteTemplate(
+  # The identifier of the template to delete.
+  $id: String!
+) {
+  templateDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates an existing template.
+mutation updateTemplate(
+  # The identifier of the template.
+  $id: String!
+  # The properties of the template to update.
+  $input: TemplateUpdateInput!
+) {
+  templateUpdate(id: $id, input: $input) {
+    ...TemplatePayload
+  }
+}
+# Makes user a regular user. Can only be called by an admin.
+mutation userDemoteAdmin(
+  # The identifier of the user to make a regular user.
+  $id: String!
+) {
+  userDemoteAdmin(id: $id) {
+    ...UserAdminPayload
+  }
+}
+# Makes user a guest. Can only be called by an admin.
+mutation userDemoteMember(
+  # The identifier of the user to make a guest.
+  $id: String!
+) {
+  userDemoteMember(id: $id) {
+    ...UserAdminPayload
+  }
+}
+# Connects the Discord user to this Linear account via OAuth2.
+mutation userDiscordConnect(
+  # The Discord OAuth code.
+  $code: String!
+  # The Discord OAuth redirect URI.
+  $redirectUri: String!
+) {
+  userDiscordConnect(code: $code, redirectUri: $redirectUri) {
+    ...UserPayload
+  }
+}
+# Disconnects the external user from this Linear account.
+mutation userExternalUserDisconnect(
+  # The external service to disconnect
+  $service: String!
+) {
+  userExternalUserDisconnect(service: $service) {
+    ...UserPayload
+  }
+}
+# Updates a user's settings flag.
+mutation updateUserFlag(
+  # Settings flag to increment.
+  $flag: UserFlagType!
+  # Flag operation to perform
+  $operation: UserFlagUpdateOperation!
+) {
+  userFlagUpdate(flag: $flag, operation: $operation) {
+    ...UserSettingsFlagPayload
+  }
+}
+# Connects the GitHub user to this Linear account via OAuth2.
+mutation userGitHubConnect(
+  # The GitHub OAuth code.
+  $code: String!
+) {
+  userGitHubConnect(code: $code) {
+    ...UserPayload
+  }
+}
+# Connects the Google Calendar to the user to this Linear account via OAuth2.
+mutation userGoogleCalendarConnect(
+  # [Internal] The Google OAuth code.
+  $code: String!
+) {
+  userGoogleCalendarConnect(code: $code) {
+    ...UserPayload
+  }
+}
+# Makes user an admin. Can only be called by an admin.
+mutation userPromoteAdmin(
+  # The identifier of the user to make an admin.
+  $id: String!
+) {
+  userPromoteAdmin(id: $id) {
+    ...UserAdminPayload
+  }
+}
+# Makes user a regular user. Can only be called by an admin.
+mutation userPromoteMember(
+  # The identifier of the user to make a regular user.
+  $id: String!
+) {
+  userPromoteMember(id: $id) {
+    ...UserAdminPayload
+  }
+}
+# [Deprecated] Updates a user's settings flag.
+mutation userSettingsFlagIncrement(
+  # Flag to increment.
+  $flag: String!
+) {
+  userSettingsFlagIncrement(flag: $flag) {
+    ...UserSettingsFlagPayload
+  }
+}
+# Resets user's setting flags.
+mutation userSettingsFlagsReset(
+  # The flags to reset. If not provided all flags will be reset.
+  $flags: [UserFlagType!]
+) {
+  userSettingsFlagsReset(flags: $flags) {
+    ...UserSettingsFlagsResetPayload
+  }
+}
+# Updates the user's settings.
+mutation updateUserSettings(
+  # The identifier of the userSettings to update.
+  $id: String!
+  # A partial notification object to update the settings with.
+  $input: UserSettingsUpdateInput!
+) {
+  userSettingsUpdate(id: $id, input: $input) {
+    ...UserSettingsPayload
+  }
+}
+# Suspends a user. Can only be called by an admin.
+mutation suspendUser(
+  # The identifier of the user to suspend.
+  $id: String!
+) {
+  userSuspend(id: $id) {
+    ...UserAdminPayload
+  }
+}
+# Un-suspends a user. Can only be called by an admin.
+mutation unsuspendUser(
+  # The identifier of the user to unsuspend.
+  $id: String!
+) {
+  userUnsuspend(id: $id) {
+    ...UserAdminPayload
+  }
+}
+# Updates a user. Only available to organization admins and the user themselves.
+mutation updateUser(
+  # The identifier of the user to update. Use `me` to reference currently authenticated user.
+  $id: String!
+  # A partial user object to update the user with.
+  $input: UpdateUserInput!
+) {
+  userUpdate(id: $id, input: $input) {
+    ...UserPayload
+  }
+}
+# Creates a new ViewPreferences object.
+mutation createViewPreferences(
+  # The ViewPreferences object to create.
+  $input: ViewPreferencesCreateInput!
+) {
+  viewPreferencesCreate(input: $input) {
+    ...ViewPreferencesPayload
+  }
+}
+# Deletes a ViewPreferences.
+mutation deleteViewPreferences(
+  # The identifier of the ViewPreferences to delete.
+  $id: String!
+) {
+  viewPreferencesDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates an existing ViewPreferences object.
+mutation updateViewPreferences(
+  # The identifier of the ViewPreferences object.
+  $id: String!
+  # The properties of the view preferences.
+  $input: ViewPreferencesUpdateInput!
+) {
+  viewPreferencesUpdate(id: $id, input: $input) {
+    ...ViewPreferencesPayload
+  }
+}
+# Creates a new webhook.
+mutation createWebhook(
+  # The webhook object to create.
+  $input: WebhookCreateInput!
+) {
+  webhookCreate(input: $input) {
+    ...WebhookPayload
+  }
+}
+# Deletes a Webhook.
+mutation deleteWebhook(
+  # The identifier of the Webhook to delete.
+  $id: String!
+) {
+  webhookDelete(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Updates an existing Webhook.
+mutation updateWebhook(
+  # The identifier of the Webhook.
+  $id: String!
+  # The properties of the Webhook.
+  $input: WebhookUpdateInput!
+) {
+  webhookUpdate(id: $id, input: $input) {
+    ...WebhookPayload
+  }
+}
+# Archives a state. Only states with issues that have all been archived can be archived.
+mutation archiveWorkflowState(
+  # The identifier of the state to archive.
+  $id: String!
+) {
+  workflowStateArchive(id: $id) {
+    ...ArchivePayload
+  }
+}
+# Creates a new state, adding it to the workflow of a team.
+mutation createWorkflowState(
+  # The state to create.
+  $input: WorkflowStateCreateInput!
+) {
+  workflowStateCreate(input: $input) {
+    ...WorkflowStatePayload
+  }
+}
+# Updates a state.
+mutation updateWorkflowState(
+  # The identifier of the state to update.
+  $id: String!
+  # A partial state object to update.
+  $input: WorkflowStateUpdateInput!
+) {
+  workflowStateUpdate(id: $id, input: $input) {
+    ...WorkflowStatePayload
+  }
+}
+# One specific project milestone.
+query ProjectMilestone($id: String!) {
+  ProjectMilestone(id: $id) {
+    ...ProjectMilestone
+  }
+}
+# All milestones for the project.
+query ProjectMilestones(
+  # A cursor to be used with first for forward pagination
+  $after: String
+  # A cursor to be used with last for backward pagination.
+  $before: String
+  # The number of items to forward paginate (used with after). Defaults to 50.
+  $first: Int
+  # Should archived resources be included (default: false)
+  $includeArchived: Boolean
+  # The number of items to backward paginate (used with before). Defaults to 50.
+  $last: Int
+  # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+  $orderBy: PaginationOrderBy
+) {
+  ProjectMilestones(
+    after: $after
+    before: $before
+    first: $first
+    includeArchived: $includeArchived
+    last: $last
+    orderBy: $orderBy
+  ) {
+    ...ProjectMilestoneConnection
+  }
+}
 # All teams you the user can administrate. Administrable teams are teams whose settings the user can
 # change, but to whose issues the user doesn't necessarily have access to.
 query administrableTeams(
@@ -5099,70 +6893,6 @@ query issues(
     ...IssueConnection
   }
 }
-# One specific milestone.
-query milestone($id: String!) {
-  milestone(id: $id) {
-    ...Milestone
-  }
-}
-# Projects associated with the milestone.
-query milestone_projects(
-  $id: String!
-  # A cursor to be used with first for forward pagination
-  $after: String
-  # A cursor to be used with last for backward pagination.
-  $before: String
-  # Filter returned projects.
-  $filter: ProjectFilter
-  # The number of items to forward paginate (used with after). Defaults to 50.
-  $first: Int
-  # Should archived resources be included (default: false)
-  $includeArchived: Boolean
-  # The number of items to backward paginate (used with before). Defaults to 50.
-  $last: Int
-  # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
-  $orderBy: PaginationOrderBy
-) {
-  milestone(id: $id) {
-    projects(
-      after: $after
-      before: $before
-      filter: $filter
-      first: $first
-      includeArchived: $includeArchived
-      last: $last
-      orderBy: $orderBy
-    ) {
-      ...ProjectConnection
-    }
-  }
-}
-# All milestones.
-query milestones(
-  # A cursor to be used with first for forward pagination
-  $after: String
-  # A cursor to be used with last for backward pagination.
-  $before: String
-  # The number of items to forward paginate (used with after). Defaults to 50.
-  $first: Int
-  # Should archived resources be included (default: false)
-  $includeArchived: Boolean
-  # The number of items to backward paginate (used with before). Defaults to 50.
-  $last: Int
-  # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
-  $orderBy: PaginationOrderBy
-) {
-  milestones(
-    after: $after
-    before: $before
-    first: $first
-    includeArchived: $includeArchived
-    last: $last
-    orderBy: $orderBy
-  ) {
-    ...MilestoneConnection
-  }
-}
 # One specific notification.
 query notification($id: String!) {
   notification(id: $id) {
@@ -5466,14 +7196,6 @@ query project_documents(
       orderBy: $orderBy
     ) {
       ...DocumentConnection
-    }
-  }
-}
-# The initiative that this project is associated with.
-query project_initiative($id: String!) {
-  project(id: $id) {
-    initiative {
-      ...Initiative
     }
   }
 }
@@ -6652,1762 +8374,5 @@ query workflowStates(
     orderBy: $orderBy
   ) {
     ...WorkflowStateConnection
-  }
-}
-# Creates an integration api key for Airbyte to connect with Linear
-mutation airbyteIntegrationConnect(
-  # Airbyte integration settings.
-  $input: AirbyteConfigurationInput!
-) {
-  airbyteIntegrationConnect(input: $input) {
-    ...IntegrationPayload
-  }
-}
-# Creates a new API key.
-mutation createApiKey(
-  # The api key object to create.
-  $input: ApiKeyCreateInput!
-) {
-  apiKeyCreate(input: $input) {
-    ...ApiKeyPayload
-  }
-}
-# Deletes an API key.
-mutation deleteApiKey(
-  # The identifier of the API key to delete.
-  $id: String!
-) {
-  apiKeyDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# [DEPRECATED] Archives an issue attachment.
-mutation archiveAttachment(
-  # The identifier of the attachment to archive.
-  $id: String!
-) {
-  attachmentArchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new attachment, or updates existing if the same `url` and `issueId` is used.
-mutation createAttachment(
-  # The attachment object to create.
-  $input: AttachmentCreateInput!
-) {
-  attachmentCreate(input: $input) {
-    ...AttachmentPayload
-  }
-}
-# Deletes an issue attachment.
-mutation deleteAttachment(
-  # The identifier of the attachment to delete.
-  $id: String!
-) {
-  attachmentDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Link an existing Discord message to an issue.
-mutation attachmentLinkDiscord(
-  # The Discord channel ID for the message to link.
-  $channelId: String!
-  # The issue for which to link the Discord message.
-  $issueId: String!
-  # The Discord message ID for the message to link.
-  $messageId: String!
-  # The Discord message URL for the message to link.
-  $url: String!
-) {
-  attachmentLinkDiscord(channelId: $channelId, issueId: $issueId, messageId: $messageId, url: $url) {
-    ...AttachmentPayload
-  }
-}
-# Link an existing Front conversation to an issue.
-mutation attachmentLinkFront(
-  # The Front conversation ID to link.
-  $conversationId: String!
-  # The issue for which to link the Front conversation.
-  $issueId: String!
-) {
-  attachmentLinkFront(conversationId: $conversationId, issueId: $issueId) {
-    ...FrontAttachmentPayload
-  }
-}
-# Link an existing Intercom conversation to an issue.
-mutation attachmentLinkIntercom(
-  # The Intercom conversation ID to link.
-  $conversationId: String!
-  # The issue for which to link the Intercom conversation.
-  $issueId: String!
-) {
-  attachmentLinkIntercom(conversationId: $conversationId, issueId: $issueId) {
-    ...AttachmentPayload
-  }
-}
-# Link an existing Jira issue to an issue.
-mutation attachmentLinkJiraIssue(
-  # The issue for which to link the Jira issue.
-  $issueId: String!
-  # The Jira issue key or ID to link.
-  $jiraIssueId: String!
-) {
-  attachmentLinkJiraIssue(issueId: $issueId, jiraIssueId: $jiraIssueId) {
-    ...AttachmentPayload
-  }
-}
-# Link any url to an issue.
-mutation attachmentLinkURL(
-  # The issue for which to link the url.
-  $issueId: String!
-  # The title to use for the attachment.
-  $title: String
-  # The url to link.
-  $url: String!
-) {
-  attachmentLinkURL(issueId: $issueId, title: $title, url: $url) {
-    ...AttachmentPayload
-  }
-}
-# Link an existing Zendesk ticket to an issue.
-mutation attachmentLinkZendesk(
-  # The issue for which to link the Zendesk ticket.
-  $issueId: String!
-  # The Zendesk ticket ID to link.
-  $ticketId: String!
-) {
-  attachmentLinkZendesk(issueId: $issueId, ticketId: $ticketId) {
-    ...AttachmentPayload
-  }
-}
-# Updates an existing issue attachment.
-mutation updateAttachment(
-  # The identifier of the attachment to update.
-  $id: String!
-  # A partial attachment object to update the attachment with.
-  $input: AttachmentUpdateInput!
-) {
-  attachmentUpdate(id: $id, input: $input) {
-    ...AttachmentPayload
-  }
-}
-# Creates a new comment.
-mutation createComment(
-  # The comment object to create.
-  $input: CommentCreateInput!
-) {
-  commentCreate(input: $input) {
-    ...CommentPayload
-  }
-}
-# Deletes a comment.
-mutation deleteComment(
-  # The identifier of the comment to delete.
-  $id: String!
-) {
-  commentDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a comment.
-mutation updateComment(
-  # The identifier of the comment to update.
-  $id: String!
-  # A partial comment object to update the comment with.
-  $input: CommentUpdateInput!
-) {
-  commentUpdate(id: $id, input: $input) {
-    ...CommentPayload
-  }
-}
-# Saves user message.
-mutation createContact(
-  # The contact entry to create.
-  $input: ContactCreateInput!
-) {
-  contactCreate(input: $input) {
-    ...ContactPayload
-  }
-}
-# Create CSV export report for the organization.
-mutation createCsvExportReport($includePrivateTeamIds: [String!]) {
-  createCsvExportReport(includePrivateTeamIds: $includePrivateTeamIds) {
-    ...CreateCsvExportReportPayload
-  }
-}
-# Creates an organization from onboarding.
-mutation createOrganizationFromOnboarding(
-  # Organization details for the new organization.
-  $input: CreateOrganizationInput!
-  # Onboarding survey.
-  $survey: OnboardingCustomerSurvey
-) {
-  createOrganizationFromOnboarding(input: $input, survey: $survey) {
-    ...CreateOrJoinOrganizationResponse
-  }
-}
-# Creates a new custom view.
-mutation createCustomView(
-  # The properties of the custom view to create.
-  $input: CustomViewCreateInput!
-) {
-  customViewCreate(input: $input) {
-    ...CustomViewPayload
-  }
-}
-# Deletes a custom view.
-mutation deleteCustomView(
-  # The identifier of the custom view to delete.
-  $id: String!
-) {
-  customViewDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a custom view.
-mutation updateCustomView(
-  # The identifier of the custom view to update.
-  $id: String!
-  # The properties of the custom view to update.
-  $input: CustomViewUpdateInput!
-) {
-  customViewUpdate(id: $id, input: $input) {
-    ...CustomViewPayload
-  }
-}
-# Archives a cycle.
-mutation archiveCycle(
-  # The identifier of the cycle to archive.
-  $id: String!
-) {
-  cycleArchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new cycle.
-mutation createCycle(
-  # The cycle object to create.
-  $input: CycleCreateInput!
-) {
-  cycleCreate(input: $input) {
-    ...CyclePayload
-  }
-}
-# Updates a cycle.
-mutation updateCycle(
-  # The identifier of the cycle to update.
-  $id: String!
-  # A partial cycle object to update the cycle with.
-  $input: CycleUpdateInput!
-) {
-  cycleUpdate(id: $id, input: $input) {
-    ...CyclePayload
-  }
-}
-# Creates a new document.
-mutation createDocument(
-  # The document to create.
-  $input: DocumentCreateInput!
-) {
-  documentCreate(input: $input) {
-    ...DocumentPayload
-  }
-}
-# Deletes a document.
-mutation deleteDocument(
-  # The identifier of the document to delete.
-  $id: String!
-) {
-  documentDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a document.
-mutation updateDocument(
-  # The identifier of the document to update. Also the identifier from the URL is accepted.
-  $id: String!
-  # A partial document object to update the document with.
-  $input: DocumentUpdateInput!
-) {
-  documentUpdate(id: $id, input: $input) {
-    ...DocumentPayload
-  }
-}
-# Authenticates a user account via email and authentication token.
-mutation emailTokenUserAccountAuth(
-  # The data used for token authentication.
-  $input: TokenUserAccountAuthInput!
-) {
-  emailTokenUserAccountAuth(input: $input) {
-    ...AuthResolverResponse
-  }
-}
-# Unsubscribes the user from one type of emails.
-mutation emailUnsubscribe(
-  # Unsubscription details.
-  $input: EmailUnsubscribeInput!
-) {
-  emailUnsubscribe(input: $input) {
-    ...EmailUnsubscribePayload
-  }
-}
-# Finds or creates a new user account by email and sends an email with token.
-mutation emailUserAccountAuthChallenge(
-  # The data used for email authentication.
-  $input: EmailUserAccountAuthChallengeInput!
-) {
-  emailUserAccountAuthChallenge(input: $input) {
-    ...EmailUserAccountAuthChallengeResponse
-  }
-}
-# Creates a custom emoji.
-mutation createEmoji(
-  # The emoji object to create.
-  $input: EmojiCreateInput!
-) {
-  emojiCreate(input: $input) {
-    ...EmojiPayload
-  }
-}
-# Deletes an emoji.
-mutation deleteEmoji(
-  # The identifier of the emoji to delete.
-  $id: String!
-) {
-  emojiDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# [Deprecated] Creates a new event.
-mutation createEvent(
-  # The event to create.
-  $input: EventCreateInput!
-) {
-  eventCreate(input: $input) {
-    ...EventPayload
-  }
-}
-# Creates a new favorite (project, cycle etc).
-mutation createFavorite(
-  # The favorite object to create.
-  $input: FavoriteCreateInput!
-) {
-  favoriteCreate(input: $input) {
-    ...FavoritePayload
-  }
-}
-# Deletes a favorite reference.
-mutation deleteFavorite(
-  # The identifier of the favorite reference to delete.
-  $id: String!
-) {
-  favoriteDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a favorite.
-mutation updateFavorite(
-  # The identifier of the favorite to update.
-  $id: String!
-  # A partial favorite object to update the favorite with.
-  $input: FavoriteUpdateInput!
-) {
-  favoriteUpdate(id: $id, input: $input) {
-    ...FavoritePayload
-  }
-}
-# XHR request payload to upload an images, video and other attachments directly to Linear's cloud
-# storage.
-mutation fileUpload(
-  # MIME type of the uploaded file.
-  $contentType: String!
-  # Filename of the uploaded file.
-  $filename: String!
-  # Should the file be made publicly accessible (default: false).
-  $makePublic: Boolean
-  # Optional metadata.
-  $metaData: JSON
-  # File size of the uploaded file.
-  $size: Int!
-) {
-  fileUpload(
-    contentType: $contentType
-    filename: $filename
-    makePublic: $makePublic
-    metaData: $metaData
-    size: $size
-  ) {
-    ...UploadPayload
-  }
-}
-# Authenticate user account through Google OAuth. This is the 2nd step of OAuth flow.
-mutation googleUserAccountAuth(
-  # The data used for Google authentication.
-  $input: GoogleUserAccountAuthInput!
-) {
-  googleUserAccountAuth(input: $input) {
-    ...AuthResolverResponse
-  }
-}
-# Upload an image from an URL to Linear.
-mutation imageUploadFromUrl(
-  # URL of the file to be uploaded to Linear.
-  $url: String!
-) {
-  imageUploadFromUrl(url: $url) {
-    ...ImageUploadFromUrlPayload
-  }
-}
-# Deletes an integration.
-mutation deleteIntegration(
-  # The identifier of the integration to delete.
-  $id: String!
-) {
-  integrationDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Integrates the organization with Discord.
-mutation integrationDiscord(
-  # The Discord OAuth code.
-  $code: String!
-  # The Discord OAuth redirect URI.
-  $redirectUri: String!
-) {
-  integrationDiscord(code: $code, redirectUri: $redirectUri) {
-    ...IntegrationPayload
-  }
-}
-# Integrates the organization with Figma.
-mutation integrationFigma(
-  # The Figma OAuth code.
-  $code: String!
-  # The Figma OAuth redirect URI.
-  $redirectUri: String!
-) {
-  integrationFigma(code: $code, redirectUri: $redirectUri) {
-    ...IntegrationPayload
-  }
-}
-# Integrates the organization with Front.
-mutation integrationFront(
-  # The Front OAuth code.
-  $code: String!
-  # The Front OAuth redirect URI.
-  $redirectUri: String!
-) {
-  integrationFront(code: $code, redirectUri: $redirectUri) {
-    ...IntegrationPayload
-  }
-}
-# Generates a webhook for the GitHub commit integration.
-mutation createIntegrationGithubCommit {
-  integrationGithubCommitCreate {
-    ...GitHubCommitIntegrationPayload
-  }
-}
-# Connects the organization with the GitHub App.
-mutation integrationGithubConnect(
-  # The GitHub data to connect with.
-  $installationId: String!
-) {
-  integrationGithubConnect(installationId: $installationId) {
-    ...IntegrationPayload
-  }
-}
-# Connects the organization with a GitLab Access Token.
-mutation integrationGitlabConnect(
-  # The GitLab Access Token to connect with.
-  $accessToken: String!
-  # The URL of the GitLab installation
-  $gitlabUrl: String!
-) {
-  integrationGitlabConnect(accessToken: $accessToken, gitlabUrl: $gitlabUrl) {
-    ...IntegrationPayload
-  }
-}
-# Integrates the organization with Google Sheets.
-mutation integrationGoogleSheets(
-  # The Google OAuth code.
-  $code: String!
-) {
-  integrationGoogleSheets(code: $code) {
-    ...IntegrationPayload
-  }
-}
-# Integrates the organization with Intercom.
-mutation integrationIntercom(
-  # The Intercom OAuth code.
-  $code: String!
-  # The Intercom domain URL to use for the integration. Defaults to app.intercom.com if not provided.
-  $domainUrl: String
-  # The Intercom OAuth redirect URI.
-  $redirectUri: String!
-) {
-  integrationIntercom(code: $code, domainUrl: $domainUrl, redirectUri: $redirectUri) {
-    ...IntegrationPayload
-  }
-}
-# Disconnects the organization from Intercom.
-mutation deleteIntegrationIntercom {
-  integrationIntercomDelete {
-    ...IntegrationPayload
-  }
-}
-# [DEPRECATED] Updates settings on the Intercom integration.
-mutation updateIntegrationIntercomSettings(
-  # A partial Intercom integration settings object to update the integration settings with.
-  $input: IntercomSettingsInput!
-) {
-  integrationIntercomSettingsUpdate(input: $input) {
-    ...IntegrationPayload
-  }
-}
-# Enables Loom integration for the organization.
-mutation integrationLoom {
-  integrationLoom {
-    ...IntegrationPayload
-  }
-}
-# Requests a currently unavailable integration.
-mutation integrationRequest(
-  # Integration request details.
-  $input: IntegrationRequestInput!
-) {
-  integrationRequest(input: $input) {
-    ...IntegrationRequestPayload
-  }
-}
-# Archives an integration resource.
-mutation archiveIntegrationResource(
-  # The identifier of the integration resource to archive.
-  $id: String!
-) {
-  integrationResourceArchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Integrates the organization with Sentry.
-mutation integrationSentryConnect(
-  # The Sentry grant code that's exchanged for OAuth tokens.
-  $code: String!
-  # The Sentry installationId to connect with.
-  $installationId: String!
-  # The slug of the Sentry organization being connected.
-  $organizationSlug: String!
-) {
-  integrationSentryConnect(code: $code, installationId: $installationId, organizationSlug: $organizationSlug) {
-    ...IntegrationPayload
-  }
-}
-# Integrates the organization with Slack.
-mutation integrationSlack(
-  # The Slack OAuth code.
-  $code: String!
-  # The Slack OAuth redirect URI.
-  $redirectUri: String!
-  # [DEPRECATED] Whether or not v2 of Slack OAuth should be used. No longer used.
-  $shouldUseV2Auth: Boolean
-) {
-  integrationSlack(code: $code, redirectUri: $redirectUri, shouldUseV2Auth: $shouldUseV2Auth) {
-    ...IntegrationPayload
-  }
-}
-# Imports custom emojis from your Slack workspace.
-mutation integrationSlackImportEmojis(
-  # The Slack OAuth code.
-  $code: String!
-  # The Slack OAuth redirect URI.
-  $redirectUri: String!
-) {
-  integrationSlackImportEmojis(code: $code, redirectUri: $redirectUri) {
-    ...IntegrationPayload
-  }
-}
-# Slack integration for organization level project update notifications.
-mutation integrationSlackOrgProjectUpdatesPost(
-  # The Slack OAuth code.
-  $code: String!
-  # The Slack OAuth redirect URI.
-  $redirectUri: String!
-) {
-  integrationSlackOrgProjectUpdatesPost(code: $code, redirectUri: $redirectUri) {
-    ...IntegrationPayload
-  }
-}
-# Integrates your personal notifications with Slack.
-mutation integrationSlackPersonal(
-  # The Slack OAuth code.
-  $code: String!
-  # The Slack OAuth redirect URI.
-  $redirectUri: String!
-) {
-  integrationSlackPersonal(code: $code, redirectUri: $redirectUri) {
-    ...IntegrationPayload
-  }
-}
-# Slack webhook integration.
-mutation integrationSlackPost(
-  # The Slack OAuth code.
-  $code: String!
-  # The Slack OAuth redirect URI.
-  $redirectUri: String!
-  # [DEPRECATED] Whether or not v2 of Slack OAuth should be used. No longer used.
-  $shouldUseV2Auth: Boolean
-  # Integration's associated team.
-  $teamId: String!
-) {
-  integrationSlackPost(code: $code, redirectUri: $redirectUri, shouldUseV2Auth: $shouldUseV2Auth, teamId: $teamId) {
-    ...IntegrationPayload
-  }
-}
-# Slack integration for project notifications.
-mutation integrationSlackProjectPost(
-  # The Slack OAuth code.
-  $code: String!
-  # Integration's associated project.
-  $projectId: String!
-  # The Slack OAuth redirect URI.
-  $redirectUri: String!
-  # The service to enable once connected, either 'notifications' or 'updates'.
-  $service: String!
-) {
-  integrationSlackProjectPost(code: $code, projectId: $projectId, redirectUri: $redirectUri, service: $service) {
-    ...IntegrationPayload
-  }
-}
-# Creates a new integrationTemplate join.
-mutation createIntegrationTemplate(
-  # The properties of the integrationTemplate to create.
-  $input: IntegrationTemplateCreateInput!
-) {
-  integrationTemplateCreate(input: $input) {
-    ...IntegrationTemplatePayload
-  }
-}
-# Deletes a integrationTemplate.
-mutation deleteIntegrationTemplate(
-  # The identifier of the integrationTemplate to delete.
-  $id: String!
-) {
-  integrationTemplateDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Integrates the organization with Zendesk.
-mutation integrationZendesk(
-  # The Zendesk OAuth code.
-  $code: String!
-  # The Zendesk OAuth redirect URI.
-  $redirectUri: String!
-  # The Zendesk OAuth scopes.
-  $scope: String!
-  # The Zendesk installation subdomain.
-  $subdomain: String!
-) {
-  integrationZendesk(code: $code, redirectUri: $redirectUri, scope: $scope, subdomain: $subdomain) {
-    ...IntegrationPayload
-  }
-}
-# Creates new settings for one or more integrations.
-mutation createIntegrationsSettings(
-  # The settings to create.
-  $input: IntegrationsSettingsCreateInput!
-) {
-  integrationsSettingsCreate(input: $input) {
-    ...IntegrationsSettingsPayload
-  }
-}
-# Updates settings related to integrations for a project or a team.
-mutation updateIntegrationsSettings(
-  # The identifier of the settings to update.
-  $id: String!
-  # A settings object to update the settings with.
-  $input: IntegrationsSettingsUpdateInput!
-) {
-  integrationsSettingsUpdate(id: $id, input: $input) {
-    ...IntegrationsSettingsPayload
-  }
-}
-# Archives an issue.
-mutation archiveIssue(
-  # The identifier of the issue to archive.
-  $id: String!
-  # Whether to trash the issue
-  $trash: Boolean
-) {
-  issueArchive(id: $id, trash: $trash) {
-    ...ArchivePayload
-  }
-}
-# Updates multiple issues at once.
-mutation updateIssueBatch(
-  # The id's of the issues to update. Can't be more than 50 at a time.
-  $ids: [UUID!]!
-  # A partial issue object to update the issues with.
-  $input: IssueUpdateInput!
-) {
-  issueBatchUpdate(ids: $ids, input: $input) {
-    ...IssueBatchPayload
-  }
-}
-# Creates a new issue.
-mutation createIssue(
-  # The issue object to create.
-  $input: IssueCreateInput!
-) {
-  issueCreate(input: $input) {
-    ...IssuePayload
-  }
-}
-# Deletes (trashes) an issue.
-mutation deleteIssue(
-  # The identifier of the issue to delete.
-  $id: String!
-) {
-  issueDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Kicks off an Asana import job.
-mutation issueImportCreateAsana(
-  # Asana team name to choose which issues we should import.
-  $asanaTeamName: String!
-  # Asana token to fetch information from the Asana API.
-  $asanaToken: String!
-  # ID of issue import. If not provided it will be generated.
-  $id: String
-  # Whether or not we should collect the data for closed issues.
-  $includeClosedIssues: Boolean
-  # Whether to instantly process the import with the default configuration mapping.
-  $instantProcess: Boolean
-  # ID of the organization into which to import data.
-  $organizationId: String
-  # ID of the team into which to import data.
-  $teamId: String
-  # Name of new team. When teamId is not set.
-  $teamName: String
-) {
-  issueImportCreateAsana(
-    asanaTeamName: $asanaTeamName
-    asanaToken: $asanaToken
-    id: $id
-    includeClosedIssues: $includeClosedIssues
-    instantProcess: $instantProcess
-    organizationId: $organizationId
-    teamId: $teamId
-    teamName: $teamName
-  ) {
-    ...IssueImportPayload
-  }
-}
-# Kicks off a Shortcut (formerly Clubhouse) import job.
-mutation issueImportCreateClubhouse(
-  # Shortcut (formerly Clubhouse) team name to choose which issues we should import.
-  $clubhouseTeamName: String!
-  # Shortcut (formerly Clubhouse) token to fetch information from the Clubhouse API.
-  $clubhouseToken: String!
-  # ID of issue import. If not provided it will be generated.
-  $id: String
-  # Whether or not we should collect the data for closed issues.
-  $includeClosedIssues: Boolean
-  # Whether to instantly process the import with the default configuration mapping.
-  $instantProcess: Boolean
-  # ID of the organization into which to import data.
-  $organizationId: String
-  # ID of the team into which to import data.
-  $teamId: String
-  # Name of new team. When teamId is not set.
-  $teamName: String
-) {
-  issueImportCreateClubhouse(
-    clubhouseTeamName: $clubhouseTeamName
-    clubhouseToken: $clubhouseToken
-    id: $id
-    includeClosedIssues: $includeClosedIssues
-    instantProcess: $instantProcess
-    organizationId: $organizationId
-    teamId: $teamId
-    teamName: $teamName
-  ) {
-    ...IssueImportPayload
-  }
-}
-# Kicks off a GitHub import job.
-mutation issueImportCreateGithub(
-  # GitHub repository name from which we will import data.
-  $githubRepoName: String!
-  # GitHub owner (user or org) for the repository from which we will import data.
-  $githubRepoOwner: String!
-  # Whether or not we should import GitHub organization level projects.
-  $githubShouldImportOrgProjects: Boolean
-  # GitHub token to fetch information from the GitHub API.
-  $githubToken: String!
-  # ID of issue import. If not provided it will be generated.
-  $id: String
-  # Whether or not we should collect the data for closed issues.
-  $includeClosedIssues: Boolean
-  # Whether to instantly process the import with the default configuration mapping.
-  $instantProcess: Boolean
-  # ID of the organization into which to import data.
-  $organizationId: String
-  # ID of the team into which to import data.
-  $teamId: String
-  # Name of new team. When teamId is not set.
-  $teamName: String
-) {
-  issueImportCreateGithub(
-    githubRepoName: $githubRepoName
-    githubRepoOwner: $githubRepoOwner
-    githubShouldImportOrgProjects: $githubShouldImportOrgProjects
-    githubToken: $githubToken
-    id: $id
-    includeClosedIssues: $includeClosedIssues
-    instantProcess: $instantProcess
-    organizationId: $organizationId
-    teamId: $teamId
-    teamName: $teamName
-  ) {
-    ...IssueImportPayload
-  }
-}
-# Kicks off a Jira import job.
-mutation issueImportCreateJira(
-  # ID of issue import. If not provided it will be generated.
-  $id: String
-  # Whether or not we should collect the data for closed issues.
-  $includeClosedIssues: Boolean
-  # Whether to instantly process the import with the default configuration mapping.
-  $instantProcess: Boolean
-  # Jira user account email.
-  $jiraEmail: String!
-  # Jira installation or cloud hostname.
-  $jiraHostname: String!
-  # Jira project key from which we will import data.
-  $jiraProject: String!
-  # Jira personal access token to access Jira REST API.
-  $jiraToken: String!
-  # ID of the organization into which to import data.
-  $organizationId: String
-  # ID of the team into which to import data. Empty to create new team.
-  $teamId: String
-  # Name of new team. When teamId is not set.
-  $teamName: String
-) {
-  issueImportCreateJira(
-    id: $id
-    includeClosedIssues: $includeClosedIssues
-    instantProcess: $instantProcess
-    jiraEmail: $jiraEmail
-    jiraHostname: $jiraHostname
-    jiraProject: $jiraProject
-    jiraToken: $jiraToken
-    organizationId: $organizationId
-    teamId: $teamId
-    teamName: $teamName
-  ) {
-    ...IssueImportPayload
-  }
-}
-# Deletes an import job.
-mutation deleteIssueImport(
-  # ID of the issue import to delete.
-  $issueImportId: String!
-) {
-  issueImportDelete(issueImportId: $issueImportId) {
-    ...IssueImportDeletePayload
-  }
-}
-# Kicks off import processing.
-mutation issueImportProcess(
-  # ID of the issue import which we're going to process.
-  $issueImportId: String!
-  # The mapping configuration to use for processing the import.
-  $mapping: JSONObject!
-) {
-  issueImportProcess(issueImportId: $issueImportId, mapping: $mapping) {
-    ...IssueImportPayload
-  }
-}
-# Updates the mapping for the issue import.
-mutation updateIssueImport(
-  # The identifier of the issue import.
-  $id: String!
-  # The properties of the issue import to update.
-  $input: IssueImportUpdateInput!
-) {
-  issueImportUpdate(id: $id, input: $input) {
-    ...IssueImportPayload
-  }
-}
-# Deletes an issue label.
-mutation archiveIssueLabel(
-  # The identifier of the label to archive.
-  $id: String!
-) {
-  issueLabelArchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new label.
-mutation createIssueLabel(
-  # The issue label to create.
-  $input: IssueLabelCreateInput!
-  # Whether to replace all team-specific labels with the same name with this newly created workspace label.
-  $replaceTeamLabels: Boolean
-) {
-  issueLabelCreate(input: $input, replaceTeamLabels: $replaceTeamLabels) {
-    ...IssueLabelPayload
-  }
-}
-# Deletes an issue label.
-mutation deleteIssueLabel(
-  # The identifier of the label to delete.
-  $id: String!
-) {
-  issueLabelDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates an label.
-mutation updateIssueLabel(
-  # The identifier of the label to update.
-  $id: String!
-  # A partial label object to update.
-  $input: IssueLabelUpdateInput!
-) {
-  issueLabelUpdate(id: $id, input: $input) {
-    ...IssueLabelPayload
-  }
-}
-# Creates a new issue relation.
-mutation createIssueRelation(
-  # The issue relation to create.
-  $input: IssueRelationCreateInput!
-) {
-  issueRelationCreate(input: $input) {
-    ...IssueRelationPayload
-  }
-}
-# Deletes an issue relation.
-mutation deleteIssueRelation(
-  # The identifier of the issue relation to delete.
-  $id: String!
-) {
-  issueRelationDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates an issue relation.
-mutation updateIssueRelation(
-  # The identifier of the issue relation to update.
-  $id: String!
-  # The properties of the issue relation to update.
-  $input: IssueRelationUpdateInput!
-) {
-  issueRelationUpdate(id: $id, input: $input) {
-    ...IssueRelationPayload
-  }
-}
-# Adds an issue reminder. Will cause a notification to be sent when the issue reminder time is
-# reached.
-mutation issueReminder(
-  # The identifier of the issue to add a reminder for.
-  $id: String!
-  # The time when a reminder notification will be sent.
-  $reminderAt: DateTime!
-) {
-  issueReminder(id: $id, reminderAt: $reminderAt) {
-    ...IssuePayload
-  }
-}
-# Unarchives an issue.
-mutation unarchiveIssue(
-  # The identifier of the issue to archive.
-  $id: String!
-) {
-  issueUnarchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates an issue.
-mutation updateIssue(
-  # The identifier of the issue to update.
-  $id: String!
-  # A partial issue object to update the issue with.
-  $input: IssueUpdateInput!
-) {
-  issueUpdate(id: $id, input: $input) {
-    ...IssuePayload
-  }
-}
-# Join an organization from onboarding.
-mutation joinOrganizationFromOnboarding(
-  # Organization details for the organization to join.
-  $input: JoinOrganizationInput!
-) {
-  joinOrganizationFromOnboarding(input: $input) {
-    ...CreateOrJoinOrganizationResponse
-  }
-}
-# Leave an organization.
-mutation leaveOrganization(
-  # ID of the organization to leave.
-  $organizationId: String!
-) {
-  leaveOrganization(organizationId: $organizationId) {
-    ...CreateOrJoinOrganizationResponse
-  }
-}
-# Logout of all clients.
-mutation logout {
-  logout {
-    ...LogoutResponse
-  }
-}
-# Migrates milestones to roadmaps
-mutation migrateMilestonesToRoadmaps(
-  # Ids for milestones to migrate and milestones to delete
-  $input: MilestonesMigrateInput!
-) {
-  migrateMilestonesToRoadmaps(input: $input) {
-    ...MilestoneMigrationPayload
-  }
-}
-# Creates a new milestone.
-mutation createMilestone(
-  # The issue object to create.
-  $input: MilestoneCreateInput!
-) {
-  milestoneCreate(input: $input) {
-    ...MilestonePayload
-  }
-}
-# Deletes a milestone.
-mutation deleteMilestone(
-  # The identifier of the milestone to delete.
-  $id: String!
-) {
-  milestoneDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a milestone.
-mutation updateMilestone(
-  # The identifier of the milestone to update.
-  $id: String!
-  # A partial milestone object to update the milestone with.
-  $input: MilestoneUpdateInput!
-) {
-  milestoneUpdate(id: $id, input: $input) {
-    ...MilestonePayload
-  }
-}
-# Archives a notification.
-mutation archiveNotification(
-  # The id of the notification to archive.
-  $id: String!
-) {
-  notificationArchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new notification subscription for a team or a project.
-mutation createNotificationSubscription(
-  # The subscription object to create.
-  $input: NotificationSubscriptionCreateInput!
-) {
-  notificationSubscriptionCreate(input: $input) {
-    ...NotificationSubscriptionPayload
-  }
-}
-# Deletes a notification subscription reference.
-mutation deleteNotificationSubscription(
-  # The identifier of the notification subscription reference to delete.
-  $id: String!
-) {
-  notificationSubscriptionDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a notification subscription.
-mutation updateNotificationSubscription(
-  # The identifier of the notification subscription to update.
-  $id: String!
-  # A partial notification subscription object to update the notification subscription with.
-  $input: NotificationSubscriptionUpdateInput!
-) {
-  notificationSubscriptionUpdate(id: $id, input: $input) {
-    ...NotificationSubscriptionPayload
-  }
-}
-# Unarchives a notification.
-mutation unarchiveNotification(
-  # The id of the notification to archive.
-  $id: String!
-) {
-  notificationUnarchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a notification.
-mutation updateNotification(
-  # The identifier of the notification to update.
-  $id: String!
-  # A partial notification object to update the notification with.
-  $input: NotificationUpdateInput!
-) {
-  notificationUpdate(id: $id, input: $input) {
-    ...NotificationPayload
-  }
-}
-# Cancels the deletion of an organization. Administrator privileges required.
-mutation deleteOrganizationCancel {
-  organizationCancelDelete {
-    ...OrganizationCancelDeletePayload
-  }
-}
-# Delete's an organization. Administrator privileges required.
-mutation deleteOrganization(
-  # Information required to delete an organization.
-  $input: DeleteOrganizationInput!
-) {
-  organizationDelete(input: $input) {
-    ...OrganizationDeletePayload
-  }
-}
-# Get an organization's delete confirmation token. Administrator privileges required.
-mutation organizationDeleteChallenge {
-  organizationDeleteChallenge {
-    ...OrganizationDeletePayload
-  }
-}
-# Deletes a domain.
-mutation deleteOrganizationDomain(
-  # The identifier of the domain to delete.
-  $id: String!
-) {
-  organizationDomainDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new organization invite.
-mutation createOrganizationInvite(
-  # The organization invite object to create.
-  $input: OrganizationInviteCreateInput!
-) {
-  organizationInviteCreate(input: $input) {
-    ...OrganizationInvitePayload
-  }
-}
-# Deletes an organization invite.
-mutation deleteOrganizationInvite(
-  # The identifier of the organization invite to delete.
-  $id: String!
-) {
-  organizationInviteDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates an organization invite.
-mutation updateOrganizationInvite(
-  # The identifier of the organization invite to update.
-  $id: String!
-  # The updates to make to the organization invite object.
-  $input: OrganizationInviteUpdateInput!
-) {
-  organizationInviteUpdate(id: $id, input: $input) {
-    ...OrganizationInvitePayload
-  }
-}
-# Updates the user's organization.
-mutation updateOrganization(
-  # A partial organization object to update the organization with.
-  $input: UpdateOrganizationInput!
-) {
-  organizationUpdate(input: $input) {
-    ...OrganizationPayload
-  }
-}
-# Archives a project.
-mutation archiveProject(
-  # The identifier of the project to archive. Also the identifier from the URL is accepted.
-  $id: String!
-) {
-  projectArchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new project.
-mutation createProject(
-  # The issue object to create.
-  $input: ProjectCreateInput!
-) {
-  projectCreate(input: $input) {
-    ...ProjectPayload
-  }
-}
-# Deletes a project. All issues will be disassociated from the deleted project.
-mutation deleteProject(
-  # The identifier of the project to delete. Also the identifier from the URL is accepted.
-  $id: String!
-) {
-  projectDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new project link.
-mutation createProjectLink(
-  # The project link object to create.
-  $input: ProjectLinkCreateInput!
-) {
-  projectLinkCreate(input: $input) {
-    ...ProjectLinkPayload
-  }
-}
-# Deletes a project link.
-mutation deleteProjectLink(
-  # The identifier of the project link to delete.
-  $id: String!
-) {
-  projectLinkDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a project link.
-mutation updateProjectLink(
-  # The identifier of the project link to update.
-  $id: String!
-  # The project link object to update.
-  $input: ProjectLinkUpdateInput!
-) {
-  projectLinkUpdate(id: $id, input: $input) {
-    ...ProjectLinkPayload
-  }
-}
-# Unarchives a project.
-mutation unarchiveProject(
-  # The identifier of the project to restore. Also the identifier from the URL is accepted.
-  $id: String!
-) {
-  projectUnarchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a project.
-mutation updateProject(
-  # The identifier of the project to update. Also the identifier from the URL is accepted.
-  $id: String!
-  # A partial project object to update the project with.
-  $input: ProjectUpdateInput!
-) {
-  projectUpdate(id: $id, input: $input) {
-    ...ProjectPayload
-  }
-}
-# Creates a new project update.
-mutation createProjectUpdate(
-  # Data for the project update to create.
-  $input: ProjectUpdateCreateInput!
-) {
-  projectUpdateCreate(input: $input) {
-    ...ProjectUpdatePayload
-  }
-}
-# Deletes a project update.
-mutation deleteProjectUpdate(
-  # The identifier of the project update to delete.
-  $id: String!
-) {
-  projectUpdateDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new interaction on a project update.
-mutation createProjectUpdateInteraction(
-  # Data for the project update interaction to create.
-  $input: ProjectUpdateInteractionCreateInput!
-) {
-  projectUpdateInteractionCreate(input: $input) {
-    ...ProjectUpdateInteractionPayload
-  }
-}
-# Mark a project update as read.
-mutation projectUpdateMarkAsRead(
-  # The identifier of the project update.
-  $id: String!
-) {
-  projectUpdateMarkAsRead(id: $id) {
-    ...ProjectUpdateWithInteractionPayload
-  }
-}
-# Updates a project update.
-mutation updateProjectUpdate(
-  # The identifier of the project update to update.
-  $id: String!
-  # A data to update the project update with.
-  $input: ProjectUpdateUpdateInput!
-) {
-  projectUpdateUpdate(id: $id, input: $input) {
-    ...ProjectUpdatePayload
-  }
-}
-# Creates a push subscription.
-mutation createPushSubscription(
-  # The push subscription to create.
-  $input: PushSubscriptionCreateInput!
-) {
-  pushSubscriptionCreate(input: $input) {
-    ...PushSubscriptionPayload
-  }
-}
-# Deletes a push subscription.
-mutation deletePushSubscription(
-  # The identifier of the push subscription to delete.
-  $id: String!
-) {
-  pushSubscriptionDelete(id: $id) {
-    ...PushSubscriptionPayload
-  }
-}
-# Creates a new reaction.
-mutation createReaction(
-  # The reaction object to create.
-  $input: ReactionCreateInput!
-) {
-  reactionCreate(input: $input) {
-    ...ReactionPayload
-  }
-}
-# Deletes a reaction.
-mutation deleteReaction(
-  # The identifier of the reaction to delete.
-  $id: String!
-) {
-  reactionDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Manually update Google Sheets data.
-mutation refreshGoogleSheetsData(
-  # The identifier of the Google Sheets integration to update.
-  $id: String!
-) {
-  refreshGoogleSheetsData(id: $id) {
-    ...IntegrationPayload
-  }
-}
-# Re-send an organization invite.
-mutation resendOrganizationInvite(
-  # The identifier of the organization invite to be re-send.
-  $id: String!
-) {
-  resendOrganizationInvite(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new roadmap.
-mutation createRoadmap(
-  # The properties of the roadmap to create.
-  $input: RoadmapCreateInput!
-) {
-  roadmapCreate(input: $input) {
-    ...RoadmapPayload
-  }
-}
-# Deletes a roadmap.
-mutation deleteRoadmap(
-  # The identifier of the roadmap to delete.
-  $id: String!
-) {
-  roadmapDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new roadmapToProject join.
-mutation createRoadmapToProject(
-  # The properties of the roadmapToProject to create.
-  $input: RoadmapToProjectCreateInput!
-) {
-  roadmapToProjectCreate(input: $input) {
-    ...RoadmapToProjectPayload
-  }
-}
-# Deletes a roadmapToProject.
-mutation deleteRoadmapToProject(
-  # The identifier of the roadmapToProject to delete.
-  $id: String!
-) {
-  roadmapToProjectDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a roadmapToProject.
-mutation updateRoadmapToProject(
-  # The identifier of the roadmapToProject to update.
-  $id: String!
-  # The properties of the roadmapToProject to update.
-  $input: RoadmapToProjectUpdateInput!
-) {
-  roadmapToProjectUpdate(id: $id, input: $input) {
-    ...RoadmapToProjectPayload
-  }
-}
-# Updates a roadmap.
-mutation updateRoadmap(
-  # The identifier of the roadmap to update.
-  $id: String!
-  # The properties of the roadmap to update.
-  $input: RoadmapUpdateInput!
-) {
-  roadmapUpdate(id: $id, input: $input) {
-    ...RoadmapPayload
-  }
-}
-# Authenticates a user account via email and authentication token for SAML.
-mutation samlTokenUserAccountAuth(
-  # The data used for token authentication.
-  $input: TokenUserAccountAuthInput!
-) {
-  samlTokenUserAccountAuth(input: $input) {
-    ...AuthResolverResponse
-  }
-}
-# Creates a new team. The user who creates the team will automatically be added as a member to the
-# newly created team.
-mutation createTeam(
-  # The team id to copy settings from.
-  $copySettingsFromTeamId: String
-  # The team object to create.
-  $input: TeamCreateInput!
-) {
-  teamCreate(copySettingsFromTeamId: $copySettingsFromTeamId, input: $input) {
-    ...TeamPayload
-  }
-}
-# Deletes team's cycles data
-mutation deleteTeamCycles(
-  # The identifier of the team, which cycles will be deleted.
-  $id: String!
-) {
-  teamCyclesDelete(id: $id) {
-    ...TeamPayload
-  }
-}
-# Deletes a team.
-mutation deleteTeam(
-  # The identifier of the team to delete.
-  $id: String!
-) {
-  teamDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Deletes a previously used team key.
-mutation deleteTeamKey(
-  # The identifier of the team key to delete.
-  $id: String!
-) {
-  teamKeyDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new team membership.
-mutation createTeamMembership(
-  # The team membership object to create.
-  $input: TeamMembershipCreateInput!
-) {
-  teamMembershipCreate(input: $input) {
-    ...TeamMembershipPayload
-  }
-}
-# Deletes a team membership.
-mutation deleteTeamMembership(
-  # The identifier of the team membership to delete.
-  $id: String!
-) {
-  teamMembershipDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates a team membership.
-mutation updateTeamMembership(
-  # The identifier of the team membership to update.
-  $id: String!
-  # A partial team membership object to update the team membership with.
-  $input: TeamMembershipUpdateInput!
-) {
-  teamMembershipUpdate(id: $id, input: $input) {
-    ...TeamMembershipPayload
-  }
-}
-# Updates a team.
-mutation updateTeam(
-  # The identifier of the team to update.
-  $id: String!
-  # A partial team object to update the team with.
-  $input: TeamUpdateInput!
-) {
-  teamUpdate(id: $id, input: $input) {
-    ...TeamPayload
-  }
-}
-# Creates a new template.
-mutation createTemplate(
-  # The template object to create.
-  $input: TemplateCreateInput!
-) {
-  templateCreate(input: $input) {
-    ...TemplatePayload
-  }
-}
-# Deletes a template.
-mutation deleteTemplate(
-  # The identifier of the template to delete.
-  $id: String!
-) {
-  templateDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates an existing template.
-mutation updateTemplate(
-  # The identifier of the template.
-  $id: String!
-  # The properties of the template to update.
-  $input: TemplateUpdateInput!
-) {
-  templateUpdate(id: $id, input: $input) {
-    ...TemplatePayload
-  }
-}
-# Makes user a regular user. Can only be called by an admin.
-mutation userDemoteAdmin(
-  # The identifier of the user to make a regular user.
-  $id: String!
-) {
-  userDemoteAdmin(id: $id) {
-    ...UserAdminPayload
-  }
-}
-# Makes user a guest. Can only be called by an admin.
-mutation userDemoteMember(
-  # The identifier of the user to make a guest.
-  $id: String!
-) {
-  userDemoteMember(id: $id) {
-    ...UserAdminPayload
-  }
-}
-# Connects the Discord user to this Linear account via OAuth2.
-mutation userDiscordConnect(
-  # The Discord OAuth code.
-  $code: String!
-  # The Discord OAuth redirect URI.
-  $redirectUri: String!
-) {
-  userDiscordConnect(code: $code, redirectUri: $redirectUri) {
-    ...UserPayload
-  }
-}
-# Disconnects the external user from this Linear account.
-mutation userExternalUserDisconnect(
-  # The external service to disconnect
-  $service: String!
-) {
-  userExternalUserDisconnect(service: $service) {
-    ...UserPayload
-  }
-}
-# Updates a user's settings flag.
-mutation updateUserFlag(
-  # Settings flag to increment.
-  $flag: UserFlagType!
-  # Flag operation to perform
-  $operation: UserFlagUpdateOperation!
-) {
-  userFlagUpdate(flag: $flag, operation: $operation) {
-    ...UserSettingsFlagPayload
-  }
-}
-# Connects the GitHub user to this Linear account via OAuth2.
-mutation userGitHubConnect(
-  # The GitHub OAuth code.
-  $code: String!
-) {
-  userGitHubConnect(code: $code) {
-    ...UserPayload
-  }
-}
-# Connects the Google Calendar to the user to this Linear account via OAuth2.
-mutation userGoogleCalendarConnect(
-  # [Internal] The Google OAuth code.
-  $code: String!
-) {
-  userGoogleCalendarConnect(code: $code) {
-    ...UserPayload
-  }
-}
-# Makes user an admin. Can only be called by an admin.
-mutation userPromoteAdmin(
-  # The identifier of the user to make an admin.
-  $id: String!
-) {
-  userPromoteAdmin(id: $id) {
-    ...UserAdminPayload
-  }
-}
-# Makes user a regular user. Can only be called by an admin.
-mutation userPromoteMember(
-  # The identifier of the user to make a regular user.
-  $id: String!
-) {
-  userPromoteMember(id: $id) {
-    ...UserAdminPayload
-  }
-}
-# [Deprecated] Updates a user's settings flag.
-mutation userSettingsFlagIncrement(
-  # Flag to increment.
-  $flag: String!
-) {
-  userSettingsFlagIncrement(flag: $flag) {
-    ...UserSettingsFlagPayload
-  }
-}
-# Resets user's setting flags.
-mutation userSettingsFlagsReset(
-  # The flags to reset. If not provided all flags will be reset.
-  $flags: [UserFlagType!]
-) {
-  userSettingsFlagsReset(flags: $flags) {
-    ...UserSettingsFlagsResetPayload
-  }
-}
-# Updates the user's settings.
-mutation updateUserSettings(
-  # The identifier of the userSettings to update.
-  $id: String!
-  # A partial notification object to update the settings with.
-  $input: UserSettingsUpdateInput!
-) {
-  userSettingsUpdate(id: $id, input: $input) {
-    ...UserSettingsPayload
-  }
-}
-# Suspends a user. Can only be called by an admin.
-mutation suspendUser(
-  # The identifier of the user to suspend.
-  $id: String!
-) {
-  userSuspend(id: $id) {
-    ...UserAdminPayload
-  }
-}
-# Un-suspends a user. Can only be called by an admin.
-mutation unsuspendUser(
-  # The identifier of the user to unsuspend.
-  $id: String!
-) {
-  userUnsuspend(id: $id) {
-    ...UserAdminPayload
-  }
-}
-# Updates a user. Only available to organization admins and the user themselves.
-mutation updateUser(
-  # The identifier of the user to update. Use `me` to reference currently authenticated user.
-  $id: String!
-  # A partial user object to update the user with.
-  $input: UpdateUserInput!
-) {
-  userUpdate(id: $id, input: $input) {
-    ...UserPayload
-  }
-}
-# Creates a new ViewPreferences object.
-mutation createViewPreferences(
-  # The ViewPreferences object to create.
-  $input: ViewPreferencesCreateInput!
-) {
-  viewPreferencesCreate(input: $input) {
-    ...ViewPreferencesPayload
-  }
-}
-# Deletes a ViewPreferences.
-mutation deleteViewPreferences(
-  # The identifier of the ViewPreferences to delete.
-  $id: String!
-) {
-  viewPreferencesDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates an existing ViewPreferences object.
-mutation updateViewPreferences(
-  # The identifier of the ViewPreferences object.
-  $id: String!
-  # The properties of the view preferences.
-  $input: ViewPreferencesUpdateInput!
-) {
-  viewPreferencesUpdate(id: $id, input: $input) {
-    ...ViewPreferencesPayload
-  }
-}
-# Creates a new webhook.
-mutation createWebhook(
-  # The webhook object to create.
-  $input: WebhookCreateInput!
-) {
-  webhookCreate(input: $input) {
-    ...WebhookPayload
-  }
-}
-# Deletes a Webhook.
-mutation deleteWebhook(
-  # The identifier of the Webhook to delete.
-  $id: String!
-) {
-  webhookDelete(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Updates an existing Webhook.
-mutation updateWebhook(
-  # The identifier of the Webhook.
-  $id: String!
-  # The properties of the Webhook.
-  $input: WebhookUpdateInput!
-) {
-  webhookUpdate(id: $id, input: $input) {
-    ...WebhookPayload
-  }
-}
-# Archives a state. Only states with issues that have all been archived can be archived.
-mutation archiveWorkflowState(
-  # The identifier of the state to archive.
-  $id: String!
-) {
-  workflowStateArchive(id: $id) {
-    ...ArchivePayload
-  }
-}
-# Creates a new state, adding it to the workflow of a team.
-mutation createWorkflowState(
-  # The state to create.
-  $input: WorkflowStateCreateInput!
-) {
-  workflowStateCreate(input: $input) {
-    ...WorkflowStatePayload
-  }
-}
-# Updates a state.
-mutation updateWorkflowState(
-  # The identifier of the state to update.
-  $id: String!
-  # A partial state object to update.
-  $input: WorkflowStateUpdateInput!
-) {
-  workflowStateUpdate(id: $id, input: $input) {
-    ...WorkflowStatePayload
   }
 }

--- a/packages/sdk/src/_generated_documents.ts
+++ b/packages/sdk/src/_generated_documents.ts
@@ -183,7 +183,7 @@ export type AttachmentCollectionFilter = {
   /** Filters that needs to be matched by some attachments. */
   some?: Maybe<AttachmentFilter>;
   /** Comparator for the source type. */
-  sourceType?: Maybe<NestedStringComparator>;
+  sourceType?: Maybe<SourceTypeComparator>;
   /** Comparator for the subtitle. */
   subtitle?: Maybe<NullableStringComparator>;
   /** Comparator for the title. */
@@ -246,7 +246,7 @@ export type AttachmentFilter = {
   /** Compound filters, one of which need to be matched by the attachment. */
   or?: Maybe<Array<AttachmentFilter>>;
   /** Comparator for the source type. */
-  sourceType?: Maybe<NestedStringComparator>;
+  sourceType?: Maybe<SourceTypeComparator>;
   /** Comparator for the subtitle. */
   subtitle?: Maybe<NullableStringComparator>;
   /** Comparator for the title. */
@@ -297,6 +297,8 @@ export type AuditEntry = Node & {
   ip?: Maybe<Scalars["String"]>;
   /** Additional metadata related to the audit entry. */
   metadata?: Maybe<Scalars["JSONObject"]>;
+  /** The organization the audit log belongs to. */
+  organization?: Maybe<Organization>;
   /** Additional information related to the request which performed the action. */
   requestInformation?: Maybe<Scalars["JSONObject"]>;
   type: Scalars["String"];
@@ -419,7 +421,7 @@ export type Comment = Node & {
   id: Scalars["ID"];
   /** The issue that the comment is associated with. */
   issue: Issue;
-  /** The parent of the comment. */
+  /** The parent comment under which the current comment is nested. */
   parent?: Maybe<Comment>;
   /** Emoji reaction summary, grouped by emoji type */
   reactionData: Scalars["JSONObject"];
@@ -490,11 +492,13 @@ export type CommentCreateInput = {
   createdAt?: Maybe<Scalars["DateTime"]>;
   /** Provide an external user avatar URL. Can only be used in conjunction with the `createAsUser` options. This option is only available to OAuth applications creating comments in `actor=application` mode. */
   displayIconUrl?: Maybe<Scalars["String"]>;
+  /** Flag to prevent auto subscription to the issue the comment is created on. */
+  doNotSubscribeToIssue?: Maybe<Scalars["Boolean"]>;
   /** The identifier in UUID v4 format. If none is provided, the backend will generate one. */
   id?: Maybe<Scalars["String"]>;
   /** The issue to associate the comment with. */
   issueId: Scalars["String"];
-  /** [Internal] The parent under which to nest the comment. */
+  /** The parent comment under which to nest a current comment. */
   parentId?: Maybe<Scalars["String"]>;
 };
 
@@ -1472,47 +1476,6 @@ export type ImageUploadFromUrlPayload = {
   url?: Maybe<Scalars["String"]>;
 };
 
-/** A initiative that contains projects. */
-export type Initiative = Node & {
-  __typename?: "Initiative";
-  /** The time at which the entity was archived. Null if the entity has not been archived. */
-  archivedAt?: Maybe<Scalars["DateTime"]>;
-  /** The time at which the entity was created. */
-  createdAt: Scalars["DateTime"];
-  /** The initiative's description. */
-  description?: Maybe<Scalars["String"]>;
-  /** The unique identifier of the entity. */
-  id: Scalars["ID"];
-  /** The name of the initiative. */
-  name: Scalars["String"];
-  /** The organization that the initiative belongs to. */
-  organization: Organization;
-  /** The sort order for the initiative. */
-  sortOrder: Scalars["Float"];
-  /** The estimated completion date of the initiative. */
-  targetDate?: Maybe<Scalars["TimelessDate"]>;
-  /**
-   * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
-   *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
-   *     been updated after creation.
-   */
-  updatedAt: Scalars["DateTime"];
-};
-
-export type InitiativeConnection = {
-  __typename?: "InitiativeConnection";
-  edges: Array<InitiativeEdge>;
-  nodes: Array<Initiative>;
-  pageInfo: PageInfo;
-};
-
-export type InitiativeEdge = {
-  __typename?: "InitiativeEdge";
-  /** Used in `before` and `after` args */
-  cursor: Scalars["String"];
-  node: Initiative;
-};
-
 /** An integration with an external service. */
 export type Integration = Node & {
   __typename?: "Integration";
@@ -1639,6 +1602,7 @@ export type IntegrationSettings = {
   googleSheets?: Maybe<GoogleSheetsSettings>;
   intercom?: Maybe<IntercomSettings>;
   jira?: Maybe<JiraSettings>;
+  notion?: Maybe<NotionSettings>;
   sentry?: Maybe<SentrySettings>;
   slackOrgProjectUpdatesPost?: Maybe<SlackPostSettings>;
   slackPost?: Maybe<SlackPostSettings>;
@@ -1652,6 +1616,7 @@ export type IntegrationSettingsInput = {
   googleSheets?: Maybe<GoogleSheetsSettingsInput>;
   intercom?: Maybe<IntercomSettingsInput>;
   jira?: Maybe<JiraSettingsInput>;
+  notion?: Maybe<NotionSettingsInput>;
   sentry?: Maybe<SentrySettingsInput>;
   slackOrgProjectUpdatesPost?: Maybe<SlackPostSettingsInput>;
   slackPost?: Maybe<SlackPostSettingsInput>;
@@ -1724,18 +1689,22 @@ export type IntegrationsSettings = Node & {
   id: Scalars["ID"];
   /** Project which those settings apply to. */
   project?: Maybe<Project>;
+  /** Whether to send a Slack message when a new issue is added to triage. */
+  slackIssueAddedToTriage?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when a new issue is created for the project or the team. */
   slackIssueCreated?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when a comment is created on any of the project or team's issues. */
   slackIssueNewComment?: Maybe<Scalars["Boolean"]>;
+  /** Whether to send a Slack message when an SLA is breached */
+  slackIssueSlaBreached?: Maybe<Scalars["Boolean"]>;
+  /** Whether to send a Slack message when an SLA is at high risk */
+  slackIssueSlaHighRisk?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when any of the project or team's issues has a change in status. */
   slackIssueStatusChangedAll?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when any of the project or team's issues change to completed or cancelled. */
   slackIssueStatusChangedDone?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when a project update is created. */
   slackProjectUpdateCreated?: Maybe<Scalars["Boolean"]>;
-  /** Whether to send a new project update to milestone Slack channels. */
-  slackProjectUpdateCreatedToMilestone?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a new project update to team Slack channels. */
   slackProjectUpdateCreatedToTeam?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a new project update to workspace Slack channel. */
@@ -1762,18 +1731,22 @@ export type IntegrationsSettingsCreateInput = {
   id?: Maybe<Scalars["String"]>;
   /** The identifier of the project to create settings for. */
   projectId?: Maybe<Scalars["String"]>;
+  /** Whether to send a Slack message when a new issue is added to triage. */
+  slackIssueAddedToTriage?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when a new issue is created for the project or the team. */
   slackIssueCreated?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when a comment is created on any of the project or team's issues. */
   slackIssueNewComment?: Maybe<Scalars["Boolean"]>;
+  /** Whether to receive notification when an SLA has breached on Slack. */
+  slackIssueSlaBreached?: Maybe<Scalars["Boolean"]>;
+  /** Whether to send a Slack message when an SLA is at high risk */
+  slackIssueSlaHighRisk?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when any of the project or team's issues has a change in status. */
   slackIssueStatusChangedAll?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when any of the project or team's issues change to completed or cancelled. */
   slackIssueStatusChangedDone?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when a project update is created. */
   slackProjectUpdateCreated?: Maybe<Scalars["Boolean"]>;
-  /** Whether to send a Slack message when a project update is created to milestone channels. */
-  slackProjectUpdateCreatedToMilestone?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when a project update is created to team channels. */
   slackProjectUpdateCreatedToTeam?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when a project update is created to workspace channel. */
@@ -1800,18 +1773,22 @@ export type IntegrationsSettingsPayload = {
 };
 
 export type IntegrationsSettingsUpdateInput = {
+  /** Whether to send a Slack message when a new issue is added to triage. */
+  slackIssueAddedToTriage?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when a new issue is created for the project or the team. */
   slackIssueCreated?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when a comment is created on any of the project or team's issues. */
   slackIssueNewComment?: Maybe<Scalars["Boolean"]>;
+  /** Whether to receive notification when an SLA has breached on Slack. */
+  slackIssueSlaBreached?: Maybe<Scalars["Boolean"]>;
+  /** Whether to send a Slack message when an SLA is at high risk */
+  slackIssueSlaHighRisk?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when any of the project or team's issues has a change in status. */
   slackIssueStatusChangedAll?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when any of the project or team's issues change to completed or cancelled. */
   slackIssueStatusChangedDone?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when a project update is created. */
   slackProjectUpdateCreated?: Maybe<Scalars["Boolean"]>;
-  /** Whether to send a Slack message when a project update is created to milestone channels. */
-  slackProjectUpdateCreatedToMilestone?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when a project update is created to team channels. */
   slackProjectUpdateCreatedToTeam?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when a project update is created to workspace channel. */
@@ -1917,8 +1894,14 @@ export type Issue = Node & {
   priorityLabel: Scalars["String"];
   /** The project that the issue is associated with. */
   project?: Maybe<Project>;
+  /** [ALPHA] The projectMilestone that the issue is associated with. */
+  projectMilestone?: Maybe<ProjectMilestone>;
   /** Relations associated with this issue. */
   relations: IssueRelationConnection;
+  /** [Internal] The time at which the issue's SLA will breach. */
+  slaBreachesAt?: Maybe<Scalars["DateTime"]>;
+  /** [Internal] The time at which the issue's SLA began. */
+  slaStartedAt?: Maybe<Scalars["DateTime"]>;
   /** The user who snoozed the issue. */
   snoozedBy?: Maybe<User>;
   /** The time until an issue will be snoozed in Triage view. */
@@ -1927,6 +1910,8 @@ export type Issue = Node & {
   sortOrder: Scalars["Float"];
   /** The time at which the issue was moved into started state. */
   startedAt?: Maybe<Scalars["DateTime"]>;
+  /** The time at which the issue entered triage. */
+  startedTriageAt?: Maybe<Scalars["DateTime"]>;
   /** The workflow state that the issue is associated with. */
   state: WorkflowState;
   /** The order of the item in the sub-issue list. Only set if the issue has a parent. */
@@ -2117,6 +2102,8 @@ export type IssueCollectionFilter = {
   project?: Maybe<NullableProjectFilter>;
   /** [Internal] Comparator for the issues content. */
   searchableContent?: Maybe<ContentComparator>;
+  /** Comparator for the issues sla status. */
+  slaStatus?: Maybe<SlaStatusComparator>;
   /** Filters that the issues snoozer must satisfy. */
   snoozedBy?: Maybe<NullableUserFilter>;
   /** Comparator for the issues snoozed until date. */
@@ -2175,6 +2162,8 @@ export type IssueCreateInput = {
   priority?: Maybe<Scalars["Int"]>;
   /** The project associated with the issue. */
   projectId?: Maybe<Scalars["String"]>;
+  /** [ALPHA] The project milestone associated with the issue. */
+  projectMilestoneId?: Maybe<Scalars["String"]>;
   /** The comment the issue is referencing. */
   referenceCommentId?: Maybe<Scalars["String"]>;
   /** The position of the issue related to other issues. */
@@ -2189,6 +2178,57 @@ export type IssueCreateInput = {
   teamId: Scalars["String"];
   /** The title of the issue. */
   title: Scalars["String"];
+};
+
+/** [Internal] A draft issue. */
+export type IssueDraft = Node & {
+  __typename?: "IssueDraft";
+  /** The time at which the entity was archived. Null if the entity has not been archived. */
+  archivedAt?: Maybe<Scalars["DateTime"]>;
+  /** The user assigned to the draft. */
+  assigneeId?: Maybe<Scalars["String"]>;
+  /** Serialized array of JSONs representing attachments. */
+  attachments: Scalars["JSONObject"];
+  /** The time at which the entity was created. */
+  createdAt: Scalars["DateTime"];
+  /** The user who created the draft. */
+  creator: User;
+  /** The cycle associated with the draft. */
+  cycleId?: Maybe<Scalars["String"]>;
+  /** The draft's description in markdown format. */
+  description?: Maybe<Scalars["String"]>;
+  /** [Internal] The draft's description as a Prosemirror document. */
+  descriptionData?: Maybe<Scalars["JSON"]>;
+  /** The date at which the issue would be due. */
+  dueDate?: Maybe<Scalars["TimelessDate"]>;
+  /** The estimate of the complexity of the draft. */
+  estimate?: Maybe<Scalars["Float"]>;
+  /** The unique identifier of the entity. */
+  id: Scalars["ID"];
+  /** The parent draft of the draft. */
+  parent?: Maybe<IssueDraft>;
+  /** The parent issue of the draft. */
+  parentIssue?: Maybe<Issue>;
+  /** The priority of the draft. */
+  priority: Scalars["Float"];
+  /** Label for the priority. */
+  priorityLabel: Scalars["String"];
+  /** The project associated with the draft. */
+  projectId?: Maybe<Scalars["String"]>;
+  /** The workflow state associated with the draft. */
+  stateId: Scalars["String"];
+  /** The order of items in the sub-draft list. Only set if the draft has `parent` set. */
+  subIssueSortOrder?: Maybe<Scalars["Float"]>;
+  /** The team associated with the draft. */
+  teamId: Scalars["String"];
+  /** The draft's title. */
+  title: Scalars["String"];
+  /**
+   * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+   *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+   *     been updated after creation.
+   */
+  updatedAt: Scalars["DateTime"];
 };
 
 export type IssueEdge = {
@@ -2254,6 +2294,8 @@ export type IssueFilter = {
   project?: Maybe<NullableProjectFilter>;
   /** [Internal] Comparator for the issues content. */
   searchableContent?: Maybe<ContentComparator>;
+  /** Comparator for the issues sla status. */
+  slaStatus?: Maybe<SlaStatusComparator>;
   /** Filters that the issues snoozer must satisfy. */
   snoozedBy?: Maybe<NullableUserFilter>;
   /** Comparator for the issues snoozed until date. */
@@ -2293,6 +2335,8 @@ export type IssueHistory = Node & {
   autoArchived?: Maybe<Scalars["Boolean"]>;
   /** Whether the issue was auto-closed. */
   autoClosed?: Maybe<Scalars["Boolean"]>;
+  /** [Internal] Serialized JSON representing changes for certain non-relational properties. */
+  changes?: Maybe<Scalars["JSONObject"]>;
   /** The time at which the entity was created. */
   createdAt: Scalars["DateTime"];
   /** The user from whom the issue was re-assigned from. */
@@ -2790,6 +2834,10 @@ export type IssueUpdateInput = {
   priority?: Maybe<Scalars["Int"]>;
   /** The project associated with the issue. */
   projectId?: Maybe<Scalars["String"]>;
+  /** [ALPHA] The project milestone associated with the issue. */
+  projectMilestoneId?: Maybe<Scalars["String"]>;
+  /** [Internal] The timestamp at which an issue will be considered in breach of SLA. */
+  slaBreachesAt?: Maybe<Scalars["DateTime"]>;
   /** The identifier of the user who snoozed the issue. */
   snoozedById?: Maybe<Scalars["String"]>;
   /** The time until an issue will be snoozed in Triage view. */
@@ -2882,116 +2930,6 @@ export type LogoutResponse = {
   __typename?: "LogoutResponse";
   /** Whether the operation was successful. */
   success: Scalars["Boolean"];
-};
-
-/** A milestone that contains projects. */
-export type Milestone = Node & {
-  __typename?: "Milestone";
-  /** The time at which the entity was archived. Null if the entity has not been archived. */
-  archivedAt?: Maybe<Scalars["DateTime"]>;
-  /** The time at which the entity was created. */
-  createdAt: Scalars["DateTime"];
-  /** [ALPHA] The milestone's description. */
-  description?: Maybe<Scalars["String"]>;
-  /** The unique identifier of the entity. */
-  id: Scalars["ID"];
-  /** The name of the milestone. */
-  name: Scalars["String"];
-  /** The organization that the milestone belongs to. */
-  organization: Organization;
-  /**
-   * Projects associated with the milestone.
-   * @deprecated Milestones will be removed. Use roadmaps instead.
-   */
-  projects: ProjectConnection;
-  /** The sort order for the milestone. */
-  sortOrder: Scalars["Float"];
-  /** [ALPHA] The estimated completion date of the initiative. */
-  targetDate?: Maybe<Scalars["TimelessDate"]>;
-  /**
-   * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
-   *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
-   *     been updated after creation.
-   */
-  updatedAt: Scalars["DateTime"];
-};
-
-/** A milestone that contains projects. */
-export type MilestoneProjectsArgs = {
-  after?: Maybe<Scalars["String"]>;
-  before?: Maybe<Scalars["String"]>;
-  filter?: Maybe<ProjectFilter>;
-  first?: Maybe<Scalars["Int"]>;
-  includeArchived?: Maybe<Scalars["Boolean"]>;
-  last?: Maybe<Scalars["Int"]>;
-  orderBy?: Maybe<PaginationOrderBy>;
-};
-
-export type MilestoneConnection = {
-  __typename?: "MilestoneConnection";
-  edges: Array<MilestoneEdge>;
-  nodes: Array<Milestone>;
-  pageInfo: PageInfo;
-};
-
-export type MilestoneCreateInput = {
-  /** [ALPHA] The description for the milestone. */
-  description?: Maybe<Scalars["String"]>;
-  /** The identifier in UUID v4 format. If none is provided, the backend will generate one. */
-  id?: Maybe<Scalars["String"]>;
-  /** The name of the milestone. */
-  name: Scalars["String"];
-  /** The sort order of the milestone. */
-  sortOrder?: Maybe<Scalars["Float"]>;
-  /** [ALPHA] The planned target date of the milestone. */
-  targetDate?: Maybe<Scalars["TimelessDate"]>;
-  /** [ALPHA] The identifiers of the teams this milestone is associated with. */
-  teamIds?: Maybe<Array<Scalars["String"]>>;
-};
-
-export type MilestoneEdge = {
-  __typename?: "MilestoneEdge";
-  /** Used in `before` and `after` args */
-  cursor: Scalars["String"];
-  node: Milestone;
-};
-
-export type MilestoneMigrationPayload = {
-  __typename?: "MilestoneMigrationPayload";
-  /** The identifier of the last sync operation. */
-  lastSyncId: Scalars["Float"];
-  /** Whether the operation was successful. */
-  success: Scalars["Boolean"];
-};
-
-export type MilestonePayload = {
-  __typename?: "MilestonePayload";
-  /** The identifier of the last sync operation. */
-  lastSyncId: Scalars["Float"];
-  /** The milesteone that was created or updated. */
-  milestone?: Maybe<Milestone>;
-  /** Whether the operation was successful. */
-  success: Scalars["Boolean"];
-};
-
-export type MilestoneUpdateInput = {
-  /** [ALPHA] The description for the milestone. */
-  description?: Maybe<Scalars["String"]>;
-  /** The name of the milestone. */
-  name?: Maybe<Scalars["String"]>;
-  /** The sort order of the milestone. */
-  sortOrder?: Maybe<Scalars["Float"]>;
-  /** [ALPHA] The planned target date of the milestone. */
-  targetDate?: Maybe<Scalars["TimelessDate"]>;
-  /** [ALPHA] The identifiers of the teams this milestone is associated with. */
-  teamIds?: Maybe<Array<Scalars["String"]>>;
-};
-
-export type MilestonesMigrateInput = {
-  /** IDs of the milestones to delete. */
-  milestonesToDelete?: Maybe<Array<Scalars["String"]>>;
-  /** IDs of the milestones to migrate. */
-  milestonesToMigrate?: Maybe<Array<Scalars["String"]>>;
 };
 
 export type Mutation = {
@@ -3154,6 +3092,8 @@ export type Mutation = {
   issueCreate: IssuePayload;
   /** Deletes (trashes) an issue. */
   issueDelete: ArchivePayload;
+  /** [INTERNAL] Updates an issue description from the Front app to handle Front attachments correctly. */
+  issueDescriptionUpdateFromFront: IssuePayload;
   /** Kicks off an Asana import job. */
   issueImportCreateAsana: IssueImportPayload;
   /** Kicks off a Shortcut (formerly Clubhouse) import job. */
@@ -3199,23 +3139,6 @@ export type Mutation = {
   leaveOrganization: CreateOrJoinOrganizationResponse;
   /** Logout of all clients. */
   logout: LogoutResponse;
-  /** Migrates milestones to roadmaps */
-  migrateMilestonesToRoadmaps: MilestoneMigrationPayload;
-  /**
-   * Creates a new milestone.
-   * @deprecated Milestones will be removed. Use roadmaps instead.
-   */
-  milestoneCreate: MilestonePayload;
-  /**
-   * Deletes a milestone.
-   * @deprecated Milestones will be removed. Use roadmaps instead.
-   */
-  milestoneDelete: ArchivePayload;
-  /**
-   * Updates a milestone.
-   * @deprecated Milestones will be removed. Use roadmaps instead.
-   */
-  milestoneUpdate: MilestonePayload;
   /** Archives a notification. */
   notificationArchive: ArchivePayload;
   /** Creates a new notification subscription for a team or a project. */
@@ -3265,6 +3188,12 @@ export type Mutation = {
   projectLinkDelete: ArchivePayload;
   /** Updates a project link. */
   projectLinkUpdate: ProjectLinkPayload;
+  /** Creates a new project milestone. */
+  projectMilestoneCreate: ProjectMilestonePayload;
+  /** Deletes a project milestone. */
+  projectMilestoneDelete: ArchivePayload;
+  /** Updates a project milestone. */
+  projectMilestoneUpdate: ProjectMilestonePayload;
   /** Unarchives a project. */
   projectUnarchive: ArchivePayload;
   /** Updates a project. */
@@ -3327,12 +3256,6 @@ export type Mutation = {
   templateDelete: ArchivePayload;
   /** Updates an existing template. */
   templateUpdate: TemplatePayload;
-  /** [INTERNAL] Cancels an ongoing email change for the user account */
-  userAccountEmailChangeCancel: UserAccountEmailVerificationPayload;
-  /** [INTERNAL] Creates an email verification challenge from the app for a user account that wants to change email. */
-  userAccountEmailChangeCreate: UserAccountEmailVerificationPayload;
-  /** [INTERNAL] Verifies the email address and code for a user account that wants to change email. */
-  userAccountEmailChangeVerifyCode: UserAccountEmailChangeVerifyCodePayload;
   /** Makes user a regular user. Can only be called by an admin. */
   userDemoteAdmin: UserAdminPayload;
   /** Makes user a guest. Can only be called by an admin. */
@@ -3430,6 +3353,7 @@ export type MutationAttachmentLinkJiraIssueArgs = {
 };
 
 export type MutationAttachmentLinkUrlArgs = {
+  id?: Maybe<Scalars["String"]>;
   issueId: Scalars["String"];
   title?: Maybe<Scalars["String"]>;
   url: Scalars["String"];
@@ -3709,6 +3633,11 @@ export type MutationIssueDeleteArgs = {
   id: Scalars["String"];
 };
 
+export type MutationIssueDescriptionUpdateFromFrontArgs = {
+  description: Scalars["String"];
+  id: Scalars["String"];
+};
+
 export type MutationIssueImportCreateAsanaArgs = {
   asanaTeamName: Scalars["String"];
   asanaToken: Scalars["String"];
@@ -3828,23 +3757,6 @@ export type MutationLeaveOrganizationArgs = {
   organizationId: Scalars["String"];
 };
 
-export type MutationMigrateMilestonesToRoadmapsArgs = {
-  input: MilestonesMigrateInput;
-};
-
-export type MutationMilestoneCreateArgs = {
-  input: MilestoneCreateInput;
-};
-
-export type MutationMilestoneDeleteArgs = {
-  id: Scalars["String"];
-};
-
-export type MutationMilestoneUpdateArgs = {
-  id: Scalars["String"];
-  input: MilestoneUpdateInput;
-};
-
 export type MutationNotificationArchiveArgs = {
   id: Scalars["String"];
 };
@@ -3932,6 +3844,19 @@ export type MutationProjectLinkDeleteArgs = {
 export type MutationProjectLinkUpdateArgs = {
   id: Scalars["String"];
   input: ProjectLinkUpdateInput;
+};
+
+export type MutationProjectMilestoneCreateArgs = {
+  input: ProjectMilestoneCreateInput;
+};
+
+export type MutationProjectMilestoneDeleteArgs = {
+  id: Scalars["String"];
+};
+
+export type MutationProjectMilestoneUpdateArgs = {
+  id: Scalars["String"];
+  input: ProjectMilestoneUpdateInput;
 };
 
 export type MutationProjectUnarchiveArgs = {
@@ -4066,21 +3991,6 @@ export type MutationTemplateUpdateArgs = {
   input: TemplateUpdateInput;
 };
 
-export type MutationUserAccountEmailChangeCancelArgs = {
-  id: Scalars["String"];
-};
-
-export type MutationUserAccountEmailChangeCreateArgs = {
-  hasExistingAccount: Scalars["Boolean"];
-  id: Scalars["String"];
-  newEmail: Scalars["String"];
-};
-
-export type MutationUserAccountEmailChangeVerifyCodeArgs = {
-  code: Scalars["String"];
-  email: Scalars["String"];
-};
-
 export type MutationUserDemoteAdminArgs = {
   id: Scalars["String"];
 };
@@ -4182,38 +4092,6 @@ export type MutationWorkflowStateCreateArgs = {
 export type MutationWorkflowStateUpdateArgs = {
   id: Scalars["String"];
   input: WorkflowStateUpdateInput;
-};
-
-/** Comparator for strings. */
-export type NestedStringComparator = {
-  /** Contains constraint. Matches any values that contain the given string. */
-  contains?: Maybe<Scalars["String"]>;
-  /** Contains case insensitive constraint. Matches any values that contain the given string case insensitive. */
-  containsIgnoreCase?: Maybe<Scalars["String"]>;
-  /** Ends with constraint. Matches any values that end with the given string. */
-  endsWith?: Maybe<Scalars["String"]>;
-  /** Equals constraint. */
-  eq?: Maybe<Scalars["String"]>;
-  /** Equals case insensitive. Matches any values that matches the given string case insensitive. */
-  eqIgnoreCase?: Maybe<Scalars["String"]>;
-  /** In-array constraint. */
-  in?: Maybe<Array<Scalars["String"]>>;
-  /** Not-equals constraint. */
-  neq?: Maybe<Scalars["String"]>;
-  /** Not-equals case insensitive. Matches any values that don't match the given string case insensitive. */
-  neqIgnoreCase?: Maybe<Scalars["String"]>;
-  /** Not-in-array constraint. */
-  nin?: Maybe<Array<Scalars["String"]>>;
-  /** Doesn't contain constraint. Matches any values that don't contain the given string. */
-  notContains?: Maybe<Scalars["String"]>;
-  /** Doesn't contain case insensitive constraint. Matches any values that don't contain the given string case insensitive. */
-  notContainsIgnoreCase?: Maybe<Scalars["String"]>;
-  /** Doesn't end with constraint. Matches any values that don't end with the given string. */
-  notEndsWith?: Maybe<Scalars["String"]>;
-  /** Doesn't start with constraint. Matches any values that don't start with the given string. */
-  notStartsWith?: Maybe<Scalars["String"]>;
-  /** Starts with constraint. Matches any values that start with the given string. */
-  startsWith?: Maybe<Scalars["String"]>;
 };
 
 export type Node = {
@@ -4318,6 +4196,8 @@ export type NotificationSubscriptionCreateInput = {
   projectNotificationSubscriptionType?: Maybe<ProjectNotificationSubscriptionType>;
   /** The identifier of the team to subscribe to. */
   teamId?: Maybe<Scalars["String"]>;
+  /** The types of notifications of the team subscription. */
+  teamNotificationSubscriptionTypes?: Maybe<Array<Scalars["String"]>>;
 };
 
 export type NotificationSubscriptionEdge = {
@@ -4339,7 +4219,9 @@ export type NotificationSubscriptionPayload = {
 
 export type NotificationSubscriptionUpdateInput = {
   /** The type of the project subscription. */
-  projectNotificationSubscriptionType: ProjectNotificationSubscriptionType;
+  projectNotificationSubscriptionType?: Maybe<ProjectNotificationSubscriptionType>;
+  /** The types of notifications of the team subscription. */
+  teamNotificationSubscriptionTypes?: Maybe<Array<Scalars["String"]>>;
 };
 
 export type NotificationUpdateInput = {
@@ -4349,6 +4231,22 @@ export type NotificationUpdateInput = {
   readAt?: Maybe<Scalars["DateTime"]>;
   /** The time until a notification will be snoozed. After that it will appear in the inbox again. */
   snoozedUntilAt?: Maybe<Scalars["DateTime"]>;
+};
+
+/** Notion specific settings. */
+export type NotionSettings = {
+  __typename?: "NotionSettings";
+  /** The ID of the Notion workspace being connected. */
+  workspaceId: Scalars["String"];
+  /** The name of the Notion workspace being connected. */
+  workspaceName: Scalars["String"];
+};
+
+export type NotionSettingsInput = {
+  /** The ID of the Notion workspace being connected. */
+  workspaceId: Scalars["String"];
+  /** The name of the Notion workspace being connected. */
+  workspaceName: Scalars["String"];
 };
 
 /** Cycle filtering options. */
@@ -4471,6 +4369,8 @@ export type NullableIssueFilter = {
   project?: Maybe<NullableProjectFilter>;
   /** [Internal] Comparator for the issues content. */
   searchableContent?: Maybe<ContentComparator>;
+  /** Comparator for the issues sla status. */
+  slaStatus?: Maybe<SlaStatusComparator>;
   /** Filters that the issues snoozer must satisfy. */
   snoozedBy?: Maybe<NullableUserFilter>;
   /** Comparator for the issues snoozed until date. */
@@ -5138,7 +5038,7 @@ export type PaidSubscription = Node & {
   pendingChangeType?: Maybe<Scalars["String"]>;
   /** The number of seats in the subscription. */
   seats: Scalars["Float"];
-  /** The maximum number of seats that can be added to the subscription. */
+  /** The maximum number of seats that will be billed in the subscription. */
   seatsMaximum?: Maybe<Scalars["Float"]>;
   /** The minimum number of seats that will be billed in the subscription. */
   seatsMinimum?: Maybe<Scalars["Float"]>;
@@ -5150,6 +5050,27 @@ export type PaidSubscription = Node & {
    *     been updated after creation.
    */
   updatedAt: Scalars["DateTime"];
+};
+
+/** A personal note for a user */
+export type PersonalNote = Node & {
+  __typename?: "PersonalNote";
+  /** The time at which the entity was archived. Null if the entity has not been archived. */
+  archivedAt?: Maybe<Scalars["DateTime"]>;
+  /** The note content as JSON. */
+  contentData?: Maybe<Scalars["JSONObject"]>;
+  /** The time at which the entity was created. */
+  createdAt: Scalars["DateTime"];
+  /** The unique identifier of the entity. */
+  id: Scalars["ID"];
+  /**
+   * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+   *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+   *     been updated after creation.
+   */
+  updatedAt: Scalars["DateTime"];
+  /** The user that owns the note. */
+  user: User;
 };
 
 /** A project. */
@@ -5185,8 +5106,6 @@ export type Project = Node & {
   id: Scalars["ID"];
   /** The number of in progress estimation points after each week. */
   inProgressScopeHistory: Array<Scalars["Float"]>;
-  /** The initiative that this project is associated with. */
-  initiative?: Maybe<Initiative>;
   /** Settings for all integrations associated with that project. */
   integrationsSettings?: Maybe<IntegrationsSettings>;
   /** The total number of issues in the project after each week. */
@@ -5199,15 +5118,12 @@ export type Project = Node & {
   links: ProjectLinkConnection;
   /** Users that are members of the project. */
   members: UserConnection;
-  /**
-   * The milestone that this project is associated with.
-   * @deprecated Milestones will be removed. Use roadmaps instead.
-   */
-  milestone?: Maybe<Milestone>;
   /** The project's name. */
   name: Scalars["String"];
   /** The overall progress of the project. This is the (completed estimate points + 0.25 * in progress estimate points) / total estimate points. */
   progress: Scalars["Float"];
+  /** [ALPHA] Milestones associated with the project. */
+  projectMilestones: ProjectMilestoneConnection;
   /** The time until which project update reminders are paused. */
   projectUpdateRemindersPausedUntilAt?: Maybe<Scalars["DateTime"]>;
   /** Project updates associated with the project. */
@@ -5224,7 +5140,7 @@ export type Project = Node & {
   slackNewIssue: Scalars["Boolean"];
   /** The project's unique URL slug. */
   slugId: Scalars["String"];
-  /** The sort order for the project within its milestone/initiative. */
+  /** The sort order for the project within the organizion. */
   sortOrder: Scalars["Float"];
   /** [Internal] The estimated start date of the project. */
   startDate?: Maybe<Scalars["TimelessDate"]>;
@@ -5285,6 +5201,16 @@ export type ProjectMembersArgs = {
   first?: Maybe<Scalars["Int"]>;
   includeArchived?: Maybe<Scalars["Boolean"]>;
   includeDisabled?: Maybe<Scalars["Boolean"]>;
+  last?: Maybe<Scalars["Int"]>;
+  orderBy?: Maybe<PaginationOrderBy>;
+};
+
+/** A project. */
+export type ProjectProjectMilestonesArgs = {
+  after?: Maybe<Scalars["String"]>;
+  before?: Maybe<Scalars["String"]>;
+  first?: Maybe<Scalars["Int"]>;
+  includeArchived?: Maybe<Scalars["Boolean"]>;
   last?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<PaginationOrderBy>;
 };
@@ -5372,8 +5298,6 @@ export type ProjectCreateInput = {
   leadId?: Maybe<Scalars["String"]>;
   /** The identifiers of the members of this project. */
   memberIds?: Maybe<Array<Scalars["String"]>>;
-  /** The identifier of the milestone to associate the project with. */
-  milestoneId?: Maybe<Scalars["String"]>;
   /** The name of the project. */
   name: Scalars["String"];
   /** The sort order for the project within shared views. */
@@ -5494,6 +5418,79 @@ export type ProjectLinkUpdateInput = {
   label?: Maybe<Scalars["String"]>;
   /** The URL of the link. */
   url?: Maybe<Scalars["String"]>;
+};
+
+/** A milestone for a project. */
+export type ProjectMilestone = Node & {
+  __typename?: "ProjectMilestone";
+  /** The time at which the entity was archived. Null if the entity has not been archived. */
+  archivedAt?: Maybe<Scalars["DateTime"]>;
+  /** The time at which the entity was created. */
+  createdAt: Scalars["DateTime"];
+  /** The description of the project milestone. */
+  description?: Maybe<Scalars["String"]>;
+  /** The unique identifier of the entity. */
+  id: Scalars["ID"];
+  /** The name of the project milestone. */
+  name: Scalars["String"];
+  /** The project of the milestone. */
+  project: Project;
+  /** The planned completion date of the milestone. */
+  targetDate?: Maybe<Scalars["TimelessDate"]>;
+  /**
+   * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+   *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+   *     been updated after creation.
+   */
+  updatedAt: Scalars["DateTime"];
+};
+
+export type ProjectMilestoneConnection = {
+  __typename?: "ProjectMilestoneConnection";
+  edges: Array<ProjectMilestoneEdge>;
+  nodes: Array<ProjectMilestone>;
+  pageInfo: PageInfo;
+};
+
+export type ProjectMilestoneCreateInput = {
+  /** The description of the project milestone. */
+  description?: Maybe<Scalars["String"]>;
+  /** The identifier in UUID v4 format. If none is provided, the backend will generate one. */
+  id?: Maybe<Scalars["String"]>;
+  /** The name of the project milestone. */
+  name: Scalars["String"];
+  /** Related project for the project milestone. */
+  projectId: Scalars["String"];
+  /** The planned target date of the project milestone. */
+  targetDate?: Maybe<Scalars["TimelessDate"]>;
+};
+
+export type ProjectMilestoneEdge = {
+  __typename?: "ProjectMilestoneEdge";
+  /** Used in `before` and `after` args */
+  cursor: Scalars["String"];
+  node: ProjectMilestone;
+};
+
+export type ProjectMilestonePayload = {
+  __typename?: "ProjectMilestonePayload";
+  /** The identifier of the last sync operation. */
+  lastSyncId: Scalars["Float"];
+  /** The project milestone that was created or updated. */
+  projectMilestone: ProjectMilestone;
+  /** Whether the operation was successful. */
+  success: Scalars["Boolean"];
+};
+
+export type ProjectMilestoneUpdateInput = {
+  /** The description of the project milestone. */
+  description?: Maybe<Scalars["String"]>;
+  /** The name of the project milestone. */
+  name?: Maybe<Scalars["String"]>;
+  /** Related project for the project milestone. */
+  projectId?: Maybe<Scalars["String"]>;
+  /** The planned target date of the project milestone. */
+  targetDate?: Maybe<Scalars["TimelessDate"]>;
 };
 
 /** A project related notification */
@@ -5662,8 +5659,6 @@ export type ProjectUpdateInput = {
   leadId?: Maybe<Scalars["String"]>;
   /** The identifiers of the members of this project. */
   memberIds?: Maybe<Array<Scalars["String"]>>;
-  /** The identifier of the milestone to associate the project with. */
-  milestoneId?: Maybe<Scalars["String"]>;
   /** The name of the project. */
   name?: Maybe<Scalars["String"]>;
   /** The time until which project update reminders are paused. */
@@ -5883,6 +5878,10 @@ export enum PushSubscriptionType {
 
 export type Query = {
   __typename?: "Query";
+  /** One specific project milestone. */
+  ProjectMilestone: ProjectMilestone;
+  /** All milestones for the project. */
+  ProjectMilestones: ProjectMilestoneConnection;
   /** All teams you the user can administrate. Administrable teams are teams whose settings the user can change, but to whose issues the user doesn't necessarily have access to. */
   administrableTeams: TeamConnection;
   /** All API keys for the user. */
@@ -5985,16 +5984,6 @@ export type Query = {
   issueVcsBranchSearch?: Maybe<Issue>;
   /** All issues. */
   issues: IssueConnection;
-  /**
-   * One specific milestone.
-   * @deprecated Milestones will be removed. Use roadmaps instead.
-   */
-  milestone: Milestone;
-  /**
-   * All milestones.
-   * @deprecated Milestones will be removed. Use roadmaps instead.
-   */
-  milestones: MilestoneConnection;
   /** One specific notification. */
   notification: Notification;
   /** One specific notification subscription. */
@@ -6059,8 +6048,6 @@ export type Query = {
   templates: Array<Template>;
   /** One specific user. */
   user: User;
-  /** [INTERNAL] Checks if there's a currently active email verification challenge for a user account. */
-  userAccountEmailChangeFind: UserAccountEmailChangeFindPayload;
   /** Finds a user account by email. */
   userAccountExists?: Maybe<UserAccountExistsPayload>;
   /** The user's settings. */
@@ -6079,6 +6066,19 @@ export type Query = {
   workflowStates: WorkflowStateConnection;
   /** [INTERNAL] Get all authorized applications (with limited fields) for a workspace */
   workspaceAuthorizedApplications: Array<WorkspaceAuthorizedApplication>;
+};
+
+export type QueryProjectMilestoneArgs = {
+  id: Scalars["String"];
+};
+
+export type QueryProjectMilestonesArgs = {
+  after?: Maybe<Scalars["String"]>;
+  before?: Maybe<Scalars["String"]>;
+  first?: Maybe<Scalars["Int"]>;
+  includeArchived?: Maybe<Scalars["Boolean"]>;
+  last?: Maybe<Scalars["Int"]>;
+  orderBy?: Maybe<PaginationOrderBy>;
 };
 
 export type QueryAdministrableTeamsArgs = {
@@ -6341,19 +6341,6 @@ export type QueryIssuesArgs = {
   orderBy?: Maybe<PaginationOrderBy>;
 };
 
-export type QueryMilestoneArgs = {
-  id: Scalars["String"];
-};
-
-export type QueryMilestonesArgs = {
-  after?: Maybe<Scalars["String"]>;
-  before?: Maybe<Scalars["String"]>;
-  first?: Maybe<Scalars["Int"]>;
-  includeArchived?: Maybe<Scalars["Boolean"]>;
-  last?: Maybe<Scalars["Int"]>;
-  orderBy?: Maybe<PaginationOrderBy>;
-};
-
 export type QueryNotificationArgs = {
   id: Scalars["String"];
 };
@@ -6522,10 +6509,6 @@ export type QueryTemplateArgs = {
 
 export type QueryUserArgs = {
   id: Scalars["String"];
-};
-
-export type QueryUserAccountEmailChangeFindArgs = {
-  email: Scalars["String"];
 };
 
 export type QueryUserAccountExistsArgs = {
@@ -6818,7 +6801,7 @@ export type RoadmapToProjectCreateInput = {
   projectId: Scalars["String"];
   /** The identifier of the roadmap. */
   roadmapId: Scalars["String"];
-  /** The sort order for the project within its milestone. */
+  /** The sort order for the project within its organization. */
   sortOrder?: Maybe<Scalars["Float"]>;
 };
 
@@ -6840,7 +6823,7 @@ export type RoadmapToProjectPayload = {
 };
 
 export type RoadmapToProjectUpdateInput = {
-  /** The sort order for the project within its milestone. */
+  /** The sort order for the project within its organization. */
   sortOrder?: Maybe<Scalars["Float"]>;
 };
 
@@ -6932,6 +6915,28 @@ export type SentrySettingsInput = {
   organizationSlug: Scalars["String"];
 };
 
+export enum SlaStatus {
+  Breached = "Breached",
+  Completed = "Completed",
+  HighRisk = "HighRisk",
+  LowRisk = "LowRisk",
+  MediumRisk = "MediumRisk",
+}
+
+/** Comparator for sla status. */
+export type SlaStatusComparator = {
+  /** Equals constraint. */
+  eq?: Maybe<SlaStatus>;
+  /** In-array constraint. */
+  in?: Maybe<Array<SlaStatus>>;
+  /** Not-equals constraint. */
+  neq?: Maybe<SlaStatus>;
+  /** Not-in-array constraint. */
+  nin?: Maybe<Array<SlaStatus>>;
+  /** Null constraint. Matches any non-null values if the given value is false, otherwise it matches null values. */
+  null?: Maybe<Scalars["Boolean"]>;
+};
+
 /** Slack notification specific settings. */
 export type SlackPostSettings = {
   __typename?: "SlackPostSettings";
@@ -6944,6 +6949,38 @@ export type SlackPostSettingsInput = {
   channel: Scalars["String"];
   channelId: Scalars["String"];
   configurationUrl: Scalars["String"];
+};
+
+/** Comparator for `sourceType` field. */
+export type SourceTypeComparator = {
+  /** Contains constraint. Matches any values that contain the given string. */
+  contains?: Maybe<Scalars["String"]>;
+  /** Contains case insensitive constraint. Matches any values that contain the given string case insensitive. */
+  containsIgnoreCase?: Maybe<Scalars["String"]>;
+  /** Ends with constraint. Matches any values that end with the given string. */
+  endsWith?: Maybe<Scalars["String"]>;
+  /** Equals constraint. */
+  eq?: Maybe<Scalars["String"]>;
+  /** Equals case insensitive. Matches any values that matches the given string case insensitive. */
+  eqIgnoreCase?: Maybe<Scalars["String"]>;
+  /** In-array constraint. */
+  in?: Maybe<Array<Scalars["String"]>>;
+  /** Not-equals constraint. */
+  neq?: Maybe<Scalars["String"]>;
+  /** Not-equals case insensitive. Matches any values that don't match the given string case insensitive. */
+  neqIgnoreCase?: Maybe<Scalars["String"]>;
+  /** Not-in-array constraint. */
+  nin?: Maybe<Array<Scalars["String"]>>;
+  /** Doesn't contain constraint. Matches any values that don't contain the given string. */
+  notContains?: Maybe<Scalars["String"]>;
+  /** Doesn't contain case insensitive constraint. Matches any values that don't contain the given string case insensitive. */
+  notContainsIgnoreCase?: Maybe<Scalars["String"]>;
+  /** Doesn't end with constraint. Matches any values that don't end with the given string. */
+  notEndsWith?: Maybe<Scalars["String"]>;
+  /** Doesn't start with constraint. Matches any values that don't start with the given string. */
+  notStartsWith?: Maybe<Scalars["String"]>;
+  /** Starts with constraint. Matches any values that start with the given string. */
+  startsWith?: Maybe<Scalars["String"]>;
 };
 
 export type SsoUrlFromEmailResponse = {
@@ -7115,6 +7152,8 @@ export type Team = Node & {
   private: Scalars["Boolean"];
   /** Projects associated with the team. */
   projects: ProjectConnection;
+  /** Whether an issue needs to have a priority set before leaving triage */
+  requirePriorityToLeaveTriage: Scalars["Boolean"];
   /** The workflow state into which issues are moved when a review has been requested for the PR. */
   reviewWorkflowState?: Maybe<WorkflowState>;
   /** Whether to send new issue comment notifications to Slack. */
@@ -7308,6 +7347,8 @@ export type TeamCreateInput = {
   organizationId?: Maybe<Scalars["String"]>;
   /** Internal. Whether the team is private or not. */
   private?: Maybe<Scalars["Boolean"]>;
+  /** Whether an issue needs to have a priority set before leaving triage. */
+  requirePriorityToLeaveTriage?: Maybe<Scalars["Boolean"]>;
   /** The timezone of the team. */
   timezone?: Maybe<Scalars["String"]>;
   /** Whether triage mode is enabled for the team. */
@@ -7512,6 +7553,8 @@ export type TeamUpdateInput = {
   name?: Maybe<Scalars["String"]>;
   /** Whether the team is private or not. */
   private?: Maybe<Scalars["Boolean"]>;
+  /** Whether an issue needs to have a priority set before leaving triage. */
+  requirePriorityToLeaveTriage?: Maybe<Scalars["Boolean"]>;
   /** The workflow state into which issues are moved when a review has been requested for the PR. */
   reviewWorkflowStateId?: Maybe<Scalars["String"]>;
   /** Whether to send new issue comment notifications to Slack. */
@@ -7671,6 +7714,8 @@ export type UpdateOrganizationInput = {
   reducedPersonalInformation?: Maybe<Scalars["Boolean"]>;
   /** Whether the organization is using roadmap. */
   roadmapEnabled?: Maybe<Scalars["Boolean"]>;
+  /** Internal. Whether SLA's have been enabled for the organization. */
+  slaEnabled?: Maybe<Scalars["Boolean"]>;
   /** The URL key of the organization. */
   urlKey?: Maybe<Scalars["String"]>;
 };
@@ -7885,35 +7930,6 @@ export type UserAccountEmailChange = {
   oldEmailVerifiedAt?: Maybe<Scalars["DateTime"]>;
   /** The time at which the model was updated. */
   updatedAt: Scalars["DateTime"];
-};
-
-/** [INTERNAL] Result of searching for a verification challenge for a user account. */
-export type UserAccountEmailChangeFindPayload = {
-  __typename?: "UserAccountEmailChangeFindPayload";
-  /** [INTERNAL] Whether there is a currently active change. */
-  hasChangeActive: Scalars["Boolean"];
-  /** The identifier of the last sync operation. */
-  lastSyncId: Scalars["Float"];
-};
-
-/** [INTERNAL] Result of verifying an email and code. */
-export type UserAccountEmailChangeVerifyCodePayload = {
-  __typename?: "UserAccountEmailChangeVerifyCodePayload";
-  /** [INTERNAL] Reason why the operation was not successful. */
-  failureReason?: Maybe<Scalars["Float"]>;
-  /** [INTERNAL] Whether the operation was successful. */
-  success: Scalars["Boolean"];
-};
-
-/** [INTERNAL] Result of creating or cancelling a verification challenge for email change. */
-export type UserAccountEmailVerificationPayload = {
-  __typename?: "UserAccountEmailVerificationPayload";
-  /** [INTERNAL] Reason why the operation was not successful. */
-  failureReason?: Maybe<Scalars["Float"]>;
-  /** The identifier of the last sync operation. */
-  lastSyncId: Scalars["Float"];
-  /** [INTERNAL] Whether the operation was successful. */
-  success: Scalars["Boolean"];
 };
 
 /** [INTERNAL] Result of looking up a user account by email. */
@@ -8233,8 +8249,10 @@ export enum ViewType {
   Inbox = "inbox",
   Label = "label",
   MyIssues = "myIssues",
+  MyIssuesActivity = "myIssuesActivity",
   MyIssuesCreatedByMe = "myIssuesCreatedByMe",
   MyIssuesSubscribedTo = "myIssuesSubscribedTo",
+  MyIssuesTouchedByMe = "myIssuesTouchedByMe",
   Project = "project",
   Projects = "projects",
   ProjectsAll = "projectsAll",
@@ -8340,10 +8358,12 @@ export type WebhookUpdateInput = {
   url?: Maybe<Scalars["String"]>;
 };
 
-/** The conditions to match different events, which need to be true for workflow to be started. */
-export type WorkflowConditions = {
-  /** The conditions to match triggers based on issue (creation, update, deletion). */
-  issue: WorkflowEntityPropertyMatcher;
+/** A condition to match for the workflow to be triggered. */
+export type WorkflowCondition = {
+  /** Trigger the workflow when an issue matches the filter. Can only be used when the trigger type is `Issue`. */
+  issueFilter?: Maybe<IssueFilter>;
+  /** Triggers the workflow when a project matches the filter. Can only be used when the trigger type is `Project`. */
+  projectFilter?: Maybe<ProjectFilter>;
 };
 
 export type WorkflowDefinition = Node & {
@@ -8352,28 +8372,32 @@ export type WorkflowDefinition = Node & {
   activities: Scalars["JSONObject"];
   /** The time at which the entity was archived. Null if the entity has not been archived. */
   archivedAt?: Maybe<Scalars["DateTime"]>;
-  /** One or more conditions that need to be true for workflow to be triggered. */
+  /** The conditions that need to be match for the workflow to be triggered. */
   conditions: Scalars["JSONObject"];
   /** The time at which the entity was created. */
   createdAt: Scalars["DateTime"];
   /** The user who created the workflow. */
   creator: User;
-  /** The workflow description. */
+  /** The description of the workflow. */
   description?: Maybe<Scalars["String"]>;
   enabled: Scalars["Boolean"];
+  /** The name of the group that the workflow belongs to. */
+  groupName?: Maybe<Scalars["String"]>;
   /** The unique identifier of the entity. */
   id: Scalars["ID"];
   /** The name of the workflow. */
   name: Scalars["String"];
-  /** The organization where workflow was created. */
-  organization: Organization;
   /** Cron schedule which is used to execute the workflow. Only applicable for cron based workflows. */
   schedule: Scalars["JSONObject"];
-  /** The team associated with the workflow. */
-  team: Team;
-  /** The type of the trigger that kicks off the workflow. */
-  trigger: WorkflowTriggerType;
-  /** The type of the workflow */
+  /** The sort order of the workflow definition within its siblings. */
+  sortOrder: Scalars["String"];
+  /** The team associated with the workflow. If not set, the workflow is associated with the entire organization. */
+  team?: Maybe<Team>;
+  /** The type of the event that triggers off the workflow. */
+  trigger: WorkflowTrigger;
+  /** The object type (e.g. Issue) that triggers this workflow. */
+  triggerType: WorkflowTriggerType;
+  /** The type of the workflow. */
   type: WorkflowType;
   /**
    * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
@@ -8383,18 +8407,18 @@ export type WorkflowDefinition = Node & {
   updatedAt: Scalars["DateTime"];
 };
 
-/** Object to provide conditions to match an entity change. */
-export type WorkflowEntityPropertyMatcher = {
-  /** The optional list of property matchers that all have to match. */
-  and?: Maybe<Array<WorkflowEntityPropertyMatcher>>;
-  /** The initial value of the property to match. */
-  fromValue?: Maybe<Scalars["String"]>;
-  /** The optional list of property matchers where at least one have to match. */
-  or?: Maybe<Array<WorkflowEntityPropertyMatcher>>;
-  /** The property to check for matching. */
-  property: Scalars["String"];
-  /** The new value of the property to match. */
-  toValue?: Maybe<Scalars["String"]>;
+export type WorkflowDefinitionConnection = {
+  __typename?: "WorkflowDefinitionConnection";
+  edges: Array<WorkflowDefinitionEdge>;
+  nodes: Array<WorkflowDefinition>;
+  pageInfo: PageInfo;
+};
+
+export type WorkflowDefinitionEdge = {
+  __typename?: "WorkflowDefinitionEdge";
+  /** Used in `before` and `after` args */
+  cursor: Scalars["String"];
+  node: WorkflowDefinition;
 };
 
 /** A state in a team workflow. */
@@ -8517,16 +8541,24 @@ export type WorkflowStateUpdateInput = {
   position?: Maybe<Scalars["Float"]>;
 };
 
-export enum WorkflowTriggerType {
+export enum WorkflowTrigger {
   Cron = "cron",
-  IssueCreated = "issueCreated",
-  IssueDeleted = "issueDeleted",
-  IssueUpdated = "issueUpdated",
+  EntityCreated = "entityCreated",
+  EntityCreatedOrUpdated = "entityCreatedOrUpdated",
+  EntityRemoved = "entityRemoved",
+  EntityUnarchived = "entityUnarchived",
+  EntityUpdated = "entityUpdated",
+}
+
+export enum WorkflowTriggerType {
+  Issue = "issue",
+  Project = "project",
 }
 
 export enum WorkflowType {
   Custom = "custom",
   RecurringIssue = "recurringIssue",
+  Sla = "sla",
 }
 
 /** [INTERNAL] Public information of the OAuth application, plus the userIds and scopes for those users. */
@@ -8660,15 +8692,10 @@ export type DocumentFragment = { __typename: "Document" } & Pick<
     updatedBy: { __typename?: "User" } & Pick<User, "id">;
   };
 
-export type InitiativeFragment = { __typename: "Initiative" } & Pick<
-  Initiative,
-  "targetDate" | "description" | "updatedAt" | "name" | "sortOrder" | "archivedAt" | "createdAt" | "id"
->;
-
-export type MilestoneFragment = { __typename: "Milestone" } & Pick<
-  Milestone,
-  "updatedAt" | "name" | "sortOrder" | "archivedAt" | "createdAt" | "id"
->;
+export type ProjectMilestoneFragment = { __typename: "ProjectMilestone" } & Pick<
+  ProjectMilestone,
+  "description" | "updatedAt" | "name" | "targetDate" | "archivedAt" | "createdAt" | "id"
+> & { project: { __typename?: "Project" } & Pick<Project, "id"> };
 
 type Notification_IssueNotification_Fragment = { __typename: "IssueNotification" } & Pick<
   IssueNotification,
@@ -8698,6 +8725,11 @@ export type NotificationFragment =
   | Notification_IssueNotification_Fragment
   | Notification_OauthClientApprovalNotification_Fragment
   | Notification_ProjectNotification_Fragment;
+
+export type PersonalNoteFragment = { __typename: "PersonalNote" } & Pick<
+  PersonalNote,
+  "updatedAt" | "contentData" | "archivedAt" | "createdAt" | "id"
+> & { user: { __typename?: "User" } & Pick<User, "id"> };
 
 export type ProjectNotificationSubscriptionFragment = { __typename: "ProjectNotificationSubscription" } & Pick<
   ProjectNotificationSubscription,
@@ -8750,8 +8782,6 @@ export type ProjectFragment = { __typename: "Project" } & Pick<
   | "slackIssueStatuses"
 > & {
     integrationsSettings?: Maybe<{ __typename?: "IntegrationsSettings" } & Pick<IntegrationsSettings, "id">>;
-    initiative?: Maybe<{ __typename?: "Initiative" } & InitiativeFragment>;
-    milestone?: Maybe<{ __typename?: "Milestone" } & Pick<Milestone, "id">>;
     lead?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
     convertedFromIssue?: Maybe<{ __typename?: "Issue" } & Pick<Issue, "id">>;
     creator: { __typename?: "User" } & Pick<User, "id">;
@@ -9023,6 +9053,7 @@ export type IssueFragment = { __typename: "Issue" } & Pick<
   | "priority"
   | "archivedAt"
   | "createdAt"
+  | "startedTriageAt"
   | "triagedAt"
   | "autoArchivedAt"
   | "autoClosedAt"
@@ -9103,6 +9134,7 @@ export type TeamFragment = { __typename: "Team" } & Pick<
   | "id"
   | "inviteHash"
   | "defaultIssueEstimate"
+  | "requirePriorityToLeaveTriage"
   | "issueOrderingNoPriorityFirst"
   | "private"
   | "cyclesEnabled"
@@ -9271,6 +9303,11 @@ export type NotificationSubscriptionFragment =
   | NotificationSubscription_ProjectNotificationSubscription_Fragment
   | NotificationSubscription_TeamNotificationSubscription_Fragment;
 
+export type NotionSettingsFragment = { __typename: "NotionSettings" } & Pick<
+  NotionSettings,
+  "workspaceId" | "workspaceName"
+>;
+
 export type OauthClientFragment = { __typename: "OauthClient" } & Pick<
   OauthClient,
   | "imageUrl"
@@ -9395,11 +9432,13 @@ export type IntegrationsSettingsFragment = { __typename: "IntegrationsSettings" 
   | "createdAt"
   | "id"
   | "slackIssueNewComment"
+  | "slackIssueAddedToTriage"
   | "slackIssueCreated"
   | "slackProjectUpdateCreated"
+  | "slackIssueSlaHighRisk"
+  | "slackIssueSlaBreached"
   | "slackIssueStatusChangedDone"
   | "slackIssueStatusChangedAll"
-  | "slackProjectUpdateCreatedToMilestone"
   | "slackProjectUpdateCreatedToTeam"
   | "slackProjectUpdateCreatedToWorkspace"
 > & {
@@ -9413,6 +9452,7 @@ export type IntegrationSettingsFragment = { __typename: "IntegrationSettings" } 
   googleSheets?: Maybe<{ __typename?: "GoogleSheetsSettings" } & GoogleSheetsSettingsFragment>;
   intercom?: Maybe<{ __typename?: "IntercomSettings" } & IntercomSettingsFragment>;
   jira?: Maybe<{ __typename?: "JiraSettings" } & JiraSettingsFragment>;
+  notion?: Maybe<{ __typename?: "NotionSettings" } & NotionSettingsFragment>;
   sentry?: Maybe<{ __typename?: "SentrySettings" } & SentrySettingsFragment>;
   slackOrgProjectUpdatesPost?: Maybe<{ __typename?: "SlackPostSettings" } & SlackPostSettingsFragment>;
   slackPost?: Maybe<{ __typename?: "SlackPostSettings" } & SlackPostSettingsFragment>;
@@ -9643,11 +9683,6 @@ export type ImageUploadFromUrlPayloadFragment = { __typename: "ImageUploadFromUr
   "url" | "lastSyncId" | "success"
 >;
 
-export type InitiativeConnectionFragment = { __typename: "InitiativeConnection" } & {
-  nodes: Array<{ __typename?: "Initiative" } & InitiativeFragment>;
-  pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
-};
-
 export type IntegrationConnectionFragment = { __typename: "IntegrationConnection" } & {
   nodes: Array<{ __typename?: "Integration" } & IntegrationFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
@@ -9744,21 +9779,6 @@ export type IssueRelationPayloadFragment = { __typename: "IssueRelationPayload" 
 
 export type LogoutResponseFragment = { __typename: "LogoutResponse" } & Pick<LogoutResponse, "success">;
 
-export type MilestoneConnectionFragment = { __typename: "MilestoneConnection" } & {
-  nodes: Array<{ __typename?: "Milestone" } & MilestoneFragment>;
-  pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
-};
-
-export type MilestoneMigrationPayloadFragment = { __typename: "MilestoneMigrationPayload" } & Pick<
-  MilestoneMigrationPayload,
-  "lastSyncId" | "success"
->;
-
-export type MilestonePayloadFragment = { __typename: "MilestonePayload" } & Pick<
-  MilestonePayload,
-  "lastSyncId" | "success"
-> & { milestone?: Maybe<{ __typename?: "Milestone" } & Pick<Milestone, "id">> };
-
 type Node_ApiKey_Fragment = { __typename: "ApiKey" } & Pick<ApiKey, "id">;
 
 type Node_Attachment_Fragment = { __typename: "Attachment" } & Pick<Attachment, "id">;
@@ -9777,8 +9797,6 @@ type Node_Emoji_Fragment = { __typename: "Emoji" } & Pick<Emoji, "id">;
 
 type Node_Favorite_Fragment = { __typename: "Favorite" } & Pick<Favorite, "id">;
 
-type Node_Initiative_Fragment = { __typename: "Initiative" } & Pick<Initiative, "id">;
-
 type Node_Integration_Fragment = { __typename: "Integration" } & Pick<Integration, "id">;
 
 type Node_IntegrationResource_Fragment = { __typename: "IntegrationResource" } & Pick<IntegrationResource, "id">;
@@ -9789,6 +9807,8 @@ type Node_IntegrationsSettings_Fragment = { __typename: "IntegrationsSettings" }
 
 type Node_Issue_Fragment = { __typename: "Issue" } & Pick<Issue, "id">;
 
+type Node_IssueDraft_Fragment = { __typename: "IssueDraft" } & Pick<IssueDraft, "id">;
+
 type Node_IssueHistory_Fragment = { __typename: "IssueHistory" } & Pick<IssueHistory, "id">;
 
 type Node_IssueImport_Fragment = { __typename: "IssueImport" } & Pick<IssueImport, "id">;
@@ -9798,8 +9818,6 @@ type Node_IssueLabel_Fragment = { __typename: "IssueLabel" } & Pick<IssueLabel, 
 type Node_IssueNotification_Fragment = { __typename: "IssueNotification" } & Pick<IssueNotification, "id">;
 
 type Node_IssueRelation_Fragment = { __typename: "IssueRelation" } & Pick<IssueRelation, "id">;
-
-type Node_Milestone_Fragment = { __typename: "Milestone" } & Pick<Milestone, "id">;
 
 type Node_OauthClient_Fragment = { __typename: "OauthClient" } & Pick<OauthClient, "id">;
 
@@ -9818,9 +9836,13 @@ type Node_OrganizationInvite_Fragment = { __typename: "OrganizationInvite" } & P
 
 type Node_PaidSubscription_Fragment = { __typename: "PaidSubscription" } & Pick<PaidSubscription, "id">;
 
+type Node_PersonalNote_Fragment = { __typename: "PersonalNote" } & Pick<PersonalNote, "id">;
+
 type Node_Project_Fragment = { __typename: "Project" } & Pick<Project, "id">;
 
 type Node_ProjectLink_Fragment = { __typename: "ProjectLink" } & Pick<ProjectLink, "id">;
+
+type Node_ProjectMilestone_Fragment = { __typename: "ProjectMilestone" } & Pick<ProjectMilestone, "id">;
 
 type Node_ProjectNotification_Fragment = { __typename: "ProjectNotification" } & Pick<ProjectNotification, "id">;
 
@@ -9877,18 +9899,17 @@ export type NodeFragment =
   | Node_Document_Fragment
   | Node_Emoji_Fragment
   | Node_Favorite_Fragment
-  | Node_Initiative_Fragment
   | Node_Integration_Fragment
   | Node_IntegrationResource_Fragment
   | Node_IntegrationTemplate_Fragment
   | Node_IntegrationsSettings_Fragment
   | Node_Issue_Fragment
+  | Node_IssueDraft_Fragment
   | Node_IssueHistory_Fragment
   | Node_IssueImport_Fragment
   | Node_IssueLabel_Fragment
   | Node_IssueNotification_Fragment
   | Node_IssueRelation_Fragment
-  | Node_Milestone_Fragment
   | Node_OauthClient_Fragment
   | Node_OauthClientApproval_Fragment
   | Node_OauthClientApprovalNotification_Fragment
@@ -9896,8 +9917,10 @@ export type NodeFragment =
   | Node_OrganizationDomain_Fragment
   | Node_OrganizationInvite_Fragment
   | Node_PaidSubscription_Fragment
+  | Node_PersonalNote_Fragment
   | Node_Project_Fragment
   | Node_ProjectLink_Fragment
+  | Node_ProjectMilestone_Fragment
   | Node_ProjectNotification_Fragment
   | Node_ProjectNotificationSubscription_Fragment
   | Node_ProjectUpdate_Fragment
@@ -10020,6 +10043,16 @@ export type ProjectLinkPayloadFragment = { __typename: "ProjectLinkPayload" } & 
   ProjectLinkPayload,
   "lastSyncId" | "success"
 > & { projectLink: { __typename?: "ProjectLink" } & Pick<ProjectLink, "id"> };
+
+export type ProjectMilestoneConnectionFragment = { __typename: "ProjectMilestoneConnection" } & {
+  nodes: Array<{ __typename?: "ProjectMilestone" } & ProjectMilestoneFragment>;
+  pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
+};
+
+export type ProjectMilestonePayloadFragment = { __typename: "ProjectMilestonePayload" } & Pick<
+  ProjectMilestonePayload,
+  "lastSyncId" | "success"
+> & { projectMilestone: { __typename?: "ProjectMilestone" } & Pick<ProjectMilestone, "id"> };
 
 export type ProjectPayloadFragment = { __typename: "ProjectPayload" } & Pick<
   ProjectPayload,
@@ -10204,14 +10237,21 @@ export type WorkflowDefinitionFragment = { __typename: "WorkflowDefinition" } & 
   | "activities"
   | "schedule"
   | "conditions"
+  | "description"
   | "updatedAt"
+  | "groupName"
   | "name"
+  | "sortOrder"
   | "archivedAt"
   | "createdAt"
   | "id"
-  | "description"
   | "enabled"
-> & { team: { __typename?: "Team" } & Pick<Team, "id">; creator: { __typename?: "User" } & Pick<User, "id"> };
+> & { team?: Maybe<{ __typename?: "Team" } & Pick<Team, "id">>; creator: { __typename?: "User" } & Pick<User, "id"> };
+
+export type WorkflowDefinitionConnectionFragment = { __typename: "WorkflowDefinitionConnection" } & {
+  nodes: Array<{ __typename?: "WorkflowDefinition" } & WorkflowDefinitionFragment>;
+  pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
+};
 
 export type WorkflowStateConnectionFragment = { __typename: "WorkflowStateConnection" } & {
   nodes: Array<{ __typename?: "WorkflowState" } & WorkflowStateFragment>;
@@ -10222,6 +10262,1482 @@ export type WorkflowStatePayloadFragment = { __typename: "WorkflowStatePayload" 
   WorkflowStatePayload,
   "lastSyncId" | "success"
 > & { workflowState: { __typename?: "WorkflowState" } & Pick<WorkflowState, "id"> };
+
+export type AirbyteIntegrationConnectMutationVariables = Exact<{
+  input: AirbyteConfigurationInput;
+}>;
+
+export type AirbyteIntegrationConnectMutation = { __typename?: "Mutation" } & {
+  airbyteIntegrationConnect: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type CreateApiKeyMutationVariables = Exact<{
+  input: ApiKeyCreateInput;
+}>;
+
+export type CreateApiKeyMutation = { __typename?: "Mutation" } & {
+  apiKeyCreate: { __typename?: "ApiKeyPayload" } & ApiKeyPayloadFragment;
+};
+
+export type DeleteApiKeyMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteApiKeyMutation = { __typename?: "Mutation" } & {
+  apiKeyDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type ArchiveAttachmentMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type ArchiveAttachmentMutation = { __typename?: "Mutation" } & {
+  attachmentArchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type CreateAttachmentMutationVariables = Exact<{
+  input: AttachmentCreateInput;
+}>;
+
+export type CreateAttachmentMutation = { __typename?: "Mutation" } & {
+  attachmentCreate: { __typename?: "AttachmentPayload" } & AttachmentPayloadFragment;
+};
+
+export type DeleteAttachmentMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteAttachmentMutation = { __typename?: "Mutation" } & {
+  attachmentDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type AttachmentLinkDiscordMutationVariables = Exact<{
+  channelId: Scalars["String"];
+  issueId: Scalars["String"];
+  messageId: Scalars["String"];
+  url: Scalars["String"];
+}>;
+
+export type AttachmentLinkDiscordMutation = { __typename?: "Mutation" } & {
+  attachmentLinkDiscord: { __typename?: "AttachmentPayload" } & AttachmentPayloadFragment;
+};
+
+export type AttachmentLinkFrontMutationVariables = Exact<{
+  conversationId: Scalars["String"];
+  issueId: Scalars["String"];
+}>;
+
+export type AttachmentLinkFrontMutation = { __typename?: "Mutation" } & {
+  attachmentLinkFront: { __typename?: "FrontAttachmentPayload" } & FrontAttachmentPayloadFragment;
+};
+
+export type AttachmentLinkIntercomMutationVariables = Exact<{
+  conversationId: Scalars["String"];
+  issueId: Scalars["String"];
+}>;
+
+export type AttachmentLinkIntercomMutation = { __typename?: "Mutation" } & {
+  attachmentLinkIntercom: { __typename?: "AttachmentPayload" } & AttachmentPayloadFragment;
+};
+
+export type AttachmentLinkJiraIssueMutationVariables = Exact<{
+  issueId: Scalars["String"];
+  jiraIssueId: Scalars["String"];
+}>;
+
+export type AttachmentLinkJiraIssueMutation = { __typename?: "Mutation" } & {
+  attachmentLinkJiraIssue: { __typename?: "AttachmentPayload" } & AttachmentPayloadFragment;
+};
+
+export type AttachmentLinkUrlMutationVariables = Exact<{
+  id?: Maybe<Scalars["String"]>;
+  issueId: Scalars["String"];
+  title?: Maybe<Scalars["String"]>;
+  url: Scalars["String"];
+}>;
+
+export type AttachmentLinkUrlMutation = { __typename?: "Mutation" } & {
+  attachmentLinkURL: { __typename?: "AttachmentPayload" } & AttachmentPayloadFragment;
+};
+
+export type AttachmentLinkZendeskMutationVariables = Exact<{
+  issueId: Scalars["String"];
+  ticketId: Scalars["String"];
+}>;
+
+export type AttachmentLinkZendeskMutation = { __typename?: "Mutation" } & {
+  attachmentLinkZendesk: { __typename?: "AttachmentPayload" } & AttachmentPayloadFragment;
+};
+
+export type UpdateAttachmentMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: AttachmentUpdateInput;
+}>;
+
+export type UpdateAttachmentMutation = { __typename?: "Mutation" } & {
+  attachmentUpdate: { __typename?: "AttachmentPayload" } & AttachmentPayloadFragment;
+};
+
+export type CreateCommentMutationVariables = Exact<{
+  input: CommentCreateInput;
+}>;
+
+export type CreateCommentMutation = { __typename?: "Mutation" } & {
+  commentCreate: { __typename?: "CommentPayload" } & CommentPayloadFragment;
+};
+
+export type DeleteCommentMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteCommentMutation = { __typename?: "Mutation" } & {
+  commentDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateCommentMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: CommentUpdateInput;
+}>;
+
+export type UpdateCommentMutation = { __typename?: "Mutation" } & {
+  commentUpdate: { __typename?: "CommentPayload" } & CommentPayloadFragment;
+};
+
+export type CreateContactMutationVariables = Exact<{
+  input: ContactCreateInput;
+}>;
+
+export type CreateContactMutation = { __typename?: "Mutation" } & {
+  contactCreate: { __typename?: "ContactPayload" } & ContactPayloadFragment;
+};
+
+export type CreateCsvExportReportMutationVariables = Exact<{
+  includePrivateTeamIds?: Maybe<Array<Scalars["String"]> | Scalars["String"]>;
+}>;
+
+export type CreateCsvExportReportMutation = { __typename?: "Mutation" } & {
+  createCsvExportReport: { __typename?: "CreateCsvExportReportPayload" } & CreateCsvExportReportPayloadFragment;
+};
+
+export type CreateOrganizationFromOnboardingMutationVariables = Exact<{
+  input: CreateOrganizationInput;
+  survey?: Maybe<OnboardingCustomerSurvey>;
+}>;
+
+export type CreateOrganizationFromOnboardingMutation = { __typename?: "Mutation" } & {
+  createOrganizationFromOnboarding: {
+    __typename?: "CreateOrJoinOrganizationResponse";
+  } & CreateOrJoinOrganizationResponseFragment;
+};
+
+export type CreateCustomViewMutationVariables = Exact<{
+  input: CustomViewCreateInput;
+}>;
+
+export type CreateCustomViewMutation = { __typename?: "Mutation" } & {
+  customViewCreate: { __typename?: "CustomViewPayload" } & CustomViewPayloadFragment;
+};
+
+export type DeleteCustomViewMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteCustomViewMutation = { __typename?: "Mutation" } & {
+  customViewDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateCustomViewMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: CustomViewUpdateInput;
+}>;
+
+export type UpdateCustomViewMutation = { __typename?: "Mutation" } & {
+  customViewUpdate: { __typename?: "CustomViewPayload" } & CustomViewPayloadFragment;
+};
+
+export type ArchiveCycleMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type ArchiveCycleMutation = { __typename?: "Mutation" } & {
+  cycleArchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type CreateCycleMutationVariables = Exact<{
+  input: CycleCreateInput;
+}>;
+
+export type CreateCycleMutation = { __typename?: "Mutation" } & {
+  cycleCreate: { __typename?: "CyclePayload" } & CyclePayloadFragment;
+};
+
+export type UpdateCycleMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: CycleUpdateInput;
+}>;
+
+export type UpdateCycleMutation = { __typename?: "Mutation" } & {
+  cycleUpdate: { __typename?: "CyclePayload" } & CyclePayloadFragment;
+};
+
+export type CreateDocumentMutationVariables = Exact<{
+  input: DocumentCreateInput;
+}>;
+
+export type CreateDocumentMutation = { __typename?: "Mutation" } & {
+  documentCreate: { __typename?: "DocumentPayload" } & DocumentPayloadFragment;
+};
+
+export type DeleteDocumentMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteDocumentMutation = { __typename?: "Mutation" } & {
+  documentDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateDocumentMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: DocumentUpdateInput;
+}>;
+
+export type UpdateDocumentMutation = { __typename?: "Mutation" } & {
+  documentUpdate: { __typename?: "DocumentPayload" } & DocumentPayloadFragment;
+};
+
+export type EmailTokenUserAccountAuthMutationVariables = Exact<{
+  input: TokenUserAccountAuthInput;
+}>;
+
+export type EmailTokenUserAccountAuthMutation = { __typename?: "Mutation" } & {
+  emailTokenUserAccountAuth: { __typename?: "AuthResolverResponse" } & AuthResolverResponseFragment;
+};
+
+export type EmailUnsubscribeMutationVariables = Exact<{
+  input: EmailUnsubscribeInput;
+}>;
+
+export type EmailUnsubscribeMutation = { __typename?: "Mutation" } & {
+  emailUnsubscribe: { __typename?: "EmailUnsubscribePayload" } & EmailUnsubscribePayloadFragment;
+};
+
+export type EmailUserAccountAuthChallengeMutationVariables = Exact<{
+  input: EmailUserAccountAuthChallengeInput;
+}>;
+
+export type EmailUserAccountAuthChallengeMutation = { __typename?: "Mutation" } & {
+  emailUserAccountAuthChallenge: {
+    __typename?: "EmailUserAccountAuthChallengeResponse";
+  } & EmailUserAccountAuthChallengeResponseFragment;
+};
+
+export type CreateEmojiMutationVariables = Exact<{
+  input: EmojiCreateInput;
+}>;
+
+export type CreateEmojiMutation = { __typename?: "Mutation" } & {
+  emojiCreate: { __typename?: "EmojiPayload" } & EmojiPayloadFragment;
+};
+
+export type DeleteEmojiMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteEmojiMutation = { __typename?: "Mutation" } & {
+  emojiDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type CreateEventMutationVariables = Exact<{
+  input: EventCreateInput;
+}>;
+
+export type CreateEventMutation = { __typename?: "Mutation" } & {
+  eventCreate: { __typename?: "EventPayload" } & EventPayloadFragment;
+};
+
+export type CreateFavoriteMutationVariables = Exact<{
+  input: FavoriteCreateInput;
+}>;
+
+export type CreateFavoriteMutation = { __typename?: "Mutation" } & {
+  favoriteCreate: { __typename?: "FavoritePayload" } & FavoritePayloadFragment;
+};
+
+export type DeleteFavoriteMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteFavoriteMutation = { __typename?: "Mutation" } & {
+  favoriteDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateFavoriteMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: FavoriteUpdateInput;
+}>;
+
+export type UpdateFavoriteMutation = { __typename?: "Mutation" } & {
+  favoriteUpdate: { __typename?: "FavoritePayload" } & FavoritePayloadFragment;
+};
+
+export type FileUploadMutationVariables = Exact<{
+  contentType: Scalars["String"];
+  filename: Scalars["String"];
+  makePublic?: Maybe<Scalars["Boolean"]>;
+  metaData?: Maybe<Scalars["JSON"]>;
+  size: Scalars["Int"];
+}>;
+
+export type FileUploadMutation = { __typename?: "Mutation" } & {
+  fileUpload: { __typename?: "UploadPayload" } & UploadPayloadFragment;
+};
+
+export type GoogleUserAccountAuthMutationVariables = Exact<{
+  input: GoogleUserAccountAuthInput;
+}>;
+
+export type GoogleUserAccountAuthMutation = { __typename?: "Mutation" } & {
+  googleUserAccountAuth: { __typename?: "AuthResolverResponse" } & AuthResolverResponseFragment;
+};
+
+export type ImageUploadFromUrlMutationVariables = Exact<{
+  url: Scalars["String"];
+}>;
+
+export type ImageUploadFromUrlMutation = { __typename?: "Mutation" } & {
+  imageUploadFromUrl: { __typename?: "ImageUploadFromUrlPayload" } & ImageUploadFromUrlPayloadFragment;
+};
+
+export type DeleteIntegrationMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteIntegrationMutation = { __typename?: "Mutation" } & {
+  integrationDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type IntegrationDiscordMutationVariables = Exact<{
+  code: Scalars["String"];
+  redirectUri: Scalars["String"];
+}>;
+
+export type IntegrationDiscordMutation = { __typename?: "Mutation" } & {
+  integrationDiscord: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type IntegrationFigmaMutationVariables = Exact<{
+  code: Scalars["String"];
+  redirectUri: Scalars["String"];
+}>;
+
+export type IntegrationFigmaMutation = { __typename?: "Mutation" } & {
+  integrationFigma: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type IntegrationFrontMutationVariables = Exact<{
+  code: Scalars["String"];
+  redirectUri: Scalars["String"];
+}>;
+
+export type IntegrationFrontMutation = { __typename?: "Mutation" } & {
+  integrationFront: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type CreateIntegrationGithubCommitMutationVariables = Exact<{ [key: string]: never }>;
+
+export type CreateIntegrationGithubCommitMutation = { __typename?: "Mutation" } & {
+  integrationGithubCommitCreate: {
+    __typename?: "GitHubCommitIntegrationPayload";
+  } & GitHubCommitIntegrationPayloadFragment;
+};
+
+export type IntegrationGithubConnectMutationVariables = Exact<{
+  installationId: Scalars["String"];
+}>;
+
+export type IntegrationGithubConnectMutation = { __typename?: "Mutation" } & {
+  integrationGithubConnect: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type IntegrationGitlabConnectMutationVariables = Exact<{
+  accessToken: Scalars["String"];
+  gitlabUrl: Scalars["String"];
+}>;
+
+export type IntegrationGitlabConnectMutation = { __typename?: "Mutation" } & {
+  integrationGitlabConnect: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type IntegrationGoogleSheetsMutationVariables = Exact<{
+  code: Scalars["String"];
+}>;
+
+export type IntegrationGoogleSheetsMutation = { __typename?: "Mutation" } & {
+  integrationGoogleSheets: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type IntegrationIntercomMutationVariables = Exact<{
+  code: Scalars["String"];
+  domainUrl?: Maybe<Scalars["String"]>;
+  redirectUri: Scalars["String"];
+}>;
+
+export type IntegrationIntercomMutation = { __typename?: "Mutation" } & {
+  integrationIntercom: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type DeleteIntegrationIntercomMutationVariables = Exact<{ [key: string]: never }>;
+
+export type DeleteIntegrationIntercomMutation = { __typename?: "Mutation" } & {
+  integrationIntercomDelete: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type UpdateIntegrationIntercomSettingsMutationVariables = Exact<{
+  input: IntercomSettingsInput;
+}>;
+
+export type UpdateIntegrationIntercomSettingsMutation = { __typename?: "Mutation" } & {
+  integrationIntercomSettingsUpdate: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type IntegrationLoomMutationVariables = Exact<{ [key: string]: never }>;
+
+export type IntegrationLoomMutation = { __typename?: "Mutation" } & {
+  integrationLoom: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type IntegrationRequestMutationVariables = Exact<{
+  input: IntegrationRequestInput;
+}>;
+
+export type IntegrationRequestMutation = { __typename?: "Mutation" } & {
+  integrationRequest: { __typename?: "IntegrationRequestPayload" } & IntegrationRequestPayloadFragment;
+};
+
+export type ArchiveIntegrationResourceMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type ArchiveIntegrationResourceMutation = { __typename?: "Mutation" } & {
+  integrationResourceArchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type IntegrationSentryConnectMutationVariables = Exact<{
+  code: Scalars["String"];
+  installationId: Scalars["String"];
+  organizationSlug: Scalars["String"];
+}>;
+
+export type IntegrationSentryConnectMutation = { __typename?: "Mutation" } & {
+  integrationSentryConnect: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type IntegrationSlackMutationVariables = Exact<{
+  code: Scalars["String"];
+  redirectUri: Scalars["String"];
+  shouldUseV2Auth?: Maybe<Scalars["Boolean"]>;
+}>;
+
+export type IntegrationSlackMutation = { __typename?: "Mutation" } & {
+  integrationSlack: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type IntegrationSlackImportEmojisMutationVariables = Exact<{
+  code: Scalars["String"];
+  redirectUri: Scalars["String"];
+}>;
+
+export type IntegrationSlackImportEmojisMutation = { __typename?: "Mutation" } & {
+  integrationSlackImportEmojis: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type IntegrationSlackOrgProjectUpdatesPostMutationVariables = Exact<{
+  code: Scalars["String"];
+  redirectUri: Scalars["String"];
+}>;
+
+export type IntegrationSlackOrgProjectUpdatesPostMutation = { __typename?: "Mutation" } & {
+  integrationSlackOrgProjectUpdatesPost: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type IntegrationSlackPersonalMutationVariables = Exact<{
+  code: Scalars["String"];
+  redirectUri: Scalars["String"];
+}>;
+
+export type IntegrationSlackPersonalMutation = { __typename?: "Mutation" } & {
+  integrationSlackPersonal: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type IntegrationSlackPostMutationVariables = Exact<{
+  code: Scalars["String"];
+  redirectUri: Scalars["String"];
+  shouldUseV2Auth?: Maybe<Scalars["Boolean"]>;
+  teamId: Scalars["String"];
+}>;
+
+export type IntegrationSlackPostMutation = { __typename?: "Mutation" } & {
+  integrationSlackPost: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type IntegrationSlackProjectPostMutationVariables = Exact<{
+  code: Scalars["String"];
+  projectId: Scalars["String"];
+  redirectUri: Scalars["String"];
+  service: Scalars["String"];
+}>;
+
+export type IntegrationSlackProjectPostMutation = { __typename?: "Mutation" } & {
+  integrationSlackProjectPost: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type CreateIntegrationTemplateMutationVariables = Exact<{
+  input: IntegrationTemplateCreateInput;
+}>;
+
+export type CreateIntegrationTemplateMutation = { __typename?: "Mutation" } & {
+  integrationTemplateCreate: { __typename?: "IntegrationTemplatePayload" } & IntegrationTemplatePayloadFragment;
+};
+
+export type DeleteIntegrationTemplateMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteIntegrationTemplateMutation = { __typename?: "Mutation" } & {
+  integrationTemplateDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type IntegrationZendeskMutationVariables = Exact<{
+  code: Scalars["String"];
+  redirectUri: Scalars["String"];
+  scope: Scalars["String"];
+  subdomain: Scalars["String"];
+}>;
+
+export type IntegrationZendeskMutation = { __typename?: "Mutation" } & {
+  integrationZendesk: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type CreateIntegrationsSettingsMutationVariables = Exact<{
+  input: IntegrationsSettingsCreateInput;
+}>;
+
+export type CreateIntegrationsSettingsMutation = { __typename?: "Mutation" } & {
+  integrationsSettingsCreate: { __typename?: "IntegrationsSettingsPayload" } & IntegrationsSettingsPayloadFragment;
+};
+
+export type UpdateIntegrationsSettingsMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: IntegrationsSettingsUpdateInput;
+}>;
+
+export type UpdateIntegrationsSettingsMutation = { __typename?: "Mutation" } & {
+  integrationsSettingsUpdate: { __typename?: "IntegrationsSettingsPayload" } & IntegrationsSettingsPayloadFragment;
+};
+
+export type ArchiveIssueMutationVariables = Exact<{
+  id: Scalars["String"];
+  trash?: Maybe<Scalars["Boolean"]>;
+}>;
+
+export type ArchiveIssueMutation = { __typename?: "Mutation" } & {
+  issueArchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateIssueBatchMutationVariables = Exact<{
+  ids: Array<Scalars["UUID"]> | Scalars["UUID"];
+  input: IssueUpdateInput;
+}>;
+
+export type UpdateIssueBatchMutation = { __typename?: "Mutation" } & {
+  issueBatchUpdate: { __typename?: "IssueBatchPayload" } & IssueBatchPayloadFragment;
+};
+
+export type CreateIssueMutationVariables = Exact<{
+  input: IssueCreateInput;
+}>;
+
+export type CreateIssueMutation = { __typename?: "Mutation" } & {
+  issueCreate: { __typename?: "IssuePayload" } & IssuePayloadFragment;
+};
+
+export type DeleteIssueMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteIssueMutation = { __typename?: "Mutation" } & {
+  issueDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type IssueImportCreateAsanaMutationVariables = Exact<{
+  asanaTeamName: Scalars["String"];
+  asanaToken: Scalars["String"];
+  id?: Maybe<Scalars["String"]>;
+  includeClosedIssues?: Maybe<Scalars["Boolean"]>;
+  instantProcess?: Maybe<Scalars["Boolean"]>;
+  organizationId?: Maybe<Scalars["String"]>;
+  teamId?: Maybe<Scalars["String"]>;
+  teamName?: Maybe<Scalars["String"]>;
+}>;
+
+export type IssueImportCreateAsanaMutation = { __typename?: "Mutation" } & {
+  issueImportCreateAsana: { __typename?: "IssueImportPayload" } & IssueImportPayloadFragment;
+};
+
+export type IssueImportCreateClubhouseMutationVariables = Exact<{
+  clubhouseTeamName: Scalars["String"];
+  clubhouseToken: Scalars["String"];
+  id?: Maybe<Scalars["String"]>;
+  includeClosedIssues?: Maybe<Scalars["Boolean"]>;
+  instantProcess?: Maybe<Scalars["Boolean"]>;
+  organizationId?: Maybe<Scalars["String"]>;
+  teamId?: Maybe<Scalars["String"]>;
+  teamName?: Maybe<Scalars["String"]>;
+}>;
+
+export type IssueImportCreateClubhouseMutation = { __typename?: "Mutation" } & {
+  issueImportCreateClubhouse: { __typename?: "IssueImportPayload" } & IssueImportPayloadFragment;
+};
+
+export type IssueImportCreateGithubMutationVariables = Exact<{
+  githubRepoName: Scalars["String"];
+  githubRepoOwner: Scalars["String"];
+  githubShouldImportOrgProjects?: Maybe<Scalars["Boolean"]>;
+  githubToken: Scalars["String"];
+  id?: Maybe<Scalars["String"]>;
+  includeClosedIssues?: Maybe<Scalars["Boolean"]>;
+  instantProcess?: Maybe<Scalars["Boolean"]>;
+  organizationId?: Maybe<Scalars["String"]>;
+  teamId?: Maybe<Scalars["String"]>;
+  teamName?: Maybe<Scalars["String"]>;
+}>;
+
+export type IssueImportCreateGithubMutation = { __typename?: "Mutation" } & {
+  issueImportCreateGithub: { __typename?: "IssueImportPayload" } & IssueImportPayloadFragment;
+};
+
+export type IssueImportCreateJiraMutationVariables = Exact<{
+  id?: Maybe<Scalars["String"]>;
+  includeClosedIssues?: Maybe<Scalars["Boolean"]>;
+  instantProcess?: Maybe<Scalars["Boolean"]>;
+  jiraEmail: Scalars["String"];
+  jiraHostname: Scalars["String"];
+  jiraProject: Scalars["String"];
+  jiraToken: Scalars["String"];
+  organizationId?: Maybe<Scalars["String"]>;
+  teamId?: Maybe<Scalars["String"]>;
+  teamName?: Maybe<Scalars["String"]>;
+}>;
+
+export type IssueImportCreateJiraMutation = { __typename?: "Mutation" } & {
+  issueImportCreateJira: { __typename?: "IssueImportPayload" } & IssueImportPayloadFragment;
+};
+
+export type DeleteIssueImportMutationVariables = Exact<{
+  issueImportId: Scalars["String"];
+}>;
+
+export type DeleteIssueImportMutation = { __typename?: "Mutation" } & {
+  issueImportDelete: { __typename?: "IssueImportDeletePayload" } & IssueImportDeletePayloadFragment;
+};
+
+export type IssueImportProcessMutationVariables = Exact<{
+  issueImportId: Scalars["String"];
+  mapping: Scalars["JSONObject"];
+}>;
+
+export type IssueImportProcessMutation = { __typename?: "Mutation" } & {
+  issueImportProcess: { __typename?: "IssueImportPayload" } & IssueImportPayloadFragment;
+};
+
+export type UpdateIssueImportMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: IssueImportUpdateInput;
+}>;
+
+export type UpdateIssueImportMutation = { __typename?: "Mutation" } & {
+  issueImportUpdate: { __typename?: "IssueImportPayload" } & IssueImportPayloadFragment;
+};
+
+export type ArchiveIssueLabelMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type ArchiveIssueLabelMutation = { __typename?: "Mutation" } & {
+  issueLabelArchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type CreateIssueLabelMutationVariables = Exact<{
+  input: IssueLabelCreateInput;
+  replaceTeamLabels?: Maybe<Scalars["Boolean"]>;
+}>;
+
+export type CreateIssueLabelMutation = { __typename?: "Mutation" } & {
+  issueLabelCreate: { __typename?: "IssueLabelPayload" } & IssueLabelPayloadFragment;
+};
+
+export type DeleteIssueLabelMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteIssueLabelMutation = { __typename?: "Mutation" } & {
+  issueLabelDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateIssueLabelMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: IssueLabelUpdateInput;
+}>;
+
+export type UpdateIssueLabelMutation = { __typename?: "Mutation" } & {
+  issueLabelUpdate: { __typename?: "IssueLabelPayload" } & IssueLabelPayloadFragment;
+};
+
+export type CreateIssueRelationMutationVariables = Exact<{
+  input: IssueRelationCreateInput;
+}>;
+
+export type CreateIssueRelationMutation = { __typename?: "Mutation" } & {
+  issueRelationCreate: { __typename?: "IssueRelationPayload" } & IssueRelationPayloadFragment;
+};
+
+export type DeleteIssueRelationMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteIssueRelationMutation = { __typename?: "Mutation" } & {
+  issueRelationDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateIssueRelationMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: IssueRelationUpdateInput;
+}>;
+
+export type UpdateIssueRelationMutation = { __typename?: "Mutation" } & {
+  issueRelationUpdate: { __typename?: "IssueRelationPayload" } & IssueRelationPayloadFragment;
+};
+
+export type IssueReminderMutationVariables = Exact<{
+  id: Scalars["String"];
+  reminderAt: Scalars["DateTime"];
+}>;
+
+export type IssueReminderMutation = { __typename?: "Mutation" } & {
+  issueReminder: { __typename?: "IssuePayload" } & IssuePayloadFragment;
+};
+
+export type UnarchiveIssueMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type UnarchiveIssueMutation = { __typename?: "Mutation" } & {
+  issueUnarchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateIssueMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: IssueUpdateInput;
+}>;
+
+export type UpdateIssueMutation = { __typename?: "Mutation" } & {
+  issueUpdate: { __typename?: "IssuePayload" } & IssuePayloadFragment;
+};
+
+export type JoinOrganizationFromOnboardingMutationVariables = Exact<{
+  input: JoinOrganizationInput;
+}>;
+
+export type JoinOrganizationFromOnboardingMutation = { __typename?: "Mutation" } & {
+  joinOrganizationFromOnboarding: {
+    __typename?: "CreateOrJoinOrganizationResponse";
+  } & CreateOrJoinOrganizationResponseFragment;
+};
+
+export type LeaveOrganizationMutationVariables = Exact<{
+  organizationId: Scalars["String"];
+}>;
+
+export type LeaveOrganizationMutation = { __typename?: "Mutation" } & {
+  leaveOrganization: { __typename?: "CreateOrJoinOrganizationResponse" } & CreateOrJoinOrganizationResponseFragment;
+};
+
+export type LogoutMutationVariables = Exact<{ [key: string]: never }>;
+
+export type LogoutMutation = { __typename?: "Mutation" } & {
+  logout: { __typename?: "LogoutResponse" } & LogoutResponseFragment;
+};
+
+export type ArchiveNotificationMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type ArchiveNotificationMutation = { __typename?: "Mutation" } & {
+  notificationArchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type CreateNotificationSubscriptionMutationVariables = Exact<{
+  input: NotificationSubscriptionCreateInput;
+}>;
+
+export type CreateNotificationSubscriptionMutation = { __typename?: "Mutation" } & {
+  notificationSubscriptionCreate: {
+    __typename?: "NotificationSubscriptionPayload";
+  } & NotificationSubscriptionPayloadFragment;
+};
+
+export type DeleteNotificationSubscriptionMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteNotificationSubscriptionMutation = { __typename?: "Mutation" } & {
+  notificationSubscriptionDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateNotificationSubscriptionMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: NotificationSubscriptionUpdateInput;
+}>;
+
+export type UpdateNotificationSubscriptionMutation = { __typename?: "Mutation" } & {
+  notificationSubscriptionUpdate: {
+    __typename?: "NotificationSubscriptionPayload";
+  } & NotificationSubscriptionPayloadFragment;
+};
+
+export type UnarchiveNotificationMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type UnarchiveNotificationMutation = { __typename?: "Mutation" } & {
+  notificationUnarchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateNotificationMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: NotificationUpdateInput;
+}>;
+
+export type UpdateNotificationMutation = { __typename?: "Mutation" } & {
+  notificationUpdate: { __typename?: "NotificationPayload" } & NotificationPayloadFragment;
+};
+
+export type DeleteOrganizationCancelMutationVariables = Exact<{ [key: string]: never }>;
+
+export type DeleteOrganizationCancelMutation = { __typename?: "Mutation" } & {
+  organizationCancelDelete: {
+    __typename?: "OrganizationCancelDeletePayload";
+  } & OrganizationCancelDeletePayloadFragment;
+};
+
+export type DeleteOrganizationMutationVariables = Exact<{
+  input: DeleteOrganizationInput;
+}>;
+
+export type DeleteOrganizationMutation = { __typename?: "Mutation" } & {
+  organizationDelete: { __typename?: "OrganizationDeletePayload" } & OrganizationDeletePayloadFragment;
+};
+
+export type OrganizationDeleteChallengeMutationVariables = Exact<{ [key: string]: never }>;
+
+export type OrganizationDeleteChallengeMutation = { __typename?: "Mutation" } & {
+  organizationDeleteChallenge: { __typename?: "OrganizationDeletePayload" } & OrganizationDeletePayloadFragment;
+};
+
+export type DeleteOrganizationDomainMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteOrganizationDomainMutation = { __typename?: "Mutation" } & {
+  organizationDomainDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type CreateOrganizationInviteMutationVariables = Exact<{
+  input: OrganizationInviteCreateInput;
+}>;
+
+export type CreateOrganizationInviteMutation = { __typename?: "Mutation" } & {
+  organizationInviteCreate: { __typename?: "OrganizationInvitePayload" } & OrganizationInvitePayloadFragment;
+};
+
+export type DeleteOrganizationInviteMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteOrganizationInviteMutation = { __typename?: "Mutation" } & {
+  organizationInviteDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateOrganizationInviteMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: OrganizationInviteUpdateInput;
+}>;
+
+export type UpdateOrganizationInviteMutation = { __typename?: "Mutation" } & {
+  organizationInviteUpdate: { __typename?: "OrganizationInvitePayload" } & OrganizationInvitePayloadFragment;
+};
+
+export type UpdateOrganizationMutationVariables = Exact<{
+  input: UpdateOrganizationInput;
+}>;
+
+export type UpdateOrganizationMutation = { __typename?: "Mutation" } & {
+  organizationUpdate: { __typename?: "OrganizationPayload" } & OrganizationPayloadFragment;
+};
+
+export type ArchiveProjectMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type ArchiveProjectMutation = { __typename?: "Mutation" } & {
+  projectArchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type CreateProjectMutationVariables = Exact<{
+  input: ProjectCreateInput;
+}>;
+
+export type CreateProjectMutation = { __typename?: "Mutation" } & {
+  projectCreate: { __typename?: "ProjectPayload" } & ProjectPayloadFragment;
+};
+
+export type DeleteProjectMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteProjectMutation = { __typename?: "Mutation" } & {
+  projectDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type CreateProjectLinkMutationVariables = Exact<{
+  input: ProjectLinkCreateInput;
+}>;
+
+export type CreateProjectLinkMutation = { __typename?: "Mutation" } & {
+  projectLinkCreate: { __typename?: "ProjectLinkPayload" } & ProjectLinkPayloadFragment;
+};
+
+export type DeleteProjectLinkMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteProjectLinkMutation = { __typename?: "Mutation" } & {
+  projectLinkDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateProjectLinkMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: ProjectLinkUpdateInput;
+}>;
+
+export type UpdateProjectLinkMutation = { __typename?: "Mutation" } & {
+  projectLinkUpdate: { __typename?: "ProjectLinkPayload" } & ProjectLinkPayloadFragment;
+};
+
+export type CreateProjectMilestoneMutationVariables = Exact<{
+  input: ProjectMilestoneCreateInput;
+}>;
+
+export type CreateProjectMilestoneMutation = { __typename?: "Mutation" } & {
+  projectMilestoneCreate: { __typename?: "ProjectMilestonePayload" } & ProjectMilestonePayloadFragment;
+};
+
+export type DeleteProjectMilestoneMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteProjectMilestoneMutation = { __typename?: "Mutation" } & {
+  projectMilestoneDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateProjectMilestoneMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: ProjectMilestoneUpdateInput;
+}>;
+
+export type UpdateProjectMilestoneMutation = { __typename?: "Mutation" } & {
+  projectMilestoneUpdate: { __typename?: "ProjectMilestonePayload" } & ProjectMilestonePayloadFragment;
+};
+
+export type UnarchiveProjectMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type UnarchiveProjectMutation = { __typename?: "Mutation" } & {
+  projectUnarchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateProjectMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: ProjectUpdateInput;
+}>;
+
+export type UpdateProjectMutation = { __typename?: "Mutation" } & {
+  projectUpdate: { __typename?: "ProjectPayload" } & ProjectPayloadFragment;
+};
+
+export type CreateProjectUpdateMutationVariables = Exact<{
+  input: ProjectUpdateCreateInput;
+}>;
+
+export type CreateProjectUpdateMutation = { __typename?: "Mutation" } & {
+  projectUpdateCreate: { __typename?: "ProjectUpdatePayload" } & ProjectUpdatePayloadFragment;
+};
+
+export type DeleteProjectUpdateMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteProjectUpdateMutation = { __typename?: "Mutation" } & {
+  projectUpdateDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type CreateProjectUpdateInteractionMutationVariables = Exact<{
+  input: ProjectUpdateInteractionCreateInput;
+}>;
+
+export type CreateProjectUpdateInteractionMutation = { __typename?: "Mutation" } & {
+  projectUpdateInteractionCreate: {
+    __typename?: "ProjectUpdateInteractionPayload";
+  } & ProjectUpdateInteractionPayloadFragment;
+};
+
+export type ProjectUpdateMarkAsReadMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type ProjectUpdateMarkAsReadMutation = { __typename?: "Mutation" } & {
+  projectUpdateMarkAsRead: {
+    __typename?: "ProjectUpdateWithInteractionPayload";
+  } & ProjectUpdateWithInteractionPayloadFragment;
+};
+
+export type UpdateProjectUpdateMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: ProjectUpdateUpdateInput;
+}>;
+
+export type UpdateProjectUpdateMutation = { __typename?: "Mutation" } & {
+  projectUpdateUpdate: { __typename?: "ProjectUpdatePayload" } & ProjectUpdatePayloadFragment;
+};
+
+export type CreatePushSubscriptionMutationVariables = Exact<{
+  input: PushSubscriptionCreateInput;
+}>;
+
+export type CreatePushSubscriptionMutation = { __typename?: "Mutation" } & {
+  pushSubscriptionCreate: { __typename?: "PushSubscriptionPayload" } & PushSubscriptionPayloadFragment;
+};
+
+export type DeletePushSubscriptionMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeletePushSubscriptionMutation = { __typename?: "Mutation" } & {
+  pushSubscriptionDelete: { __typename?: "PushSubscriptionPayload" } & PushSubscriptionPayloadFragment;
+};
+
+export type CreateReactionMutationVariables = Exact<{
+  input: ReactionCreateInput;
+}>;
+
+export type CreateReactionMutation = { __typename?: "Mutation" } & {
+  reactionCreate: { __typename?: "ReactionPayload" } & ReactionPayloadFragment;
+};
+
+export type DeleteReactionMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteReactionMutation = { __typename?: "Mutation" } & {
+  reactionDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type RefreshGoogleSheetsDataMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type RefreshGoogleSheetsDataMutation = { __typename?: "Mutation" } & {
+  refreshGoogleSheetsData: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
+};
+
+export type ResendOrganizationInviteMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type ResendOrganizationInviteMutation = { __typename?: "Mutation" } & {
+  resendOrganizationInvite: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type CreateRoadmapMutationVariables = Exact<{
+  input: RoadmapCreateInput;
+}>;
+
+export type CreateRoadmapMutation = { __typename?: "Mutation" } & {
+  roadmapCreate: { __typename?: "RoadmapPayload" } & RoadmapPayloadFragment;
+};
+
+export type DeleteRoadmapMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteRoadmapMutation = { __typename?: "Mutation" } & {
+  roadmapDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type CreateRoadmapToProjectMutationVariables = Exact<{
+  input: RoadmapToProjectCreateInput;
+}>;
+
+export type CreateRoadmapToProjectMutation = { __typename?: "Mutation" } & {
+  roadmapToProjectCreate: { __typename?: "RoadmapToProjectPayload" } & RoadmapToProjectPayloadFragment;
+};
+
+export type DeleteRoadmapToProjectMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteRoadmapToProjectMutation = { __typename?: "Mutation" } & {
+  roadmapToProjectDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateRoadmapToProjectMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: RoadmapToProjectUpdateInput;
+}>;
+
+export type UpdateRoadmapToProjectMutation = { __typename?: "Mutation" } & {
+  roadmapToProjectUpdate: { __typename?: "RoadmapToProjectPayload" } & RoadmapToProjectPayloadFragment;
+};
+
+export type UpdateRoadmapMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: RoadmapUpdateInput;
+}>;
+
+export type UpdateRoadmapMutation = { __typename?: "Mutation" } & {
+  roadmapUpdate: { __typename?: "RoadmapPayload" } & RoadmapPayloadFragment;
+};
+
+export type SamlTokenUserAccountAuthMutationVariables = Exact<{
+  input: TokenUserAccountAuthInput;
+}>;
+
+export type SamlTokenUserAccountAuthMutation = { __typename?: "Mutation" } & {
+  samlTokenUserAccountAuth: { __typename?: "AuthResolverResponse" } & AuthResolverResponseFragment;
+};
+
+export type CreateTeamMutationVariables = Exact<{
+  copySettingsFromTeamId?: Maybe<Scalars["String"]>;
+  input: TeamCreateInput;
+}>;
+
+export type CreateTeamMutation = { __typename?: "Mutation" } & {
+  teamCreate: { __typename?: "TeamPayload" } & TeamPayloadFragment;
+};
+
+export type DeleteTeamCyclesMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteTeamCyclesMutation = { __typename?: "Mutation" } & {
+  teamCyclesDelete: { __typename?: "TeamPayload" } & TeamPayloadFragment;
+};
+
+export type DeleteTeamMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteTeamMutation = { __typename?: "Mutation" } & {
+  teamDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type DeleteTeamKeyMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteTeamKeyMutation = { __typename?: "Mutation" } & {
+  teamKeyDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type CreateTeamMembershipMutationVariables = Exact<{
+  input: TeamMembershipCreateInput;
+}>;
+
+export type CreateTeamMembershipMutation = { __typename?: "Mutation" } & {
+  teamMembershipCreate: { __typename?: "TeamMembershipPayload" } & TeamMembershipPayloadFragment;
+};
+
+export type DeleteTeamMembershipMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteTeamMembershipMutation = { __typename?: "Mutation" } & {
+  teamMembershipDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateTeamMembershipMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: TeamMembershipUpdateInput;
+}>;
+
+export type UpdateTeamMembershipMutation = { __typename?: "Mutation" } & {
+  teamMembershipUpdate: { __typename?: "TeamMembershipPayload" } & TeamMembershipPayloadFragment;
+};
+
+export type UpdateTeamMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: TeamUpdateInput;
+}>;
+
+export type UpdateTeamMutation = { __typename?: "Mutation" } & {
+  teamUpdate: { __typename?: "TeamPayload" } & TeamPayloadFragment;
+};
+
+export type CreateTemplateMutationVariables = Exact<{
+  input: TemplateCreateInput;
+}>;
+
+export type CreateTemplateMutation = { __typename?: "Mutation" } & {
+  templateCreate: { __typename?: "TemplatePayload" } & TemplatePayloadFragment;
+};
+
+export type DeleteTemplateMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteTemplateMutation = { __typename?: "Mutation" } & {
+  templateDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateTemplateMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: TemplateUpdateInput;
+}>;
+
+export type UpdateTemplateMutation = { __typename?: "Mutation" } & {
+  templateUpdate: { __typename?: "TemplatePayload" } & TemplatePayloadFragment;
+};
+
+export type UserDemoteAdminMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type UserDemoteAdminMutation = { __typename?: "Mutation" } & {
+  userDemoteAdmin: { __typename?: "UserAdminPayload" } & UserAdminPayloadFragment;
+};
+
+export type UserDemoteMemberMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type UserDemoteMemberMutation = { __typename?: "Mutation" } & {
+  userDemoteMember: { __typename?: "UserAdminPayload" } & UserAdminPayloadFragment;
+};
+
+export type UserDiscordConnectMutationVariables = Exact<{
+  code: Scalars["String"];
+  redirectUri: Scalars["String"];
+}>;
+
+export type UserDiscordConnectMutation = { __typename?: "Mutation" } & {
+  userDiscordConnect: { __typename?: "UserPayload" } & UserPayloadFragment;
+};
+
+export type UserExternalUserDisconnectMutationVariables = Exact<{
+  service: Scalars["String"];
+}>;
+
+export type UserExternalUserDisconnectMutation = { __typename?: "Mutation" } & {
+  userExternalUserDisconnect: { __typename?: "UserPayload" } & UserPayloadFragment;
+};
+
+export type UpdateUserFlagMutationVariables = Exact<{
+  flag: UserFlagType;
+  operation: UserFlagUpdateOperation;
+}>;
+
+export type UpdateUserFlagMutation = { __typename?: "Mutation" } & {
+  userFlagUpdate: { __typename?: "UserSettingsFlagPayload" } & UserSettingsFlagPayloadFragment;
+};
+
+export type UserGitHubConnectMutationVariables = Exact<{
+  code: Scalars["String"];
+}>;
+
+export type UserGitHubConnectMutation = { __typename?: "Mutation" } & {
+  userGitHubConnect: { __typename?: "UserPayload" } & UserPayloadFragment;
+};
+
+export type UserGoogleCalendarConnectMutationVariables = Exact<{
+  code: Scalars["String"];
+}>;
+
+export type UserGoogleCalendarConnectMutation = { __typename?: "Mutation" } & {
+  userGoogleCalendarConnect: { __typename?: "UserPayload" } & UserPayloadFragment;
+};
+
+export type UserPromoteAdminMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type UserPromoteAdminMutation = { __typename?: "Mutation" } & {
+  userPromoteAdmin: { __typename?: "UserAdminPayload" } & UserAdminPayloadFragment;
+};
+
+export type UserPromoteMemberMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type UserPromoteMemberMutation = { __typename?: "Mutation" } & {
+  userPromoteMember: { __typename?: "UserAdminPayload" } & UserAdminPayloadFragment;
+};
+
+export type UserSettingsFlagIncrementMutationVariables = Exact<{
+  flag: Scalars["String"];
+}>;
+
+export type UserSettingsFlagIncrementMutation = { __typename?: "Mutation" } & {
+  userSettingsFlagIncrement: { __typename?: "UserSettingsFlagPayload" } & UserSettingsFlagPayloadFragment;
+};
+
+export type UserSettingsFlagsResetMutationVariables = Exact<{
+  flags?: Maybe<Array<UserFlagType> | UserFlagType>;
+}>;
+
+export type UserSettingsFlagsResetMutation = { __typename?: "Mutation" } & {
+  userSettingsFlagsReset: { __typename?: "UserSettingsFlagsResetPayload" } & UserSettingsFlagsResetPayloadFragment;
+};
+
+export type UpdateUserSettingsMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: UserSettingsUpdateInput;
+}>;
+
+export type UpdateUserSettingsMutation = { __typename?: "Mutation" } & {
+  userSettingsUpdate: { __typename?: "UserSettingsPayload" } & UserSettingsPayloadFragment;
+};
+
+export type SuspendUserMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type SuspendUserMutation = { __typename?: "Mutation" } & {
+  userSuspend: { __typename?: "UserAdminPayload" } & UserAdminPayloadFragment;
+};
+
+export type UnsuspendUserMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type UnsuspendUserMutation = { __typename?: "Mutation" } & {
+  userUnsuspend: { __typename?: "UserAdminPayload" } & UserAdminPayloadFragment;
+};
+
+export type UpdateUserMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: UpdateUserInput;
+}>;
+
+export type UpdateUserMutation = { __typename?: "Mutation" } & {
+  userUpdate: { __typename?: "UserPayload" } & UserPayloadFragment;
+};
+
+export type CreateViewPreferencesMutationVariables = Exact<{
+  input: ViewPreferencesCreateInput;
+}>;
+
+export type CreateViewPreferencesMutation = { __typename?: "Mutation" } & {
+  viewPreferencesCreate: { __typename?: "ViewPreferencesPayload" } & ViewPreferencesPayloadFragment;
+};
+
+export type DeleteViewPreferencesMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteViewPreferencesMutation = { __typename?: "Mutation" } & {
+  viewPreferencesDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateViewPreferencesMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: ViewPreferencesUpdateInput;
+}>;
+
+export type UpdateViewPreferencesMutation = { __typename?: "Mutation" } & {
+  viewPreferencesUpdate: { __typename?: "ViewPreferencesPayload" } & ViewPreferencesPayloadFragment;
+};
+
+export type CreateWebhookMutationVariables = Exact<{
+  input: WebhookCreateInput;
+}>;
+
+export type CreateWebhookMutation = { __typename?: "Mutation" } & {
+  webhookCreate: { __typename?: "WebhookPayload" } & WebhookPayloadFragment;
+};
+
+export type DeleteWebhookMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteWebhookMutation = { __typename?: "Mutation" } & {
+  webhookDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type UpdateWebhookMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: WebhookUpdateInput;
+}>;
+
+export type UpdateWebhookMutation = { __typename?: "Mutation" } & {
+  webhookUpdate: { __typename?: "WebhookPayload" } & WebhookPayloadFragment;
+};
+
+export type ArchiveWorkflowStateMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type ArchiveWorkflowStateMutation = { __typename?: "Mutation" } & {
+  workflowStateArchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
+};
+
+export type CreateWorkflowStateMutationVariables = Exact<{
+  input: WorkflowStateCreateInput;
+}>;
+
+export type CreateWorkflowStateMutation = { __typename?: "Mutation" } & {
+  workflowStateCreate: { __typename?: "WorkflowStatePayload" } & WorkflowStatePayloadFragment;
+};
+
+export type UpdateWorkflowStateMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: WorkflowStateUpdateInput;
+}>;
+
+export type UpdateWorkflowStateMutation = { __typename?: "Mutation" } & {
+  workflowStateUpdate: { __typename?: "WorkflowStatePayload" } & WorkflowStatePayloadFragment;
+};
+
+export type ProjectMilestoneQueryVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type ProjectMilestoneQuery = { __typename?: "Query" } & {
+  ProjectMilestone: { __typename?: "ProjectMilestone" } & ProjectMilestoneFragment;
+};
+
+export type ProjectMilestonesQueryVariables = Exact<{
+  after?: Maybe<Scalars["String"]>;
+  before?: Maybe<Scalars["String"]>;
+  first?: Maybe<Scalars["Int"]>;
+  includeArchived?: Maybe<Scalars["Boolean"]>;
+  last?: Maybe<Scalars["Int"]>;
+  orderBy?: Maybe<PaginationOrderBy>;
+}>;
+
+export type ProjectMilestonesQuery = { __typename?: "Query" } & {
+  ProjectMilestones: { __typename?: "ProjectMilestoneConnection" } & ProjectMilestoneConnectionFragment;
+};
 
 export type AdministrableTeamsQueryVariables = Exact<{
   after?: Maybe<Scalars["String"]>;
@@ -11105,42 +12621,6 @@ export type IssuesQuery = { __typename?: "Query" } & {
   issues: { __typename?: "IssueConnection" } & IssueConnectionFragment;
 };
 
-export type MilestoneQueryVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type MilestoneQuery = { __typename?: "Query" } & { milestone: { __typename?: "Milestone" } & MilestoneFragment };
-
-export type Milestone_ProjectsQueryVariables = Exact<{
-  id: Scalars["String"];
-  after?: Maybe<Scalars["String"]>;
-  before?: Maybe<Scalars["String"]>;
-  filter?: Maybe<ProjectFilter>;
-  first?: Maybe<Scalars["Int"]>;
-  includeArchived?: Maybe<Scalars["Boolean"]>;
-  last?: Maybe<Scalars["Int"]>;
-  orderBy?: Maybe<PaginationOrderBy>;
-}>;
-
-export type Milestone_ProjectsQuery = { __typename?: "Query" } & {
-  milestone: { __typename?: "Milestone" } & {
-    projects: { __typename?: "ProjectConnection" } & ProjectConnectionFragment;
-  };
-};
-
-export type MilestonesQueryVariables = Exact<{
-  after?: Maybe<Scalars["String"]>;
-  before?: Maybe<Scalars["String"]>;
-  first?: Maybe<Scalars["Int"]>;
-  includeArchived?: Maybe<Scalars["Boolean"]>;
-  last?: Maybe<Scalars["Int"]>;
-  orderBy?: Maybe<PaginationOrderBy>;
-}>;
-
-export type MilestonesQuery = { __typename?: "Query" } & {
-  milestones: { __typename?: "MilestoneConnection" } & MilestoneConnectionFragment;
-};
-
 export type NotificationQueryVariables = Exact<{
   id: Scalars["String"];
 }>;
@@ -11341,14 +12821,6 @@ export type Project_DocumentsQuery = { __typename?: "Query" } & {
   project: { __typename?: "Project" } & {
     documents: { __typename?: "DocumentConnection" } & DocumentConnectionFragment;
   };
-};
-
-export type Project_InitiativeQueryVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type Project_InitiativeQuery = { __typename?: "Query" } & {
-  project: { __typename?: "Project" } & { initiative?: Maybe<{ __typename?: "Initiative" } & InitiativeFragment> };
 };
 
 export type Project_IssuesQueryVariables = Exact<{
@@ -11981,1468 +13453,6 @@ export type WorkflowStatesQuery = { __typename?: "Query" } & {
   workflowStates: { __typename?: "WorkflowStateConnection" } & WorkflowStateConnectionFragment;
 };
 
-export type AirbyteIntegrationConnectMutationVariables = Exact<{
-  input: AirbyteConfigurationInput;
-}>;
-
-export type AirbyteIntegrationConnectMutation = { __typename?: "Mutation" } & {
-  airbyteIntegrationConnect: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type CreateApiKeyMutationVariables = Exact<{
-  input: ApiKeyCreateInput;
-}>;
-
-export type CreateApiKeyMutation = { __typename?: "Mutation" } & {
-  apiKeyCreate: { __typename?: "ApiKeyPayload" } & ApiKeyPayloadFragment;
-};
-
-export type DeleteApiKeyMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteApiKeyMutation = { __typename?: "Mutation" } & {
-  apiKeyDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type ArchiveAttachmentMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type ArchiveAttachmentMutation = { __typename?: "Mutation" } & {
-  attachmentArchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type CreateAttachmentMutationVariables = Exact<{
-  input: AttachmentCreateInput;
-}>;
-
-export type CreateAttachmentMutation = { __typename?: "Mutation" } & {
-  attachmentCreate: { __typename?: "AttachmentPayload" } & AttachmentPayloadFragment;
-};
-
-export type DeleteAttachmentMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteAttachmentMutation = { __typename?: "Mutation" } & {
-  attachmentDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type AttachmentLinkDiscordMutationVariables = Exact<{
-  channelId: Scalars["String"];
-  issueId: Scalars["String"];
-  messageId: Scalars["String"];
-  url: Scalars["String"];
-}>;
-
-export type AttachmentLinkDiscordMutation = { __typename?: "Mutation" } & {
-  attachmentLinkDiscord: { __typename?: "AttachmentPayload" } & AttachmentPayloadFragment;
-};
-
-export type AttachmentLinkFrontMutationVariables = Exact<{
-  conversationId: Scalars["String"];
-  issueId: Scalars["String"];
-}>;
-
-export type AttachmentLinkFrontMutation = { __typename?: "Mutation" } & {
-  attachmentLinkFront: { __typename?: "FrontAttachmentPayload" } & FrontAttachmentPayloadFragment;
-};
-
-export type AttachmentLinkIntercomMutationVariables = Exact<{
-  conversationId: Scalars["String"];
-  issueId: Scalars["String"];
-}>;
-
-export type AttachmentLinkIntercomMutation = { __typename?: "Mutation" } & {
-  attachmentLinkIntercom: { __typename?: "AttachmentPayload" } & AttachmentPayloadFragment;
-};
-
-export type AttachmentLinkJiraIssueMutationVariables = Exact<{
-  issueId: Scalars["String"];
-  jiraIssueId: Scalars["String"];
-}>;
-
-export type AttachmentLinkJiraIssueMutation = { __typename?: "Mutation" } & {
-  attachmentLinkJiraIssue: { __typename?: "AttachmentPayload" } & AttachmentPayloadFragment;
-};
-
-export type AttachmentLinkUrlMutationVariables = Exact<{
-  issueId: Scalars["String"];
-  title?: Maybe<Scalars["String"]>;
-  url: Scalars["String"];
-}>;
-
-export type AttachmentLinkUrlMutation = { __typename?: "Mutation" } & {
-  attachmentLinkURL: { __typename?: "AttachmentPayload" } & AttachmentPayloadFragment;
-};
-
-export type AttachmentLinkZendeskMutationVariables = Exact<{
-  issueId: Scalars["String"];
-  ticketId: Scalars["String"];
-}>;
-
-export type AttachmentLinkZendeskMutation = { __typename?: "Mutation" } & {
-  attachmentLinkZendesk: { __typename?: "AttachmentPayload" } & AttachmentPayloadFragment;
-};
-
-export type UpdateAttachmentMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: AttachmentUpdateInput;
-}>;
-
-export type UpdateAttachmentMutation = { __typename?: "Mutation" } & {
-  attachmentUpdate: { __typename?: "AttachmentPayload" } & AttachmentPayloadFragment;
-};
-
-export type CreateCommentMutationVariables = Exact<{
-  input: CommentCreateInput;
-}>;
-
-export type CreateCommentMutation = { __typename?: "Mutation" } & {
-  commentCreate: { __typename?: "CommentPayload" } & CommentPayloadFragment;
-};
-
-export type DeleteCommentMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteCommentMutation = { __typename?: "Mutation" } & {
-  commentDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateCommentMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: CommentUpdateInput;
-}>;
-
-export type UpdateCommentMutation = { __typename?: "Mutation" } & {
-  commentUpdate: { __typename?: "CommentPayload" } & CommentPayloadFragment;
-};
-
-export type CreateContactMutationVariables = Exact<{
-  input: ContactCreateInput;
-}>;
-
-export type CreateContactMutation = { __typename?: "Mutation" } & {
-  contactCreate: { __typename?: "ContactPayload" } & ContactPayloadFragment;
-};
-
-export type CreateCsvExportReportMutationVariables = Exact<{
-  includePrivateTeamIds?: Maybe<Array<Scalars["String"]> | Scalars["String"]>;
-}>;
-
-export type CreateCsvExportReportMutation = { __typename?: "Mutation" } & {
-  createCsvExportReport: { __typename?: "CreateCsvExportReportPayload" } & CreateCsvExportReportPayloadFragment;
-};
-
-export type CreateOrganizationFromOnboardingMutationVariables = Exact<{
-  input: CreateOrganizationInput;
-  survey?: Maybe<OnboardingCustomerSurvey>;
-}>;
-
-export type CreateOrganizationFromOnboardingMutation = { __typename?: "Mutation" } & {
-  createOrganizationFromOnboarding: {
-    __typename?: "CreateOrJoinOrganizationResponse";
-  } & CreateOrJoinOrganizationResponseFragment;
-};
-
-export type CreateCustomViewMutationVariables = Exact<{
-  input: CustomViewCreateInput;
-}>;
-
-export type CreateCustomViewMutation = { __typename?: "Mutation" } & {
-  customViewCreate: { __typename?: "CustomViewPayload" } & CustomViewPayloadFragment;
-};
-
-export type DeleteCustomViewMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteCustomViewMutation = { __typename?: "Mutation" } & {
-  customViewDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateCustomViewMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: CustomViewUpdateInput;
-}>;
-
-export type UpdateCustomViewMutation = { __typename?: "Mutation" } & {
-  customViewUpdate: { __typename?: "CustomViewPayload" } & CustomViewPayloadFragment;
-};
-
-export type ArchiveCycleMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type ArchiveCycleMutation = { __typename?: "Mutation" } & {
-  cycleArchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type CreateCycleMutationVariables = Exact<{
-  input: CycleCreateInput;
-}>;
-
-export type CreateCycleMutation = { __typename?: "Mutation" } & {
-  cycleCreate: { __typename?: "CyclePayload" } & CyclePayloadFragment;
-};
-
-export type UpdateCycleMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: CycleUpdateInput;
-}>;
-
-export type UpdateCycleMutation = { __typename?: "Mutation" } & {
-  cycleUpdate: { __typename?: "CyclePayload" } & CyclePayloadFragment;
-};
-
-export type CreateDocumentMutationVariables = Exact<{
-  input: DocumentCreateInput;
-}>;
-
-export type CreateDocumentMutation = { __typename?: "Mutation" } & {
-  documentCreate: { __typename?: "DocumentPayload" } & DocumentPayloadFragment;
-};
-
-export type DeleteDocumentMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteDocumentMutation = { __typename?: "Mutation" } & {
-  documentDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateDocumentMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: DocumentUpdateInput;
-}>;
-
-export type UpdateDocumentMutation = { __typename?: "Mutation" } & {
-  documentUpdate: { __typename?: "DocumentPayload" } & DocumentPayloadFragment;
-};
-
-export type EmailTokenUserAccountAuthMutationVariables = Exact<{
-  input: TokenUserAccountAuthInput;
-}>;
-
-export type EmailTokenUserAccountAuthMutation = { __typename?: "Mutation" } & {
-  emailTokenUserAccountAuth: { __typename?: "AuthResolverResponse" } & AuthResolverResponseFragment;
-};
-
-export type EmailUnsubscribeMutationVariables = Exact<{
-  input: EmailUnsubscribeInput;
-}>;
-
-export type EmailUnsubscribeMutation = { __typename?: "Mutation" } & {
-  emailUnsubscribe: { __typename?: "EmailUnsubscribePayload" } & EmailUnsubscribePayloadFragment;
-};
-
-export type EmailUserAccountAuthChallengeMutationVariables = Exact<{
-  input: EmailUserAccountAuthChallengeInput;
-}>;
-
-export type EmailUserAccountAuthChallengeMutation = { __typename?: "Mutation" } & {
-  emailUserAccountAuthChallenge: {
-    __typename?: "EmailUserAccountAuthChallengeResponse";
-  } & EmailUserAccountAuthChallengeResponseFragment;
-};
-
-export type CreateEmojiMutationVariables = Exact<{
-  input: EmojiCreateInput;
-}>;
-
-export type CreateEmojiMutation = { __typename?: "Mutation" } & {
-  emojiCreate: { __typename?: "EmojiPayload" } & EmojiPayloadFragment;
-};
-
-export type DeleteEmojiMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteEmojiMutation = { __typename?: "Mutation" } & {
-  emojiDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type CreateEventMutationVariables = Exact<{
-  input: EventCreateInput;
-}>;
-
-export type CreateEventMutation = { __typename?: "Mutation" } & {
-  eventCreate: { __typename?: "EventPayload" } & EventPayloadFragment;
-};
-
-export type CreateFavoriteMutationVariables = Exact<{
-  input: FavoriteCreateInput;
-}>;
-
-export type CreateFavoriteMutation = { __typename?: "Mutation" } & {
-  favoriteCreate: { __typename?: "FavoritePayload" } & FavoritePayloadFragment;
-};
-
-export type DeleteFavoriteMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteFavoriteMutation = { __typename?: "Mutation" } & {
-  favoriteDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateFavoriteMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: FavoriteUpdateInput;
-}>;
-
-export type UpdateFavoriteMutation = { __typename?: "Mutation" } & {
-  favoriteUpdate: { __typename?: "FavoritePayload" } & FavoritePayloadFragment;
-};
-
-export type FileUploadMutationVariables = Exact<{
-  contentType: Scalars["String"];
-  filename: Scalars["String"];
-  makePublic?: Maybe<Scalars["Boolean"]>;
-  metaData?: Maybe<Scalars["JSON"]>;
-  size: Scalars["Int"];
-}>;
-
-export type FileUploadMutation = { __typename?: "Mutation" } & {
-  fileUpload: { __typename?: "UploadPayload" } & UploadPayloadFragment;
-};
-
-export type GoogleUserAccountAuthMutationVariables = Exact<{
-  input: GoogleUserAccountAuthInput;
-}>;
-
-export type GoogleUserAccountAuthMutation = { __typename?: "Mutation" } & {
-  googleUserAccountAuth: { __typename?: "AuthResolverResponse" } & AuthResolverResponseFragment;
-};
-
-export type ImageUploadFromUrlMutationVariables = Exact<{
-  url: Scalars["String"];
-}>;
-
-export type ImageUploadFromUrlMutation = { __typename?: "Mutation" } & {
-  imageUploadFromUrl: { __typename?: "ImageUploadFromUrlPayload" } & ImageUploadFromUrlPayloadFragment;
-};
-
-export type DeleteIntegrationMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteIntegrationMutation = { __typename?: "Mutation" } & {
-  integrationDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type IntegrationDiscordMutationVariables = Exact<{
-  code: Scalars["String"];
-  redirectUri: Scalars["String"];
-}>;
-
-export type IntegrationDiscordMutation = { __typename?: "Mutation" } & {
-  integrationDiscord: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type IntegrationFigmaMutationVariables = Exact<{
-  code: Scalars["String"];
-  redirectUri: Scalars["String"];
-}>;
-
-export type IntegrationFigmaMutation = { __typename?: "Mutation" } & {
-  integrationFigma: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type IntegrationFrontMutationVariables = Exact<{
-  code: Scalars["String"];
-  redirectUri: Scalars["String"];
-}>;
-
-export type IntegrationFrontMutation = { __typename?: "Mutation" } & {
-  integrationFront: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type CreateIntegrationGithubCommitMutationVariables = Exact<{ [key: string]: never }>;
-
-export type CreateIntegrationGithubCommitMutation = { __typename?: "Mutation" } & {
-  integrationGithubCommitCreate: {
-    __typename?: "GitHubCommitIntegrationPayload";
-  } & GitHubCommitIntegrationPayloadFragment;
-};
-
-export type IntegrationGithubConnectMutationVariables = Exact<{
-  installationId: Scalars["String"];
-}>;
-
-export type IntegrationGithubConnectMutation = { __typename?: "Mutation" } & {
-  integrationGithubConnect: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type IntegrationGitlabConnectMutationVariables = Exact<{
-  accessToken: Scalars["String"];
-  gitlabUrl: Scalars["String"];
-}>;
-
-export type IntegrationGitlabConnectMutation = { __typename?: "Mutation" } & {
-  integrationGitlabConnect: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type IntegrationGoogleSheetsMutationVariables = Exact<{
-  code: Scalars["String"];
-}>;
-
-export type IntegrationGoogleSheetsMutation = { __typename?: "Mutation" } & {
-  integrationGoogleSheets: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type IntegrationIntercomMutationVariables = Exact<{
-  code: Scalars["String"];
-  domainUrl?: Maybe<Scalars["String"]>;
-  redirectUri: Scalars["String"];
-}>;
-
-export type IntegrationIntercomMutation = { __typename?: "Mutation" } & {
-  integrationIntercom: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type DeleteIntegrationIntercomMutationVariables = Exact<{ [key: string]: never }>;
-
-export type DeleteIntegrationIntercomMutation = { __typename?: "Mutation" } & {
-  integrationIntercomDelete: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type UpdateIntegrationIntercomSettingsMutationVariables = Exact<{
-  input: IntercomSettingsInput;
-}>;
-
-export type UpdateIntegrationIntercomSettingsMutation = { __typename?: "Mutation" } & {
-  integrationIntercomSettingsUpdate: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type IntegrationLoomMutationVariables = Exact<{ [key: string]: never }>;
-
-export type IntegrationLoomMutation = { __typename?: "Mutation" } & {
-  integrationLoom: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type IntegrationRequestMutationVariables = Exact<{
-  input: IntegrationRequestInput;
-}>;
-
-export type IntegrationRequestMutation = { __typename?: "Mutation" } & {
-  integrationRequest: { __typename?: "IntegrationRequestPayload" } & IntegrationRequestPayloadFragment;
-};
-
-export type ArchiveIntegrationResourceMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type ArchiveIntegrationResourceMutation = { __typename?: "Mutation" } & {
-  integrationResourceArchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type IntegrationSentryConnectMutationVariables = Exact<{
-  code: Scalars["String"];
-  installationId: Scalars["String"];
-  organizationSlug: Scalars["String"];
-}>;
-
-export type IntegrationSentryConnectMutation = { __typename?: "Mutation" } & {
-  integrationSentryConnect: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type IntegrationSlackMutationVariables = Exact<{
-  code: Scalars["String"];
-  redirectUri: Scalars["String"];
-  shouldUseV2Auth?: Maybe<Scalars["Boolean"]>;
-}>;
-
-export type IntegrationSlackMutation = { __typename?: "Mutation" } & {
-  integrationSlack: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type IntegrationSlackImportEmojisMutationVariables = Exact<{
-  code: Scalars["String"];
-  redirectUri: Scalars["String"];
-}>;
-
-export type IntegrationSlackImportEmojisMutation = { __typename?: "Mutation" } & {
-  integrationSlackImportEmojis: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type IntegrationSlackOrgProjectUpdatesPostMutationVariables = Exact<{
-  code: Scalars["String"];
-  redirectUri: Scalars["String"];
-}>;
-
-export type IntegrationSlackOrgProjectUpdatesPostMutation = { __typename?: "Mutation" } & {
-  integrationSlackOrgProjectUpdatesPost: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type IntegrationSlackPersonalMutationVariables = Exact<{
-  code: Scalars["String"];
-  redirectUri: Scalars["String"];
-}>;
-
-export type IntegrationSlackPersonalMutation = { __typename?: "Mutation" } & {
-  integrationSlackPersonal: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type IntegrationSlackPostMutationVariables = Exact<{
-  code: Scalars["String"];
-  redirectUri: Scalars["String"];
-  shouldUseV2Auth?: Maybe<Scalars["Boolean"]>;
-  teamId: Scalars["String"];
-}>;
-
-export type IntegrationSlackPostMutation = { __typename?: "Mutation" } & {
-  integrationSlackPost: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type IntegrationSlackProjectPostMutationVariables = Exact<{
-  code: Scalars["String"];
-  projectId: Scalars["String"];
-  redirectUri: Scalars["String"];
-  service: Scalars["String"];
-}>;
-
-export type IntegrationSlackProjectPostMutation = { __typename?: "Mutation" } & {
-  integrationSlackProjectPost: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type CreateIntegrationTemplateMutationVariables = Exact<{
-  input: IntegrationTemplateCreateInput;
-}>;
-
-export type CreateIntegrationTemplateMutation = { __typename?: "Mutation" } & {
-  integrationTemplateCreate: { __typename?: "IntegrationTemplatePayload" } & IntegrationTemplatePayloadFragment;
-};
-
-export type DeleteIntegrationTemplateMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteIntegrationTemplateMutation = { __typename?: "Mutation" } & {
-  integrationTemplateDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type IntegrationZendeskMutationVariables = Exact<{
-  code: Scalars["String"];
-  redirectUri: Scalars["String"];
-  scope: Scalars["String"];
-  subdomain: Scalars["String"];
-}>;
-
-export type IntegrationZendeskMutation = { __typename?: "Mutation" } & {
-  integrationZendesk: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type CreateIntegrationsSettingsMutationVariables = Exact<{
-  input: IntegrationsSettingsCreateInput;
-}>;
-
-export type CreateIntegrationsSettingsMutation = { __typename?: "Mutation" } & {
-  integrationsSettingsCreate: { __typename?: "IntegrationsSettingsPayload" } & IntegrationsSettingsPayloadFragment;
-};
-
-export type UpdateIntegrationsSettingsMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: IntegrationsSettingsUpdateInput;
-}>;
-
-export type UpdateIntegrationsSettingsMutation = { __typename?: "Mutation" } & {
-  integrationsSettingsUpdate: { __typename?: "IntegrationsSettingsPayload" } & IntegrationsSettingsPayloadFragment;
-};
-
-export type ArchiveIssueMutationVariables = Exact<{
-  id: Scalars["String"];
-  trash?: Maybe<Scalars["Boolean"]>;
-}>;
-
-export type ArchiveIssueMutation = { __typename?: "Mutation" } & {
-  issueArchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateIssueBatchMutationVariables = Exact<{
-  ids: Array<Scalars["UUID"]> | Scalars["UUID"];
-  input: IssueUpdateInput;
-}>;
-
-export type UpdateIssueBatchMutation = { __typename?: "Mutation" } & {
-  issueBatchUpdate: { __typename?: "IssueBatchPayload" } & IssueBatchPayloadFragment;
-};
-
-export type CreateIssueMutationVariables = Exact<{
-  input: IssueCreateInput;
-}>;
-
-export type CreateIssueMutation = { __typename?: "Mutation" } & {
-  issueCreate: { __typename?: "IssuePayload" } & IssuePayloadFragment;
-};
-
-export type DeleteIssueMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteIssueMutation = { __typename?: "Mutation" } & {
-  issueDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type IssueImportCreateAsanaMutationVariables = Exact<{
-  asanaTeamName: Scalars["String"];
-  asanaToken: Scalars["String"];
-  id?: Maybe<Scalars["String"]>;
-  includeClosedIssues?: Maybe<Scalars["Boolean"]>;
-  instantProcess?: Maybe<Scalars["Boolean"]>;
-  organizationId?: Maybe<Scalars["String"]>;
-  teamId?: Maybe<Scalars["String"]>;
-  teamName?: Maybe<Scalars["String"]>;
-}>;
-
-export type IssueImportCreateAsanaMutation = { __typename?: "Mutation" } & {
-  issueImportCreateAsana: { __typename?: "IssueImportPayload" } & IssueImportPayloadFragment;
-};
-
-export type IssueImportCreateClubhouseMutationVariables = Exact<{
-  clubhouseTeamName: Scalars["String"];
-  clubhouseToken: Scalars["String"];
-  id?: Maybe<Scalars["String"]>;
-  includeClosedIssues?: Maybe<Scalars["Boolean"]>;
-  instantProcess?: Maybe<Scalars["Boolean"]>;
-  organizationId?: Maybe<Scalars["String"]>;
-  teamId?: Maybe<Scalars["String"]>;
-  teamName?: Maybe<Scalars["String"]>;
-}>;
-
-export type IssueImportCreateClubhouseMutation = { __typename?: "Mutation" } & {
-  issueImportCreateClubhouse: { __typename?: "IssueImportPayload" } & IssueImportPayloadFragment;
-};
-
-export type IssueImportCreateGithubMutationVariables = Exact<{
-  githubRepoName: Scalars["String"];
-  githubRepoOwner: Scalars["String"];
-  githubShouldImportOrgProjects?: Maybe<Scalars["Boolean"]>;
-  githubToken: Scalars["String"];
-  id?: Maybe<Scalars["String"]>;
-  includeClosedIssues?: Maybe<Scalars["Boolean"]>;
-  instantProcess?: Maybe<Scalars["Boolean"]>;
-  organizationId?: Maybe<Scalars["String"]>;
-  teamId?: Maybe<Scalars["String"]>;
-  teamName?: Maybe<Scalars["String"]>;
-}>;
-
-export type IssueImportCreateGithubMutation = { __typename?: "Mutation" } & {
-  issueImportCreateGithub: { __typename?: "IssueImportPayload" } & IssueImportPayloadFragment;
-};
-
-export type IssueImportCreateJiraMutationVariables = Exact<{
-  id?: Maybe<Scalars["String"]>;
-  includeClosedIssues?: Maybe<Scalars["Boolean"]>;
-  instantProcess?: Maybe<Scalars["Boolean"]>;
-  jiraEmail: Scalars["String"];
-  jiraHostname: Scalars["String"];
-  jiraProject: Scalars["String"];
-  jiraToken: Scalars["String"];
-  organizationId?: Maybe<Scalars["String"]>;
-  teamId?: Maybe<Scalars["String"]>;
-  teamName?: Maybe<Scalars["String"]>;
-}>;
-
-export type IssueImportCreateJiraMutation = { __typename?: "Mutation" } & {
-  issueImportCreateJira: { __typename?: "IssueImportPayload" } & IssueImportPayloadFragment;
-};
-
-export type DeleteIssueImportMutationVariables = Exact<{
-  issueImportId: Scalars["String"];
-}>;
-
-export type DeleteIssueImportMutation = { __typename?: "Mutation" } & {
-  issueImportDelete: { __typename?: "IssueImportDeletePayload" } & IssueImportDeletePayloadFragment;
-};
-
-export type IssueImportProcessMutationVariables = Exact<{
-  issueImportId: Scalars["String"];
-  mapping: Scalars["JSONObject"];
-}>;
-
-export type IssueImportProcessMutation = { __typename?: "Mutation" } & {
-  issueImportProcess: { __typename?: "IssueImportPayload" } & IssueImportPayloadFragment;
-};
-
-export type UpdateIssueImportMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: IssueImportUpdateInput;
-}>;
-
-export type UpdateIssueImportMutation = { __typename?: "Mutation" } & {
-  issueImportUpdate: { __typename?: "IssueImportPayload" } & IssueImportPayloadFragment;
-};
-
-export type ArchiveIssueLabelMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type ArchiveIssueLabelMutation = { __typename?: "Mutation" } & {
-  issueLabelArchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type CreateIssueLabelMutationVariables = Exact<{
-  input: IssueLabelCreateInput;
-  replaceTeamLabels?: Maybe<Scalars["Boolean"]>;
-}>;
-
-export type CreateIssueLabelMutation = { __typename?: "Mutation" } & {
-  issueLabelCreate: { __typename?: "IssueLabelPayload" } & IssueLabelPayloadFragment;
-};
-
-export type DeleteIssueLabelMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteIssueLabelMutation = { __typename?: "Mutation" } & {
-  issueLabelDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateIssueLabelMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: IssueLabelUpdateInput;
-}>;
-
-export type UpdateIssueLabelMutation = { __typename?: "Mutation" } & {
-  issueLabelUpdate: { __typename?: "IssueLabelPayload" } & IssueLabelPayloadFragment;
-};
-
-export type CreateIssueRelationMutationVariables = Exact<{
-  input: IssueRelationCreateInput;
-}>;
-
-export type CreateIssueRelationMutation = { __typename?: "Mutation" } & {
-  issueRelationCreate: { __typename?: "IssueRelationPayload" } & IssueRelationPayloadFragment;
-};
-
-export type DeleteIssueRelationMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteIssueRelationMutation = { __typename?: "Mutation" } & {
-  issueRelationDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateIssueRelationMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: IssueRelationUpdateInput;
-}>;
-
-export type UpdateIssueRelationMutation = { __typename?: "Mutation" } & {
-  issueRelationUpdate: { __typename?: "IssueRelationPayload" } & IssueRelationPayloadFragment;
-};
-
-export type IssueReminderMutationVariables = Exact<{
-  id: Scalars["String"];
-  reminderAt: Scalars["DateTime"];
-}>;
-
-export type IssueReminderMutation = { __typename?: "Mutation" } & {
-  issueReminder: { __typename?: "IssuePayload" } & IssuePayloadFragment;
-};
-
-export type UnarchiveIssueMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type UnarchiveIssueMutation = { __typename?: "Mutation" } & {
-  issueUnarchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateIssueMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: IssueUpdateInput;
-}>;
-
-export type UpdateIssueMutation = { __typename?: "Mutation" } & {
-  issueUpdate: { __typename?: "IssuePayload" } & IssuePayloadFragment;
-};
-
-export type JoinOrganizationFromOnboardingMutationVariables = Exact<{
-  input: JoinOrganizationInput;
-}>;
-
-export type JoinOrganizationFromOnboardingMutation = { __typename?: "Mutation" } & {
-  joinOrganizationFromOnboarding: {
-    __typename?: "CreateOrJoinOrganizationResponse";
-  } & CreateOrJoinOrganizationResponseFragment;
-};
-
-export type LeaveOrganizationMutationVariables = Exact<{
-  organizationId: Scalars["String"];
-}>;
-
-export type LeaveOrganizationMutation = { __typename?: "Mutation" } & {
-  leaveOrganization: { __typename?: "CreateOrJoinOrganizationResponse" } & CreateOrJoinOrganizationResponseFragment;
-};
-
-export type LogoutMutationVariables = Exact<{ [key: string]: never }>;
-
-export type LogoutMutation = { __typename?: "Mutation" } & {
-  logout: { __typename?: "LogoutResponse" } & LogoutResponseFragment;
-};
-
-export type MigrateMilestonesToRoadmapsMutationVariables = Exact<{
-  input: MilestonesMigrateInput;
-}>;
-
-export type MigrateMilestonesToRoadmapsMutation = { __typename?: "Mutation" } & {
-  migrateMilestonesToRoadmaps: { __typename?: "MilestoneMigrationPayload" } & MilestoneMigrationPayloadFragment;
-};
-
-export type CreateMilestoneMutationVariables = Exact<{
-  input: MilestoneCreateInput;
-}>;
-
-export type CreateMilestoneMutation = { __typename?: "Mutation" } & {
-  milestoneCreate: { __typename?: "MilestonePayload" } & MilestonePayloadFragment;
-};
-
-export type DeleteMilestoneMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteMilestoneMutation = { __typename?: "Mutation" } & {
-  milestoneDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateMilestoneMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: MilestoneUpdateInput;
-}>;
-
-export type UpdateMilestoneMutation = { __typename?: "Mutation" } & {
-  milestoneUpdate: { __typename?: "MilestonePayload" } & MilestonePayloadFragment;
-};
-
-export type ArchiveNotificationMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type ArchiveNotificationMutation = { __typename?: "Mutation" } & {
-  notificationArchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type CreateNotificationSubscriptionMutationVariables = Exact<{
-  input: NotificationSubscriptionCreateInput;
-}>;
-
-export type CreateNotificationSubscriptionMutation = { __typename?: "Mutation" } & {
-  notificationSubscriptionCreate: {
-    __typename?: "NotificationSubscriptionPayload";
-  } & NotificationSubscriptionPayloadFragment;
-};
-
-export type DeleteNotificationSubscriptionMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteNotificationSubscriptionMutation = { __typename?: "Mutation" } & {
-  notificationSubscriptionDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateNotificationSubscriptionMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: NotificationSubscriptionUpdateInput;
-}>;
-
-export type UpdateNotificationSubscriptionMutation = { __typename?: "Mutation" } & {
-  notificationSubscriptionUpdate: {
-    __typename?: "NotificationSubscriptionPayload";
-  } & NotificationSubscriptionPayloadFragment;
-};
-
-export type UnarchiveNotificationMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type UnarchiveNotificationMutation = { __typename?: "Mutation" } & {
-  notificationUnarchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateNotificationMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: NotificationUpdateInput;
-}>;
-
-export type UpdateNotificationMutation = { __typename?: "Mutation" } & {
-  notificationUpdate: { __typename?: "NotificationPayload" } & NotificationPayloadFragment;
-};
-
-export type DeleteOrganizationCancelMutationVariables = Exact<{ [key: string]: never }>;
-
-export type DeleteOrganizationCancelMutation = { __typename?: "Mutation" } & {
-  organizationCancelDelete: {
-    __typename?: "OrganizationCancelDeletePayload";
-  } & OrganizationCancelDeletePayloadFragment;
-};
-
-export type DeleteOrganizationMutationVariables = Exact<{
-  input: DeleteOrganizationInput;
-}>;
-
-export type DeleteOrganizationMutation = { __typename?: "Mutation" } & {
-  organizationDelete: { __typename?: "OrganizationDeletePayload" } & OrganizationDeletePayloadFragment;
-};
-
-export type OrganizationDeleteChallengeMutationVariables = Exact<{ [key: string]: never }>;
-
-export type OrganizationDeleteChallengeMutation = { __typename?: "Mutation" } & {
-  organizationDeleteChallenge: { __typename?: "OrganizationDeletePayload" } & OrganizationDeletePayloadFragment;
-};
-
-export type DeleteOrganizationDomainMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteOrganizationDomainMutation = { __typename?: "Mutation" } & {
-  organizationDomainDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type CreateOrganizationInviteMutationVariables = Exact<{
-  input: OrganizationInviteCreateInput;
-}>;
-
-export type CreateOrganizationInviteMutation = { __typename?: "Mutation" } & {
-  organizationInviteCreate: { __typename?: "OrganizationInvitePayload" } & OrganizationInvitePayloadFragment;
-};
-
-export type DeleteOrganizationInviteMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteOrganizationInviteMutation = { __typename?: "Mutation" } & {
-  organizationInviteDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateOrganizationInviteMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: OrganizationInviteUpdateInput;
-}>;
-
-export type UpdateOrganizationInviteMutation = { __typename?: "Mutation" } & {
-  organizationInviteUpdate: { __typename?: "OrganizationInvitePayload" } & OrganizationInvitePayloadFragment;
-};
-
-export type UpdateOrganizationMutationVariables = Exact<{
-  input: UpdateOrganizationInput;
-}>;
-
-export type UpdateOrganizationMutation = { __typename?: "Mutation" } & {
-  organizationUpdate: { __typename?: "OrganizationPayload" } & OrganizationPayloadFragment;
-};
-
-export type ArchiveProjectMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type ArchiveProjectMutation = { __typename?: "Mutation" } & {
-  projectArchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type CreateProjectMutationVariables = Exact<{
-  input: ProjectCreateInput;
-}>;
-
-export type CreateProjectMutation = { __typename?: "Mutation" } & {
-  projectCreate: { __typename?: "ProjectPayload" } & ProjectPayloadFragment;
-};
-
-export type DeleteProjectMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteProjectMutation = { __typename?: "Mutation" } & {
-  projectDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type CreateProjectLinkMutationVariables = Exact<{
-  input: ProjectLinkCreateInput;
-}>;
-
-export type CreateProjectLinkMutation = { __typename?: "Mutation" } & {
-  projectLinkCreate: { __typename?: "ProjectLinkPayload" } & ProjectLinkPayloadFragment;
-};
-
-export type DeleteProjectLinkMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteProjectLinkMutation = { __typename?: "Mutation" } & {
-  projectLinkDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateProjectLinkMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: ProjectLinkUpdateInput;
-}>;
-
-export type UpdateProjectLinkMutation = { __typename?: "Mutation" } & {
-  projectLinkUpdate: { __typename?: "ProjectLinkPayload" } & ProjectLinkPayloadFragment;
-};
-
-export type UnarchiveProjectMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type UnarchiveProjectMutation = { __typename?: "Mutation" } & {
-  projectUnarchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateProjectMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: ProjectUpdateInput;
-}>;
-
-export type UpdateProjectMutation = { __typename?: "Mutation" } & {
-  projectUpdate: { __typename?: "ProjectPayload" } & ProjectPayloadFragment;
-};
-
-export type CreateProjectUpdateMutationVariables = Exact<{
-  input: ProjectUpdateCreateInput;
-}>;
-
-export type CreateProjectUpdateMutation = { __typename?: "Mutation" } & {
-  projectUpdateCreate: { __typename?: "ProjectUpdatePayload" } & ProjectUpdatePayloadFragment;
-};
-
-export type DeleteProjectUpdateMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteProjectUpdateMutation = { __typename?: "Mutation" } & {
-  projectUpdateDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type CreateProjectUpdateInteractionMutationVariables = Exact<{
-  input: ProjectUpdateInteractionCreateInput;
-}>;
-
-export type CreateProjectUpdateInteractionMutation = { __typename?: "Mutation" } & {
-  projectUpdateInteractionCreate: {
-    __typename?: "ProjectUpdateInteractionPayload";
-  } & ProjectUpdateInteractionPayloadFragment;
-};
-
-export type ProjectUpdateMarkAsReadMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type ProjectUpdateMarkAsReadMutation = { __typename?: "Mutation" } & {
-  projectUpdateMarkAsRead: {
-    __typename?: "ProjectUpdateWithInteractionPayload";
-  } & ProjectUpdateWithInteractionPayloadFragment;
-};
-
-export type UpdateProjectUpdateMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: ProjectUpdateUpdateInput;
-}>;
-
-export type UpdateProjectUpdateMutation = { __typename?: "Mutation" } & {
-  projectUpdateUpdate: { __typename?: "ProjectUpdatePayload" } & ProjectUpdatePayloadFragment;
-};
-
-export type CreatePushSubscriptionMutationVariables = Exact<{
-  input: PushSubscriptionCreateInput;
-}>;
-
-export type CreatePushSubscriptionMutation = { __typename?: "Mutation" } & {
-  pushSubscriptionCreate: { __typename?: "PushSubscriptionPayload" } & PushSubscriptionPayloadFragment;
-};
-
-export type DeletePushSubscriptionMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeletePushSubscriptionMutation = { __typename?: "Mutation" } & {
-  pushSubscriptionDelete: { __typename?: "PushSubscriptionPayload" } & PushSubscriptionPayloadFragment;
-};
-
-export type CreateReactionMutationVariables = Exact<{
-  input: ReactionCreateInput;
-}>;
-
-export type CreateReactionMutation = { __typename?: "Mutation" } & {
-  reactionCreate: { __typename?: "ReactionPayload" } & ReactionPayloadFragment;
-};
-
-export type DeleteReactionMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteReactionMutation = { __typename?: "Mutation" } & {
-  reactionDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type RefreshGoogleSheetsDataMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type RefreshGoogleSheetsDataMutation = { __typename?: "Mutation" } & {
-  refreshGoogleSheetsData: { __typename?: "IntegrationPayload" } & IntegrationPayloadFragment;
-};
-
-export type ResendOrganizationInviteMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type ResendOrganizationInviteMutation = { __typename?: "Mutation" } & {
-  resendOrganizationInvite: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type CreateRoadmapMutationVariables = Exact<{
-  input: RoadmapCreateInput;
-}>;
-
-export type CreateRoadmapMutation = { __typename?: "Mutation" } & {
-  roadmapCreate: { __typename?: "RoadmapPayload" } & RoadmapPayloadFragment;
-};
-
-export type DeleteRoadmapMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteRoadmapMutation = { __typename?: "Mutation" } & {
-  roadmapDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type CreateRoadmapToProjectMutationVariables = Exact<{
-  input: RoadmapToProjectCreateInput;
-}>;
-
-export type CreateRoadmapToProjectMutation = { __typename?: "Mutation" } & {
-  roadmapToProjectCreate: { __typename?: "RoadmapToProjectPayload" } & RoadmapToProjectPayloadFragment;
-};
-
-export type DeleteRoadmapToProjectMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteRoadmapToProjectMutation = { __typename?: "Mutation" } & {
-  roadmapToProjectDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateRoadmapToProjectMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: RoadmapToProjectUpdateInput;
-}>;
-
-export type UpdateRoadmapToProjectMutation = { __typename?: "Mutation" } & {
-  roadmapToProjectUpdate: { __typename?: "RoadmapToProjectPayload" } & RoadmapToProjectPayloadFragment;
-};
-
-export type UpdateRoadmapMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: RoadmapUpdateInput;
-}>;
-
-export type UpdateRoadmapMutation = { __typename?: "Mutation" } & {
-  roadmapUpdate: { __typename?: "RoadmapPayload" } & RoadmapPayloadFragment;
-};
-
-export type SamlTokenUserAccountAuthMutationVariables = Exact<{
-  input: TokenUserAccountAuthInput;
-}>;
-
-export type SamlTokenUserAccountAuthMutation = { __typename?: "Mutation" } & {
-  samlTokenUserAccountAuth: { __typename?: "AuthResolverResponse" } & AuthResolverResponseFragment;
-};
-
-export type CreateTeamMutationVariables = Exact<{
-  copySettingsFromTeamId?: Maybe<Scalars["String"]>;
-  input: TeamCreateInput;
-}>;
-
-export type CreateTeamMutation = { __typename?: "Mutation" } & {
-  teamCreate: { __typename?: "TeamPayload" } & TeamPayloadFragment;
-};
-
-export type DeleteTeamCyclesMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteTeamCyclesMutation = { __typename?: "Mutation" } & {
-  teamCyclesDelete: { __typename?: "TeamPayload" } & TeamPayloadFragment;
-};
-
-export type DeleteTeamMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteTeamMutation = { __typename?: "Mutation" } & {
-  teamDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type DeleteTeamKeyMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteTeamKeyMutation = { __typename?: "Mutation" } & {
-  teamKeyDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type CreateTeamMembershipMutationVariables = Exact<{
-  input: TeamMembershipCreateInput;
-}>;
-
-export type CreateTeamMembershipMutation = { __typename?: "Mutation" } & {
-  teamMembershipCreate: { __typename?: "TeamMembershipPayload" } & TeamMembershipPayloadFragment;
-};
-
-export type DeleteTeamMembershipMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteTeamMembershipMutation = { __typename?: "Mutation" } & {
-  teamMembershipDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateTeamMembershipMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: TeamMembershipUpdateInput;
-}>;
-
-export type UpdateTeamMembershipMutation = { __typename?: "Mutation" } & {
-  teamMembershipUpdate: { __typename?: "TeamMembershipPayload" } & TeamMembershipPayloadFragment;
-};
-
-export type UpdateTeamMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: TeamUpdateInput;
-}>;
-
-export type UpdateTeamMutation = { __typename?: "Mutation" } & {
-  teamUpdate: { __typename?: "TeamPayload" } & TeamPayloadFragment;
-};
-
-export type CreateTemplateMutationVariables = Exact<{
-  input: TemplateCreateInput;
-}>;
-
-export type CreateTemplateMutation = { __typename?: "Mutation" } & {
-  templateCreate: { __typename?: "TemplatePayload" } & TemplatePayloadFragment;
-};
-
-export type DeleteTemplateMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteTemplateMutation = { __typename?: "Mutation" } & {
-  templateDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateTemplateMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: TemplateUpdateInput;
-}>;
-
-export type UpdateTemplateMutation = { __typename?: "Mutation" } & {
-  templateUpdate: { __typename?: "TemplatePayload" } & TemplatePayloadFragment;
-};
-
-export type UserDemoteAdminMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type UserDemoteAdminMutation = { __typename?: "Mutation" } & {
-  userDemoteAdmin: { __typename?: "UserAdminPayload" } & UserAdminPayloadFragment;
-};
-
-export type UserDemoteMemberMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type UserDemoteMemberMutation = { __typename?: "Mutation" } & {
-  userDemoteMember: { __typename?: "UserAdminPayload" } & UserAdminPayloadFragment;
-};
-
-export type UserDiscordConnectMutationVariables = Exact<{
-  code: Scalars["String"];
-  redirectUri: Scalars["String"];
-}>;
-
-export type UserDiscordConnectMutation = { __typename?: "Mutation" } & {
-  userDiscordConnect: { __typename?: "UserPayload" } & UserPayloadFragment;
-};
-
-export type UserExternalUserDisconnectMutationVariables = Exact<{
-  service: Scalars["String"];
-}>;
-
-export type UserExternalUserDisconnectMutation = { __typename?: "Mutation" } & {
-  userExternalUserDisconnect: { __typename?: "UserPayload" } & UserPayloadFragment;
-};
-
-export type UpdateUserFlagMutationVariables = Exact<{
-  flag: UserFlagType;
-  operation: UserFlagUpdateOperation;
-}>;
-
-export type UpdateUserFlagMutation = { __typename?: "Mutation" } & {
-  userFlagUpdate: { __typename?: "UserSettingsFlagPayload" } & UserSettingsFlagPayloadFragment;
-};
-
-export type UserGitHubConnectMutationVariables = Exact<{
-  code: Scalars["String"];
-}>;
-
-export type UserGitHubConnectMutation = { __typename?: "Mutation" } & {
-  userGitHubConnect: { __typename?: "UserPayload" } & UserPayloadFragment;
-};
-
-export type UserGoogleCalendarConnectMutationVariables = Exact<{
-  code: Scalars["String"];
-}>;
-
-export type UserGoogleCalendarConnectMutation = { __typename?: "Mutation" } & {
-  userGoogleCalendarConnect: { __typename?: "UserPayload" } & UserPayloadFragment;
-};
-
-export type UserPromoteAdminMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type UserPromoteAdminMutation = { __typename?: "Mutation" } & {
-  userPromoteAdmin: { __typename?: "UserAdminPayload" } & UserAdminPayloadFragment;
-};
-
-export type UserPromoteMemberMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type UserPromoteMemberMutation = { __typename?: "Mutation" } & {
-  userPromoteMember: { __typename?: "UserAdminPayload" } & UserAdminPayloadFragment;
-};
-
-export type UserSettingsFlagIncrementMutationVariables = Exact<{
-  flag: Scalars["String"];
-}>;
-
-export type UserSettingsFlagIncrementMutation = { __typename?: "Mutation" } & {
-  userSettingsFlagIncrement: { __typename?: "UserSettingsFlagPayload" } & UserSettingsFlagPayloadFragment;
-};
-
-export type UserSettingsFlagsResetMutationVariables = Exact<{
-  flags?: Maybe<Array<UserFlagType> | UserFlagType>;
-}>;
-
-export type UserSettingsFlagsResetMutation = { __typename?: "Mutation" } & {
-  userSettingsFlagsReset: { __typename?: "UserSettingsFlagsResetPayload" } & UserSettingsFlagsResetPayloadFragment;
-};
-
-export type UpdateUserSettingsMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: UserSettingsUpdateInput;
-}>;
-
-export type UpdateUserSettingsMutation = { __typename?: "Mutation" } & {
-  userSettingsUpdate: { __typename?: "UserSettingsPayload" } & UserSettingsPayloadFragment;
-};
-
-export type SuspendUserMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type SuspendUserMutation = { __typename?: "Mutation" } & {
-  userSuspend: { __typename?: "UserAdminPayload" } & UserAdminPayloadFragment;
-};
-
-export type UnsuspendUserMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type UnsuspendUserMutation = { __typename?: "Mutation" } & {
-  userUnsuspend: { __typename?: "UserAdminPayload" } & UserAdminPayloadFragment;
-};
-
-export type UpdateUserMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: UpdateUserInput;
-}>;
-
-export type UpdateUserMutation = { __typename?: "Mutation" } & {
-  userUpdate: { __typename?: "UserPayload" } & UserPayloadFragment;
-};
-
-export type CreateViewPreferencesMutationVariables = Exact<{
-  input: ViewPreferencesCreateInput;
-}>;
-
-export type CreateViewPreferencesMutation = { __typename?: "Mutation" } & {
-  viewPreferencesCreate: { __typename?: "ViewPreferencesPayload" } & ViewPreferencesPayloadFragment;
-};
-
-export type DeleteViewPreferencesMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteViewPreferencesMutation = { __typename?: "Mutation" } & {
-  viewPreferencesDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateViewPreferencesMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: ViewPreferencesUpdateInput;
-}>;
-
-export type UpdateViewPreferencesMutation = { __typename?: "Mutation" } & {
-  viewPreferencesUpdate: { __typename?: "ViewPreferencesPayload" } & ViewPreferencesPayloadFragment;
-};
-
-export type CreateWebhookMutationVariables = Exact<{
-  input: WebhookCreateInput;
-}>;
-
-export type CreateWebhookMutation = { __typename?: "Mutation" } & {
-  webhookCreate: { __typename?: "WebhookPayload" } & WebhookPayloadFragment;
-};
-
-export type DeleteWebhookMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type DeleteWebhookMutation = { __typename?: "Mutation" } & {
-  webhookDelete: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type UpdateWebhookMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: WebhookUpdateInput;
-}>;
-
-export type UpdateWebhookMutation = { __typename?: "Mutation" } & {
-  webhookUpdate: { __typename?: "WebhookPayload" } & WebhookPayloadFragment;
-};
-
-export type ArchiveWorkflowStateMutationVariables = Exact<{
-  id: Scalars["String"];
-}>;
-
-export type ArchiveWorkflowStateMutation = { __typename?: "Mutation" } & {
-  workflowStateArchive: { __typename?: "ArchivePayload" } & ArchivePayloadFragment;
-};
-
-export type CreateWorkflowStateMutationVariables = Exact<{
-  input: WorkflowStateCreateInput;
-}>;
-
-export type CreateWorkflowStateMutation = { __typename?: "Mutation" } & {
-  workflowStateCreate: { __typename?: "WorkflowStatePayload" } & WorkflowStatePayloadFragment;
-};
-
-export type UpdateWorkflowStateMutationVariables = Exact<{
-  id: Scalars["String"];
-  input: WorkflowStateUpdateInput;
-}>;
-
-export type UpdateWorkflowStateMutation = { __typename?: "Mutation" } & {
-  workflowStateUpdate: { __typename?: "WorkflowStatePayload" } & WorkflowStatePayloadFragment;
-};
-
 export const EntityFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -13463,6 +13473,35 @@ export const EntityFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<EntityFragment, unknown>;
+export const PersonalNoteFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "PersonalNote" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "PersonalNote" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "contentData" } },
+          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "user" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<PersonalNoteFragment, unknown>;
 export const ProjectNotificationSubscriptionFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -14038,6 +14077,24 @@ export const JiraSettingsFragmentDoc = {
     ...JiraLinearMappingFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<JiraSettingsFragment, unknown>;
+export const NotionSettingsFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "NotionSettings" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "NotionSettings" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "workspaceId" } },
+          { kind: "Field", name: { kind: "Name", value: "workspaceName" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<NotionSettingsFragment, unknown>;
 export const SentrySettingsFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -14151,6 +14208,14 @@ export const IntegrationSettingsFragmentDoc = {
           },
           {
             kind: "Field",
+            name: { kind: "Name", value: "notion" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "NotionSettings" } }],
+            },
+          },
+          {
+            kind: "Field",
             name: { kind: "Name", value: "sentry" },
             selectionSet: {
               kind: "SelectionSet",
@@ -14197,6 +14262,7 @@ export const IntegrationSettingsFragmentDoc = {
     ...GoogleSheetsSettingsFragmentDoc.definitions,
     ...IntercomSettingsFragmentDoc.definitions,
     ...JiraSettingsFragmentDoc.definitions,
+    ...NotionSettingsFragmentDoc.definitions,
     ...SentrySettingsFragmentDoc.definitions,
     ...SlackPostSettingsFragmentDoc.definitions,
     ...ZendeskSettingsFragmentDoc.definitions,
@@ -15634,64 +15700,6 @@ export const ImageUploadFromUrlPayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<ImageUploadFromUrlPayloadFragment, unknown>;
-export const InitiativeFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "Initiative" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Initiative" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "targetDate" } },
-          { kind: "Field", name: { kind: "Name", value: "description" } },
-          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
-          { kind: "Field", name: { kind: "Name", value: "name" } },
-          { kind: "Field", name: { kind: "Name", value: "sortOrder" } },
-          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
-          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
-          { kind: "Field", name: { kind: "Name", value: "id" } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<InitiativeFragment, unknown>;
-export const InitiativeConnectionFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "InitiativeConnection" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "InitiativeConnection" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "nodes" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "Initiative" } }],
-            },
-          },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "pageInfo" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "PageInfo" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...InitiativeFragmentDoc.definitions,
-    ...PageInfoFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<InitiativeConnectionFragment, unknown>;
 export const IntegrationFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -16187,11 +16195,13 @@ export const IntegrationsSettingsFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
           { kind: "Field", name: { kind: "Name", value: "slackIssueNewComment" } },
+          { kind: "Field", name: { kind: "Name", value: "slackIssueAddedToTriage" } },
           { kind: "Field", name: { kind: "Name", value: "slackIssueCreated" } },
           { kind: "Field", name: { kind: "Name", value: "slackProjectUpdateCreated" } },
+          { kind: "Field", name: { kind: "Name", value: "slackIssueSlaHighRisk" } },
+          { kind: "Field", name: { kind: "Name", value: "slackIssueSlaBreached" } },
           { kind: "Field", name: { kind: "Name", value: "slackIssueStatusChangedDone" } },
           { kind: "Field", name: { kind: "Name", value: "slackIssueStatusChangedAll" } },
-          { kind: "Field", name: { kind: "Name", value: "slackProjectUpdateCreatedToMilestone" } },
           { kind: "Field", name: { kind: "Name", value: "slackProjectUpdateCreatedToTeam" } },
           { kind: "Field", name: { kind: "Name", value: "slackProjectUpdateCreatedToWorkspace" } },
         ],
@@ -16321,6 +16331,7 @@ export const IssueFragmentDoc = {
           },
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "startedTriageAt" } },
           { kind: "Field", name: { kind: "Name", value: "triagedAt" } },
           { kind: "Field", name: { kind: "Name", value: "autoArchivedAt" } },
           { kind: "Field", name: { kind: "Name", value: "autoClosedAt" } },
@@ -17021,106 +17032,6 @@ export const LogoutResponseFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<LogoutResponseFragment, unknown>;
-export const MilestoneFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "Milestone" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Milestone" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
-          { kind: "Field", name: { kind: "Name", value: "name" } },
-          { kind: "Field", name: { kind: "Name", value: "sortOrder" } },
-          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
-          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
-          { kind: "Field", name: { kind: "Name", value: "id" } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<MilestoneFragment, unknown>;
-export const MilestoneConnectionFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "MilestoneConnection" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "MilestoneConnection" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "nodes" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "Milestone" } }],
-            },
-          },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "pageInfo" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "PageInfo" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...MilestoneFragmentDoc.definitions,
-    ...PageInfoFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<MilestoneConnectionFragment, unknown>;
-export const MilestoneMigrationPayloadFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "MilestoneMigrationPayload" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "MilestoneMigrationPayload" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
-          { kind: "Field", name: { kind: "Name", value: "success" } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<MilestoneMigrationPayloadFragment, unknown>;
-export const MilestonePayloadFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "MilestonePayload" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "MilestonePayload" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "milestone" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
-            },
-          },
-          { kind: "Field", name: { kind: "Name", value: "success" } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<MilestonePayloadFragment, unknown>;
 export const NodeFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -17790,23 +17701,7 @@ export const ProjectFragmentDoc = {
           },
           { kind: "Field", name: { kind: "Name", value: "targetDate" } },
           { kind: "Field", name: { kind: "Name", value: "icon" } },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "initiative" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "Initiative" } }],
-            },
-          },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "milestone" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
-            },
-          },
           { kind: "Field", name: { kind: "Name", value: "completedScopeHistory" } },
           { kind: "Field", name: { kind: "Name", value: "completedIssueCountHistory" } },
           { kind: "Field", name: { kind: "Name", value: "inProgressScopeHistory" } },
@@ -17858,7 +17753,6 @@ export const ProjectFragmentDoc = {
         ],
       },
     },
-    ...InitiativeFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<ProjectFragment, unknown>;
 export const ProjectConnectionFragmentDoc = {
@@ -17993,6 +17887,97 @@ export const ProjectLinkPayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<ProjectLinkPayloadFragment, unknown>;
+export const ProjectMilestoneFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "ProjectMilestone" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "ProjectMilestone" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "description" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "targetDate" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "project" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ProjectMilestoneFragment, unknown>;
+export const ProjectMilestoneConnectionFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "ProjectMilestoneConnection" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "ProjectMilestoneConnection" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "nodes" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectMilestone" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "pageInfo" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "PageInfo" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ProjectMilestoneFragmentDoc.definitions,
+    ...PageInfoFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<ProjectMilestoneConnectionFragment, unknown>;
+export const ProjectMilestonePayloadFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "ProjectMilestonePayload" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "ProjectMilestonePayload" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "projectMilestone" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ProjectMilestonePayloadFragment, unknown>;
 export const ProjectPayloadFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -18854,6 +18839,7 @@ export const TeamFragmentDoc = {
           },
           { kind: "Field", name: { kind: "Name", value: "inviteHash" } },
           { kind: "Field", name: { kind: "Name", value: "defaultIssueEstimate" } },
+          { kind: "Field", name: { kind: "Name", value: "requirePriorityToLeaveTriage" } },
           { kind: "Field", name: { kind: "Name", value: "issueOrderingNoPriorityFirst" } },
           { kind: "Field", name: { kind: "Name", value: "private" } },
           { kind: "Field", name: { kind: "Name", value: "cyclesEnabled" } },
@@ -19453,8 +19439,11 @@ export const WorkflowDefinitionFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "activities" } },
           { kind: "Field", name: { kind: "Name", value: "schedule" } },
           { kind: "Field", name: { kind: "Name", value: "conditions" } },
+          { kind: "Field", name: { kind: "Name", value: "description" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "groupName" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "sortOrder" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "team" },
@@ -19474,13 +19463,46 @@ export const WorkflowDefinitionFragmentDoc = {
               selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
             },
           },
-          { kind: "Field", name: { kind: "Name", value: "description" } },
           { kind: "Field", name: { kind: "Name", value: "enabled" } },
         ],
       },
     },
   ],
 } as unknown as DocumentNode<WorkflowDefinitionFragment, unknown>;
+export const WorkflowDefinitionConnectionFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "WorkflowDefinitionConnection" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "WorkflowDefinitionConnection" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "nodes" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "WorkflowDefinition" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "pageInfo" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "PageInfo" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...WorkflowDefinitionFragmentDoc.definitions,
+    ...PageInfoFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<WorkflowDefinitionConnectionFragment, unknown>;
 export const WorkflowStateFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -19574,6 +19596,7713 @@ export const WorkflowStatePayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<WorkflowStatePayloadFragment, unknown>;
+export const AirbyteIntegrationConnectDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "airbyteIntegrationConnect" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "AirbyteConfigurationInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "airbyteIntegrationConnect" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<AirbyteIntegrationConnectMutation, AirbyteIntegrationConnectMutationVariables>;
+export const CreateApiKeyDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createApiKey" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ApiKeyCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "apiKeyCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ApiKeyPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ApiKeyPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateApiKeyMutation, CreateApiKeyMutationVariables>;
+export const DeleteApiKeyDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteApiKey" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "apiKeyDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteApiKeyMutation, DeleteApiKeyMutationVariables>;
+export const ArchiveAttachmentDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "archiveAttachment" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "attachmentArchive" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<ArchiveAttachmentMutation, ArchiveAttachmentMutationVariables>;
+export const CreateAttachmentDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createAttachment" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "AttachmentCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "attachmentCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AttachmentPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...AttachmentPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateAttachmentMutation, CreateAttachmentMutationVariables>;
+export const DeleteAttachmentDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteAttachment" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "attachmentDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteAttachmentMutation, DeleteAttachmentMutationVariables>;
+export const AttachmentLinkDiscordDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "attachmentLinkDiscord" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "channelId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "messageId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "url" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "attachmentLinkDiscord" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "channelId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "channelId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "issueId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "messageId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "messageId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "url" },
+                value: { kind: "Variable", name: { kind: "Name", value: "url" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AttachmentPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...AttachmentPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<AttachmentLinkDiscordMutation, AttachmentLinkDiscordMutationVariables>;
+export const AttachmentLinkFrontDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "attachmentLinkFront" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "conversationId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "attachmentLinkFront" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "conversationId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "conversationId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "issueId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "FrontAttachmentPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...FrontAttachmentPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<AttachmentLinkFrontMutation, AttachmentLinkFrontMutationVariables>;
+export const AttachmentLinkIntercomDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "attachmentLinkIntercom" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "conversationId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "attachmentLinkIntercom" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "conversationId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "conversationId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "issueId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AttachmentPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...AttachmentPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<AttachmentLinkIntercomMutation, AttachmentLinkIntercomMutationVariables>;
+export const AttachmentLinkJiraIssueDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "attachmentLinkJiraIssue" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "jiraIssueId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "attachmentLinkJiraIssue" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "issueId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "jiraIssueId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "jiraIssueId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AttachmentPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...AttachmentPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<AttachmentLinkJiraIssueMutation, AttachmentLinkJiraIssueMutationVariables>;
+export const AttachmentLinkUrlDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "attachmentLinkURL" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "title" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "url" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "attachmentLinkURL" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "issueId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "title" },
+                value: { kind: "Variable", name: { kind: "Name", value: "title" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "url" },
+                value: { kind: "Variable", name: { kind: "Name", value: "url" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AttachmentPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...AttachmentPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<AttachmentLinkUrlMutation, AttachmentLinkUrlMutationVariables>;
+export const AttachmentLinkZendeskDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "attachmentLinkZendesk" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "ticketId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "attachmentLinkZendesk" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "issueId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "ticketId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "ticketId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AttachmentPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...AttachmentPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<AttachmentLinkZendeskMutation, AttachmentLinkZendeskMutationVariables>;
+export const UpdateAttachmentDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateAttachment" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "AttachmentUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "attachmentUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AttachmentPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...AttachmentPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateAttachmentMutation, UpdateAttachmentMutationVariables>;
+export const CreateCommentDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createComment" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "CommentCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "commentCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CommentPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...CommentPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateCommentMutation, CreateCommentMutationVariables>;
+export const DeleteCommentDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteComment" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "commentDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteCommentMutation, DeleteCommentMutationVariables>;
+export const UpdateCommentDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateComment" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "CommentUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "commentUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CommentPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...CommentPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateCommentMutation, UpdateCommentMutationVariables>;
+export const CreateContactDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createContact" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ContactCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "contactCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ContactPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ContactPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateContactMutation, CreateContactMutationVariables>;
+export const CreateCsvExportReportDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createCsvExportReport" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "includePrivateTeamIds" } },
+          type: {
+            kind: "ListType",
+            type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "createCsvExportReport" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "includePrivateTeamIds" },
+                value: { kind: "Variable", name: { kind: "Name", value: "includePrivateTeamIds" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CreateCsvExportReportPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...CreateCsvExportReportPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateCsvExportReportMutation, CreateCsvExportReportMutationVariables>;
+export const CreateOrganizationFromOnboardingDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createOrganizationFromOnboarding" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "CreateOrganizationInput" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "survey" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "OnboardingCustomerSurvey" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "createOrganizationFromOnboarding" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "survey" },
+                value: { kind: "Variable", name: { kind: "Name", value: "survey" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "FragmentSpread", name: { kind: "Name", value: "CreateOrJoinOrganizationResponse" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    ...CreateOrJoinOrganizationResponseFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<
+  CreateOrganizationFromOnboardingMutation,
+  CreateOrganizationFromOnboardingMutationVariables
+>;
+export const CreateCustomViewDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createCustomView" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "CustomViewCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "customViewCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CustomViewPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...CustomViewPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateCustomViewMutation, CreateCustomViewMutationVariables>;
+export const DeleteCustomViewDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteCustomView" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "customViewDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteCustomViewMutation, DeleteCustomViewMutationVariables>;
+export const UpdateCustomViewDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateCustomView" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "CustomViewUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "customViewUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CustomViewPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...CustomViewPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateCustomViewMutation, UpdateCustomViewMutationVariables>;
+export const ArchiveCycleDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "archiveCycle" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "cycleArchive" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<ArchiveCycleMutation, ArchiveCycleMutationVariables>;
+export const CreateCycleDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createCycle" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "CycleCreateInput" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "cycleCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CyclePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...CyclePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateCycleMutation, CreateCycleMutationVariables>;
+export const UpdateCycleDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateCycle" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "CycleUpdateInput" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "cycleUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CyclePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...CyclePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateCycleMutation, UpdateCycleMutationVariables>;
+export const CreateDocumentDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createDocument" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "DocumentCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "documentCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "DocumentPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...DocumentPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateDocumentMutation, CreateDocumentMutationVariables>;
+export const DeleteDocumentDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteDocument" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "documentDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteDocumentMutation, DeleteDocumentMutationVariables>;
+export const UpdateDocumentDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateDocument" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "DocumentUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "documentUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "DocumentPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...DocumentPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateDocumentMutation, UpdateDocumentMutationVariables>;
+export const EmailTokenUserAccountAuthDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "emailTokenUserAccountAuth" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "TokenUserAccountAuthInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "emailTokenUserAccountAuth" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AuthResolverResponse" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...AuthResolverResponseFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<EmailTokenUserAccountAuthMutation, EmailTokenUserAccountAuthMutationVariables>;
+export const EmailUnsubscribeDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "emailUnsubscribe" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "EmailUnsubscribeInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "emailUnsubscribe" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "EmailUnsubscribePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...EmailUnsubscribePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<EmailUnsubscribeMutation, EmailUnsubscribeMutationVariables>;
+export const EmailUserAccountAuthChallengeDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "emailUserAccountAuthChallenge" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "EmailUserAccountAuthChallengeInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "emailUserAccountAuthChallenge" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "FragmentSpread", name: { kind: "Name", value: "EmailUserAccountAuthChallengeResponse" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    ...EmailUserAccountAuthChallengeResponseFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<EmailUserAccountAuthChallengeMutation, EmailUserAccountAuthChallengeMutationVariables>;
+export const CreateEmojiDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createEmoji" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "EmojiCreateInput" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "emojiCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "EmojiPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...EmojiPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateEmojiMutation, CreateEmojiMutationVariables>;
+export const DeleteEmojiDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteEmoji" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "emojiDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteEmojiMutation, DeleteEmojiMutationVariables>;
+export const CreateEventDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createEvent" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "EventCreateInput" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "eventCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "EventPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...EventPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateEventMutation, CreateEventMutationVariables>;
+export const CreateFavoriteDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createFavorite" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "FavoriteCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "favoriteCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "FavoritePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...FavoritePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateFavoriteMutation, CreateFavoriteMutationVariables>;
+export const DeleteFavoriteDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteFavorite" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "favoriteDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteFavoriteMutation, DeleteFavoriteMutationVariables>;
+export const UpdateFavoriteDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateFavorite" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "FavoriteUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "favoriteUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "FavoritePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...FavoritePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateFavoriteMutation, UpdateFavoriteMutationVariables>;
+export const FileUploadDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "fileUpload" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "contentType" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "filename" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "makePublic" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "metaData" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "JSON" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "size" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "Int" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "fileUpload" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "contentType" },
+                value: { kind: "Variable", name: { kind: "Name", value: "contentType" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "filename" },
+                value: { kind: "Variable", name: { kind: "Name", value: "filename" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "makePublic" },
+                value: { kind: "Variable", name: { kind: "Name", value: "makePublic" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "metaData" },
+                value: { kind: "Variable", name: { kind: "Name", value: "metaData" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "size" },
+                value: { kind: "Variable", name: { kind: "Name", value: "size" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UploadPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...UploadPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<FileUploadMutation, FileUploadMutationVariables>;
+export const GoogleUserAccountAuthDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "googleUserAccountAuth" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "GoogleUserAccountAuthInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "googleUserAccountAuth" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AuthResolverResponse" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...AuthResolverResponseFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<GoogleUserAccountAuthMutation, GoogleUserAccountAuthMutationVariables>;
+export const ImageUploadFromUrlDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "imageUploadFromUrl" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "url" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "imageUploadFromUrl" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "url" },
+                value: { kind: "Variable", name: { kind: "Name", value: "url" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ImageUploadFromUrlPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ImageUploadFromUrlPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<ImageUploadFromUrlMutation, ImageUploadFromUrlMutationVariables>;
+export const DeleteIntegrationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteIntegration" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteIntegrationMutation, DeleteIntegrationMutationVariables>;
+export const IntegrationDiscordDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "integrationDiscord" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationDiscord" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "code" },
+                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "redirectUri" },
+                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IntegrationDiscordMutation, IntegrationDiscordMutationVariables>;
+export const IntegrationFigmaDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "integrationFigma" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationFigma" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "code" },
+                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "redirectUri" },
+                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IntegrationFigmaMutation, IntegrationFigmaMutationVariables>;
+export const IntegrationFrontDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "integrationFront" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationFront" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "code" },
+                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "redirectUri" },
+                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IntegrationFrontMutation, IntegrationFrontMutationVariables>;
+export const CreateIntegrationGithubCommitDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createIntegrationGithubCommit" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationGithubCommitCreate" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "GitHubCommitIntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...GitHubCommitIntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateIntegrationGithubCommitMutation, CreateIntegrationGithubCommitMutationVariables>;
+export const IntegrationGithubConnectDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "integrationGithubConnect" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "installationId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationGithubConnect" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "installationId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "installationId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IntegrationGithubConnectMutation, IntegrationGithubConnectMutationVariables>;
+export const IntegrationGitlabConnectDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "integrationGitlabConnect" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "accessToken" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "gitlabUrl" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationGitlabConnect" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "accessToken" },
+                value: { kind: "Variable", name: { kind: "Name", value: "accessToken" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "gitlabUrl" },
+                value: { kind: "Variable", name: { kind: "Name", value: "gitlabUrl" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IntegrationGitlabConnectMutation, IntegrationGitlabConnectMutationVariables>;
+export const IntegrationGoogleSheetsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "integrationGoogleSheets" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationGoogleSheets" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "code" },
+                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IntegrationGoogleSheetsMutation, IntegrationGoogleSheetsMutationVariables>;
+export const IntegrationIntercomDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "integrationIntercom" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "domainUrl" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationIntercom" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "code" },
+                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "domainUrl" },
+                value: { kind: "Variable", name: { kind: "Name", value: "domainUrl" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "redirectUri" },
+                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IntegrationIntercomMutation, IntegrationIntercomMutationVariables>;
+export const DeleteIntegrationIntercomDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteIntegrationIntercom" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationIntercomDelete" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteIntegrationIntercomMutation, DeleteIntegrationIntercomMutationVariables>;
+export const UpdateIntegrationIntercomSettingsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateIntegrationIntercomSettings" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "IntercomSettingsInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationIntercomSettingsUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<
+  UpdateIntegrationIntercomSettingsMutation,
+  UpdateIntegrationIntercomSettingsMutationVariables
+>;
+export const IntegrationLoomDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "integrationLoom" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationLoom" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IntegrationLoomMutation, IntegrationLoomMutationVariables>;
+export const IntegrationRequestDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "integrationRequest" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "IntegrationRequestInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationRequest" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationRequestPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationRequestPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IntegrationRequestMutation, IntegrationRequestMutationVariables>;
+export const ArchiveIntegrationResourceDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "archiveIntegrationResource" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationResourceArchive" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<ArchiveIntegrationResourceMutation, ArchiveIntegrationResourceMutationVariables>;
+export const IntegrationSentryConnectDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "integrationSentryConnect" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "installationId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "organizationSlug" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationSentryConnect" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "code" },
+                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "installationId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "installationId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "organizationSlug" },
+                value: { kind: "Variable", name: { kind: "Name", value: "organizationSlug" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IntegrationSentryConnectMutation, IntegrationSentryConnectMutationVariables>;
+export const IntegrationSlackDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "integrationSlack" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "shouldUseV2Auth" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationSlack" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "code" },
+                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "redirectUri" },
+                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "shouldUseV2Auth" },
+                value: { kind: "Variable", name: { kind: "Name", value: "shouldUseV2Auth" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IntegrationSlackMutation, IntegrationSlackMutationVariables>;
+export const IntegrationSlackImportEmojisDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "integrationSlackImportEmojis" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationSlackImportEmojis" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "code" },
+                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "redirectUri" },
+                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IntegrationSlackImportEmojisMutation, IntegrationSlackImportEmojisMutationVariables>;
+export const IntegrationSlackOrgProjectUpdatesPostDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "integrationSlackOrgProjectUpdatesPost" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationSlackOrgProjectUpdatesPost" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "code" },
+                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "redirectUri" },
+                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<
+  IntegrationSlackOrgProjectUpdatesPostMutation,
+  IntegrationSlackOrgProjectUpdatesPostMutationVariables
+>;
+export const IntegrationSlackPersonalDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "integrationSlackPersonal" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationSlackPersonal" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "code" },
+                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "redirectUri" },
+                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IntegrationSlackPersonalMutation, IntegrationSlackPersonalMutationVariables>;
+export const IntegrationSlackPostDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "integrationSlackPost" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "shouldUseV2Auth" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationSlackPost" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "code" },
+                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "redirectUri" },
+                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "shouldUseV2Auth" },
+                value: { kind: "Variable", name: { kind: "Name", value: "shouldUseV2Auth" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "teamId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IntegrationSlackPostMutation, IntegrationSlackPostMutationVariables>;
+export const IntegrationSlackProjectPostDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "integrationSlackProjectPost" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "projectId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "service" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationSlackProjectPost" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "code" },
+                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "projectId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "projectId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "redirectUri" },
+                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "service" },
+                value: { kind: "Variable", name: { kind: "Name", value: "service" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IntegrationSlackProjectPostMutation, IntegrationSlackProjectPostMutationVariables>;
+export const CreateIntegrationTemplateDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createIntegrationTemplate" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "IntegrationTemplateCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationTemplateCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationTemplatePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationTemplatePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateIntegrationTemplateMutation, CreateIntegrationTemplateMutationVariables>;
+export const DeleteIntegrationTemplateDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteIntegrationTemplate" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationTemplateDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteIntegrationTemplateMutation, DeleteIntegrationTemplateMutationVariables>;
+export const IntegrationZendeskDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "integrationZendesk" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "scope" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "subdomain" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationZendesk" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "code" },
+                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "redirectUri" },
+                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "scope" },
+                value: { kind: "Variable", name: { kind: "Name", value: "scope" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "subdomain" },
+                value: { kind: "Variable", name: { kind: "Name", value: "subdomain" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IntegrationZendeskMutation, IntegrationZendeskMutationVariables>;
+export const CreateIntegrationsSettingsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createIntegrationsSettings" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "IntegrationsSettingsCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationsSettingsCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationsSettingsPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationsSettingsPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateIntegrationsSettingsMutation, CreateIntegrationsSettingsMutationVariables>;
+export const UpdateIntegrationsSettingsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateIntegrationsSettings" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "IntegrationsSettingsUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationsSettingsUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationsSettingsPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationsSettingsPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateIntegrationsSettingsMutation, UpdateIntegrationsSettingsMutationVariables>;
+export const ArchiveIssueDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "archiveIssue" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "trash" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueArchive" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "trash" },
+                value: { kind: "Variable", name: { kind: "Name", value: "trash" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<ArchiveIssueMutation, ArchiveIssueMutationVariables>;
+export const UpdateIssueBatchDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateIssueBatch" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "ids" } },
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "ListType",
+              type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "UUID" } } },
+            },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "IssueUpdateInput" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueBatchUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "ids" },
+                value: { kind: "Variable", name: { kind: "Name", value: "ids" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueBatchPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IssueBatchPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateIssueBatchMutation, UpdateIssueBatchMutationVariables>;
+export const CreateIssueDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createIssue" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "IssueCreateInput" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssuePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IssuePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateIssueMutation, CreateIssueMutationVariables>;
+export const DeleteIssueDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteIssue" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteIssueMutation, DeleteIssueMutationVariables>;
+export const IssueImportCreateAsanaDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "issueImportCreateAsana" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "asanaTeamName" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "asanaToken" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "includeClosedIssues" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "instantProcess" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "teamName" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueImportCreateAsana" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "asanaTeamName" },
+                value: { kind: "Variable", name: { kind: "Name", value: "asanaTeamName" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "asanaToken" },
+                value: { kind: "Variable", name: { kind: "Name", value: "asanaToken" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "includeClosedIssues" },
+                value: { kind: "Variable", name: { kind: "Name", value: "includeClosedIssues" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "instantProcess" },
+                value: { kind: "Variable", name: { kind: "Name", value: "instantProcess" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "organizationId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "teamId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "teamName" },
+                value: { kind: "Variable", name: { kind: "Name", value: "teamName" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueImportPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IssueImportPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IssueImportCreateAsanaMutation, IssueImportCreateAsanaMutationVariables>;
+export const IssueImportCreateClubhouseDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "issueImportCreateClubhouse" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "clubhouseTeamName" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "clubhouseToken" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "includeClosedIssues" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "instantProcess" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "teamName" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueImportCreateClubhouse" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "clubhouseTeamName" },
+                value: { kind: "Variable", name: { kind: "Name", value: "clubhouseTeamName" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "clubhouseToken" },
+                value: { kind: "Variable", name: { kind: "Name", value: "clubhouseToken" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "includeClosedIssues" },
+                value: { kind: "Variable", name: { kind: "Name", value: "includeClosedIssues" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "instantProcess" },
+                value: { kind: "Variable", name: { kind: "Name", value: "instantProcess" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "organizationId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "teamId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "teamName" },
+                value: { kind: "Variable", name: { kind: "Name", value: "teamName" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueImportPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IssueImportPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IssueImportCreateClubhouseMutation, IssueImportCreateClubhouseMutationVariables>;
+export const IssueImportCreateGithubDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "issueImportCreateGithub" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "githubRepoName" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "githubRepoOwner" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "githubShouldImportOrgProjects" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "githubToken" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "includeClosedIssues" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "instantProcess" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "teamName" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueImportCreateGithub" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "githubRepoName" },
+                value: { kind: "Variable", name: { kind: "Name", value: "githubRepoName" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "githubRepoOwner" },
+                value: { kind: "Variable", name: { kind: "Name", value: "githubRepoOwner" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "githubShouldImportOrgProjects" },
+                value: { kind: "Variable", name: { kind: "Name", value: "githubShouldImportOrgProjects" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "githubToken" },
+                value: { kind: "Variable", name: { kind: "Name", value: "githubToken" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "includeClosedIssues" },
+                value: { kind: "Variable", name: { kind: "Name", value: "includeClosedIssues" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "instantProcess" },
+                value: { kind: "Variable", name: { kind: "Name", value: "instantProcess" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "organizationId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "teamId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "teamName" },
+                value: { kind: "Variable", name: { kind: "Name", value: "teamName" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueImportPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IssueImportPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IssueImportCreateGithubMutation, IssueImportCreateGithubMutationVariables>;
+export const IssueImportCreateJiraDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "issueImportCreateJira" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "includeClosedIssues" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "instantProcess" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "jiraEmail" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "jiraHostname" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "jiraProject" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "jiraToken" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "teamName" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueImportCreateJira" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "includeClosedIssues" },
+                value: { kind: "Variable", name: { kind: "Name", value: "includeClosedIssues" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "instantProcess" },
+                value: { kind: "Variable", name: { kind: "Name", value: "instantProcess" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "jiraEmail" },
+                value: { kind: "Variable", name: { kind: "Name", value: "jiraEmail" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "jiraHostname" },
+                value: { kind: "Variable", name: { kind: "Name", value: "jiraHostname" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "jiraProject" },
+                value: { kind: "Variable", name: { kind: "Name", value: "jiraProject" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "jiraToken" },
+                value: { kind: "Variable", name: { kind: "Name", value: "jiraToken" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "organizationId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "teamId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "teamName" },
+                value: { kind: "Variable", name: { kind: "Name", value: "teamName" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueImportPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IssueImportPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IssueImportCreateJiraMutation, IssueImportCreateJiraMutationVariables>;
+export const DeleteIssueImportDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteIssueImport" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "issueImportId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueImportDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "issueImportId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "issueImportId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueImportDeletePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IssueImportDeletePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteIssueImportMutation, DeleteIssueImportMutationVariables>;
+export const IssueImportProcessDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "issueImportProcess" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "issueImportId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "mapping" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "JSONObject" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueImportProcess" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "issueImportId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "issueImportId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "mapping" },
+                value: { kind: "Variable", name: { kind: "Name", value: "mapping" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueImportPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IssueImportPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IssueImportProcessMutation, IssueImportProcessMutationVariables>;
+export const UpdateIssueImportDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateIssueImport" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "IssueImportUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueImportUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueImportPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IssueImportPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateIssueImportMutation, UpdateIssueImportMutationVariables>;
+export const ArchiveIssueLabelDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "archiveIssueLabel" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueLabelArchive" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<ArchiveIssueLabelMutation, ArchiveIssueLabelMutationVariables>;
+export const CreateIssueLabelDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createIssueLabel" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "IssueLabelCreateInput" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "replaceTeamLabels" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueLabelCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "replaceTeamLabels" },
+                value: { kind: "Variable", name: { kind: "Name", value: "replaceTeamLabels" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueLabelPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IssueLabelPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateIssueLabelMutation, CreateIssueLabelMutationVariables>;
+export const DeleteIssueLabelDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteIssueLabel" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueLabelDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteIssueLabelMutation, DeleteIssueLabelMutationVariables>;
+export const UpdateIssueLabelDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateIssueLabel" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "IssueLabelUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueLabelUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueLabelPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IssueLabelPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateIssueLabelMutation, UpdateIssueLabelMutationVariables>;
+export const CreateIssueRelationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createIssueRelation" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "IssueRelationCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueRelationCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueRelationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IssueRelationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateIssueRelationMutation, CreateIssueRelationMutationVariables>;
+export const DeleteIssueRelationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteIssueRelation" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueRelationDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteIssueRelationMutation, DeleteIssueRelationMutationVariables>;
+export const UpdateIssueRelationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateIssueRelation" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "IssueRelationUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueRelationUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueRelationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IssueRelationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateIssueRelationMutation, UpdateIssueRelationMutationVariables>;
+export const IssueReminderDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "issueReminder" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "reminderAt" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "DateTime" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueReminder" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "reminderAt" },
+                value: { kind: "Variable", name: { kind: "Name", value: "reminderAt" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssuePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IssuePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IssueReminderMutation, IssueReminderMutationVariables>;
+export const UnarchiveIssueDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "unarchiveIssue" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueUnarchive" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UnarchiveIssueMutation, UnarchiveIssueMutationVariables>;
+export const UpdateIssueDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateIssue" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "IssueUpdateInput" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssuePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IssuePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateIssueMutation, UpdateIssueMutationVariables>;
+export const JoinOrganizationFromOnboardingDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "joinOrganizationFromOnboarding" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "JoinOrganizationInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "joinOrganizationFromOnboarding" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "FragmentSpread", name: { kind: "Name", value: "CreateOrJoinOrganizationResponse" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    ...CreateOrJoinOrganizationResponseFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<JoinOrganizationFromOnboardingMutation, JoinOrganizationFromOnboardingMutationVariables>;
+export const LeaveOrganizationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "leaveOrganization" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "leaveOrganization" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "organizationId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "FragmentSpread", name: { kind: "Name", value: "CreateOrJoinOrganizationResponse" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    ...CreateOrJoinOrganizationResponseFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<LeaveOrganizationMutation, LeaveOrganizationMutationVariables>;
+export const LogoutDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "logout" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "logout" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "LogoutResponse" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...LogoutResponseFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<LogoutMutation, LogoutMutationVariables>;
+export const ArchiveNotificationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "archiveNotification" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "notificationArchive" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<ArchiveNotificationMutation, ArchiveNotificationMutationVariables>;
+export const CreateNotificationSubscriptionDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createNotificationSubscription" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "NotificationSubscriptionCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "notificationSubscriptionCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "FragmentSpread", name: { kind: "Name", value: "NotificationSubscriptionPayload" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    ...NotificationSubscriptionPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateNotificationSubscriptionMutation, CreateNotificationSubscriptionMutationVariables>;
+export const DeleteNotificationSubscriptionDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteNotificationSubscription" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "notificationSubscriptionDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteNotificationSubscriptionMutation, DeleteNotificationSubscriptionMutationVariables>;
+export const UpdateNotificationSubscriptionDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateNotificationSubscription" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "NotificationSubscriptionUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "notificationSubscriptionUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "FragmentSpread", name: { kind: "Name", value: "NotificationSubscriptionPayload" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    ...NotificationSubscriptionPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateNotificationSubscriptionMutation, UpdateNotificationSubscriptionMutationVariables>;
+export const UnarchiveNotificationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "unarchiveNotification" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "notificationUnarchive" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UnarchiveNotificationMutation, UnarchiveNotificationMutationVariables>;
+export const UpdateNotificationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateNotification" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "NotificationUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "notificationUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "NotificationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...NotificationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateNotificationMutation, UpdateNotificationMutationVariables>;
+export const DeleteOrganizationCancelDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteOrganizationCancel" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "organizationCancelDelete" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "FragmentSpread", name: { kind: "Name", value: "OrganizationCancelDeletePayload" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    ...OrganizationCancelDeletePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteOrganizationCancelMutation, DeleteOrganizationCancelMutationVariables>;
+export const DeleteOrganizationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteOrganization" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "DeleteOrganizationInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "organizationDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "OrganizationDeletePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...OrganizationDeletePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteOrganizationMutation, DeleteOrganizationMutationVariables>;
+export const OrganizationDeleteChallengeDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "organizationDeleteChallenge" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "organizationDeleteChallenge" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "OrganizationDeletePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...OrganizationDeletePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<OrganizationDeleteChallengeMutation, OrganizationDeleteChallengeMutationVariables>;
+export const DeleteOrganizationDomainDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteOrganizationDomain" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "organizationDomainDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteOrganizationDomainMutation, DeleteOrganizationDomainMutationVariables>;
+export const CreateOrganizationInviteDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createOrganizationInvite" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "OrganizationInviteCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "organizationInviteCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "OrganizationInvitePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...OrganizationInvitePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateOrganizationInviteMutation, CreateOrganizationInviteMutationVariables>;
+export const DeleteOrganizationInviteDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteOrganizationInvite" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "organizationInviteDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteOrganizationInviteMutation, DeleteOrganizationInviteMutationVariables>;
+export const UpdateOrganizationInviteDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateOrganizationInvite" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "OrganizationInviteUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "organizationInviteUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "OrganizationInvitePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...OrganizationInvitePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateOrganizationInviteMutation, UpdateOrganizationInviteMutationVariables>;
+export const UpdateOrganizationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateOrganization" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "UpdateOrganizationInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "organizationUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "OrganizationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...OrganizationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateOrganizationMutation, UpdateOrganizationMutationVariables>;
+export const ArchiveProjectDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "archiveProject" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "projectArchive" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<ArchiveProjectMutation, ArchiveProjectMutationVariables>;
+export const CreateProjectDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createProject" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ProjectCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "projectCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ProjectPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateProjectMutation, CreateProjectMutationVariables>;
+export const DeleteProjectDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteProject" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "projectDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteProjectMutation, DeleteProjectMutationVariables>;
+export const CreateProjectLinkDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createProjectLink" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ProjectLinkCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "projectLinkCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectLinkPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ProjectLinkPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateProjectLinkMutation, CreateProjectLinkMutationVariables>;
+export const DeleteProjectLinkDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteProjectLink" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "projectLinkDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteProjectLinkMutation, DeleteProjectLinkMutationVariables>;
+export const UpdateProjectLinkDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateProjectLink" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ProjectLinkUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "projectLinkUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectLinkPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ProjectLinkPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateProjectLinkMutation, UpdateProjectLinkMutationVariables>;
+export const CreateProjectMilestoneDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createProjectMilestone" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ProjectMilestoneCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "projectMilestoneCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectMilestonePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ProjectMilestonePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateProjectMilestoneMutation, CreateProjectMilestoneMutationVariables>;
+export const DeleteProjectMilestoneDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteProjectMilestone" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "projectMilestoneDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteProjectMilestoneMutation, DeleteProjectMilestoneMutationVariables>;
+export const UpdateProjectMilestoneDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateProjectMilestone" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ProjectMilestoneUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "projectMilestoneUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectMilestonePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ProjectMilestonePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateProjectMilestoneMutation, UpdateProjectMilestoneMutationVariables>;
+export const UnarchiveProjectDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "unarchiveProject" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "projectUnarchive" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UnarchiveProjectMutation, UnarchiveProjectMutationVariables>;
+export const UpdateProjectDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateProject" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ProjectUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "projectUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ProjectPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateProjectMutation, UpdateProjectMutationVariables>;
+export const CreateProjectUpdateDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createProjectUpdate" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ProjectUpdateCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "projectUpdateCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectUpdatePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ProjectUpdatePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateProjectUpdateMutation, CreateProjectUpdateMutationVariables>;
+export const DeleteProjectUpdateDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteProjectUpdate" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "projectUpdateDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteProjectUpdateMutation, DeleteProjectUpdateMutationVariables>;
+export const CreateProjectUpdateInteractionDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createProjectUpdateInteraction" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ProjectUpdateInteractionCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "projectUpdateInteractionCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "FragmentSpread", name: { kind: "Name", value: "ProjectUpdateInteractionPayload" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    ...ProjectUpdateInteractionPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateProjectUpdateInteractionMutation, CreateProjectUpdateInteractionMutationVariables>;
+export const ProjectUpdateMarkAsReadDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "projectUpdateMarkAsRead" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "projectUpdateMarkAsRead" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "FragmentSpread", name: { kind: "Name", value: "ProjectUpdateWithInteractionPayload" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    ...ProjectUpdateWithInteractionPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<ProjectUpdateMarkAsReadMutation, ProjectUpdateMarkAsReadMutationVariables>;
+export const UpdateProjectUpdateDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateProjectUpdate" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ProjectUpdateUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "projectUpdateUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectUpdatePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ProjectUpdatePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateProjectUpdateMutation, UpdateProjectUpdateMutationVariables>;
+export const CreatePushSubscriptionDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createPushSubscription" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "PushSubscriptionCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "pushSubscriptionCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "PushSubscriptionPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...PushSubscriptionPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreatePushSubscriptionMutation, CreatePushSubscriptionMutationVariables>;
+export const DeletePushSubscriptionDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deletePushSubscription" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "pushSubscriptionDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "PushSubscriptionPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...PushSubscriptionPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeletePushSubscriptionMutation, DeletePushSubscriptionMutationVariables>;
+export const CreateReactionDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createReaction" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ReactionCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "reactionCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ReactionPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ReactionPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateReactionMutation, CreateReactionMutationVariables>;
+export const DeleteReactionDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteReaction" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "reactionDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteReactionMutation, DeleteReactionMutationVariables>;
+export const RefreshGoogleSheetsDataDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "refreshGoogleSheetsData" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "refreshGoogleSheetsData" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<RefreshGoogleSheetsDataMutation, RefreshGoogleSheetsDataMutationVariables>;
+export const ResendOrganizationInviteDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "resendOrganizationInvite" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "resendOrganizationInvite" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<ResendOrganizationInviteMutation, ResendOrganizationInviteMutationVariables>;
+export const CreateRoadmapDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createRoadmap" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "RoadmapCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "roadmapCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "RoadmapPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...RoadmapPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateRoadmapMutation, CreateRoadmapMutationVariables>;
+export const DeleteRoadmapDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteRoadmap" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "roadmapDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteRoadmapMutation, DeleteRoadmapMutationVariables>;
+export const CreateRoadmapToProjectDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createRoadmapToProject" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "RoadmapToProjectCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "roadmapToProjectCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "RoadmapToProjectPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...RoadmapToProjectPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateRoadmapToProjectMutation, CreateRoadmapToProjectMutationVariables>;
+export const DeleteRoadmapToProjectDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteRoadmapToProject" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "roadmapToProjectDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteRoadmapToProjectMutation, DeleteRoadmapToProjectMutationVariables>;
+export const UpdateRoadmapToProjectDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateRoadmapToProject" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "RoadmapToProjectUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "roadmapToProjectUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "RoadmapToProjectPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...RoadmapToProjectPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateRoadmapToProjectMutation, UpdateRoadmapToProjectMutationVariables>;
+export const UpdateRoadmapDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateRoadmap" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "RoadmapUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "roadmapUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "RoadmapPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...RoadmapPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateRoadmapMutation, UpdateRoadmapMutationVariables>;
+export const SamlTokenUserAccountAuthDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "samlTokenUserAccountAuth" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "TokenUserAccountAuthInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "samlTokenUserAccountAuth" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AuthResolverResponse" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...AuthResolverResponseFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<SamlTokenUserAccountAuthMutation, SamlTokenUserAccountAuthMutationVariables>;
+export const CreateTeamDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createTeam" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "copySettingsFromTeamId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "TeamCreateInput" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "teamCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "copySettingsFromTeamId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "copySettingsFromTeamId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "TeamPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...TeamPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateTeamMutation, CreateTeamMutationVariables>;
+export const DeleteTeamCyclesDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteTeamCycles" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "teamCyclesDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "TeamPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...TeamPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteTeamCyclesMutation, DeleteTeamCyclesMutationVariables>;
+export const DeleteTeamDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteTeam" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "teamDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteTeamMutation, DeleteTeamMutationVariables>;
+export const DeleteTeamKeyDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteTeamKey" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "teamKeyDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteTeamKeyMutation, DeleteTeamKeyMutationVariables>;
+export const CreateTeamMembershipDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createTeamMembership" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "TeamMembershipCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "teamMembershipCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "TeamMembershipPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...TeamMembershipPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateTeamMembershipMutation, CreateTeamMembershipMutationVariables>;
+export const DeleteTeamMembershipDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteTeamMembership" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "teamMembershipDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteTeamMembershipMutation, DeleteTeamMembershipMutationVariables>;
+export const UpdateTeamMembershipDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateTeamMembership" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "TeamMembershipUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "teamMembershipUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "TeamMembershipPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...TeamMembershipPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateTeamMembershipMutation, UpdateTeamMembershipMutationVariables>;
+export const UpdateTeamDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateTeam" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "TeamUpdateInput" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "teamUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "TeamPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...TeamPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateTeamMutation, UpdateTeamMutationVariables>;
+export const CreateTemplateDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createTemplate" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "TemplateCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "templateCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "TemplatePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...TemplatePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateTemplateMutation, CreateTemplateMutationVariables>;
+export const DeleteTemplateDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteTemplate" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "templateDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteTemplateMutation, DeleteTemplateMutationVariables>;
+export const UpdateTemplateDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateTemplate" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "TemplateUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "templateUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "TemplatePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...TemplatePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateTemplateMutation, UpdateTemplateMutationVariables>;
+export const UserDemoteAdminDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "userDemoteAdmin" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "userDemoteAdmin" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserAdminPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...UserAdminPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UserDemoteAdminMutation, UserDemoteAdminMutationVariables>;
+export const UserDemoteMemberDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "userDemoteMember" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "userDemoteMember" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserAdminPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...UserAdminPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UserDemoteMemberMutation, UserDemoteMemberMutationVariables>;
+export const UserDiscordConnectDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "userDiscordConnect" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "userDiscordConnect" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "code" },
+                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "redirectUri" },
+                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...UserPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UserDiscordConnectMutation, UserDiscordConnectMutationVariables>;
+export const UserExternalUserDisconnectDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "userExternalUserDisconnect" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "service" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "userExternalUserDisconnect" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "service" },
+                value: { kind: "Variable", name: { kind: "Name", value: "service" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...UserPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UserExternalUserDisconnectMutation, UserExternalUserDisconnectMutationVariables>;
+export const UpdateUserFlagDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateUserFlag" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "flag" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "UserFlagType" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "operation" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "UserFlagUpdateOperation" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "userFlagUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "flag" },
+                value: { kind: "Variable", name: { kind: "Name", value: "flag" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "operation" },
+                value: { kind: "Variable", name: { kind: "Name", value: "operation" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserSettingsFlagPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...UserSettingsFlagPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateUserFlagMutation, UpdateUserFlagMutationVariables>;
+export const UserGitHubConnectDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "userGitHubConnect" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "userGitHubConnect" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "code" },
+                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...UserPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UserGitHubConnectMutation, UserGitHubConnectMutationVariables>;
+export const UserGoogleCalendarConnectDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "userGoogleCalendarConnect" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "userGoogleCalendarConnect" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "code" },
+                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...UserPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UserGoogleCalendarConnectMutation, UserGoogleCalendarConnectMutationVariables>;
+export const UserPromoteAdminDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "userPromoteAdmin" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "userPromoteAdmin" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserAdminPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...UserAdminPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UserPromoteAdminMutation, UserPromoteAdminMutationVariables>;
+export const UserPromoteMemberDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "userPromoteMember" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "userPromoteMember" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserAdminPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...UserAdminPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UserPromoteMemberMutation, UserPromoteMemberMutationVariables>;
+export const UserSettingsFlagIncrementDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "userSettingsFlagIncrement" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "flag" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "userSettingsFlagIncrement" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "flag" },
+                value: { kind: "Variable", name: { kind: "Name", value: "flag" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserSettingsFlagPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...UserSettingsFlagPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UserSettingsFlagIncrementMutation, UserSettingsFlagIncrementMutationVariables>;
+export const UserSettingsFlagsResetDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "userSettingsFlagsReset" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "flags" } },
+          type: {
+            kind: "ListType",
+            type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "UserFlagType" } } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "userSettingsFlagsReset" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "flags" },
+                value: { kind: "Variable", name: { kind: "Name", value: "flags" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserSettingsFlagsResetPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...UserSettingsFlagsResetPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UserSettingsFlagsResetMutation, UserSettingsFlagsResetMutationVariables>;
+export const UpdateUserSettingsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateUserSettings" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "UserSettingsUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "userSettingsUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserSettingsPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...UserSettingsPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateUserSettingsMutation, UpdateUserSettingsMutationVariables>;
+export const SuspendUserDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "suspendUser" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "userSuspend" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserAdminPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...UserAdminPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<SuspendUserMutation, SuspendUserMutationVariables>;
+export const UnsuspendUserDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "unsuspendUser" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "userUnsuspend" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserAdminPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...UserAdminPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UnsuspendUserMutation, UnsuspendUserMutationVariables>;
+export const UpdateUserDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateUser" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "UpdateUserInput" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "userUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...UserPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateUserMutation, UpdateUserMutationVariables>;
+export const CreateViewPreferencesDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createViewPreferences" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ViewPreferencesCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "viewPreferencesCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ViewPreferencesPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ViewPreferencesPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateViewPreferencesMutation, CreateViewPreferencesMutationVariables>;
+export const DeleteViewPreferencesDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteViewPreferences" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "viewPreferencesDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteViewPreferencesMutation, DeleteViewPreferencesMutationVariables>;
+export const UpdateViewPreferencesDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateViewPreferences" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ViewPreferencesUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "viewPreferencesUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ViewPreferencesPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ViewPreferencesPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateViewPreferencesMutation, UpdateViewPreferencesMutationVariables>;
+export const CreateWebhookDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createWebhook" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "WebhookCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "webhookCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "WebhookPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...WebhookPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateWebhookMutation, CreateWebhookMutationVariables>;
+export const DeleteWebhookDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteWebhook" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "webhookDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteWebhookMutation, DeleteWebhookMutationVariables>;
+export const UpdateWebhookDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateWebhook" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "WebhookUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "webhookUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "WebhookPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...WebhookPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateWebhookMutation, UpdateWebhookMutationVariables>;
+export const ArchiveWorkflowStateDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "archiveWorkflowState" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "workflowStateArchive" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ArchivePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<ArchiveWorkflowStateMutation, ArchiveWorkflowStateMutationVariables>;
+export const CreateWorkflowStateDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createWorkflowState" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "WorkflowStateCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "workflowStateCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "WorkflowStatePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...WorkflowStatePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateWorkflowStateMutation, CreateWorkflowStateMutationVariables>;
+export const UpdateWorkflowStateDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateWorkflowState" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "WorkflowStateUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "workflowStateUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "WorkflowStatePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...WorkflowStatePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateWorkflowStateMutation, UpdateWorkflowStateMutationVariables>;
+export const ProjectMilestoneDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "ProjectMilestone" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "ProjectMilestone" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectMilestone" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ProjectMilestoneFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<ProjectMilestoneQuery, ProjectMilestoneQueryVariables>;
+export const ProjectMilestonesDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "ProjectMilestones" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "before" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "includeArchived" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "last" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "orderBy" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "PaginationOrderBy" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "ProjectMilestones" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "after" },
+                value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "before" },
+                value: { kind: "Variable", name: { kind: "Name", value: "before" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "first" },
+                value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "includeArchived" },
+                value: { kind: "Variable", name: { kind: "Name", value: "includeArchived" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "last" },
+                value: { kind: "Variable", name: { kind: "Name", value: "last" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "orderBy" },
+                value: { kind: "Variable", name: { kind: "Name", value: "orderBy" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectMilestoneConnection" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ProjectMilestoneConnectionFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<ProjectMilestonesQuery, ProjectMilestonesQueryVariables>;
 export const AdministrableTeamsDocument = {
   kind: "Document",
   definitions: [
@@ -25462,251 +33191,6 @@ export const IssuesDocument = {
     ...IssueConnectionFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<IssuesQuery, IssuesQueryVariables>;
-export const MilestoneDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "query",
-      name: { kind: "Name", value: "milestone" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "milestone" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "Milestone" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...MilestoneFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<MilestoneQuery, MilestoneQueryVariables>;
-export const Milestone_ProjectsDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "query",
-      name: { kind: "Name", value: "milestone_projects" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "before" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "filter" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "ProjectFilter" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "includeArchived" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "last" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "orderBy" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "PaginationOrderBy" } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "milestone" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [
-                {
-                  kind: "Field",
-                  name: { kind: "Name", value: "projects" },
-                  arguments: [
-                    {
-                      kind: "Argument",
-                      name: { kind: "Name", value: "after" },
-                      value: { kind: "Variable", name: { kind: "Name", value: "after" } },
-                    },
-                    {
-                      kind: "Argument",
-                      name: { kind: "Name", value: "before" },
-                      value: { kind: "Variable", name: { kind: "Name", value: "before" } },
-                    },
-                    {
-                      kind: "Argument",
-                      name: { kind: "Name", value: "filter" },
-                      value: { kind: "Variable", name: { kind: "Name", value: "filter" } },
-                    },
-                    {
-                      kind: "Argument",
-                      name: { kind: "Name", value: "first" },
-                      value: { kind: "Variable", name: { kind: "Name", value: "first" } },
-                    },
-                    {
-                      kind: "Argument",
-                      name: { kind: "Name", value: "includeArchived" },
-                      value: { kind: "Variable", name: { kind: "Name", value: "includeArchived" } },
-                    },
-                    {
-                      kind: "Argument",
-                      name: { kind: "Name", value: "last" },
-                      value: { kind: "Variable", name: { kind: "Name", value: "last" } },
-                    },
-                    {
-                      kind: "Argument",
-                      name: { kind: "Name", value: "orderBy" },
-                      value: { kind: "Variable", name: { kind: "Name", value: "orderBy" } },
-                    },
-                  ],
-                  selectionSet: {
-                    kind: "SelectionSet",
-                    selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectConnection" } }],
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    ...ProjectConnectionFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<Milestone_ProjectsQuery, Milestone_ProjectsQueryVariables>;
-export const MilestonesDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "query",
-      name: { kind: "Name", value: "milestones" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "before" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "includeArchived" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "last" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "orderBy" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "PaginationOrderBy" } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "milestones" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "after" },
-                value: { kind: "Variable", name: { kind: "Name", value: "after" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "before" },
-                value: { kind: "Variable", name: { kind: "Name", value: "before" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "first" },
-                value: { kind: "Variable", name: { kind: "Name", value: "first" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "includeArchived" },
-                value: { kind: "Variable", name: { kind: "Name", value: "includeArchived" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "last" },
-                value: { kind: "Variable", name: { kind: "Name", value: "last" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "orderBy" },
-                value: { kind: "Variable", name: { kind: "Name", value: "orderBy" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "MilestoneConnection" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...MilestoneConnectionFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<MilestonesQuery, MilestonesQueryVariables>;
 export const NotificationDocument = {
   kind: "Document",
   definitions: [
@@ -26884,53 +34368,6 @@ export const Project_DocumentsDocument = {
     ...DocumentConnectionFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<Project_DocumentsQuery, Project_DocumentsQueryVariables>;
-export const Project_InitiativeDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "query",
-      name: { kind: "Name", value: "project_initiative" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "project" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [
-                {
-                  kind: "Field",
-                  name: { kind: "Name", value: "initiative" },
-                  selectionSet: {
-                    kind: "SelectionSet",
-                    selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "Initiative" } }],
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    ...InitiativeFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<Project_InitiativeQuery, Project_InitiativeQueryVariables>;
 export const Project_IssuesDocument = {
   kind: "Document",
   definitions: [
@@ -31295,7615 +38732,3 @@ export const WorkflowStatesDocument = {
     ...WorkflowStateConnectionFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<WorkflowStatesQuery, WorkflowStatesQueryVariables>;
-export const AirbyteIntegrationConnectDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "airbyteIntegrationConnect" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "AirbyteConfigurationInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "airbyteIntegrationConnect" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<AirbyteIntegrationConnectMutation, AirbyteIntegrationConnectMutationVariables>;
-export const CreateApiKeyDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createApiKey" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "ApiKeyCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "apiKeyCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ApiKeyPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ApiKeyPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateApiKeyMutation, CreateApiKeyMutationVariables>;
-export const DeleteApiKeyDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteApiKey" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "apiKeyDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteApiKeyMutation, DeleteApiKeyMutationVariables>;
-export const ArchiveAttachmentDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "archiveAttachment" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "attachmentArchive" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<ArchiveAttachmentMutation, ArchiveAttachmentMutationVariables>;
-export const CreateAttachmentDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createAttachment" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "AttachmentCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "attachmentCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AttachmentPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...AttachmentPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateAttachmentMutation, CreateAttachmentMutationVariables>;
-export const DeleteAttachmentDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteAttachment" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "attachmentDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteAttachmentMutation, DeleteAttachmentMutationVariables>;
-export const AttachmentLinkDiscordDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "attachmentLinkDiscord" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "channelId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "messageId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "url" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "attachmentLinkDiscord" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "channelId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "channelId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "issueId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "messageId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "messageId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "url" },
-                value: { kind: "Variable", name: { kind: "Name", value: "url" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AttachmentPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...AttachmentPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<AttachmentLinkDiscordMutation, AttachmentLinkDiscordMutationVariables>;
-export const AttachmentLinkFrontDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "attachmentLinkFront" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "conversationId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "attachmentLinkFront" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "conversationId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "conversationId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "issueId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "FrontAttachmentPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...FrontAttachmentPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<AttachmentLinkFrontMutation, AttachmentLinkFrontMutationVariables>;
-export const AttachmentLinkIntercomDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "attachmentLinkIntercom" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "conversationId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "attachmentLinkIntercom" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "conversationId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "conversationId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "issueId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AttachmentPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...AttachmentPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<AttachmentLinkIntercomMutation, AttachmentLinkIntercomMutationVariables>;
-export const AttachmentLinkJiraIssueDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "attachmentLinkJiraIssue" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "jiraIssueId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "attachmentLinkJiraIssue" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "issueId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "jiraIssueId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "jiraIssueId" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AttachmentPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...AttachmentPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<AttachmentLinkJiraIssueMutation, AttachmentLinkJiraIssueMutationVariables>;
-export const AttachmentLinkUrlDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "attachmentLinkURL" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "title" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "url" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "attachmentLinkURL" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "issueId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "title" },
-                value: { kind: "Variable", name: { kind: "Name", value: "title" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "url" },
-                value: { kind: "Variable", name: { kind: "Name", value: "url" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AttachmentPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...AttachmentPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<AttachmentLinkUrlMutation, AttachmentLinkUrlMutationVariables>;
-export const AttachmentLinkZendeskDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "attachmentLinkZendesk" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "ticketId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "attachmentLinkZendesk" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "issueId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "ticketId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "ticketId" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AttachmentPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...AttachmentPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<AttachmentLinkZendeskMutation, AttachmentLinkZendeskMutationVariables>;
-export const UpdateAttachmentDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateAttachment" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "AttachmentUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "attachmentUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AttachmentPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...AttachmentPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateAttachmentMutation, UpdateAttachmentMutationVariables>;
-export const CreateCommentDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createComment" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "CommentCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "commentCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CommentPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...CommentPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateCommentMutation, CreateCommentMutationVariables>;
-export const DeleteCommentDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteComment" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "commentDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteCommentMutation, DeleteCommentMutationVariables>;
-export const UpdateCommentDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateComment" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "CommentUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "commentUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CommentPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...CommentPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateCommentMutation, UpdateCommentMutationVariables>;
-export const CreateContactDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createContact" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "ContactCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "contactCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ContactPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ContactPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateContactMutation, CreateContactMutationVariables>;
-export const CreateCsvExportReportDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createCsvExportReport" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "includePrivateTeamIds" } },
-          type: {
-            kind: "ListType",
-            type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "createCsvExportReport" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "includePrivateTeamIds" },
-                value: { kind: "Variable", name: { kind: "Name", value: "includePrivateTeamIds" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CreateCsvExportReportPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...CreateCsvExportReportPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateCsvExportReportMutation, CreateCsvExportReportMutationVariables>;
-export const CreateOrganizationFromOnboardingDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createOrganizationFromOnboarding" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "CreateOrganizationInput" } },
-          },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "survey" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "OnboardingCustomerSurvey" } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "createOrganizationFromOnboarding" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "survey" },
-                value: { kind: "Variable", name: { kind: "Name", value: "survey" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [
-                { kind: "FragmentSpread", name: { kind: "Name", value: "CreateOrJoinOrganizationResponse" } },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    ...CreateOrJoinOrganizationResponseFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<
-  CreateOrganizationFromOnboardingMutation,
-  CreateOrganizationFromOnboardingMutationVariables
->;
-export const CreateCustomViewDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createCustomView" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "CustomViewCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "customViewCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CustomViewPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...CustomViewPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateCustomViewMutation, CreateCustomViewMutationVariables>;
-export const DeleteCustomViewDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteCustomView" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "customViewDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteCustomViewMutation, DeleteCustomViewMutationVariables>;
-export const UpdateCustomViewDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateCustomView" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "CustomViewUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "customViewUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CustomViewPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...CustomViewPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateCustomViewMutation, UpdateCustomViewMutationVariables>;
-export const ArchiveCycleDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "archiveCycle" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "cycleArchive" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<ArchiveCycleMutation, ArchiveCycleMutationVariables>;
-export const CreateCycleDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createCycle" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "CycleCreateInput" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "cycleCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CyclePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...CyclePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateCycleMutation, CreateCycleMutationVariables>;
-export const UpdateCycleDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateCycle" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "CycleUpdateInput" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "cycleUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CyclePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...CyclePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateCycleMutation, UpdateCycleMutationVariables>;
-export const CreateDocumentDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createDocument" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "DocumentCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "documentCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "DocumentPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...DocumentPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateDocumentMutation, CreateDocumentMutationVariables>;
-export const DeleteDocumentDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteDocument" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "documentDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteDocumentMutation, DeleteDocumentMutationVariables>;
-export const UpdateDocumentDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateDocument" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "DocumentUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "documentUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "DocumentPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...DocumentPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateDocumentMutation, UpdateDocumentMutationVariables>;
-export const EmailTokenUserAccountAuthDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "emailTokenUserAccountAuth" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "TokenUserAccountAuthInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "emailTokenUserAccountAuth" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AuthResolverResponse" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...AuthResolverResponseFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<EmailTokenUserAccountAuthMutation, EmailTokenUserAccountAuthMutationVariables>;
-export const EmailUnsubscribeDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "emailUnsubscribe" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "EmailUnsubscribeInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "emailUnsubscribe" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "EmailUnsubscribePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...EmailUnsubscribePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<EmailUnsubscribeMutation, EmailUnsubscribeMutationVariables>;
-export const EmailUserAccountAuthChallengeDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "emailUserAccountAuthChallenge" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "EmailUserAccountAuthChallengeInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "emailUserAccountAuthChallenge" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [
-                { kind: "FragmentSpread", name: { kind: "Name", value: "EmailUserAccountAuthChallengeResponse" } },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    ...EmailUserAccountAuthChallengeResponseFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<EmailUserAccountAuthChallengeMutation, EmailUserAccountAuthChallengeMutationVariables>;
-export const CreateEmojiDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createEmoji" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "EmojiCreateInput" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "emojiCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "EmojiPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...EmojiPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateEmojiMutation, CreateEmojiMutationVariables>;
-export const DeleteEmojiDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteEmoji" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "emojiDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteEmojiMutation, DeleteEmojiMutationVariables>;
-export const CreateEventDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createEvent" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "EventCreateInput" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "eventCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "EventPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...EventPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateEventMutation, CreateEventMutationVariables>;
-export const CreateFavoriteDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createFavorite" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "FavoriteCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "favoriteCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "FavoritePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...FavoritePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateFavoriteMutation, CreateFavoriteMutationVariables>;
-export const DeleteFavoriteDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteFavorite" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "favoriteDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteFavoriteMutation, DeleteFavoriteMutationVariables>;
-export const UpdateFavoriteDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateFavorite" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "FavoriteUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "favoriteUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "FavoritePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...FavoritePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateFavoriteMutation, UpdateFavoriteMutationVariables>;
-export const FileUploadDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "fileUpload" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "contentType" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "filename" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "makePublic" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "metaData" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "JSON" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "size" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "Int" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "fileUpload" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "contentType" },
-                value: { kind: "Variable", name: { kind: "Name", value: "contentType" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "filename" },
-                value: { kind: "Variable", name: { kind: "Name", value: "filename" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "makePublic" },
-                value: { kind: "Variable", name: { kind: "Name", value: "makePublic" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "metaData" },
-                value: { kind: "Variable", name: { kind: "Name", value: "metaData" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "size" },
-                value: { kind: "Variable", name: { kind: "Name", value: "size" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UploadPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...UploadPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<FileUploadMutation, FileUploadMutationVariables>;
-export const GoogleUserAccountAuthDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "googleUserAccountAuth" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "GoogleUserAccountAuthInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "googleUserAccountAuth" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AuthResolverResponse" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...AuthResolverResponseFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<GoogleUserAccountAuthMutation, GoogleUserAccountAuthMutationVariables>;
-export const ImageUploadFromUrlDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "imageUploadFromUrl" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "url" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "imageUploadFromUrl" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "url" },
-                value: { kind: "Variable", name: { kind: "Name", value: "url" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ImageUploadFromUrlPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ImageUploadFromUrlPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<ImageUploadFromUrlMutation, ImageUploadFromUrlMutationVariables>;
-export const DeleteIntegrationDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteIntegration" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteIntegrationMutation, DeleteIntegrationMutationVariables>;
-export const IntegrationDiscordDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "integrationDiscord" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationDiscord" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "code" },
-                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "redirectUri" },
-                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IntegrationDiscordMutation, IntegrationDiscordMutationVariables>;
-export const IntegrationFigmaDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "integrationFigma" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationFigma" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "code" },
-                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "redirectUri" },
-                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IntegrationFigmaMutation, IntegrationFigmaMutationVariables>;
-export const IntegrationFrontDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "integrationFront" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationFront" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "code" },
-                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "redirectUri" },
-                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IntegrationFrontMutation, IntegrationFrontMutationVariables>;
-export const CreateIntegrationGithubCommitDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createIntegrationGithubCommit" },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationGithubCommitCreate" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "GitHubCommitIntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...GitHubCommitIntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateIntegrationGithubCommitMutation, CreateIntegrationGithubCommitMutationVariables>;
-export const IntegrationGithubConnectDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "integrationGithubConnect" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "installationId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationGithubConnect" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "installationId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "installationId" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IntegrationGithubConnectMutation, IntegrationGithubConnectMutationVariables>;
-export const IntegrationGitlabConnectDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "integrationGitlabConnect" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "accessToken" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "gitlabUrl" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationGitlabConnect" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "accessToken" },
-                value: { kind: "Variable", name: { kind: "Name", value: "accessToken" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "gitlabUrl" },
-                value: { kind: "Variable", name: { kind: "Name", value: "gitlabUrl" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IntegrationGitlabConnectMutation, IntegrationGitlabConnectMutationVariables>;
-export const IntegrationGoogleSheetsDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "integrationGoogleSheets" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationGoogleSheets" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "code" },
-                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IntegrationGoogleSheetsMutation, IntegrationGoogleSheetsMutationVariables>;
-export const IntegrationIntercomDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "integrationIntercom" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "domainUrl" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationIntercom" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "code" },
-                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "domainUrl" },
-                value: { kind: "Variable", name: { kind: "Name", value: "domainUrl" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "redirectUri" },
-                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IntegrationIntercomMutation, IntegrationIntercomMutationVariables>;
-export const DeleteIntegrationIntercomDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteIntegrationIntercom" },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationIntercomDelete" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteIntegrationIntercomMutation, DeleteIntegrationIntercomMutationVariables>;
-export const UpdateIntegrationIntercomSettingsDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateIntegrationIntercomSettings" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "IntercomSettingsInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationIntercomSettingsUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<
-  UpdateIntegrationIntercomSettingsMutation,
-  UpdateIntegrationIntercomSettingsMutationVariables
->;
-export const IntegrationLoomDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "integrationLoom" },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationLoom" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IntegrationLoomMutation, IntegrationLoomMutationVariables>;
-export const IntegrationRequestDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "integrationRequest" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "IntegrationRequestInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationRequest" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationRequestPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationRequestPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IntegrationRequestMutation, IntegrationRequestMutationVariables>;
-export const ArchiveIntegrationResourceDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "archiveIntegrationResource" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationResourceArchive" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<ArchiveIntegrationResourceMutation, ArchiveIntegrationResourceMutationVariables>;
-export const IntegrationSentryConnectDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "integrationSentryConnect" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "installationId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "organizationSlug" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationSentryConnect" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "code" },
-                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "installationId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "installationId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "organizationSlug" },
-                value: { kind: "Variable", name: { kind: "Name", value: "organizationSlug" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IntegrationSentryConnectMutation, IntegrationSentryConnectMutationVariables>;
-export const IntegrationSlackDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "integrationSlack" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "shouldUseV2Auth" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationSlack" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "code" },
-                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "redirectUri" },
-                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "shouldUseV2Auth" },
-                value: { kind: "Variable", name: { kind: "Name", value: "shouldUseV2Auth" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IntegrationSlackMutation, IntegrationSlackMutationVariables>;
-export const IntegrationSlackImportEmojisDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "integrationSlackImportEmojis" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationSlackImportEmojis" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "code" },
-                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "redirectUri" },
-                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IntegrationSlackImportEmojisMutation, IntegrationSlackImportEmojisMutationVariables>;
-export const IntegrationSlackOrgProjectUpdatesPostDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "integrationSlackOrgProjectUpdatesPost" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationSlackOrgProjectUpdatesPost" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "code" },
-                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "redirectUri" },
-                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<
-  IntegrationSlackOrgProjectUpdatesPostMutation,
-  IntegrationSlackOrgProjectUpdatesPostMutationVariables
->;
-export const IntegrationSlackPersonalDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "integrationSlackPersonal" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationSlackPersonal" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "code" },
-                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "redirectUri" },
-                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IntegrationSlackPersonalMutation, IntegrationSlackPersonalMutationVariables>;
-export const IntegrationSlackPostDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "integrationSlackPost" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "shouldUseV2Auth" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationSlackPost" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "code" },
-                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "redirectUri" },
-                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "shouldUseV2Auth" },
-                value: { kind: "Variable", name: { kind: "Name", value: "shouldUseV2Auth" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "teamId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IntegrationSlackPostMutation, IntegrationSlackPostMutationVariables>;
-export const IntegrationSlackProjectPostDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "integrationSlackProjectPost" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "projectId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "service" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationSlackProjectPost" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "code" },
-                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "projectId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "projectId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "redirectUri" },
-                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "service" },
-                value: { kind: "Variable", name: { kind: "Name", value: "service" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IntegrationSlackProjectPostMutation, IntegrationSlackProjectPostMutationVariables>;
-export const CreateIntegrationTemplateDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createIntegrationTemplate" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "IntegrationTemplateCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationTemplateCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationTemplatePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationTemplatePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateIntegrationTemplateMutation, CreateIntegrationTemplateMutationVariables>;
-export const DeleteIntegrationTemplateDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteIntegrationTemplate" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationTemplateDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteIntegrationTemplateMutation, DeleteIntegrationTemplateMutationVariables>;
-export const IntegrationZendeskDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "integrationZendesk" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "scope" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "subdomain" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationZendesk" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "code" },
-                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "redirectUri" },
-                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "scope" },
-                value: { kind: "Variable", name: { kind: "Name", value: "scope" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "subdomain" },
-                value: { kind: "Variable", name: { kind: "Name", value: "subdomain" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IntegrationZendeskMutation, IntegrationZendeskMutationVariables>;
-export const CreateIntegrationsSettingsDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createIntegrationsSettings" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "IntegrationsSettingsCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationsSettingsCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationsSettingsPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationsSettingsPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateIntegrationsSettingsMutation, CreateIntegrationsSettingsMutationVariables>;
-export const UpdateIntegrationsSettingsDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateIntegrationsSettings" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "IntegrationsSettingsUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "integrationsSettingsUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationsSettingsPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationsSettingsPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateIntegrationsSettingsMutation, UpdateIntegrationsSettingsMutationVariables>;
-export const ArchiveIssueDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "archiveIssue" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "trash" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueArchive" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "trash" },
-                value: { kind: "Variable", name: { kind: "Name", value: "trash" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<ArchiveIssueMutation, ArchiveIssueMutationVariables>;
-export const UpdateIssueBatchDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateIssueBatch" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "ids" } },
-          type: {
-            kind: "NonNullType",
-            type: {
-              kind: "ListType",
-              type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "UUID" } } },
-            },
-          },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "IssueUpdateInput" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueBatchUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "ids" },
-                value: { kind: "Variable", name: { kind: "Name", value: "ids" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueBatchPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IssueBatchPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateIssueBatchMutation, UpdateIssueBatchMutationVariables>;
-export const CreateIssueDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createIssue" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "IssueCreateInput" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssuePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IssuePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateIssueMutation, CreateIssueMutationVariables>;
-export const DeleteIssueDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteIssue" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteIssueMutation, DeleteIssueMutationVariables>;
-export const IssueImportCreateAsanaDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "issueImportCreateAsana" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "asanaTeamName" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "asanaToken" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "includeClosedIssues" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "instantProcess" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "teamName" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueImportCreateAsana" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "asanaTeamName" },
-                value: { kind: "Variable", name: { kind: "Name", value: "asanaTeamName" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "asanaToken" },
-                value: { kind: "Variable", name: { kind: "Name", value: "asanaToken" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "includeClosedIssues" },
-                value: { kind: "Variable", name: { kind: "Name", value: "includeClosedIssues" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "instantProcess" },
-                value: { kind: "Variable", name: { kind: "Name", value: "instantProcess" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "organizationId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "teamId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "teamName" },
-                value: { kind: "Variable", name: { kind: "Name", value: "teamName" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueImportPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IssueImportPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IssueImportCreateAsanaMutation, IssueImportCreateAsanaMutationVariables>;
-export const IssueImportCreateClubhouseDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "issueImportCreateClubhouse" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "clubhouseTeamName" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "clubhouseToken" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "includeClosedIssues" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "instantProcess" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "teamName" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueImportCreateClubhouse" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "clubhouseTeamName" },
-                value: { kind: "Variable", name: { kind: "Name", value: "clubhouseTeamName" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "clubhouseToken" },
-                value: { kind: "Variable", name: { kind: "Name", value: "clubhouseToken" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "includeClosedIssues" },
-                value: { kind: "Variable", name: { kind: "Name", value: "includeClosedIssues" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "instantProcess" },
-                value: { kind: "Variable", name: { kind: "Name", value: "instantProcess" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "organizationId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "teamId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "teamName" },
-                value: { kind: "Variable", name: { kind: "Name", value: "teamName" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueImportPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IssueImportPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IssueImportCreateClubhouseMutation, IssueImportCreateClubhouseMutationVariables>;
-export const IssueImportCreateGithubDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "issueImportCreateGithub" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "githubRepoName" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "githubRepoOwner" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "githubShouldImportOrgProjects" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "githubToken" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "includeClosedIssues" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "instantProcess" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "teamName" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueImportCreateGithub" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "githubRepoName" },
-                value: { kind: "Variable", name: { kind: "Name", value: "githubRepoName" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "githubRepoOwner" },
-                value: { kind: "Variable", name: { kind: "Name", value: "githubRepoOwner" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "githubShouldImportOrgProjects" },
-                value: { kind: "Variable", name: { kind: "Name", value: "githubShouldImportOrgProjects" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "githubToken" },
-                value: { kind: "Variable", name: { kind: "Name", value: "githubToken" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "includeClosedIssues" },
-                value: { kind: "Variable", name: { kind: "Name", value: "includeClosedIssues" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "instantProcess" },
-                value: { kind: "Variable", name: { kind: "Name", value: "instantProcess" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "organizationId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "teamId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "teamName" },
-                value: { kind: "Variable", name: { kind: "Name", value: "teamName" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueImportPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IssueImportPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IssueImportCreateGithubMutation, IssueImportCreateGithubMutationVariables>;
-export const IssueImportCreateJiraDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "issueImportCreateJira" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "includeClosedIssues" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "instantProcess" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "jiraEmail" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "jiraHostname" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "jiraProject" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "jiraToken" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "teamName" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueImportCreateJira" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "includeClosedIssues" },
-                value: { kind: "Variable", name: { kind: "Name", value: "includeClosedIssues" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "instantProcess" },
-                value: { kind: "Variable", name: { kind: "Name", value: "instantProcess" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "jiraEmail" },
-                value: { kind: "Variable", name: { kind: "Name", value: "jiraEmail" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "jiraHostname" },
-                value: { kind: "Variable", name: { kind: "Name", value: "jiraHostname" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "jiraProject" },
-                value: { kind: "Variable", name: { kind: "Name", value: "jiraProject" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "jiraToken" },
-                value: { kind: "Variable", name: { kind: "Name", value: "jiraToken" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "organizationId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "teamId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "teamId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "teamName" },
-                value: { kind: "Variable", name: { kind: "Name", value: "teamName" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueImportPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IssueImportPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IssueImportCreateJiraMutation, IssueImportCreateJiraMutationVariables>;
-export const DeleteIssueImportDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteIssueImport" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "issueImportId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueImportDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "issueImportId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "issueImportId" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueImportDeletePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IssueImportDeletePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteIssueImportMutation, DeleteIssueImportMutationVariables>;
-export const IssueImportProcessDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "issueImportProcess" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "issueImportId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "mapping" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "JSONObject" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueImportProcess" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "issueImportId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "issueImportId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "mapping" },
-                value: { kind: "Variable", name: { kind: "Name", value: "mapping" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueImportPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IssueImportPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IssueImportProcessMutation, IssueImportProcessMutationVariables>;
-export const UpdateIssueImportDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateIssueImport" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "IssueImportUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueImportUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueImportPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IssueImportPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateIssueImportMutation, UpdateIssueImportMutationVariables>;
-export const ArchiveIssueLabelDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "archiveIssueLabel" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueLabelArchive" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<ArchiveIssueLabelMutation, ArchiveIssueLabelMutationVariables>;
-export const CreateIssueLabelDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createIssueLabel" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "IssueLabelCreateInput" } },
-          },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "replaceTeamLabels" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueLabelCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "replaceTeamLabels" },
-                value: { kind: "Variable", name: { kind: "Name", value: "replaceTeamLabels" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueLabelPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IssueLabelPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateIssueLabelMutation, CreateIssueLabelMutationVariables>;
-export const DeleteIssueLabelDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteIssueLabel" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueLabelDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteIssueLabelMutation, DeleteIssueLabelMutationVariables>;
-export const UpdateIssueLabelDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateIssueLabel" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "IssueLabelUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueLabelUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueLabelPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IssueLabelPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateIssueLabelMutation, UpdateIssueLabelMutationVariables>;
-export const CreateIssueRelationDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createIssueRelation" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "IssueRelationCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueRelationCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueRelationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IssueRelationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateIssueRelationMutation, CreateIssueRelationMutationVariables>;
-export const DeleteIssueRelationDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteIssueRelation" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueRelationDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteIssueRelationMutation, DeleteIssueRelationMutationVariables>;
-export const UpdateIssueRelationDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateIssueRelation" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "IssueRelationUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueRelationUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueRelationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IssueRelationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateIssueRelationMutation, UpdateIssueRelationMutationVariables>;
-export const IssueReminderDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "issueReminder" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "reminderAt" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "DateTime" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueReminder" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "reminderAt" },
-                value: { kind: "Variable", name: { kind: "Name", value: "reminderAt" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssuePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IssuePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<IssueReminderMutation, IssueReminderMutationVariables>;
-export const UnarchiveIssueDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "unarchiveIssue" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueUnarchive" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UnarchiveIssueMutation, UnarchiveIssueMutationVariables>;
-export const UpdateIssueDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateIssue" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "IssueUpdateInput" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "issueUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssuePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IssuePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateIssueMutation, UpdateIssueMutationVariables>;
-export const JoinOrganizationFromOnboardingDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "joinOrganizationFromOnboarding" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "JoinOrganizationInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "joinOrganizationFromOnboarding" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [
-                { kind: "FragmentSpread", name: { kind: "Name", value: "CreateOrJoinOrganizationResponse" } },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    ...CreateOrJoinOrganizationResponseFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<JoinOrganizationFromOnboardingMutation, JoinOrganizationFromOnboardingMutationVariables>;
-export const LeaveOrganizationDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "leaveOrganization" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "leaveOrganization" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "organizationId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [
-                { kind: "FragmentSpread", name: { kind: "Name", value: "CreateOrJoinOrganizationResponse" } },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    ...CreateOrJoinOrganizationResponseFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<LeaveOrganizationMutation, LeaveOrganizationMutationVariables>;
-export const LogoutDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "logout" },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "logout" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "LogoutResponse" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...LogoutResponseFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<LogoutMutation, LogoutMutationVariables>;
-export const MigrateMilestonesToRoadmapsDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "migrateMilestonesToRoadmaps" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "MilestonesMigrateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "migrateMilestonesToRoadmaps" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "MilestoneMigrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...MilestoneMigrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<MigrateMilestonesToRoadmapsMutation, MigrateMilestonesToRoadmapsMutationVariables>;
-export const CreateMilestoneDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createMilestone" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "MilestoneCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "milestoneCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "MilestonePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...MilestonePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateMilestoneMutation, CreateMilestoneMutationVariables>;
-export const DeleteMilestoneDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteMilestone" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "milestoneDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteMilestoneMutation, DeleteMilestoneMutationVariables>;
-export const UpdateMilestoneDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateMilestone" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "MilestoneUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "milestoneUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "MilestonePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...MilestonePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateMilestoneMutation, UpdateMilestoneMutationVariables>;
-export const ArchiveNotificationDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "archiveNotification" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "notificationArchive" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<ArchiveNotificationMutation, ArchiveNotificationMutationVariables>;
-export const CreateNotificationSubscriptionDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createNotificationSubscription" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "NotificationSubscriptionCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "notificationSubscriptionCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [
-                { kind: "FragmentSpread", name: { kind: "Name", value: "NotificationSubscriptionPayload" } },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    ...NotificationSubscriptionPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateNotificationSubscriptionMutation, CreateNotificationSubscriptionMutationVariables>;
-export const DeleteNotificationSubscriptionDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteNotificationSubscription" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "notificationSubscriptionDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteNotificationSubscriptionMutation, DeleteNotificationSubscriptionMutationVariables>;
-export const UpdateNotificationSubscriptionDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateNotificationSubscription" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "NotificationSubscriptionUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "notificationSubscriptionUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [
-                { kind: "FragmentSpread", name: { kind: "Name", value: "NotificationSubscriptionPayload" } },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    ...NotificationSubscriptionPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateNotificationSubscriptionMutation, UpdateNotificationSubscriptionMutationVariables>;
-export const UnarchiveNotificationDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "unarchiveNotification" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "notificationUnarchive" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UnarchiveNotificationMutation, UnarchiveNotificationMutationVariables>;
-export const UpdateNotificationDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateNotification" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "NotificationUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "notificationUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "NotificationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...NotificationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateNotificationMutation, UpdateNotificationMutationVariables>;
-export const DeleteOrganizationCancelDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteOrganizationCancel" },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "organizationCancelDelete" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [
-                { kind: "FragmentSpread", name: { kind: "Name", value: "OrganizationCancelDeletePayload" } },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    ...OrganizationCancelDeletePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteOrganizationCancelMutation, DeleteOrganizationCancelMutationVariables>;
-export const DeleteOrganizationDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteOrganization" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "DeleteOrganizationInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "organizationDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "OrganizationDeletePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...OrganizationDeletePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteOrganizationMutation, DeleteOrganizationMutationVariables>;
-export const OrganizationDeleteChallengeDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "organizationDeleteChallenge" },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "organizationDeleteChallenge" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "OrganizationDeletePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...OrganizationDeletePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<OrganizationDeleteChallengeMutation, OrganizationDeleteChallengeMutationVariables>;
-export const DeleteOrganizationDomainDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteOrganizationDomain" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "organizationDomainDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteOrganizationDomainMutation, DeleteOrganizationDomainMutationVariables>;
-export const CreateOrganizationInviteDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createOrganizationInvite" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "OrganizationInviteCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "organizationInviteCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "OrganizationInvitePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...OrganizationInvitePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateOrganizationInviteMutation, CreateOrganizationInviteMutationVariables>;
-export const DeleteOrganizationInviteDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteOrganizationInvite" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "organizationInviteDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteOrganizationInviteMutation, DeleteOrganizationInviteMutationVariables>;
-export const UpdateOrganizationInviteDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateOrganizationInvite" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "OrganizationInviteUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "organizationInviteUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "OrganizationInvitePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...OrganizationInvitePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateOrganizationInviteMutation, UpdateOrganizationInviteMutationVariables>;
-export const UpdateOrganizationDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateOrganization" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "UpdateOrganizationInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "organizationUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "OrganizationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...OrganizationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateOrganizationMutation, UpdateOrganizationMutationVariables>;
-export const ArchiveProjectDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "archiveProject" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "projectArchive" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<ArchiveProjectMutation, ArchiveProjectMutationVariables>;
-export const CreateProjectDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createProject" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "ProjectCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "projectCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ProjectPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateProjectMutation, CreateProjectMutationVariables>;
-export const DeleteProjectDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteProject" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "projectDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteProjectMutation, DeleteProjectMutationVariables>;
-export const CreateProjectLinkDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createProjectLink" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "ProjectLinkCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "projectLinkCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectLinkPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ProjectLinkPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateProjectLinkMutation, CreateProjectLinkMutationVariables>;
-export const DeleteProjectLinkDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteProjectLink" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "projectLinkDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteProjectLinkMutation, DeleteProjectLinkMutationVariables>;
-export const UpdateProjectLinkDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateProjectLink" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "ProjectLinkUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "projectLinkUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectLinkPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ProjectLinkPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateProjectLinkMutation, UpdateProjectLinkMutationVariables>;
-export const UnarchiveProjectDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "unarchiveProject" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "projectUnarchive" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UnarchiveProjectMutation, UnarchiveProjectMutationVariables>;
-export const UpdateProjectDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateProject" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "ProjectUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "projectUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ProjectPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateProjectMutation, UpdateProjectMutationVariables>;
-export const CreateProjectUpdateDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createProjectUpdate" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "ProjectUpdateCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "projectUpdateCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectUpdatePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ProjectUpdatePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateProjectUpdateMutation, CreateProjectUpdateMutationVariables>;
-export const DeleteProjectUpdateDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteProjectUpdate" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "projectUpdateDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteProjectUpdateMutation, DeleteProjectUpdateMutationVariables>;
-export const CreateProjectUpdateInteractionDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createProjectUpdateInteraction" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "ProjectUpdateInteractionCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "projectUpdateInteractionCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [
-                { kind: "FragmentSpread", name: { kind: "Name", value: "ProjectUpdateInteractionPayload" } },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    ...ProjectUpdateInteractionPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateProjectUpdateInteractionMutation, CreateProjectUpdateInteractionMutationVariables>;
-export const ProjectUpdateMarkAsReadDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "projectUpdateMarkAsRead" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "projectUpdateMarkAsRead" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [
-                { kind: "FragmentSpread", name: { kind: "Name", value: "ProjectUpdateWithInteractionPayload" } },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    ...ProjectUpdateWithInteractionPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<ProjectUpdateMarkAsReadMutation, ProjectUpdateMarkAsReadMutationVariables>;
-export const UpdateProjectUpdateDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateProjectUpdate" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "ProjectUpdateUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "projectUpdateUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectUpdatePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ProjectUpdatePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateProjectUpdateMutation, UpdateProjectUpdateMutationVariables>;
-export const CreatePushSubscriptionDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createPushSubscription" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "PushSubscriptionCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "pushSubscriptionCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "PushSubscriptionPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...PushSubscriptionPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreatePushSubscriptionMutation, CreatePushSubscriptionMutationVariables>;
-export const DeletePushSubscriptionDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deletePushSubscription" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "pushSubscriptionDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "PushSubscriptionPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...PushSubscriptionPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeletePushSubscriptionMutation, DeletePushSubscriptionMutationVariables>;
-export const CreateReactionDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createReaction" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "ReactionCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "reactionCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ReactionPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ReactionPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateReactionMutation, CreateReactionMutationVariables>;
-export const DeleteReactionDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteReaction" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "reactionDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteReactionMutation, DeleteReactionMutationVariables>;
-export const RefreshGoogleSheetsDataDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "refreshGoogleSheetsData" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "refreshGoogleSheetsData" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...IntegrationPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<RefreshGoogleSheetsDataMutation, RefreshGoogleSheetsDataMutationVariables>;
-export const ResendOrganizationInviteDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "resendOrganizationInvite" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "resendOrganizationInvite" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<ResendOrganizationInviteMutation, ResendOrganizationInviteMutationVariables>;
-export const CreateRoadmapDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createRoadmap" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "RoadmapCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "roadmapCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "RoadmapPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...RoadmapPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateRoadmapMutation, CreateRoadmapMutationVariables>;
-export const DeleteRoadmapDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteRoadmap" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "roadmapDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteRoadmapMutation, DeleteRoadmapMutationVariables>;
-export const CreateRoadmapToProjectDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createRoadmapToProject" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "RoadmapToProjectCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "roadmapToProjectCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "RoadmapToProjectPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...RoadmapToProjectPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateRoadmapToProjectMutation, CreateRoadmapToProjectMutationVariables>;
-export const DeleteRoadmapToProjectDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteRoadmapToProject" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "roadmapToProjectDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteRoadmapToProjectMutation, DeleteRoadmapToProjectMutationVariables>;
-export const UpdateRoadmapToProjectDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateRoadmapToProject" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "RoadmapToProjectUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "roadmapToProjectUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "RoadmapToProjectPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...RoadmapToProjectPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateRoadmapToProjectMutation, UpdateRoadmapToProjectMutationVariables>;
-export const UpdateRoadmapDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateRoadmap" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "RoadmapUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "roadmapUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "RoadmapPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...RoadmapPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateRoadmapMutation, UpdateRoadmapMutationVariables>;
-export const SamlTokenUserAccountAuthDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "samlTokenUserAccountAuth" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "TokenUserAccountAuthInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "samlTokenUserAccountAuth" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AuthResolverResponse" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...AuthResolverResponseFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<SamlTokenUserAccountAuthMutation, SamlTokenUserAccountAuthMutationVariables>;
-export const CreateTeamDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createTeam" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "copySettingsFromTeamId" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "TeamCreateInput" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "teamCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "copySettingsFromTeamId" },
-                value: { kind: "Variable", name: { kind: "Name", value: "copySettingsFromTeamId" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "TeamPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...TeamPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateTeamMutation, CreateTeamMutationVariables>;
-export const DeleteTeamCyclesDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteTeamCycles" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "teamCyclesDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "TeamPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...TeamPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteTeamCyclesMutation, DeleteTeamCyclesMutationVariables>;
-export const DeleteTeamDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteTeam" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "teamDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteTeamMutation, DeleteTeamMutationVariables>;
-export const DeleteTeamKeyDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteTeamKey" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "teamKeyDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteTeamKeyMutation, DeleteTeamKeyMutationVariables>;
-export const CreateTeamMembershipDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createTeamMembership" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "TeamMembershipCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "teamMembershipCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "TeamMembershipPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...TeamMembershipPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateTeamMembershipMutation, CreateTeamMembershipMutationVariables>;
-export const DeleteTeamMembershipDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteTeamMembership" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "teamMembershipDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteTeamMembershipMutation, DeleteTeamMembershipMutationVariables>;
-export const UpdateTeamMembershipDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateTeamMembership" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "TeamMembershipUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "teamMembershipUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "TeamMembershipPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...TeamMembershipPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateTeamMembershipMutation, UpdateTeamMembershipMutationVariables>;
-export const UpdateTeamDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateTeam" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "TeamUpdateInput" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "teamUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "TeamPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...TeamPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateTeamMutation, UpdateTeamMutationVariables>;
-export const CreateTemplateDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createTemplate" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "TemplateCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "templateCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "TemplatePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...TemplatePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateTemplateMutation, CreateTemplateMutationVariables>;
-export const DeleteTemplateDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteTemplate" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "templateDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteTemplateMutation, DeleteTemplateMutationVariables>;
-export const UpdateTemplateDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateTemplate" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "TemplateUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "templateUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "TemplatePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...TemplatePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateTemplateMutation, UpdateTemplateMutationVariables>;
-export const UserDemoteAdminDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "userDemoteAdmin" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "userDemoteAdmin" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserAdminPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...UserAdminPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UserDemoteAdminMutation, UserDemoteAdminMutationVariables>;
-export const UserDemoteMemberDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "userDemoteMember" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "userDemoteMember" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserAdminPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...UserAdminPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UserDemoteMemberMutation, UserDemoteMemberMutationVariables>;
-export const UserDiscordConnectDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "userDiscordConnect" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "userDiscordConnect" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "code" },
-                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "redirectUri" },
-                value: { kind: "Variable", name: { kind: "Name", value: "redirectUri" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...UserPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UserDiscordConnectMutation, UserDiscordConnectMutationVariables>;
-export const UserExternalUserDisconnectDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "userExternalUserDisconnect" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "service" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "userExternalUserDisconnect" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "service" },
-                value: { kind: "Variable", name: { kind: "Name", value: "service" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...UserPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UserExternalUserDisconnectMutation, UserExternalUserDisconnectMutationVariables>;
-export const UpdateUserFlagDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateUserFlag" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "flag" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "UserFlagType" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "operation" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "UserFlagUpdateOperation" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "userFlagUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "flag" },
-                value: { kind: "Variable", name: { kind: "Name", value: "flag" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "operation" },
-                value: { kind: "Variable", name: { kind: "Name", value: "operation" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserSettingsFlagPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...UserSettingsFlagPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateUserFlagMutation, UpdateUserFlagMutationVariables>;
-export const UserGitHubConnectDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "userGitHubConnect" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "userGitHubConnect" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "code" },
-                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...UserPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UserGitHubConnectMutation, UserGitHubConnectMutationVariables>;
-export const UserGoogleCalendarConnectDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "userGoogleCalendarConnect" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "code" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "userGoogleCalendarConnect" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "code" },
-                value: { kind: "Variable", name: { kind: "Name", value: "code" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...UserPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UserGoogleCalendarConnectMutation, UserGoogleCalendarConnectMutationVariables>;
-export const UserPromoteAdminDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "userPromoteAdmin" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "userPromoteAdmin" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserAdminPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...UserAdminPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UserPromoteAdminMutation, UserPromoteAdminMutationVariables>;
-export const UserPromoteMemberDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "userPromoteMember" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "userPromoteMember" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserAdminPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...UserAdminPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UserPromoteMemberMutation, UserPromoteMemberMutationVariables>;
-export const UserSettingsFlagIncrementDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "userSettingsFlagIncrement" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "flag" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "userSettingsFlagIncrement" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "flag" },
-                value: { kind: "Variable", name: { kind: "Name", value: "flag" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserSettingsFlagPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...UserSettingsFlagPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UserSettingsFlagIncrementMutation, UserSettingsFlagIncrementMutationVariables>;
-export const UserSettingsFlagsResetDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "userSettingsFlagsReset" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "flags" } },
-          type: {
-            kind: "ListType",
-            type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "UserFlagType" } } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "userSettingsFlagsReset" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "flags" },
-                value: { kind: "Variable", name: { kind: "Name", value: "flags" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserSettingsFlagsResetPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...UserSettingsFlagsResetPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UserSettingsFlagsResetMutation, UserSettingsFlagsResetMutationVariables>;
-export const UpdateUserSettingsDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateUserSettings" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "UserSettingsUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "userSettingsUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserSettingsPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...UserSettingsPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateUserSettingsMutation, UpdateUserSettingsMutationVariables>;
-export const SuspendUserDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "suspendUser" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "userSuspend" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserAdminPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...UserAdminPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<SuspendUserMutation, SuspendUserMutationVariables>;
-export const UnsuspendUserDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "unsuspendUser" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "userUnsuspend" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserAdminPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...UserAdminPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UnsuspendUserMutation, UnsuspendUserMutationVariables>;
-export const UpdateUserDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateUser" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "UpdateUserInput" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "userUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "UserPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...UserPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateUserMutation, UpdateUserMutationVariables>;
-export const CreateViewPreferencesDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createViewPreferences" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "ViewPreferencesCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "viewPreferencesCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ViewPreferencesPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ViewPreferencesPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateViewPreferencesMutation, CreateViewPreferencesMutationVariables>;
-export const DeleteViewPreferencesDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteViewPreferences" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "viewPreferencesDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteViewPreferencesMutation, DeleteViewPreferencesMutationVariables>;
-export const UpdateViewPreferencesDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateViewPreferences" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "ViewPreferencesUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "viewPreferencesUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ViewPreferencesPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ViewPreferencesPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateViewPreferencesMutation, UpdateViewPreferencesMutationVariables>;
-export const CreateWebhookDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createWebhook" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "WebhookCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "webhookCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "WebhookPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...WebhookPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateWebhookMutation, CreateWebhookMutationVariables>;
-export const DeleteWebhookDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "deleteWebhook" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "webhookDelete" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<DeleteWebhookMutation, DeleteWebhookMutationVariables>;
-export const UpdateWebhookDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateWebhook" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "WebhookUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "webhookUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "WebhookPayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...WebhookPayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateWebhookMutation, UpdateWebhookMutationVariables>;
-export const ArchiveWorkflowStateDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "archiveWorkflowState" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "workflowStateArchive" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ArchivePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...ArchivePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<ArchiveWorkflowStateMutation, ArchiveWorkflowStateMutationVariables>;
-export const CreateWorkflowStateDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "createWorkflowState" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "WorkflowStateCreateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "workflowStateCreate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "WorkflowStatePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...WorkflowStatePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<CreateWorkflowStateMutation, CreateWorkflowStateMutationVariables>;
-export const UpdateWorkflowStateDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "updateWorkflowState" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "WorkflowStateUpdateInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "workflowStateUpdate" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "input" },
-                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "WorkflowStatePayload" } }],
-            },
-          },
-        ],
-      },
-    },
-    ...WorkflowStatePayloadFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<UpdateWorkflowStateMutation, UpdateWorkflowStateMutationVariables>;

--- a/packages/sdk/src/_generated_sdk.ts
+++ b/packages/sdk/src/_generated_sdk.ts
@@ -511,6 +511,10 @@ export class AuditEntry extends Request {
   public get actor(): LinearFetch<User> | undefined {
     return this._actor?.id ? new UserQuery(this._request).fetch(this._actor?.id) : undefined;
   }
+  /** The organization the audit log belongs to. */
+  public get organization(): LinearFetch<Organization> {
+    return new OrganizationQuery(this._request).fetch();
+  }
 }
 /**
  * AuditEntryConnection model
@@ -639,7 +643,7 @@ export class Comment extends Request {
   public get issue(): LinearFetch<Issue> | undefined {
     return new IssueQuery(this._request).fetch(this._issue.id);
   }
-  /** The parent of the comment. */
+  /** The parent comment under which the current comment is nested. */
   public get parent(): LinearFetch<Comment> | undefined {
     return this._parent?.id ? new CommentQuery(this._request).fetch(this._parent?.id) : undefined;
   }
@@ -1762,71 +1766,6 @@ export class ImageUploadFromUrlPayload extends Request {
   public url?: string;
 }
 /**
- * A initiative that contains projects.
- *
- * @param request - function to call the graphql client
- * @param data - L.InitiativeFragment response data
- */
-export class Initiative extends Request {
-  public constructor(request: LinearRequest, data: L.InitiativeFragment) {
-    super(request);
-    this.archivedAt = parseDate(data.archivedAt) ?? undefined;
-    this.createdAt = parseDate(data.createdAt) ?? new Date();
-    this.description = data.description ?? undefined;
-    this.id = data.id;
-    this.name = data.name;
-    this.sortOrder = data.sortOrder;
-    this.targetDate = data.targetDate ?? undefined;
-    this.updatedAt = parseDate(data.updatedAt) ?? new Date();
-  }
-
-  /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
-  /** The time at which the entity was created. */
-  public createdAt: Date;
-  /** The initiative's description. */
-  public description?: string;
-  /** The unique identifier of the entity. */
-  public id: string;
-  /** The name of the initiative. */
-  public name: string;
-  /** The sort order for the initiative. */
-  public sortOrder: number;
-  /** The estimated completion date of the initiative. */
-  public targetDate?: L.Scalars["TimelessDate"];
-  /**
-   * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
-   *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
-   *     been updated after creation.
-   */
-  public updatedAt: Date;
-  /** The organization that the initiative belongs to. */
-  public get organization(): LinearFetch<Organization> {
-    return new OrganizationQuery(this._request).fetch();
-  }
-}
-/**
- * InitiativeConnection model
- *
- * @param request - function to call the graphql client
- * @param fetch - function to trigger a refetch of this InitiativeConnection model
- * @param data - InitiativeConnection response data
- */
-export class InitiativeConnection extends Connection<Initiative> {
-  public constructor(
-    request: LinearRequest,
-    fetch: (connection?: LinearConnectionVariables) => LinearFetch<LinearConnection<Initiative> | undefined>,
-    data: L.InitiativeConnectionFragment
-  ) {
-    super(
-      request,
-      fetch,
-      data.nodes.map(node => new Initiative(request, node)),
-      new PageInfo(request, data.pageInfo)
-    );
-  }
-}
-/**
  * An integration with an external service.
  *
  * @param request - function to call the graphql client
@@ -2061,6 +2000,7 @@ export class IntegrationSettings extends Request {
     this.googleSheets = data.googleSheets ? new GoogleSheetsSettings(request, data.googleSheets) : undefined;
     this.intercom = data.intercom ? new IntercomSettings(request, data.intercom) : undefined;
     this.jira = data.jira ? new JiraSettings(request, data.jira) : undefined;
+    this.notion = data.notion ? new NotionSettings(request, data.notion) : undefined;
     this.sentry = data.sentry ? new SentrySettings(request, data.sentry) : undefined;
     this.slackOrgProjectUpdatesPost = data.slackOrgProjectUpdatesPost
       ? new SlackPostSettings(request, data.slackOrgProjectUpdatesPost)
@@ -2075,6 +2015,7 @@ export class IntegrationSettings extends Request {
   public googleSheets?: GoogleSheetsSettings;
   public intercom?: IntercomSettings;
   public jira?: JiraSettings;
+  public notion?: NotionSettings;
   public sentry?: SentrySettings;
   public slackOrgProjectUpdatesPost?: SlackPostSettings;
   public slackPost?: SlackPostSettings;
@@ -2192,12 +2133,14 @@ export class IntegrationsSettings extends Request {
     this.archivedAt = parseDate(data.archivedAt) ?? undefined;
     this.createdAt = parseDate(data.createdAt) ?? new Date();
     this.id = data.id;
+    this.slackIssueAddedToTriage = data.slackIssueAddedToTriage ?? undefined;
     this.slackIssueCreated = data.slackIssueCreated ?? undefined;
     this.slackIssueNewComment = data.slackIssueNewComment ?? undefined;
+    this.slackIssueSlaBreached = data.slackIssueSlaBreached ?? undefined;
+    this.slackIssueSlaHighRisk = data.slackIssueSlaHighRisk ?? undefined;
     this.slackIssueStatusChangedAll = data.slackIssueStatusChangedAll ?? undefined;
     this.slackIssueStatusChangedDone = data.slackIssueStatusChangedDone ?? undefined;
     this.slackProjectUpdateCreated = data.slackProjectUpdateCreated ?? undefined;
-    this.slackProjectUpdateCreatedToMilestone = data.slackProjectUpdateCreatedToMilestone ?? undefined;
     this.slackProjectUpdateCreatedToTeam = data.slackProjectUpdateCreatedToTeam ?? undefined;
     this.slackProjectUpdateCreatedToWorkspace = data.slackProjectUpdateCreatedToWorkspace ?? undefined;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
@@ -2211,18 +2154,22 @@ export class IntegrationsSettings extends Request {
   public createdAt: Date;
   /** The unique identifier of the entity. */
   public id: string;
+  /** Whether to send a Slack message when a new issue is added to triage. */
+  public slackIssueAddedToTriage?: boolean;
   /** Whether to send a Slack message when a new issue is created for the project or the team. */
   public slackIssueCreated?: boolean;
   /** Whether to send a Slack message when a comment is created on any of the project or team's issues. */
   public slackIssueNewComment?: boolean;
+  /** Whether to send a Slack message when an SLA is breached */
+  public slackIssueSlaBreached?: boolean;
+  /** Whether to send a Slack message when an SLA is at high risk */
+  public slackIssueSlaHighRisk?: boolean;
   /** Whether to send a Slack message when any of the project or team's issues has a change in status. */
   public slackIssueStatusChangedAll?: boolean;
   /** Whether to send a Slack message when any of the project or team's issues change to completed or cancelled. */
   public slackIssueStatusChangedDone?: boolean;
   /** Whether to send a Slack message when a project update is created. */
   public slackProjectUpdateCreated?: boolean;
-  /** Whether to send a new project update to milestone Slack channels. */
-  public slackProjectUpdateCreatedToMilestone?: boolean;
   /** Whether to send a new project update to team Slack channels. */
   public slackProjectUpdateCreatedToTeam?: boolean;
   /** Whether to send a new project update to workspace Slack channel. */
@@ -2363,6 +2310,7 @@ export class Issue extends Request {
     this.snoozedUntilAt = parseDate(data.snoozedUntilAt) ?? undefined;
     this.sortOrder = data.sortOrder;
     this.startedAt = parseDate(data.startedAt) ?? undefined;
+    this.startedTriageAt = parseDate(data.startedTriageAt) ?? undefined;
     this.subIssueSortOrder = data.subIssueSortOrder ?? undefined;
     this.title = data.title;
     this.trashed = data.trashed ?? undefined;
@@ -2421,6 +2369,8 @@ export class Issue extends Request {
   public sortOrder: number;
   /** The time at which the issue was moved into started state. */
   public startedAt?: Date;
+  /** The time at which the issue entered triage. */
+  public startedTriageAt?: Date;
   /** The order of the item in the sub-issue list. Only set if the issue has a parent. */
   public subIssueSortOrder?: number;
   /** The issue's title. */
@@ -3358,124 +3308,6 @@ export class LogoutResponse extends Request {
   public success: boolean;
 }
 /**
- * A milestone that contains projects.
- *
- * @param request - function to call the graphql client
- * @param data - L.MilestoneFragment response data
- */
-export class Milestone extends Request {
-  public constructor(request: LinearRequest, data: L.MilestoneFragment) {
-    super(request);
-    this.archivedAt = parseDate(data.archivedAt) ?? undefined;
-    this.createdAt = parseDate(data.createdAt) ?? new Date();
-    this.id = data.id;
-    this.name = data.name;
-    this.sortOrder = data.sortOrder;
-    this.updatedAt = parseDate(data.updatedAt) ?? new Date();
-  }
-
-  /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
-  /** The time at which the entity was created. */
-  public createdAt: Date;
-  /** The unique identifier of the entity. */
-  public id: string;
-  /** The name of the milestone. */
-  public name: string;
-  /** The sort order for the milestone. */
-  public sortOrder: number;
-  /**
-   * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
-   *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
-   *     been updated after creation.
-   */
-  public updatedAt: Date;
-  /** The organization that the milestone belongs to. */
-  public get organization(): LinearFetch<Organization> {
-    return new OrganizationQuery(this._request).fetch();
-  }
-  /** Projects associated with the milestone. */
-  public projects(variables?: Omit<L.Milestone_ProjectsQueryVariables, "id">) {
-    return new Milestone_ProjectsQuery(this._request, this.id, variables).fetch(variables);
-  }
-  /** Creates a new milestone. */
-  public create(input: L.MilestoneCreateInput) {
-    return new CreateMilestoneMutation(this._request).fetch(input);
-  }
-  /** Deletes a milestone. */
-  public delete() {
-    return new DeleteMilestoneMutation(this._request).fetch(this.id);
-  }
-  /** Updates a milestone. */
-  public update(input: L.MilestoneUpdateInput) {
-    return new UpdateMilestoneMutation(this._request).fetch(this.id, input);
-  }
-}
-/**
- * MilestoneConnection model
- *
- * @param request - function to call the graphql client
- * @param fetch - function to trigger a refetch of this MilestoneConnection model
- * @param data - MilestoneConnection response data
- */
-export class MilestoneConnection extends Connection<Milestone> {
-  public constructor(
-    request: LinearRequest,
-    fetch: (connection?: LinearConnectionVariables) => LinearFetch<LinearConnection<Milestone> | undefined>,
-    data: L.MilestoneConnectionFragment
-  ) {
-    super(
-      request,
-      fetch,
-      data.nodes.map(node => new Milestone(request, node)),
-      new PageInfo(request, data.pageInfo)
-    );
-  }
-}
-/**
- * MilestoneMigrationPayload model
- *
- * @param request - function to call the graphql client
- * @param data - L.MilestoneMigrationPayloadFragment response data
- */
-export class MilestoneMigrationPayload extends Request {
-  public constructor(request: LinearRequest, data: L.MilestoneMigrationPayloadFragment) {
-    super(request);
-    this.lastSyncId = data.lastSyncId;
-    this.success = data.success;
-  }
-
-  /** The identifier of the last sync operation. */
-  public lastSyncId: number;
-  /** Whether the operation was successful. */
-  public success: boolean;
-}
-/**
- * MilestonePayload model
- *
- * @param request - function to call the graphql client
- * @param data - L.MilestonePayloadFragment response data
- */
-export class MilestonePayload extends Request {
-  private _milestone?: L.MilestonePayloadFragment["milestone"];
-
-  public constructor(request: LinearRequest, data: L.MilestonePayloadFragment) {
-    super(request);
-    this.lastSyncId = data.lastSyncId;
-    this.success = data.success;
-    this._milestone = data.milestone ?? undefined;
-  }
-
-  /** The identifier of the last sync operation. */
-  public lastSyncId: number;
-  /** Whether the operation was successful. */
-  public success: boolean;
-  /** The milesteone that was created or updated. */
-  public get milestone(): LinearFetch<Milestone> | undefined {
-    return this._milestone?.id ? new MilestoneQuery(this._request).fetch(this._milestone?.id) : undefined;
-  }
-}
-/**
  * Node model
  *
  * @param request - function to call the graphql client
@@ -3738,6 +3570,24 @@ export class NotificationSubscriptionPayload extends Request {
   public lastSyncId: number;
   /** Whether the operation was successful. */
   public success: boolean;
+}
+/**
+ * Notion specific settings.
+ *
+ * @param request - function to call the graphql client
+ * @param data - L.NotionSettingsFragment response data
+ */
+export class NotionSettings extends Request {
+  public constructor(request: LinearRequest, data: L.NotionSettingsFragment) {
+    super(request);
+    this.workspaceId = data.workspaceId;
+    this.workspaceName = data.workspaceName;
+  }
+
+  /** The ID of the Notion workspace being connected. */
+  public workspaceId: string;
+  /** The name of the Notion workspace being connected. */
+  public workspaceName: string;
 }
 /**
  * OAuth2 client application
@@ -4364,7 +4214,7 @@ export class PaidSubscription extends Request {
   public pendingChangeType?: string;
   /** The number of seats in the subscription. */
   public seats: number;
-  /** The maximum number of seats that can be added to the subscription. */
+  /** The maximum number of seats that will be billed in the subscription. */
   public seatsMaximum?: number;
   /** The minimum number of seats that will be billed in the subscription. */
   public seatsMinimum?: number;
@@ -4386,6 +4236,44 @@ export class PaidSubscription extends Request {
   }
 }
 /**
+ * A personal note for a user
+ *
+ * @param request - function to call the graphql client
+ * @param data - L.PersonalNoteFragment response data
+ */
+export class PersonalNote extends Request {
+  private _user: L.PersonalNoteFragment["user"];
+
+  public constructor(request: LinearRequest, data: L.PersonalNoteFragment) {
+    super(request);
+    this.archivedAt = parseDate(data.archivedAt) ?? undefined;
+    this.contentData = parseJson(data.contentData) ?? undefined;
+    this.createdAt = parseDate(data.createdAt) ?? new Date();
+    this.id = data.id;
+    this.updatedAt = parseDate(data.updatedAt) ?? new Date();
+    this._user = data.user;
+  }
+
+  /** The time at which the entity was archived. Null if the entity has not been archived. */
+  public archivedAt?: Date;
+  /** The note content as JSON. */
+  public contentData?: Record<string, unknown>;
+  /** The time at which the entity was created. */
+  public createdAt: Date;
+  /** The unique identifier of the entity. */
+  public id: string;
+  /**
+   * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+   *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+   *     been updated after creation.
+   */
+  public updatedAt: Date;
+  /** The user that owns the note. */
+  public get user(): LinearFetch<User> | undefined {
+    return new UserQuery(this._request).fetch(this._user.id);
+  }
+}
+/**
  * A project.
  *
  * @param request - function to call the graphql client
@@ -4396,7 +4284,6 @@ export class Project extends Request {
   private _creator: L.ProjectFragment["creator"];
   private _integrationsSettings?: L.ProjectFragment["integrationsSettings"];
   private _lead?: L.ProjectFragment["lead"];
-  private _milestone?: L.ProjectFragment["milestone"];
 
   public constructor(request: LinearRequest, data: L.ProjectFragment) {
     super(request);
@@ -4428,12 +4315,10 @@ export class Project extends Request {
     this.targetDate = data.targetDate ?? undefined;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
     this.url = data.url;
-    this.initiative = data.initiative ? new Initiative(request, data.initiative) : undefined;
     this._convertedFromIssue = data.convertedFromIssue ?? undefined;
     this._creator = data.creator;
     this._integrationsSettings = data.integrationsSettings ?? undefined;
     this._lead = data.lead ?? undefined;
-    this._milestone = data.milestone ?? undefined;
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
@@ -4480,7 +4365,7 @@ export class Project extends Request {
   public slackNewIssue: boolean;
   /** The project's unique URL slug. */
   public slugId: string;
-  /** The sort order for the project within its milestone/initiative. */
+  /** The sort order for the project within the organizion. */
   public sortOrder: number;
   /** The time at which the project was moved into started state. */
   public startedAt?: Date;
@@ -4496,8 +4381,6 @@ export class Project extends Request {
   public updatedAt: Date;
   /** Project URL. */
   public url: string;
-  /** The initiative that this project is associated with. */
-  public initiative?: Initiative;
   /** The project was created based on this issue. */
   public get convertedFromIssue(): LinearFetch<Issue> | undefined {
     return this._convertedFromIssue?.id ? new IssueQuery(this._request).fetch(this._convertedFromIssue?.id) : undefined;
@@ -4515,10 +4398,6 @@ export class Project extends Request {
   /** The project lead. */
   public get lead(): LinearFetch<User> | undefined {
     return this._lead?.id ? new UserQuery(this._request).fetch(this._lead?.id) : undefined;
-  }
-  /** The milestone that this project is associated with. */
-  public get milestone(): LinearFetch<Milestone> | undefined {
-    return this._milestone?.id ? new MilestoneQuery(this._request).fetch(this._milestone?.id) : undefined;
   }
   /** Documents associated with the project. */
   public documents(variables?: Omit<L.Project_DocumentsQueryVariables, "id">) {
@@ -4561,8 +4440,8 @@ export class Project extends Request {
     return new UnarchiveProjectMutation(this._request).fetch(this.id);
   }
   /** Updates a project. */
-  public update() {
-    return new ProjectUpdateQuery(this._request).fetch(this.id);
+  public update(input: L.ProjectUpdateInput) {
+    return new UpdateProjectMutation(this._request).fetch(this.id, input);
   }
 }
 /**
@@ -4690,6 +4569,109 @@ export class ProjectLinkPayload extends Request {
   /** The project that was created or updated. */
   public get projectLink(): LinearFetch<ProjectLink> | undefined {
     return new ProjectLinkQuery(this._request).fetch(this._projectLink.id);
+  }
+}
+/**
+ * A milestone for a project.
+ *
+ * @param request - function to call the graphql client
+ * @param data - L.ProjectMilestoneFragment response data
+ */
+export class ProjectMilestone extends Request {
+  private _project: L.ProjectMilestoneFragment["project"];
+
+  public constructor(request: LinearRequest, data: L.ProjectMilestoneFragment) {
+    super(request);
+    this.archivedAt = parseDate(data.archivedAt) ?? undefined;
+    this.createdAt = parseDate(data.createdAt) ?? new Date();
+    this.description = data.description ?? undefined;
+    this.id = data.id;
+    this.name = data.name;
+    this.targetDate = data.targetDate ?? undefined;
+    this.updatedAt = parseDate(data.updatedAt) ?? new Date();
+    this._project = data.project;
+  }
+
+  /** The time at which the entity was archived. Null if the entity has not been archived. */
+  public archivedAt?: Date;
+  /** The time at which the entity was created. */
+  public createdAt: Date;
+  /** The description of the project milestone. */
+  public description?: string;
+  /** The unique identifier of the entity. */
+  public id: string;
+  /** The name of the project milestone. */
+  public name: string;
+  /** The planned completion date of the milestone. */
+  public targetDate?: L.Scalars["TimelessDate"];
+  /**
+   * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+   *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+   *     been updated after creation.
+   */
+  public updatedAt: Date;
+  /** The project of the milestone. */
+  public get project(): LinearFetch<Project> | undefined {
+    return new ProjectQuery(this._request).fetch(this._project.id);
+  }
+
+  /** Creates a new project milestone. */
+  public create(input: L.ProjectMilestoneCreateInput) {
+    return new CreateProjectMilestoneMutation(this._request).fetch(input);
+  }
+  /** Deletes a project milestone. */
+  public delete() {
+    return new DeleteProjectMilestoneMutation(this._request).fetch(this.id);
+  }
+  /** Updates a project milestone. */
+  public update(input: L.ProjectMilestoneUpdateInput) {
+    return new UpdateProjectMilestoneMutation(this._request).fetch(this.id, input);
+  }
+}
+/**
+ * ProjectMilestoneConnection model
+ *
+ * @param request - function to call the graphql client
+ * @param fetch - function to trigger a refetch of this ProjectMilestoneConnection model
+ * @param data - ProjectMilestoneConnection response data
+ */
+export class ProjectMilestoneConnection extends Connection<ProjectMilestone> {
+  public constructor(
+    request: LinearRequest,
+    fetch: (connection?: LinearConnectionVariables) => LinearFetch<LinearConnection<ProjectMilestone> | undefined>,
+    data: L.ProjectMilestoneConnectionFragment
+  ) {
+    super(
+      request,
+      fetch,
+      data.nodes.map(node => new ProjectMilestone(request, node)),
+      new PageInfo(request, data.pageInfo)
+    );
+  }
+}
+/**
+ * ProjectMilestonePayload model
+ *
+ * @param request - function to call the graphql client
+ * @param data - L.ProjectMilestonePayloadFragment response data
+ */
+export class ProjectMilestonePayload extends Request {
+  private _projectMilestone: L.ProjectMilestonePayloadFragment["projectMilestone"];
+
+  public constructor(request: LinearRequest, data: L.ProjectMilestonePayloadFragment) {
+    super(request);
+    this.lastSyncId = data.lastSyncId;
+    this.success = data.success;
+    this._projectMilestone = data.projectMilestone;
+  }
+
+  /** The identifier of the last sync operation. */
+  public lastSyncId: number;
+  /** Whether the operation was successful. */
+  public success: boolean;
+  /** The project milestone that was created or updated. */
+  public get projectMilestone(): LinearFetch<ProjectMilestone> | undefined {
+    return new ProjectMilestoneQuery(this._request).fetch(this._projectMilestone.id);
   }
 }
 /**
@@ -5843,6 +5825,7 @@ export class Team extends Request {
     this.key = data.key;
     this.name = data.name;
     this.private = data.private;
+    this.requirePriorityToLeaveTriage = data.requirePriorityToLeaveTriage;
     this.slackIssueComments = data.slackIssueComments;
     this.slackIssueStatuses = data.slackIssueStatuses;
     this.slackNewIssue = data.slackNewIssue;
@@ -5923,6 +5906,8 @@ export class Team extends Request {
   public name: string;
   /** Whether the team is private or not. */
   public private: boolean;
+  /** Whether an issue needs to have a priority set before leaving triage */
+  public requirePriorityToLeaveTriage: boolean;
   /** Whether to send new issue comment notifications to Slack. */
   public slackIssueComments: boolean;
   /** Whether to send new issue status updates to Slack. */
@@ -7013,7 +6998,7 @@ export class WebhookPayload extends Request {
  */
 export class WorkflowDefinition extends Request {
   private _creator: L.WorkflowDefinitionFragment["creator"];
-  private _team: L.WorkflowDefinitionFragment["team"];
+  private _team?: L.WorkflowDefinitionFragment["team"];
 
   public constructor(request: LinearRequest, data: L.WorkflowDefinitionFragment) {
     super(request);
@@ -7023,31 +7008,37 @@ export class WorkflowDefinition extends Request {
     this.createdAt = parseDate(data.createdAt) ?? new Date();
     this.description = data.description ?? undefined;
     this.enabled = data.enabled;
+    this.groupName = data.groupName ?? undefined;
     this.id = data.id;
     this.name = data.name;
     this.schedule = parseJson(data.schedule) ?? {};
+    this.sortOrder = data.sortOrder;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
     this._creator = data.creator;
-    this._team = data.team;
+    this._team = data.team ?? undefined;
   }
 
   /** An array of activities that will be executed as part of the workflow. */
   public activities: Record<string, unknown>;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
   public archivedAt?: Date;
-  /** One or more conditions that need to be true for workflow to be triggered. */
+  /** The conditions that need to be match for the workflow to be triggered. */
   public conditions: Record<string, unknown>;
   /** The time at which the entity was created. */
   public createdAt: Date;
-  /** The workflow description. */
+  /** The description of the workflow. */
   public description?: string;
   public enabled: boolean;
+  /** The name of the group that the workflow belongs to. */
+  public groupName?: string;
   /** The unique identifier of the entity. */
   public id: string;
   /** The name of the workflow. */
   public name: string;
   /** Cron schedule which is used to execute the workflow. Only applicable for cron based workflows. */
   public schedule: Record<string, unknown>;
+  /** The sort order of the workflow definition within its siblings. */
+  public sortOrder: string;
   /**
    * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
    *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
@@ -7058,13 +7049,30 @@ export class WorkflowDefinition extends Request {
   public get creator(): LinearFetch<User> | undefined {
     return new UserQuery(this._request).fetch(this._creator.id);
   }
-  /** The organization where workflow was created. */
-  public get organization(): LinearFetch<Organization> {
-    return new OrganizationQuery(this._request).fetch();
-  }
-  /** The team associated with the workflow. */
+  /** The team associated with the workflow. If not set, the workflow is associated with the entire organization. */
   public get team(): LinearFetch<Team> | undefined {
-    return new TeamQuery(this._request).fetch(this._team.id);
+    return this._team?.id ? new TeamQuery(this._request).fetch(this._team?.id) : undefined;
+  }
+}
+/**
+ * WorkflowDefinitionConnection model
+ *
+ * @param request - function to call the graphql client
+ * @param fetch - function to trigger a refetch of this WorkflowDefinitionConnection model
+ * @param data - WorkflowDefinitionConnection response data
+ */
+export class WorkflowDefinitionConnection extends Connection<WorkflowDefinition> {
+  public constructor(
+    request: LinearRequest,
+    fetch: (connection?: LinearConnectionVariables) => LinearFetch<LinearConnection<WorkflowDefinition> | undefined>,
+    data: L.WorkflowDefinitionConnectionFragment
+  ) {
+    super(
+      request,
+      fetch,
+      data.nodes.map(node => new WorkflowDefinition(request, node)),
+      new PageInfo(request, data.pageInfo)
+    );
   }
 }
 /**
@@ -7215,2433 +7223,6 @@ export class ZendeskSettings extends Request {
   /** The URL of the connected Zendesk organization. */
   public url: string;
 }
-/**
- * A fetchable AdministrableTeams Query
- *
- * @param request - function to call the graphql client
- */
-export class AdministrableTeamsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the AdministrableTeams query and return a TeamConnection
-   *
-   * @param variables - variables to pass into the AdministrableTeamsQuery
-   * @returns parsed response from AdministrableTeamsQuery
-   */
-  public async fetch(variables?: L.AdministrableTeamsQueryVariables): LinearFetch<TeamConnection> {
-    const response = await this._request<L.AdministrableTeamsQuery, L.AdministrableTeamsQueryVariables>(
-      L.AdministrableTeamsDocument,
-      variables
-    );
-    const data = response.administrableTeams;
-
-    return new TeamConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable ApiKeys Query
- *
- * @param request - function to call the graphql client
- */
-export class ApiKeysQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the ApiKeys query and return a ApiKeyConnection
-   *
-   * @param variables - variables to pass into the ApiKeysQuery
-   * @returns parsed response from ApiKeysQuery
-   */
-  public async fetch(variables?: L.ApiKeysQueryVariables): LinearFetch<ApiKeyConnection> {
-    const response = await this._request<L.ApiKeysQuery, L.ApiKeysQueryVariables>(L.ApiKeysDocument, variables);
-    const data = response.apiKeys;
-
-    return new ApiKeyConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable ApplicationInfo Query
- *
- * @param request - function to call the graphql client
- */
-export class ApplicationInfoQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the ApplicationInfo query and return a Application
-   *
-   * @param clientId - required clientId to pass to applicationInfo
-   * @returns parsed response from ApplicationInfoQuery
-   */
-  public async fetch(clientId: string): LinearFetch<Application> {
-    const response = await this._request<L.ApplicationInfoQuery, L.ApplicationInfoQueryVariables>(
-      L.ApplicationInfoDocument,
-      {
-        clientId,
-      }
-    );
-    const data = response.applicationInfo;
-
-    return new Application(this._request, data);
-  }
-}
-
-/**
- * A fetchable ApplicationWithAuthorization Query
- *
- * @param request - function to call the graphql client
- */
-export class ApplicationWithAuthorizationQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the ApplicationWithAuthorization query and return a UserAuthorizedApplication
-   *
-   * @param clientId - required clientId to pass to applicationWithAuthorization
-   * @param scope - required scope to pass to applicationWithAuthorization
-   * @param variables - variables without 'clientId', 'scope' to pass into the ApplicationWithAuthorizationQuery
-   * @returns parsed response from ApplicationWithAuthorizationQuery
-   */
-  public async fetch(
-    clientId: string,
-    scope: string[],
-    variables?: Omit<L.ApplicationWithAuthorizationQueryVariables, "clientId" | "scope">
-  ): LinearFetch<UserAuthorizedApplication> {
-    const response = await this._request<
-      L.ApplicationWithAuthorizationQuery,
-      L.ApplicationWithAuthorizationQueryVariables
-    >(L.ApplicationWithAuthorizationDocument, {
-      clientId,
-      scope,
-      ...variables,
-    });
-    const data = response.applicationWithAuthorization;
-
-    return new UserAuthorizedApplication(this._request, data);
-  }
-}
-
-/**
- * A fetchable Attachment Query
- *
- * @param request - function to call the graphql client
- */
-export class AttachmentQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Attachment query and return a Attachment
-   *
-   * @param id - required id to pass to attachment
-   * @returns parsed response from AttachmentQuery
-   */
-  public async fetch(id: string): LinearFetch<Attachment> {
-    const response = await this._request<L.AttachmentQuery, L.AttachmentQueryVariables>(L.AttachmentDocument, {
-      id,
-    });
-    const data = response.attachment;
-
-    return new Attachment(this._request, data);
-  }
-}
-
-/**
- * A fetchable AttachmentIssue Query
- *
- * @param request - function to call the graphql client
- */
-export class AttachmentIssueQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the AttachmentIssue query and return a Issue
-   *
-   * @param id - required id to pass to attachmentIssue
-   * @returns parsed response from AttachmentIssueQuery
-   */
-  public async fetch(id: string): LinearFetch<Issue> {
-    const response = await this._request<L.AttachmentIssueQuery, L.AttachmentIssueQueryVariables>(
-      L.AttachmentIssueDocument,
-      {
-        id,
-      }
-    );
-    const data = response.attachmentIssue;
-
-    return new Issue(this._request, data);
-  }
-}
-
-/**
- * A fetchable Attachments Query
- *
- * @param request - function to call the graphql client
- */
-export class AttachmentsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Attachments query and return a AttachmentConnection
-   *
-   * @param variables - variables to pass into the AttachmentsQuery
-   * @returns parsed response from AttachmentsQuery
-   */
-  public async fetch(variables?: L.AttachmentsQueryVariables): LinearFetch<AttachmentConnection> {
-    const response = await this._request<L.AttachmentsQuery, L.AttachmentsQueryVariables>(
-      L.AttachmentsDocument,
-      variables
-    );
-    const data = response.attachments;
-
-    return new AttachmentConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable AttachmentsForUrl Query
- *
- * @param request - function to call the graphql client
- */
-export class AttachmentsForUrlQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the AttachmentsForUrl query and return a AttachmentConnection
-   *
-   * @param url - required url to pass to attachmentsForURL
-   * @param variables - variables without 'url' to pass into the AttachmentsForUrlQuery
-   * @returns parsed response from AttachmentsForUrlQuery
-   */
-  public async fetch(
-    url: string,
-    variables?: Omit<L.AttachmentsForUrlQueryVariables, "url">
-  ): LinearFetch<AttachmentConnection> {
-    const response = await this._request<L.AttachmentsForUrlQuery, L.AttachmentsForUrlQueryVariables>(
-      L.AttachmentsForUrlDocument,
-      {
-        url,
-        ...variables,
-      }
-    );
-    const data = response.attachmentsForURL;
-
-    return new AttachmentConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          url,
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable AuditEntries Query
- *
- * @param request - function to call the graphql client
- */
-export class AuditEntriesQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the AuditEntries query and return a AuditEntryConnection
-   *
-   * @param variables - variables to pass into the AuditEntriesQuery
-   * @returns parsed response from AuditEntriesQuery
-   */
-  public async fetch(variables?: L.AuditEntriesQueryVariables): LinearFetch<AuditEntryConnection> {
-    const response = await this._request<L.AuditEntriesQuery, L.AuditEntriesQueryVariables>(
-      L.AuditEntriesDocument,
-      variables
-    );
-    const data = response.auditEntries;
-
-    return new AuditEntryConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable AuditEntryTypes Query
- *
- * @param request - function to call the graphql client
- */
-export class AuditEntryTypesQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the AuditEntryTypes query and return a AuditEntryType list
-   *
-   * @returns parsed response from AuditEntryTypesQuery
-   */
-  public async fetch(): LinearFetch<AuditEntryType[]> {
-    const response = await this._request<L.AuditEntryTypesQuery, L.AuditEntryTypesQueryVariables>(
-      L.AuditEntryTypesDocument,
-      {}
-    );
-    const data = response.auditEntryTypes;
-
-    return data.map(node => {
-      return new AuditEntryType(this._request, node);
-    });
-  }
-}
-
-/**
- * A fetchable AvailableUsers Query
- *
- * @param request - function to call the graphql client
- */
-export class AvailableUsersQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the AvailableUsers query and return a AuthResolverResponse
-   *
-   * @returns parsed response from AvailableUsersQuery
-   */
-  public async fetch(): LinearFetch<AuthResolverResponse> {
-    const response = await this._request<L.AvailableUsersQuery, L.AvailableUsersQueryVariables>(
-      L.AvailableUsersDocument,
-      {}
-    );
-    const data = response.availableUsers;
-
-    return new AuthResolverResponse(this._request, data);
-  }
-}
-
-/**
- * A fetchable Comment Query
- *
- * @param request - function to call the graphql client
- */
-export class CommentQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Comment query and return a Comment
-   *
-   * @param id - required id to pass to comment
-   * @returns parsed response from CommentQuery
-   */
-  public async fetch(id: string): LinearFetch<Comment> {
-    const response = await this._request<L.CommentQuery, L.CommentQueryVariables>(L.CommentDocument, {
-      id,
-    });
-    const data = response.comment;
-
-    return new Comment(this._request, data);
-  }
-}
-
-/**
- * A fetchable Comments Query
- *
- * @param request - function to call the graphql client
- */
-export class CommentsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Comments query and return a CommentConnection
-   *
-   * @param variables - variables to pass into the CommentsQuery
-   * @returns parsed response from CommentsQuery
-   */
-  public async fetch(variables?: L.CommentsQueryVariables): LinearFetch<CommentConnection> {
-    const response = await this._request<L.CommentsQuery, L.CommentsQueryVariables>(L.CommentsDocument, variables);
-    const data = response.comments;
-
-    return new CommentConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable CustomView Query
- *
- * @param request - function to call the graphql client
- */
-export class CustomViewQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the CustomView query and return a CustomView
-   *
-   * @param id - required id to pass to customView
-   * @returns parsed response from CustomViewQuery
-   */
-  public async fetch(id: string): LinearFetch<CustomView> {
-    const response = await this._request<L.CustomViewQuery, L.CustomViewQueryVariables>(L.CustomViewDocument, {
-      id,
-    });
-    const data = response.customView;
-
-    return new CustomView(this._request, data);
-  }
-}
-
-/**
- * A fetchable CustomViews Query
- *
- * @param request - function to call the graphql client
- */
-export class CustomViewsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the CustomViews query and return a CustomViewConnection
-   *
-   * @param variables - variables to pass into the CustomViewsQuery
-   * @returns parsed response from CustomViewsQuery
-   */
-  public async fetch(variables?: L.CustomViewsQueryVariables): LinearFetch<CustomViewConnection> {
-    const response = await this._request<L.CustomViewsQuery, L.CustomViewsQueryVariables>(
-      L.CustomViewsDocument,
-      variables
-    );
-    const data = response.customViews;
-
-    return new CustomViewConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable Cycle Query
- *
- * @param request - function to call the graphql client
- */
-export class CycleQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Cycle query and return a Cycle
-   *
-   * @param id - required id to pass to cycle
-   * @returns parsed response from CycleQuery
-   */
-  public async fetch(id: string): LinearFetch<Cycle> {
-    const response = await this._request<L.CycleQuery, L.CycleQueryVariables>(L.CycleDocument, {
-      id,
-    });
-    const data = response.cycle;
-
-    return new Cycle(this._request, data);
-  }
-}
-
-/**
- * A fetchable Cycles Query
- *
- * @param request - function to call the graphql client
- */
-export class CyclesQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Cycles query and return a CycleConnection
-   *
-   * @param variables - variables to pass into the CyclesQuery
-   * @returns parsed response from CyclesQuery
-   */
-  public async fetch(variables?: L.CyclesQueryVariables): LinearFetch<CycleConnection> {
-    const response = await this._request<L.CyclesQuery, L.CyclesQueryVariables>(L.CyclesDocument, variables);
-    const data = response.cycles;
-
-    return new CycleConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable Document Query
- *
- * @param request - function to call the graphql client
- */
-export class DocumentQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Document query and return a Document
-   *
-   * @param id - required id to pass to document
-   * @returns parsed response from DocumentQuery
-   */
-  public async fetch(id: string): LinearFetch<Document> {
-    const response = await this._request<L.DocumentQuery, L.DocumentQueryVariables>(L.DocumentDocument, {
-      id,
-    });
-    const data = response.document;
-
-    return new Document(this._request, data);
-  }
-}
-
-/**
- * A fetchable Documents Query
- *
- * @param request - function to call the graphql client
- */
-export class DocumentsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Documents query and return a DocumentConnection
-   *
-   * @param variables - variables to pass into the DocumentsQuery
-   * @returns parsed response from DocumentsQuery
-   */
-  public async fetch(variables?: L.DocumentsQueryVariables): LinearFetch<DocumentConnection> {
-    const response = await this._request<L.DocumentsQuery, L.DocumentsQueryVariables>(L.DocumentsDocument, variables);
-    const data = response.documents;
-
-    return new DocumentConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable Emoji Query
- *
- * @param request - function to call the graphql client
- */
-export class EmojiQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Emoji query and return a Emoji
-   *
-   * @param id - required id to pass to emoji
-   * @returns parsed response from EmojiQuery
-   */
-  public async fetch(id: string): LinearFetch<Emoji> {
-    const response = await this._request<L.EmojiQuery, L.EmojiQueryVariables>(L.EmojiDocument, {
-      id,
-    });
-    const data = response.emoji;
-
-    return new Emoji(this._request, data);
-  }
-}
-
-/**
- * A fetchable Emojis Query
- *
- * @param request - function to call the graphql client
- */
-export class EmojisQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Emojis query and return a EmojiConnection
-   *
-   * @param variables - variables to pass into the EmojisQuery
-   * @returns parsed response from EmojisQuery
-   */
-  public async fetch(variables?: L.EmojisQueryVariables): LinearFetch<EmojiConnection> {
-    const response = await this._request<L.EmojisQuery, L.EmojisQueryVariables>(L.EmojisDocument, variables);
-    const data = response.emojis;
-
-    return new EmojiConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable Favorite Query
- *
- * @param request - function to call the graphql client
- */
-export class FavoriteQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Favorite query and return a Favorite
-   *
-   * @param id - required id to pass to favorite
-   * @returns parsed response from FavoriteQuery
-   */
-  public async fetch(id: string): LinearFetch<Favorite> {
-    const response = await this._request<L.FavoriteQuery, L.FavoriteQueryVariables>(L.FavoriteDocument, {
-      id,
-    });
-    const data = response.favorite;
-
-    return new Favorite(this._request, data);
-  }
-}
-
-/**
- * A fetchable Favorites Query
- *
- * @param request - function to call the graphql client
- */
-export class FavoritesQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Favorites query and return a FavoriteConnection
-   *
-   * @param variables - variables to pass into the FavoritesQuery
-   * @returns parsed response from FavoritesQuery
-   */
-  public async fetch(variables?: L.FavoritesQueryVariables): LinearFetch<FavoriteConnection> {
-    const response = await this._request<L.FavoritesQuery, L.FavoritesQueryVariables>(L.FavoritesDocument, variables);
-    const data = response.favorites;
-
-    return new FavoriteConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable FigmaEmbedInfo Query
- *
- * @param request - function to call the graphql client
- */
-export class FigmaEmbedInfoQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the FigmaEmbedInfo query and return a FigmaEmbedPayload
-   *
-   * @param fileId - required fileId to pass to figmaEmbedInfo
-   * @param variables - variables without 'fileId' to pass into the FigmaEmbedInfoQuery
-   * @returns parsed response from FigmaEmbedInfoQuery
-   */
-  public async fetch(
-    fileId: string,
-    variables?: Omit<L.FigmaEmbedInfoQueryVariables, "fileId">
-  ): LinearFetch<FigmaEmbedPayload> {
-    const response = await this._request<L.FigmaEmbedInfoQuery, L.FigmaEmbedInfoQueryVariables>(
-      L.FigmaEmbedInfoDocument,
-      {
-        fileId,
-        ...variables,
-      }
-    );
-    const data = response.figmaEmbedInfo;
-
-    return new FigmaEmbedPayload(this._request, data);
-  }
-}
-
-/**
- * A fetchable Integration Query
- *
- * @param request - function to call the graphql client
- */
-export class IntegrationQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Integration query and return a Integration
-   *
-   * @param id - required id to pass to integration
-   * @returns parsed response from IntegrationQuery
-   */
-  public async fetch(id: string): LinearFetch<Integration> {
-    const response = await this._request<L.IntegrationQuery, L.IntegrationQueryVariables>(L.IntegrationDocument, {
-      id,
-    });
-    const data = response.integration;
-
-    return new Integration(this._request, data);
-  }
-}
-
-/**
- * A fetchable IntegrationTemplate Query
- *
- * @param request - function to call the graphql client
- */
-export class IntegrationTemplateQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the IntegrationTemplate query and return a IntegrationTemplate
-   *
-   * @param id - required id to pass to integrationTemplate
-   * @returns parsed response from IntegrationTemplateQuery
-   */
-  public async fetch(id: string): LinearFetch<IntegrationTemplate> {
-    const response = await this._request<L.IntegrationTemplateQuery, L.IntegrationTemplateQueryVariables>(
-      L.IntegrationTemplateDocument,
-      {
-        id,
-      }
-    );
-    const data = response.integrationTemplate;
-
-    return new IntegrationTemplate(this._request, data);
-  }
-}
-
-/**
- * A fetchable IntegrationTemplates Query
- *
- * @param request - function to call the graphql client
- */
-export class IntegrationTemplatesQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the IntegrationTemplates query and return a IntegrationTemplateConnection
-   *
-   * @param variables - variables to pass into the IntegrationTemplatesQuery
-   * @returns parsed response from IntegrationTemplatesQuery
-   */
-  public async fetch(variables?: L.IntegrationTemplatesQueryVariables): LinearFetch<IntegrationTemplateConnection> {
-    const response = await this._request<L.IntegrationTemplatesQuery, L.IntegrationTemplatesQueryVariables>(
-      L.IntegrationTemplatesDocument,
-      variables
-    );
-    const data = response.integrationTemplates;
-
-    return new IntegrationTemplateConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable Integrations Query
- *
- * @param request - function to call the graphql client
- */
-export class IntegrationsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Integrations query and return a IntegrationConnection
-   *
-   * @param variables - variables to pass into the IntegrationsQuery
-   * @returns parsed response from IntegrationsQuery
-   */
-  public async fetch(variables?: L.IntegrationsQueryVariables): LinearFetch<IntegrationConnection> {
-    const response = await this._request<L.IntegrationsQuery, L.IntegrationsQueryVariables>(
-      L.IntegrationsDocument,
-      variables
-    );
-    const data = response.integrations;
-
-    return new IntegrationConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable IntegrationsSettings Query
- *
- * @param request - function to call the graphql client
- */
-export class IntegrationsSettingsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the IntegrationsSettings query and return a IntegrationsSettings
-   *
-   * @param id - required id to pass to integrationsSettings
-   * @returns parsed response from IntegrationsSettingsQuery
-   */
-  public async fetch(id: string): LinearFetch<IntegrationsSettings> {
-    const response = await this._request<L.IntegrationsSettingsQuery, L.IntegrationsSettingsQueryVariables>(
-      L.IntegrationsSettingsDocument,
-      {
-        id,
-      }
-    );
-    const data = response.integrationsSettings;
-
-    return new IntegrationsSettings(this._request, data);
-  }
-}
-
-/**
- * A fetchable Issue Query
- *
- * @param request - function to call the graphql client
- */
-export class IssueQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Issue query and return a Issue
-   *
-   * @param id - required id to pass to issue
-   * @returns parsed response from IssueQuery
-   */
-  public async fetch(id: string): LinearFetch<Issue> {
-    const response = await this._request<L.IssueQuery, L.IssueQueryVariables>(L.IssueDocument, {
-      id,
-    });
-    const data = response.issue;
-
-    return new Issue(this._request, data);
-  }
-}
-
-/**
- * A fetchable IssueImportFinishGithubOAuth Query
- *
- * @param request - function to call the graphql client
- */
-export class IssueImportFinishGithubOAuthQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the IssueImportFinishGithubOAuth query and return a GithubOAuthTokenPayload
-   *
-   * @param code - required code to pass to issueImportFinishGithubOAuth
-   * @returns parsed response from IssueImportFinishGithubOAuthQuery
-   */
-  public async fetch(code: string): LinearFetch<GithubOAuthTokenPayload> {
-    const response = await this._request<
-      L.IssueImportFinishGithubOAuthQuery,
-      L.IssueImportFinishGithubOAuthQueryVariables
-    >(L.IssueImportFinishGithubOAuthDocument, {
-      code,
-    });
-    const data = response.issueImportFinishGithubOAuth;
-
-    return new GithubOAuthTokenPayload(this._request, data);
-  }
-}
-
-/**
- * A fetchable IssueLabel Query
- *
- * @param request - function to call the graphql client
- */
-export class IssueLabelQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the IssueLabel query and return a IssueLabel
-   *
-   * @param id - required id to pass to issueLabel
-   * @returns parsed response from IssueLabelQuery
-   */
-  public async fetch(id: string): LinearFetch<IssueLabel> {
-    const response = await this._request<L.IssueLabelQuery, L.IssueLabelQueryVariables>(L.IssueLabelDocument, {
-      id,
-    });
-    const data = response.issueLabel;
-
-    return new IssueLabel(this._request, data);
-  }
-}
-
-/**
- * A fetchable IssueLabels Query
- *
- * @param request - function to call the graphql client
- */
-export class IssueLabelsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the IssueLabels query and return a IssueLabelConnection
-   *
-   * @param variables - variables to pass into the IssueLabelsQuery
-   * @returns parsed response from IssueLabelsQuery
-   */
-  public async fetch(variables?: L.IssueLabelsQueryVariables): LinearFetch<IssueLabelConnection> {
-    const response = await this._request<L.IssueLabelsQuery, L.IssueLabelsQueryVariables>(
-      L.IssueLabelsDocument,
-      variables
-    );
-    const data = response.issueLabels;
-
-    return new IssueLabelConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable IssuePriorityValues Query
- *
- * @param request - function to call the graphql client
- */
-export class IssuePriorityValuesQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the IssuePriorityValues query and return a IssuePriorityValue list
-   *
-   * @returns parsed response from IssuePriorityValuesQuery
-   */
-  public async fetch(): LinearFetch<IssuePriorityValue[]> {
-    const response = await this._request<L.IssuePriorityValuesQuery, L.IssuePriorityValuesQueryVariables>(
-      L.IssuePriorityValuesDocument,
-      {}
-    );
-    const data = response.issuePriorityValues;
-
-    return data.map(node => {
-      return new IssuePriorityValue(this._request, node);
-    });
-  }
-}
-
-/**
- * A fetchable IssueRelation Query
- *
- * @param request - function to call the graphql client
- */
-export class IssueRelationQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the IssueRelation query and return a IssueRelation
-   *
-   * @param id - required id to pass to issueRelation
-   * @returns parsed response from IssueRelationQuery
-   */
-  public async fetch(id: string): LinearFetch<IssueRelation> {
-    const response = await this._request<L.IssueRelationQuery, L.IssueRelationQueryVariables>(L.IssueRelationDocument, {
-      id,
-    });
-    const data = response.issueRelation;
-
-    return new IssueRelation(this._request, data);
-  }
-}
-
-/**
- * A fetchable IssueRelations Query
- *
- * @param request - function to call the graphql client
- */
-export class IssueRelationsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the IssueRelations query and return a IssueRelationConnection
-   *
-   * @param variables - variables to pass into the IssueRelationsQuery
-   * @returns parsed response from IssueRelationsQuery
-   */
-  public async fetch(variables?: L.IssueRelationsQueryVariables): LinearFetch<IssueRelationConnection> {
-    const response = await this._request<L.IssueRelationsQuery, L.IssueRelationsQueryVariables>(
-      L.IssueRelationsDocument,
-      variables
-    );
-    const data = response.issueRelations;
-
-    return new IssueRelationConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable IssueVcsBranchSearch Query
- *
- * @param request - function to call the graphql client
- */
-export class IssueVcsBranchSearchQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the IssueVcsBranchSearch query and return a Issue
-   *
-   * @param branchName - required branchName to pass to issueVcsBranchSearch
-   * @returns parsed response from IssueVcsBranchSearchQuery
-   */
-  public async fetch(branchName: string): LinearFetch<Issue | undefined> {
-    const response = await this._request<L.IssueVcsBranchSearchQuery, L.IssueVcsBranchSearchQueryVariables>(
-      L.IssueVcsBranchSearchDocument,
-      {
-        branchName,
-      }
-    );
-    const data = response.issueVcsBranchSearch;
-
-    return data ? new Issue(this._request, data) : undefined;
-  }
-}
-
-/**
- * A fetchable Issues Query
- *
- * @param request - function to call the graphql client
- */
-export class IssuesQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Issues query and return a IssueConnection
-   *
-   * @param variables - variables to pass into the IssuesQuery
-   * @returns parsed response from IssuesQuery
-   */
-  public async fetch(variables?: L.IssuesQueryVariables): LinearFetch<IssueConnection> {
-    const response = await this._request<L.IssuesQuery, L.IssuesQueryVariables>(L.IssuesDocument, variables);
-    const data = response.issues;
-
-    return new IssueConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable Milestone Query
- *
- * @param request - function to call the graphql client
- */
-export class MilestoneQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Milestone query and return a Milestone
-   *
-   * @param id - required id to pass to milestone
-   * @returns parsed response from MilestoneQuery
-   */
-  public async fetch(id: string): LinearFetch<Milestone> {
-    const response = await this._request<L.MilestoneQuery, L.MilestoneQueryVariables>(L.MilestoneDocument, {
-      id,
-    });
-    const data = response.milestone;
-
-    return new Milestone(this._request, data);
-  }
-}
-
-/**
- * A fetchable Milestones Query
- *
- * @param request - function to call the graphql client
- */
-export class MilestonesQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Milestones query and return a MilestoneConnection
-   *
-   * @param variables - variables to pass into the MilestonesQuery
-   * @returns parsed response from MilestonesQuery
-   */
-  public async fetch(variables?: L.MilestonesQueryVariables): LinearFetch<MilestoneConnection> {
-    const response = await this._request<L.MilestonesQuery, L.MilestonesQueryVariables>(
-      L.MilestonesDocument,
-      variables
-    );
-    const data = response.milestones;
-
-    return new MilestoneConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable Notification Query
- *
- * @param request - function to call the graphql client
- */
-export class NotificationQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Notification query and return a Notification
-   *
-   * @param id - required id to pass to notification
-   * @returns parsed response from NotificationQuery
-   */
-  public async fetch(
-    id: string
-  ): LinearFetch<IssueNotification | OauthClientApprovalNotification | ProjectNotification | Notification> {
-    const response = await this._request<L.NotificationQuery, L.NotificationQueryVariables>(L.NotificationDocument, {
-      id,
-    });
-    const data = response.notification;
-
-    switch (data.__typename) {
-      case "IssueNotification":
-        return new IssueNotification(this._request, data as L.IssueNotificationFragment);
-      case "OauthClientApprovalNotification":
-        return new OauthClientApprovalNotification(this._request, data as L.OauthClientApprovalNotificationFragment);
-      case "ProjectNotification":
-        return new ProjectNotification(this._request, data as L.ProjectNotificationFragment);
-
-      default:
-        return new Notification(this._request, data);
-    }
-  }
-}
-
-/**
- * A fetchable NotificationSubscription Query
- *
- * @param request - function to call the graphql client
- */
-export class NotificationSubscriptionQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the NotificationSubscription query and return a NotificationSubscription
-   *
-   * @param id - required id to pass to notificationSubscription
-   * @returns parsed response from NotificationSubscriptionQuery
-   */
-  public async fetch(
-    id: string
-  ): LinearFetch<ProjectNotificationSubscription | TeamNotificationSubscription | NotificationSubscription> {
-    const response = await this._request<L.NotificationSubscriptionQuery, L.NotificationSubscriptionQueryVariables>(
-      L.NotificationSubscriptionDocument,
-      {
-        id,
-      }
-    );
-    const data = response.notificationSubscription;
-
-    switch (data.__typename) {
-      case "ProjectNotificationSubscription":
-        return new ProjectNotificationSubscription(this._request, data as L.ProjectNotificationSubscriptionFragment);
-      case "TeamNotificationSubscription":
-        return new TeamNotificationSubscription(this._request, data as L.TeamNotificationSubscriptionFragment);
-
-      default:
-        return new NotificationSubscription(this._request, data);
-    }
-  }
-}
-
-/**
- * A fetchable NotificationSubscriptions Query
- *
- * @param request - function to call the graphql client
- */
-export class NotificationSubscriptionsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the NotificationSubscriptions query and return a NotificationSubscriptionConnection
-   *
-   * @param variables - variables to pass into the NotificationSubscriptionsQuery
-   * @returns parsed response from NotificationSubscriptionsQuery
-   */
-  public async fetch(
-    variables?: L.NotificationSubscriptionsQueryVariables
-  ): LinearFetch<NotificationSubscriptionConnection> {
-    const response = await this._request<L.NotificationSubscriptionsQuery, L.NotificationSubscriptionsQueryVariables>(
-      L.NotificationSubscriptionsDocument,
-      variables
-    );
-    const data = response.notificationSubscriptions;
-
-    return new NotificationSubscriptionConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable Notifications Query
- *
- * @param request - function to call the graphql client
- */
-export class NotificationsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Notifications query and return a NotificationConnection
-   *
-   * @param variables - variables to pass into the NotificationsQuery
-   * @returns parsed response from NotificationsQuery
-   */
-  public async fetch(variables?: L.NotificationsQueryVariables): LinearFetch<NotificationConnection> {
-    const response = await this._request<L.NotificationsQuery, L.NotificationsQueryVariables>(
-      L.NotificationsDocument,
-      variables
-    );
-    const data = response.notifications;
-
-    return new NotificationConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable Organization Query
- *
- * @param request - function to call the graphql client
- */
-export class OrganizationQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Organization query and return a Organization
-   *
-   * @returns parsed response from OrganizationQuery
-   */
-  public async fetch(): LinearFetch<Organization> {
-    const response = await this._request<L.OrganizationQuery, L.OrganizationQueryVariables>(L.OrganizationDocument, {});
-    const data = response.organization;
-
-    return new Organization(this._request, data);
-  }
-}
-
-/**
- * A fetchable OrganizationExists Query
- *
- * @param request - function to call the graphql client
- */
-export class OrganizationExistsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the OrganizationExists query and return a OrganizationExistsPayload
-   *
-   * @param urlKey - required urlKey to pass to organizationExists
-   * @returns parsed response from OrganizationExistsQuery
-   */
-  public async fetch(urlKey: string): LinearFetch<OrganizationExistsPayload> {
-    const response = await this._request<L.OrganizationExistsQuery, L.OrganizationExistsQueryVariables>(
-      L.OrganizationExistsDocument,
-      {
-        urlKey,
-      }
-    );
-    const data = response.organizationExists;
-
-    return new OrganizationExistsPayload(this._request, data);
-  }
-}
-
-/**
- * A fetchable OrganizationInvite Query
- *
- * @param request - function to call the graphql client
- */
-export class OrganizationInviteQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the OrganizationInvite query and return a OrganizationInvite
-   *
-   * @param id - required id to pass to organizationInvite
-   * @returns parsed response from OrganizationInviteQuery
-   */
-  public async fetch(id: string): LinearFetch<OrganizationInvite> {
-    const response = await this._request<L.OrganizationInviteQuery, L.OrganizationInviteQueryVariables>(
-      L.OrganizationInviteDocument,
-      {
-        id,
-      }
-    );
-    const data = response.organizationInvite;
-
-    return new OrganizationInvite(this._request, data);
-  }
-}
-
-/**
- * A fetchable OrganizationInviteDetails Query
- *
- * @param request - function to call the graphql client
- */
-export class OrganizationInviteDetailsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the OrganizationInviteDetails query and return a OrganizationInviteDetailsPayload
-   *
-   * @param id - required id to pass to organizationInviteDetails
-   * @returns parsed response from OrganizationInviteDetailsQuery
-   */
-  public async fetch(id: string): LinearFetch<OrganizationInviteDetailsPayload> {
-    const response = await this._request<L.OrganizationInviteDetailsQuery, L.OrganizationInviteDetailsQueryVariables>(
-      L.OrganizationInviteDetailsDocument,
-      {
-        id,
-      }
-    );
-    const data = response.organizationInviteDetails;
-
-    return new OrganizationInviteDetailsPayload(this._request, data);
-  }
-}
-
-/**
- * A fetchable OrganizationInvites Query
- *
- * @param request - function to call the graphql client
- */
-export class OrganizationInvitesQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the OrganizationInvites query and return a OrganizationInviteConnection
-   *
-   * @param variables - variables to pass into the OrganizationInvitesQuery
-   * @returns parsed response from OrganizationInvitesQuery
-   */
-  public async fetch(variables?: L.OrganizationInvitesQueryVariables): LinearFetch<OrganizationInviteConnection> {
-    const response = await this._request<L.OrganizationInvitesQuery, L.OrganizationInvitesQueryVariables>(
-      L.OrganizationInvitesDocument,
-      variables
-    );
-    const data = response.organizationInvites;
-
-    return new OrganizationInviteConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable Project Query
- *
- * @param request - function to call the graphql client
- */
-export class ProjectQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Project query and return a Project
-   *
-   * @param id - required id to pass to project
-   * @returns parsed response from ProjectQuery
-   */
-  public async fetch(id: string): LinearFetch<Project> {
-    const response = await this._request<L.ProjectQuery, L.ProjectQueryVariables>(L.ProjectDocument, {
-      id,
-    });
-    const data = response.project;
-
-    return new Project(this._request, data);
-  }
-}
-
-/**
- * A fetchable ProjectLink Query
- *
- * @param request - function to call the graphql client
- */
-export class ProjectLinkQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the ProjectLink query and return a ProjectLink
-   *
-   * @param id - required id to pass to projectLink
-   * @returns parsed response from ProjectLinkQuery
-   */
-  public async fetch(id: string): LinearFetch<ProjectLink> {
-    const response = await this._request<L.ProjectLinkQuery, L.ProjectLinkQueryVariables>(L.ProjectLinkDocument, {
-      id,
-    });
-    const data = response.projectLink;
-
-    return new ProjectLink(this._request, data);
-  }
-}
-
-/**
- * A fetchable ProjectLinks Query
- *
- * @param request - function to call the graphql client
- */
-export class ProjectLinksQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the ProjectLinks query and return a ProjectLinkConnection
-   *
-   * @param variables - variables to pass into the ProjectLinksQuery
-   * @returns parsed response from ProjectLinksQuery
-   */
-  public async fetch(variables?: L.ProjectLinksQueryVariables): LinearFetch<ProjectLinkConnection> {
-    const response = await this._request<L.ProjectLinksQuery, L.ProjectLinksQueryVariables>(
-      L.ProjectLinksDocument,
-      variables
-    );
-    const data = response.projectLinks;
-
-    return new ProjectLinkConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable ProjectUpdate Query
- *
- * @param request - function to call the graphql client
- */
-export class ProjectUpdateQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the ProjectUpdate query and return a ProjectUpdate
-   *
-   * @param id - required id to pass to projectUpdate
-   * @returns parsed response from ProjectUpdateQuery
-   */
-  public async fetch(id: string): LinearFetch<ProjectUpdate> {
-    const response = await this._request<L.ProjectUpdateQuery, L.ProjectUpdateQueryVariables>(L.ProjectUpdateDocument, {
-      id,
-    });
-    const data = response.projectUpdate;
-
-    return new ProjectUpdate(this._request, data);
-  }
-}
-
-/**
- * A fetchable ProjectUpdateInteraction Query
- *
- * @param request - function to call the graphql client
- */
-export class ProjectUpdateInteractionQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the ProjectUpdateInteraction query and return a ProjectUpdateInteraction
-   *
-   * @param id - required id to pass to projectUpdateInteraction
-   * @returns parsed response from ProjectUpdateInteractionQuery
-   */
-  public async fetch(id: string): LinearFetch<ProjectUpdateInteraction> {
-    const response = await this._request<L.ProjectUpdateInteractionQuery, L.ProjectUpdateInteractionQueryVariables>(
-      L.ProjectUpdateInteractionDocument,
-      {
-        id,
-      }
-    );
-    const data = response.projectUpdateInteraction;
-
-    return new ProjectUpdateInteraction(this._request, data);
-  }
-}
-
-/**
- * A fetchable ProjectUpdateInteractions Query
- *
- * @param request - function to call the graphql client
- */
-export class ProjectUpdateInteractionsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the ProjectUpdateInteractions query and return a ProjectUpdateInteractionConnection
-   *
-   * @param variables - variables to pass into the ProjectUpdateInteractionsQuery
-   * @returns parsed response from ProjectUpdateInteractionsQuery
-   */
-  public async fetch(
-    variables?: L.ProjectUpdateInteractionsQueryVariables
-  ): LinearFetch<ProjectUpdateInteractionConnection> {
-    const response = await this._request<L.ProjectUpdateInteractionsQuery, L.ProjectUpdateInteractionsQueryVariables>(
-      L.ProjectUpdateInteractionsDocument,
-      variables
-    );
-    const data = response.projectUpdateInteractions;
-
-    return new ProjectUpdateInteractionConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable ProjectUpdates Query
- *
- * @param request - function to call the graphql client
- */
-export class ProjectUpdatesQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the ProjectUpdates query and return a ProjectUpdateConnection
-   *
-   * @param variables - variables to pass into the ProjectUpdatesQuery
-   * @returns parsed response from ProjectUpdatesQuery
-   */
-  public async fetch(variables?: L.ProjectUpdatesQueryVariables): LinearFetch<ProjectUpdateConnection> {
-    const response = await this._request<L.ProjectUpdatesQuery, L.ProjectUpdatesQueryVariables>(
-      L.ProjectUpdatesDocument,
-      variables
-    );
-    const data = response.projectUpdates;
-
-    return new ProjectUpdateConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable Projects Query
- *
- * @param request - function to call the graphql client
- */
-export class ProjectsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Projects query and return a ProjectConnection
-   *
-   * @param variables - variables to pass into the ProjectsQuery
-   * @returns parsed response from ProjectsQuery
-   */
-  public async fetch(variables?: L.ProjectsQueryVariables): LinearFetch<ProjectConnection> {
-    const response = await this._request<L.ProjectsQuery, L.ProjectsQueryVariables>(L.ProjectsDocument, variables);
-    const data = response.projects;
-
-    return new ProjectConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable PushSubscriptionTest Query
- *
- * @param request - function to call the graphql client
- */
-export class PushSubscriptionTestQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the PushSubscriptionTest query and return a PushSubscriptionTestPayload
-   *
-   * @returns parsed response from PushSubscriptionTestQuery
-   */
-  public async fetch(): LinearFetch<PushSubscriptionTestPayload> {
-    const response = await this._request<L.PushSubscriptionTestQuery, L.PushSubscriptionTestQueryVariables>(
-      L.PushSubscriptionTestDocument,
-      {}
-    );
-    const data = response.pushSubscriptionTest;
-
-    return new PushSubscriptionTestPayload(this._request, data);
-  }
-}
-
-/**
- * A fetchable RateLimitStatus Query
- *
- * @param request - function to call the graphql client
- */
-export class RateLimitStatusQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the RateLimitStatus query and return a RateLimitPayload
-   *
-   * @returns parsed response from RateLimitStatusQuery
-   */
-  public async fetch(): LinearFetch<RateLimitPayload> {
-    const response = await this._request<L.RateLimitStatusQuery, L.RateLimitStatusQueryVariables>(
-      L.RateLimitStatusDocument,
-      {}
-    );
-    const data = response.rateLimitStatus;
-
-    return new RateLimitPayload(this._request, data);
-  }
-}
-
-/**
- * A fetchable Roadmap Query
- *
- * @param request - function to call the graphql client
- */
-export class RoadmapQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Roadmap query and return a Roadmap
-   *
-   * @param id - required id to pass to roadmap
-   * @returns parsed response from RoadmapQuery
-   */
-  public async fetch(id: string): LinearFetch<Roadmap> {
-    const response = await this._request<L.RoadmapQuery, L.RoadmapQueryVariables>(L.RoadmapDocument, {
-      id,
-    });
-    const data = response.roadmap;
-
-    return new Roadmap(this._request, data);
-  }
-}
-
-/**
- * A fetchable RoadmapToProject Query
- *
- * @param request - function to call the graphql client
- */
-export class RoadmapToProjectQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the RoadmapToProject query and return a RoadmapToProject
-   *
-   * @param id - required id to pass to roadmapToProject
-   * @returns parsed response from RoadmapToProjectQuery
-   */
-  public async fetch(id: string): LinearFetch<RoadmapToProject> {
-    const response = await this._request<L.RoadmapToProjectQuery, L.RoadmapToProjectQueryVariables>(
-      L.RoadmapToProjectDocument,
-      {
-        id,
-      }
-    );
-    const data = response.roadmapToProject;
-
-    return new RoadmapToProject(this._request, data);
-  }
-}
-
-/**
- * A fetchable RoadmapToProjects Query
- *
- * @param request - function to call the graphql client
- */
-export class RoadmapToProjectsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the RoadmapToProjects query and return a RoadmapToProjectConnection
-   *
-   * @param variables - variables to pass into the RoadmapToProjectsQuery
-   * @returns parsed response from RoadmapToProjectsQuery
-   */
-  public async fetch(variables?: L.RoadmapToProjectsQueryVariables): LinearFetch<RoadmapToProjectConnection> {
-    const response = await this._request<L.RoadmapToProjectsQuery, L.RoadmapToProjectsQueryVariables>(
-      L.RoadmapToProjectsDocument,
-      variables
-    );
-    const data = response.roadmapToProjects;
-
-    return new RoadmapToProjectConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable Roadmaps Query
- *
- * @param request - function to call the graphql client
- */
-export class RoadmapsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Roadmaps query and return a RoadmapConnection
-   *
-   * @param variables - variables to pass into the RoadmapsQuery
-   * @returns parsed response from RoadmapsQuery
-   */
-  public async fetch(variables?: L.RoadmapsQueryVariables): LinearFetch<RoadmapConnection> {
-    const response = await this._request<L.RoadmapsQuery, L.RoadmapsQueryVariables>(L.RoadmapsDocument, variables);
-    const data = response.roadmaps;
-
-    return new RoadmapConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable SsoUrlFromEmail Query
- *
- * @param request - function to call the graphql client
- */
-export class SsoUrlFromEmailQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the SsoUrlFromEmail query and return a SsoUrlFromEmailResponse
-   *
-   * @param email - required email to pass to ssoUrlFromEmail
-   * @param variables - variables without 'email' to pass into the SsoUrlFromEmailQuery
-   * @returns parsed response from SsoUrlFromEmailQuery
-   */
-  public async fetch(
-    email: string,
-    variables?: Omit<L.SsoUrlFromEmailQueryVariables, "email">
-  ): LinearFetch<SsoUrlFromEmailResponse> {
-    const response = await this._request<L.SsoUrlFromEmailQuery, L.SsoUrlFromEmailQueryVariables>(
-      L.SsoUrlFromEmailDocument,
-      {
-        email,
-        ...variables,
-      }
-    );
-    const data = response.ssoUrlFromEmail;
-
-    return new SsoUrlFromEmailResponse(this._request, data);
-  }
-}
-
-/**
- * A fetchable Team Query
- *
- * @param request - function to call the graphql client
- */
-export class TeamQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Team query and return a Team
-   *
-   * @param id - required id to pass to team
-   * @returns parsed response from TeamQuery
-   */
-  public async fetch(id: string): LinearFetch<Team> {
-    const response = await this._request<L.TeamQuery, L.TeamQueryVariables>(L.TeamDocument, {
-      id,
-    });
-    const data = response.team;
-
-    return new Team(this._request, data);
-  }
-}
-
-/**
- * A fetchable TeamMembership Query
- *
- * @param request - function to call the graphql client
- */
-export class TeamMembershipQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the TeamMembership query and return a TeamMembership
-   *
-   * @param id - required id to pass to teamMembership
-   * @returns parsed response from TeamMembershipQuery
-   */
-  public async fetch(id: string): LinearFetch<TeamMembership> {
-    const response = await this._request<L.TeamMembershipQuery, L.TeamMembershipQueryVariables>(
-      L.TeamMembershipDocument,
-      {
-        id,
-      }
-    );
-    const data = response.teamMembership;
-
-    return new TeamMembership(this._request, data);
-  }
-}
-
-/**
- * A fetchable TeamMemberships Query
- *
- * @param request - function to call the graphql client
- */
-export class TeamMembershipsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the TeamMemberships query and return a TeamMembershipConnection
-   *
-   * @param variables - variables to pass into the TeamMembershipsQuery
-   * @returns parsed response from TeamMembershipsQuery
-   */
-  public async fetch(variables?: L.TeamMembershipsQueryVariables): LinearFetch<TeamMembershipConnection> {
-    const response = await this._request<L.TeamMembershipsQuery, L.TeamMembershipsQueryVariables>(
-      L.TeamMembershipsDocument,
-      variables
-    );
-    const data = response.teamMemberships;
-
-    return new TeamMembershipConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable Teams Query
- *
- * @param request - function to call the graphql client
- */
-export class TeamsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Teams query and return a TeamConnection
-   *
-   * @param variables - variables to pass into the TeamsQuery
-   * @returns parsed response from TeamsQuery
-   */
-  public async fetch(variables?: L.TeamsQueryVariables): LinearFetch<TeamConnection> {
-    const response = await this._request<L.TeamsQuery, L.TeamsQueryVariables>(L.TeamsDocument, variables);
-    const data = response.teams;
-
-    return new TeamConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable Template Query
- *
- * @param request - function to call the graphql client
- */
-export class TemplateQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Template query and return a Template
-   *
-   * @param id - required id to pass to template
-   * @returns parsed response from TemplateQuery
-   */
-  public async fetch(id: string): LinearFetch<Template> {
-    const response = await this._request<L.TemplateQuery, L.TemplateQueryVariables>(L.TemplateDocument, {
-      id,
-    });
-    const data = response.template;
-
-    return new Template(this._request, data);
-  }
-}
-
-/**
- * A fetchable Templates Query
- *
- * @param request - function to call the graphql client
- */
-export class TemplatesQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Templates query and return a Template list
-   *
-   * @returns parsed response from TemplatesQuery
-   */
-  public async fetch(): LinearFetch<Template[]> {
-    const response = await this._request<L.TemplatesQuery, L.TemplatesQueryVariables>(L.TemplatesDocument, {});
-    const data = response.templates;
-
-    return data.map(node => {
-      return new Template(this._request, node);
-    });
-  }
-}
-
-/**
- * A fetchable User Query
- *
- * @param request - function to call the graphql client
- */
-export class UserQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the User query and return a User
-   *
-   * @param id - required id to pass to user
-   * @returns parsed response from UserQuery
-   */
-  public async fetch(id: string): LinearFetch<User> {
-    const response = await this._request<L.UserQuery, L.UserQueryVariables>(L.UserDocument, {
-      id,
-    });
-    const data = response.user;
-
-    return new User(this._request, data);
-  }
-}
-
-/**
- * A fetchable UserSettings Query
- *
- * @param request - function to call the graphql client
- */
-export class UserSettingsQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the UserSettings query and return a UserSettings
-   *
-   * @returns parsed response from UserSettingsQuery
-   */
-  public async fetch(): LinearFetch<UserSettings> {
-    const response = await this._request<L.UserSettingsQuery, L.UserSettingsQueryVariables>(L.UserSettingsDocument, {});
-    const data = response.userSettings;
-
-    return new UserSettings(this._request, data);
-  }
-}
-
-/**
- * A fetchable Users Query
- *
- * @param request - function to call the graphql client
- */
-export class UsersQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Users query and return a UserConnection
-   *
-   * @param variables - variables to pass into the UsersQuery
-   * @returns parsed response from UsersQuery
-   */
-  public async fetch(variables?: L.UsersQueryVariables): LinearFetch<UserConnection> {
-    const response = await this._request<L.UsersQuery, L.UsersQueryVariables>(L.UsersDocument, variables);
-    const data = response.users;
-
-    return new UserConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable Viewer Query
- *
- * @param request - function to call the graphql client
- */
-export class ViewerQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Viewer query and return a User
-   *
-   * @returns parsed response from ViewerQuery
-   */
-  public async fetch(): LinearFetch<User> {
-    const response = await this._request<L.ViewerQuery, L.ViewerQueryVariables>(L.ViewerDocument, {});
-    const data = response.viewer;
-
-    return new User(this._request, data);
-  }
-}
-
-/**
- * A fetchable Webhook Query
- *
- * @param request - function to call the graphql client
- */
-export class WebhookQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Webhook query and return a Webhook
-   *
-   * @param id - required id to pass to webhook
-   * @returns parsed response from WebhookQuery
-   */
-  public async fetch(id: string): LinearFetch<Webhook> {
-    const response = await this._request<L.WebhookQuery, L.WebhookQueryVariables>(L.WebhookDocument, {
-      id,
-    });
-    const data = response.webhook;
-
-    return new Webhook(this._request, data);
-  }
-}
-
-/**
- * A fetchable Webhooks Query
- *
- * @param request - function to call the graphql client
- */
-export class WebhooksQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the Webhooks query and return a WebhookConnection
-   *
-   * @param variables - variables to pass into the WebhooksQuery
-   * @returns parsed response from WebhooksQuery
-   */
-  public async fetch(variables?: L.WebhooksQueryVariables): LinearFetch<WebhookConnection> {
-    const response = await this._request<L.WebhooksQuery, L.WebhooksQueryVariables>(L.WebhooksDocument, variables);
-    const data = response.webhooks;
-
-    return new WebhookConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
- * A fetchable WorkflowState Query
- *
- * @param request - function to call the graphql client
- */
-export class WorkflowStateQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the WorkflowState query and return a WorkflowState
-   *
-   * @param id - required id to pass to workflowState
-   * @returns parsed response from WorkflowStateQuery
-   */
-  public async fetch(id: string): LinearFetch<WorkflowState> {
-    const response = await this._request<L.WorkflowStateQuery, L.WorkflowStateQueryVariables>(L.WorkflowStateDocument, {
-      id,
-    });
-    const data = response.workflowState;
-
-    return new WorkflowState(this._request, data);
-  }
-}
-
-/**
- * A fetchable WorkflowStates Query
- *
- * @param request - function to call the graphql client
- */
-export class WorkflowStatesQuery extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the WorkflowStates query and return a WorkflowStateConnection
-   *
-   * @param variables - variables to pass into the WorkflowStatesQuery
-   * @returns parsed response from WorkflowStatesQuery
-   */
-  public async fetch(variables?: L.WorkflowStatesQueryVariables): LinearFetch<WorkflowStateConnection> {
-    const response = await this._request<L.WorkflowStatesQuery, L.WorkflowStatesQueryVariables>(
-      L.WorkflowStatesDocument,
-      variables
-    );
-    const data = response.workflowStates;
-
-    return new WorkflowStateConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
 /**
  * A fetchable AirbyteIntegrationConnect Mutation
  *
@@ -12398,124 +9979,6 @@ export class LogoutMutation extends Request {
 }
 
 /**
- * A fetchable MigrateMilestonesToRoadmaps Mutation
- *
- * @param request - function to call the graphql client
- */
-export class MigrateMilestonesToRoadmapsMutation extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the MigrateMilestonesToRoadmaps mutation and return a MilestoneMigrationPayload
-   *
-   * @param input - required input to pass to migrateMilestonesToRoadmaps
-   * @returns parsed response from MigrateMilestonesToRoadmapsMutation
-   */
-  public async fetch(input: L.MilestonesMigrateInput): LinearFetch<MilestoneMigrationPayload> {
-    const response = await this._request<
-      L.MigrateMilestonesToRoadmapsMutation,
-      L.MigrateMilestonesToRoadmapsMutationVariables
-    >(L.MigrateMilestonesToRoadmapsDocument, {
-      input,
-    });
-    const data = response.migrateMilestonesToRoadmaps;
-
-    return new MilestoneMigrationPayload(this._request, data);
-  }
-}
-
-/**
- * A fetchable CreateMilestone Mutation
- *
- * @param request - function to call the graphql client
- */
-export class CreateMilestoneMutation extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the CreateMilestone mutation and return a MilestonePayload
-   *
-   * @param input - required input to pass to createMilestone
-   * @returns parsed response from CreateMilestoneMutation
-   */
-  public async fetch(input: L.MilestoneCreateInput): LinearFetch<MilestonePayload> {
-    const response = await this._request<L.CreateMilestoneMutation, L.CreateMilestoneMutationVariables>(
-      L.CreateMilestoneDocument,
-      {
-        input,
-      }
-    );
-    const data = response.milestoneCreate;
-
-    return new MilestonePayload(this._request, data);
-  }
-}
-
-/**
- * A fetchable DeleteMilestone Mutation
- *
- * @param request - function to call the graphql client
- */
-export class DeleteMilestoneMutation extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the DeleteMilestone mutation and return a ArchivePayload
-   *
-   * @param id - required id to pass to deleteMilestone
-   * @returns parsed response from DeleteMilestoneMutation
-   */
-  public async fetch(id: string): LinearFetch<ArchivePayload> {
-    const response = await this._request<L.DeleteMilestoneMutation, L.DeleteMilestoneMutationVariables>(
-      L.DeleteMilestoneDocument,
-      {
-        id,
-      }
-    );
-    const data = response.milestoneDelete;
-
-    return new ArchivePayload(this._request, data);
-  }
-}
-
-/**
- * A fetchable UpdateMilestone Mutation
- *
- * @param request - function to call the graphql client
- */
-export class UpdateMilestoneMutation extends Request {
-  public constructor(request: LinearRequest) {
-    super(request);
-  }
-
-  /**
-   * Call the UpdateMilestone mutation and return a MilestonePayload
-   *
-   * @param id - required id to pass to updateMilestone
-   * @param input - required input to pass to updateMilestone
-   * @returns parsed response from UpdateMilestoneMutation
-   */
-  public async fetch(id: string, input: L.MilestoneUpdateInput): LinearFetch<MilestonePayload> {
-    const response = await this._request<L.UpdateMilestoneMutation, L.UpdateMilestoneMutationVariables>(
-      L.UpdateMilestoneDocument,
-      {
-        id,
-        input,
-      }
-    );
-    const data = response.milestoneUpdate;
-
-    return new MilestonePayload(this._request, data);
-  }
-}
-
-/**
  * A fetchable ArchiveNotification Mutation
  *
  * @param request - function to call the graphql client
@@ -13097,6 +10560,95 @@ export class UpdateProjectLinkMutation extends Request {
     const data = response.projectLinkUpdate;
 
     return new ProjectLinkPayload(this._request, data);
+  }
+}
+
+/**
+ * A fetchable CreateProjectMilestone Mutation
+ *
+ * @param request - function to call the graphql client
+ */
+export class CreateProjectMilestoneMutation extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the CreateProjectMilestone mutation and return a ProjectMilestonePayload
+   *
+   * @param input - required input to pass to createProjectMilestone
+   * @returns parsed response from CreateProjectMilestoneMutation
+   */
+  public async fetch(input: L.ProjectMilestoneCreateInput): LinearFetch<ProjectMilestonePayload> {
+    const response = await this._request<L.CreateProjectMilestoneMutation, L.CreateProjectMilestoneMutationVariables>(
+      L.CreateProjectMilestoneDocument,
+      {
+        input,
+      }
+    );
+    const data = response.projectMilestoneCreate;
+
+    return new ProjectMilestonePayload(this._request, data);
+  }
+}
+
+/**
+ * A fetchable DeleteProjectMilestone Mutation
+ *
+ * @param request - function to call the graphql client
+ */
+export class DeleteProjectMilestoneMutation extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the DeleteProjectMilestone mutation and return a ArchivePayload
+   *
+   * @param id - required id to pass to deleteProjectMilestone
+   * @returns parsed response from DeleteProjectMilestoneMutation
+   */
+  public async fetch(id: string): LinearFetch<ArchivePayload> {
+    const response = await this._request<L.DeleteProjectMilestoneMutation, L.DeleteProjectMilestoneMutationVariables>(
+      L.DeleteProjectMilestoneDocument,
+      {
+        id,
+      }
+    );
+    const data = response.projectMilestoneDelete;
+
+    return new ArchivePayload(this._request, data);
+  }
+}
+
+/**
+ * A fetchable UpdateProjectMilestone Mutation
+ *
+ * @param request - function to call the graphql client
+ */
+export class UpdateProjectMilestoneMutation extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the UpdateProjectMilestone mutation and return a ProjectMilestonePayload
+   *
+   * @param id - required id to pass to updateProjectMilestone
+   * @param input - required input to pass to updateProjectMilestone
+   * @returns parsed response from UpdateProjectMilestoneMutation
+   */
+  public async fetch(id: string, input: L.ProjectMilestoneUpdateInput): LinearFetch<ProjectMilestonePayload> {
+    const response = await this._request<L.UpdateProjectMilestoneMutation, L.UpdateProjectMilestoneMutationVariables>(
+      L.UpdateProjectMilestoneDocument,
+      {
+        id,
+        input,
+      }
+    );
+    const data = response.projectMilestoneUpdate;
+
+    return new ProjectMilestonePayload(this._request, data);
   }
 }
 
@@ -14710,6 +12262,2436 @@ export class UpdateWorkflowStateMutation extends Request {
     const data = response.workflowStateUpdate;
 
     return new WorkflowStatePayload(this._request, data);
+  }
+}
+
+/**
+ * A fetchable ProjectMilestone Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class ProjectMilestoneQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the ProjectMilestone query and return a ProjectMilestone
+   *
+   * @param id - required id to pass to ProjectMilestone
+   * @returns parsed response from ProjectMilestoneQuery
+   */
+  public async fetch(id: string): LinearFetch<ProjectMilestone> {
+    const response = await this._request<L.ProjectMilestoneQuery, L.ProjectMilestoneQueryVariables>(
+      L.ProjectMilestoneDocument,
+      {
+        id,
+      }
+    );
+    const data = response.ProjectMilestone;
+
+    return new ProjectMilestone(this._request, data);
+  }
+}
+
+/**
+ * A fetchable ProjectMilestones Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class ProjectMilestonesQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the ProjectMilestones query and return a ProjectMilestoneConnection
+   *
+   * @param variables - variables to pass into the ProjectMilestonesQuery
+   * @returns parsed response from ProjectMilestonesQuery
+   */
+  public async fetch(variables?: L.ProjectMilestonesQueryVariables): LinearFetch<ProjectMilestoneConnection> {
+    const response = await this._request<L.ProjectMilestonesQuery, L.ProjectMilestonesQueryVariables>(
+      L.ProjectMilestonesDocument,
+      variables
+    );
+    const data = response.ProjectMilestones;
+
+    return new ProjectMilestoneConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable AdministrableTeams Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class AdministrableTeamsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the AdministrableTeams query and return a TeamConnection
+   *
+   * @param variables - variables to pass into the AdministrableTeamsQuery
+   * @returns parsed response from AdministrableTeamsQuery
+   */
+  public async fetch(variables?: L.AdministrableTeamsQueryVariables): LinearFetch<TeamConnection> {
+    const response = await this._request<L.AdministrableTeamsQuery, L.AdministrableTeamsQueryVariables>(
+      L.AdministrableTeamsDocument,
+      variables
+    );
+    const data = response.administrableTeams;
+
+    return new TeamConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable ApiKeys Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class ApiKeysQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the ApiKeys query and return a ApiKeyConnection
+   *
+   * @param variables - variables to pass into the ApiKeysQuery
+   * @returns parsed response from ApiKeysQuery
+   */
+  public async fetch(variables?: L.ApiKeysQueryVariables): LinearFetch<ApiKeyConnection> {
+    const response = await this._request<L.ApiKeysQuery, L.ApiKeysQueryVariables>(L.ApiKeysDocument, variables);
+    const data = response.apiKeys;
+
+    return new ApiKeyConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable ApplicationInfo Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class ApplicationInfoQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the ApplicationInfo query and return a Application
+   *
+   * @param clientId - required clientId to pass to applicationInfo
+   * @returns parsed response from ApplicationInfoQuery
+   */
+  public async fetch(clientId: string): LinearFetch<Application> {
+    const response = await this._request<L.ApplicationInfoQuery, L.ApplicationInfoQueryVariables>(
+      L.ApplicationInfoDocument,
+      {
+        clientId,
+      }
+    );
+    const data = response.applicationInfo;
+
+    return new Application(this._request, data);
+  }
+}
+
+/**
+ * A fetchable ApplicationWithAuthorization Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class ApplicationWithAuthorizationQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the ApplicationWithAuthorization query and return a UserAuthorizedApplication
+   *
+   * @param clientId - required clientId to pass to applicationWithAuthorization
+   * @param scope - required scope to pass to applicationWithAuthorization
+   * @param variables - variables without 'clientId', 'scope' to pass into the ApplicationWithAuthorizationQuery
+   * @returns parsed response from ApplicationWithAuthorizationQuery
+   */
+  public async fetch(
+    clientId: string,
+    scope: string[],
+    variables?: Omit<L.ApplicationWithAuthorizationQueryVariables, "clientId" | "scope">
+  ): LinearFetch<UserAuthorizedApplication> {
+    const response = await this._request<
+      L.ApplicationWithAuthorizationQuery,
+      L.ApplicationWithAuthorizationQueryVariables
+    >(L.ApplicationWithAuthorizationDocument, {
+      clientId,
+      scope,
+      ...variables,
+    });
+    const data = response.applicationWithAuthorization;
+
+    return new UserAuthorizedApplication(this._request, data);
+  }
+}
+
+/**
+ * A fetchable Attachment Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class AttachmentQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Attachment query and return a Attachment
+   *
+   * @param id - required id to pass to attachment
+   * @returns parsed response from AttachmentQuery
+   */
+  public async fetch(id: string): LinearFetch<Attachment> {
+    const response = await this._request<L.AttachmentQuery, L.AttachmentQueryVariables>(L.AttachmentDocument, {
+      id,
+    });
+    const data = response.attachment;
+
+    return new Attachment(this._request, data);
+  }
+}
+
+/**
+ * A fetchable AttachmentIssue Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class AttachmentIssueQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the AttachmentIssue query and return a Issue
+   *
+   * @param id - required id to pass to attachmentIssue
+   * @returns parsed response from AttachmentIssueQuery
+   */
+  public async fetch(id: string): LinearFetch<Issue> {
+    const response = await this._request<L.AttachmentIssueQuery, L.AttachmentIssueQueryVariables>(
+      L.AttachmentIssueDocument,
+      {
+        id,
+      }
+    );
+    const data = response.attachmentIssue;
+
+    return new Issue(this._request, data);
+  }
+}
+
+/**
+ * A fetchable Attachments Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class AttachmentsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Attachments query and return a AttachmentConnection
+   *
+   * @param variables - variables to pass into the AttachmentsQuery
+   * @returns parsed response from AttachmentsQuery
+   */
+  public async fetch(variables?: L.AttachmentsQueryVariables): LinearFetch<AttachmentConnection> {
+    const response = await this._request<L.AttachmentsQuery, L.AttachmentsQueryVariables>(
+      L.AttachmentsDocument,
+      variables
+    );
+    const data = response.attachments;
+
+    return new AttachmentConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable AttachmentsForUrl Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class AttachmentsForUrlQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the AttachmentsForUrl query and return a AttachmentConnection
+   *
+   * @param url - required url to pass to attachmentsForURL
+   * @param variables - variables without 'url' to pass into the AttachmentsForUrlQuery
+   * @returns parsed response from AttachmentsForUrlQuery
+   */
+  public async fetch(
+    url: string,
+    variables?: Omit<L.AttachmentsForUrlQueryVariables, "url">
+  ): LinearFetch<AttachmentConnection> {
+    const response = await this._request<L.AttachmentsForUrlQuery, L.AttachmentsForUrlQueryVariables>(
+      L.AttachmentsForUrlDocument,
+      {
+        url,
+        ...variables,
+      }
+    );
+    const data = response.attachmentsForURL;
+
+    return new AttachmentConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          url,
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable AuditEntries Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class AuditEntriesQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the AuditEntries query and return a AuditEntryConnection
+   *
+   * @param variables - variables to pass into the AuditEntriesQuery
+   * @returns parsed response from AuditEntriesQuery
+   */
+  public async fetch(variables?: L.AuditEntriesQueryVariables): LinearFetch<AuditEntryConnection> {
+    const response = await this._request<L.AuditEntriesQuery, L.AuditEntriesQueryVariables>(
+      L.AuditEntriesDocument,
+      variables
+    );
+    const data = response.auditEntries;
+
+    return new AuditEntryConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable AuditEntryTypes Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class AuditEntryTypesQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the AuditEntryTypes query and return a AuditEntryType list
+   *
+   * @returns parsed response from AuditEntryTypesQuery
+   */
+  public async fetch(): LinearFetch<AuditEntryType[]> {
+    const response = await this._request<L.AuditEntryTypesQuery, L.AuditEntryTypesQueryVariables>(
+      L.AuditEntryTypesDocument,
+      {}
+    );
+    const data = response.auditEntryTypes;
+
+    return data.map(node => {
+      return new AuditEntryType(this._request, node);
+    });
+  }
+}
+
+/**
+ * A fetchable AvailableUsers Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class AvailableUsersQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the AvailableUsers query and return a AuthResolverResponse
+   *
+   * @returns parsed response from AvailableUsersQuery
+   */
+  public async fetch(): LinearFetch<AuthResolverResponse> {
+    const response = await this._request<L.AvailableUsersQuery, L.AvailableUsersQueryVariables>(
+      L.AvailableUsersDocument,
+      {}
+    );
+    const data = response.availableUsers;
+
+    return new AuthResolverResponse(this._request, data);
+  }
+}
+
+/**
+ * A fetchable Comment Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class CommentQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Comment query and return a Comment
+   *
+   * @param id - required id to pass to comment
+   * @returns parsed response from CommentQuery
+   */
+  public async fetch(id: string): LinearFetch<Comment> {
+    const response = await this._request<L.CommentQuery, L.CommentQueryVariables>(L.CommentDocument, {
+      id,
+    });
+    const data = response.comment;
+
+    return new Comment(this._request, data);
+  }
+}
+
+/**
+ * A fetchable Comments Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class CommentsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Comments query and return a CommentConnection
+   *
+   * @param variables - variables to pass into the CommentsQuery
+   * @returns parsed response from CommentsQuery
+   */
+  public async fetch(variables?: L.CommentsQueryVariables): LinearFetch<CommentConnection> {
+    const response = await this._request<L.CommentsQuery, L.CommentsQueryVariables>(L.CommentsDocument, variables);
+    const data = response.comments;
+
+    return new CommentConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable CustomView Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class CustomViewQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the CustomView query and return a CustomView
+   *
+   * @param id - required id to pass to customView
+   * @returns parsed response from CustomViewQuery
+   */
+  public async fetch(id: string): LinearFetch<CustomView> {
+    const response = await this._request<L.CustomViewQuery, L.CustomViewQueryVariables>(L.CustomViewDocument, {
+      id,
+    });
+    const data = response.customView;
+
+    return new CustomView(this._request, data);
+  }
+}
+
+/**
+ * A fetchable CustomViews Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class CustomViewsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the CustomViews query and return a CustomViewConnection
+   *
+   * @param variables - variables to pass into the CustomViewsQuery
+   * @returns parsed response from CustomViewsQuery
+   */
+  public async fetch(variables?: L.CustomViewsQueryVariables): LinearFetch<CustomViewConnection> {
+    const response = await this._request<L.CustomViewsQuery, L.CustomViewsQueryVariables>(
+      L.CustomViewsDocument,
+      variables
+    );
+    const data = response.customViews;
+
+    return new CustomViewConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable Cycle Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class CycleQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Cycle query and return a Cycle
+   *
+   * @param id - required id to pass to cycle
+   * @returns parsed response from CycleQuery
+   */
+  public async fetch(id: string): LinearFetch<Cycle> {
+    const response = await this._request<L.CycleQuery, L.CycleQueryVariables>(L.CycleDocument, {
+      id,
+    });
+    const data = response.cycle;
+
+    return new Cycle(this._request, data);
+  }
+}
+
+/**
+ * A fetchable Cycles Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class CyclesQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Cycles query and return a CycleConnection
+   *
+   * @param variables - variables to pass into the CyclesQuery
+   * @returns parsed response from CyclesQuery
+   */
+  public async fetch(variables?: L.CyclesQueryVariables): LinearFetch<CycleConnection> {
+    const response = await this._request<L.CyclesQuery, L.CyclesQueryVariables>(L.CyclesDocument, variables);
+    const data = response.cycles;
+
+    return new CycleConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable Document Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class DocumentQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Document query and return a Document
+   *
+   * @param id - required id to pass to document
+   * @returns parsed response from DocumentQuery
+   */
+  public async fetch(id: string): LinearFetch<Document> {
+    const response = await this._request<L.DocumentQuery, L.DocumentQueryVariables>(L.DocumentDocument, {
+      id,
+    });
+    const data = response.document;
+
+    return new Document(this._request, data);
+  }
+}
+
+/**
+ * A fetchable Documents Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class DocumentsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Documents query and return a DocumentConnection
+   *
+   * @param variables - variables to pass into the DocumentsQuery
+   * @returns parsed response from DocumentsQuery
+   */
+  public async fetch(variables?: L.DocumentsQueryVariables): LinearFetch<DocumentConnection> {
+    const response = await this._request<L.DocumentsQuery, L.DocumentsQueryVariables>(L.DocumentsDocument, variables);
+    const data = response.documents;
+
+    return new DocumentConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable Emoji Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class EmojiQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Emoji query and return a Emoji
+   *
+   * @param id - required id to pass to emoji
+   * @returns parsed response from EmojiQuery
+   */
+  public async fetch(id: string): LinearFetch<Emoji> {
+    const response = await this._request<L.EmojiQuery, L.EmojiQueryVariables>(L.EmojiDocument, {
+      id,
+    });
+    const data = response.emoji;
+
+    return new Emoji(this._request, data);
+  }
+}
+
+/**
+ * A fetchable Emojis Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class EmojisQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Emojis query and return a EmojiConnection
+   *
+   * @param variables - variables to pass into the EmojisQuery
+   * @returns parsed response from EmojisQuery
+   */
+  public async fetch(variables?: L.EmojisQueryVariables): LinearFetch<EmojiConnection> {
+    const response = await this._request<L.EmojisQuery, L.EmojisQueryVariables>(L.EmojisDocument, variables);
+    const data = response.emojis;
+
+    return new EmojiConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable Favorite Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class FavoriteQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Favorite query and return a Favorite
+   *
+   * @param id - required id to pass to favorite
+   * @returns parsed response from FavoriteQuery
+   */
+  public async fetch(id: string): LinearFetch<Favorite> {
+    const response = await this._request<L.FavoriteQuery, L.FavoriteQueryVariables>(L.FavoriteDocument, {
+      id,
+    });
+    const data = response.favorite;
+
+    return new Favorite(this._request, data);
+  }
+}
+
+/**
+ * A fetchable Favorites Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class FavoritesQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Favorites query and return a FavoriteConnection
+   *
+   * @param variables - variables to pass into the FavoritesQuery
+   * @returns parsed response from FavoritesQuery
+   */
+  public async fetch(variables?: L.FavoritesQueryVariables): LinearFetch<FavoriteConnection> {
+    const response = await this._request<L.FavoritesQuery, L.FavoritesQueryVariables>(L.FavoritesDocument, variables);
+    const data = response.favorites;
+
+    return new FavoriteConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable FigmaEmbedInfo Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class FigmaEmbedInfoQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the FigmaEmbedInfo query and return a FigmaEmbedPayload
+   *
+   * @param fileId - required fileId to pass to figmaEmbedInfo
+   * @param variables - variables without 'fileId' to pass into the FigmaEmbedInfoQuery
+   * @returns parsed response from FigmaEmbedInfoQuery
+   */
+  public async fetch(
+    fileId: string,
+    variables?: Omit<L.FigmaEmbedInfoQueryVariables, "fileId">
+  ): LinearFetch<FigmaEmbedPayload> {
+    const response = await this._request<L.FigmaEmbedInfoQuery, L.FigmaEmbedInfoQueryVariables>(
+      L.FigmaEmbedInfoDocument,
+      {
+        fileId,
+        ...variables,
+      }
+    );
+    const data = response.figmaEmbedInfo;
+
+    return new FigmaEmbedPayload(this._request, data);
+  }
+}
+
+/**
+ * A fetchable Integration Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class IntegrationQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Integration query and return a Integration
+   *
+   * @param id - required id to pass to integration
+   * @returns parsed response from IntegrationQuery
+   */
+  public async fetch(id: string): LinearFetch<Integration> {
+    const response = await this._request<L.IntegrationQuery, L.IntegrationQueryVariables>(L.IntegrationDocument, {
+      id,
+    });
+    const data = response.integration;
+
+    return new Integration(this._request, data);
+  }
+}
+
+/**
+ * A fetchable IntegrationTemplate Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class IntegrationTemplateQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the IntegrationTemplate query and return a IntegrationTemplate
+   *
+   * @param id - required id to pass to integrationTemplate
+   * @returns parsed response from IntegrationTemplateQuery
+   */
+  public async fetch(id: string): LinearFetch<IntegrationTemplate> {
+    const response = await this._request<L.IntegrationTemplateQuery, L.IntegrationTemplateQueryVariables>(
+      L.IntegrationTemplateDocument,
+      {
+        id,
+      }
+    );
+    const data = response.integrationTemplate;
+
+    return new IntegrationTemplate(this._request, data);
+  }
+}
+
+/**
+ * A fetchable IntegrationTemplates Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class IntegrationTemplatesQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the IntegrationTemplates query and return a IntegrationTemplateConnection
+   *
+   * @param variables - variables to pass into the IntegrationTemplatesQuery
+   * @returns parsed response from IntegrationTemplatesQuery
+   */
+  public async fetch(variables?: L.IntegrationTemplatesQueryVariables): LinearFetch<IntegrationTemplateConnection> {
+    const response = await this._request<L.IntegrationTemplatesQuery, L.IntegrationTemplatesQueryVariables>(
+      L.IntegrationTemplatesDocument,
+      variables
+    );
+    const data = response.integrationTemplates;
+
+    return new IntegrationTemplateConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable Integrations Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class IntegrationsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Integrations query and return a IntegrationConnection
+   *
+   * @param variables - variables to pass into the IntegrationsQuery
+   * @returns parsed response from IntegrationsQuery
+   */
+  public async fetch(variables?: L.IntegrationsQueryVariables): LinearFetch<IntegrationConnection> {
+    const response = await this._request<L.IntegrationsQuery, L.IntegrationsQueryVariables>(
+      L.IntegrationsDocument,
+      variables
+    );
+    const data = response.integrations;
+
+    return new IntegrationConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable IntegrationsSettings Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class IntegrationsSettingsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the IntegrationsSettings query and return a IntegrationsSettings
+   *
+   * @param id - required id to pass to integrationsSettings
+   * @returns parsed response from IntegrationsSettingsQuery
+   */
+  public async fetch(id: string): LinearFetch<IntegrationsSettings> {
+    const response = await this._request<L.IntegrationsSettingsQuery, L.IntegrationsSettingsQueryVariables>(
+      L.IntegrationsSettingsDocument,
+      {
+        id,
+      }
+    );
+    const data = response.integrationsSettings;
+
+    return new IntegrationsSettings(this._request, data);
+  }
+}
+
+/**
+ * A fetchable Issue Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class IssueQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Issue query and return a Issue
+   *
+   * @param id - required id to pass to issue
+   * @returns parsed response from IssueQuery
+   */
+  public async fetch(id: string): LinearFetch<Issue> {
+    const response = await this._request<L.IssueQuery, L.IssueQueryVariables>(L.IssueDocument, {
+      id,
+    });
+    const data = response.issue;
+
+    return new Issue(this._request, data);
+  }
+}
+
+/**
+ * A fetchable IssueImportFinishGithubOAuth Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class IssueImportFinishGithubOAuthQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the IssueImportFinishGithubOAuth query and return a GithubOAuthTokenPayload
+   *
+   * @param code - required code to pass to issueImportFinishGithubOAuth
+   * @returns parsed response from IssueImportFinishGithubOAuthQuery
+   */
+  public async fetch(code: string): LinearFetch<GithubOAuthTokenPayload> {
+    const response = await this._request<
+      L.IssueImportFinishGithubOAuthQuery,
+      L.IssueImportFinishGithubOAuthQueryVariables
+    >(L.IssueImportFinishGithubOAuthDocument, {
+      code,
+    });
+    const data = response.issueImportFinishGithubOAuth;
+
+    return new GithubOAuthTokenPayload(this._request, data);
+  }
+}
+
+/**
+ * A fetchable IssueLabel Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class IssueLabelQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the IssueLabel query and return a IssueLabel
+   *
+   * @param id - required id to pass to issueLabel
+   * @returns parsed response from IssueLabelQuery
+   */
+  public async fetch(id: string): LinearFetch<IssueLabel> {
+    const response = await this._request<L.IssueLabelQuery, L.IssueLabelQueryVariables>(L.IssueLabelDocument, {
+      id,
+    });
+    const data = response.issueLabel;
+
+    return new IssueLabel(this._request, data);
+  }
+}
+
+/**
+ * A fetchable IssueLabels Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class IssueLabelsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the IssueLabels query and return a IssueLabelConnection
+   *
+   * @param variables - variables to pass into the IssueLabelsQuery
+   * @returns parsed response from IssueLabelsQuery
+   */
+  public async fetch(variables?: L.IssueLabelsQueryVariables): LinearFetch<IssueLabelConnection> {
+    const response = await this._request<L.IssueLabelsQuery, L.IssueLabelsQueryVariables>(
+      L.IssueLabelsDocument,
+      variables
+    );
+    const data = response.issueLabels;
+
+    return new IssueLabelConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable IssuePriorityValues Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class IssuePriorityValuesQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the IssuePriorityValues query and return a IssuePriorityValue list
+   *
+   * @returns parsed response from IssuePriorityValuesQuery
+   */
+  public async fetch(): LinearFetch<IssuePriorityValue[]> {
+    const response = await this._request<L.IssuePriorityValuesQuery, L.IssuePriorityValuesQueryVariables>(
+      L.IssuePriorityValuesDocument,
+      {}
+    );
+    const data = response.issuePriorityValues;
+
+    return data.map(node => {
+      return new IssuePriorityValue(this._request, node);
+    });
+  }
+}
+
+/**
+ * A fetchable IssueRelation Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class IssueRelationQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the IssueRelation query and return a IssueRelation
+   *
+   * @param id - required id to pass to issueRelation
+   * @returns parsed response from IssueRelationQuery
+   */
+  public async fetch(id: string): LinearFetch<IssueRelation> {
+    const response = await this._request<L.IssueRelationQuery, L.IssueRelationQueryVariables>(L.IssueRelationDocument, {
+      id,
+    });
+    const data = response.issueRelation;
+
+    return new IssueRelation(this._request, data);
+  }
+}
+
+/**
+ * A fetchable IssueRelations Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class IssueRelationsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the IssueRelations query and return a IssueRelationConnection
+   *
+   * @param variables - variables to pass into the IssueRelationsQuery
+   * @returns parsed response from IssueRelationsQuery
+   */
+  public async fetch(variables?: L.IssueRelationsQueryVariables): LinearFetch<IssueRelationConnection> {
+    const response = await this._request<L.IssueRelationsQuery, L.IssueRelationsQueryVariables>(
+      L.IssueRelationsDocument,
+      variables
+    );
+    const data = response.issueRelations;
+
+    return new IssueRelationConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable IssueVcsBranchSearch Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class IssueVcsBranchSearchQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the IssueVcsBranchSearch query and return a Issue
+   *
+   * @param branchName - required branchName to pass to issueVcsBranchSearch
+   * @returns parsed response from IssueVcsBranchSearchQuery
+   */
+  public async fetch(branchName: string): LinearFetch<Issue | undefined> {
+    const response = await this._request<L.IssueVcsBranchSearchQuery, L.IssueVcsBranchSearchQueryVariables>(
+      L.IssueVcsBranchSearchDocument,
+      {
+        branchName,
+      }
+    );
+    const data = response.issueVcsBranchSearch;
+
+    return data ? new Issue(this._request, data) : undefined;
+  }
+}
+
+/**
+ * A fetchable Issues Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class IssuesQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Issues query and return a IssueConnection
+   *
+   * @param variables - variables to pass into the IssuesQuery
+   * @returns parsed response from IssuesQuery
+   */
+  public async fetch(variables?: L.IssuesQueryVariables): LinearFetch<IssueConnection> {
+    const response = await this._request<L.IssuesQuery, L.IssuesQueryVariables>(L.IssuesDocument, variables);
+    const data = response.issues;
+
+    return new IssueConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable Notification Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class NotificationQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Notification query and return a Notification
+   *
+   * @param id - required id to pass to notification
+   * @returns parsed response from NotificationQuery
+   */
+  public async fetch(
+    id: string
+  ): LinearFetch<IssueNotification | OauthClientApprovalNotification | ProjectNotification | Notification> {
+    const response = await this._request<L.NotificationQuery, L.NotificationQueryVariables>(L.NotificationDocument, {
+      id,
+    });
+    const data = response.notification;
+
+    switch (data.__typename) {
+      case "IssueNotification":
+        return new IssueNotification(this._request, data as L.IssueNotificationFragment);
+      case "OauthClientApprovalNotification":
+        return new OauthClientApprovalNotification(this._request, data as L.OauthClientApprovalNotificationFragment);
+      case "ProjectNotification":
+        return new ProjectNotification(this._request, data as L.ProjectNotificationFragment);
+
+      default:
+        return new Notification(this._request, data);
+    }
+  }
+}
+
+/**
+ * A fetchable NotificationSubscription Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class NotificationSubscriptionQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the NotificationSubscription query and return a NotificationSubscription
+   *
+   * @param id - required id to pass to notificationSubscription
+   * @returns parsed response from NotificationSubscriptionQuery
+   */
+  public async fetch(
+    id: string
+  ): LinearFetch<ProjectNotificationSubscription | TeamNotificationSubscription | NotificationSubscription> {
+    const response = await this._request<L.NotificationSubscriptionQuery, L.NotificationSubscriptionQueryVariables>(
+      L.NotificationSubscriptionDocument,
+      {
+        id,
+      }
+    );
+    const data = response.notificationSubscription;
+
+    switch (data.__typename) {
+      case "ProjectNotificationSubscription":
+        return new ProjectNotificationSubscription(this._request, data as L.ProjectNotificationSubscriptionFragment);
+      case "TeamNotificationSubscription":
+        return new TeamNotificationSubscription(this._request, data as L.TeamNotificationSubscriptionFragment);
+
+      default:
+        return new NotificationSubscription(this._request, data);
+    }
+  }
+}
+
+/**
+ * A fetchable NotificationSubscriptions Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class NotificationSubscriptionsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the NotificationSubscriptions query and return a NotificationSubscriptionConnection
+   *
+   * @param variables - variables to pass into the NotificationSubscriptionsQuery
+   * @returns parsed response from NotificationSubscriptionsQuery
+   */
+  public async fetch(
+    variables?: L.NotificationSubscriptionsQueryVariables
+  ): LinearFetch<NotificationSubscriptionConnection> {
+    const response = await this._request<L.NotificationSubscriptionsQuery, L.NotificationSubscriptionsQueryVariables>(
+      L.NotificationSubscriptionsDocument,
+      variables
+    );
+    const data = response.notificationSubscriptions;
+
+    return new NotificationSubscriptionConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable Notifications Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class NotificationsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Notifications query and return a NotificationConnection
+   *
+   * @param variables - variables to pass into the NotificationsQuery
+   * @returns parsed response from NotificationsQuery
+   */
+  public async fetch(variables?: L.NotificationsQueryVariables): LinearFetch<NotificationConnection> {
+    const response = await this._request<L.NotificationsQuery, L.NotificationsQueryVariables>(
+      L.NotificationsDocument,
+      variables
+    );
+    const data = response.notifications;
+
+    return new NotificationConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable Organization Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class OrganizationQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Organization query and return a Organization
+   *
+   * @returns parsed response from OrganizationQuery
+   */
+  public async fetch(): LinearFetch<Organization> {
+    const response = await this._request<L.OrganizationQuery, L.OrganizationQueryVariables>(L.OrganizationDocument, {});
+    const data = response.organization;
+
+    return new Organization(this._request, data);
+  }
+}
+
+/**
+ * A fetchable OrganizationExists Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class OrganizationExistsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the OrganizationExists query and return a OrganizationExistsPayload
+   *
+   * @param urlKey - required urlKey to pass to organizationExists
+   * @returns parsed response from OrganizationExistsQuery
+   */
+  public async fetch(urlKey: string): LinearFetch<OrganizationExistsPayload> {
+    const response = await this._request<L.OrganizationExistsQuery, L.OrganizationExistsQueryVariables>(
+      L.OrganizationExistsDocument,
+      {
+        urlKey,
+      }
+    );
+    const data = response.organizationExists;
+
+    return new OrganizationExistsPayload(this._request, data);
+  }
+}
+
+/**
+ * A fetchable OrganizationInvite Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class OrganizationInviteQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the OrganizationInvite query and return a OrganizationInvite
+   *
+   * @param id - required id to pass to organizationInvite
+   * @returns parsed response from OrganizationInviteQuery
+   */
+  public async fetch(id: string): LinearFetch<OrganizationInvite> {
+    const response = await this._request<L.OrganizationInviteQuery, L.OrganizationInviteQueryVariables>(
+      L.OrganizationInviteDocument,
+      {
+        id,
+      }
+    );
+    const data = response.organizationInvite;
+
+    return new OrganizationInvite(this._request, data);
+  }
+}
+
+/**
+ * A fetchable OrganizationInviteDetails Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class OrganizationInviteDetailsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the OrganizationInviteDetails query and return a OrganizationInviteDetailsPayload
+   *
+   * @param id - required id to pass to organizationInviteDetails
+   * @returns parsed response from OrganizationInviteDetailsQuery
+   */
+  public async fetch(id: string): LinearFetch<OrganizationInviteDetailsPayload> {
+    const response = await this._request<L.OrganizationInviteDetailsQuery, L.OrganizationInviteDetailsQueryVariables>(
+      L.OrganizationInviteDetailsDocument,
+      {
+        id,
+      }
+    );
+    const data = response.organizationInviteDetails;
+
+    return new OrganizationInviteDetailsPayload(this._request, data);
+  }
+}
+
+/**
+ * A fetchable OrganizationInvites Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class OrganizationInvitesQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the OrganizationInvites query and return a OrganizationInviteConnection
+   *
+   * @param variables - variables to pass into the OrganizationInvitesQuery
+   * @returns parsed response from OrganizationInvitesQuery
+   */
+  public async fetch(variables?: L.OrganizationInvitesQueryVariables): LinearFetch<OrganizationInviteConnection> {
+    const response = await this._request<L.OrganizationInvitesQuery, L.OrganizationInvitesQueryVariables>(
+      L.OrganizationInvitesDocument,
+      variables
+    );
+    const data = response.organizationInvites;
+
+    return new OrganizationInviteConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable Project Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class ProjectQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Project query and return a Project
+   *
+   * @param id - required id to pass to project
+   * @returns parsed response from ProjectQuery
+   */
+  public async fetch(id: string): LinearFetch<Project> {
+    const response = await this._request<L.ProjectQuery, L.ProjectQueryVariables>(L.ProjectDocument, {
+      id,
+    });
+    const data = response.project;
+
+    return new Project(this._request, data);
+  }
+}
+
+/**
+ * A fetchable ProjectLink Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class ProjectLinkQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the ProjectLink query and return a ProjectLink
+   *
+   * @param id - required id to pass to projectLink
+   * @returns parsed response from ProjectLinkQuery
+   */
+  public async fetch(id: string): LinearFetch<ProjectLink> {
+    const response = await this._request<L.ProjectLinkQuery, L.ProjectLinkQueryVariables>(L.ProjectLinkDocument, {
+      id,
+    });
+    const data = response.projectLink;
+
+    return new ProjectLink(this._request, data);
+  }
+}
+
+/**
+ * A fetchable ProjectLinks Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class ProjectLinksQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the ProjectLinks query and return a ProjectLinkConnection
+   *
+   * @param variables - variables to pass into the ProjectLinksQuery
+   * @returns parsed response from ProjectLinksQuery
+   */
+  public async fetch(variables?: L.ProjectLinksQueryVariables): LinearFetch<ProjectLinkConnection> {
+    const response = await this._request<L.ProjectLinksQuery, L.ProjectLinksQueryVariables>(
+      L.ProjectLinksDocument,
+      variables
+    );
+    const data = response.projectLinks;
+
+    return new ProjectLinkConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable ProjectUpdate Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class ProjectUpdateQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the ProjectUpdate query and return a ProjectUpdate
+   *
+   * @param id - required id to pass to projectUpdate
+   * @returns parsed response from ProjectUpdateQuery
+   */
+  public async fetch(id: string): LinearFetch<ProjectUpdate> {
+    const response = await this._request<L.ProjectUpdateQuery, L.ProjectUpdateQueryVariables>(L.ProjectUpdateDocument, {
+      id,
+    });
+    const data = response.projectUpdate;
+
+    return new ProjectUpdate(this._request, data);
+  }
+}
+
+/**
+ * A fetchable ProjectUpdateInteraction Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class ProjectUpdateInteractionQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the ProjectUpdateInteraction query and return a ProjectUpdateInteraction
+   *
+   * @param id - required id to pass to projectUpdateInteraction
+   * @returns parsed response from ProjectUpdateInteractionQuery
+   */
+  public async fetch(id: string): LinearFetch<ProjectUpdateInteraction> {
+    const response = await this._request<L.ProjectUpdateInteractionQuery, L.ProjectUpdateInteractionQueryVariables>(
+      L.ProjectUpdateInteractionDocument,
+      {
+        id,
+      }
+    );
+    const data = response.projectUpdateInteraction;
+
+    return new ProjectUpdateInteraction(this._request, data);
+  }
+}
+
+/**
+ * A fetchable ProjectUpdateInteractions Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class ProjectUpdateInteractionsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the ProjectUpdateInteractions query and return a ProjectUpdateInteractionConnection
+   *
+   * @param variables - variables to pass into the ProjectUpdateInteractionsQuery
+   * @returns parsed response from ProjectUpdateInteractionsQuery
+   */
+  public async fetch(
+    variables?: L.ProjectUpdateInteractionsQueryVariables
+  ): LinearFetch<ProjectUpdateInteractionConnection> {
+    const response = await this._request<L.ProjectUpdateInteractionsQuery, L.ProjectUpdateInteractionsQueryVariables>(
+      L.ProjectUpdateInteractionsDocument,
+      variables
+    );
+    const data = response.projectUpdateInteractions;
+
+    return new ProjectUpdateInteractionConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable ProjectUpdates Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class ProjectUpdatesQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the ProjectUpdates query and return a ProjectUpdateConnection
+   *
+   * @param variables - variables to pass into the ProjectUpdatesQuery
+   * @returns parsed response from ProjectUpdatesQuery
+   */
+  public async fetch(variables?: L.ProjectUpdatesQueryVariables): LinearFetch<ProjectUpdateConnection> {
+    const response = await this._request<L.ProjectUpdatesQuery, L.ProjectUpdatesQueryVariables>(
+      L.ProjectUpdatesDocument,
+      variables
+    );
+    const data = response.projectUpdates;
+
+    return new ProjectUpdateConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable Projects Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class ProjectsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Projects query and return a ProjectConnection
+   *
+   * @param variables - variables to pass into the ProjectsQuery
+   * @returns parsed response from ProjectsQuery
+   */
+  public async fetch(variables?: L.ProjectsQueryVariables): LinearFetch<ProjectConnection> {
+    const response = await this._request<L.ProjectsQuery, L.ProjectsQueryVariables>(L.ProjectsDocument, variables);
+    const data = response.projects;
+
+    return new ProjectConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable PushSubscriptionTest Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class PushSubscriptionTestQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the PushSubscriptionTest query and return a PushSubscriptionTestPayload
+   *
+   * @returns parsed response from PushSubscriptionTestQuery
+   */
+  public async fetch(): LinearFetch<PushSubscriptionTestPayload> {
+    const response = await this._request<L.PushSubscriptionTestQuery, L.PushSubscriptionTestQueryVariables>(
+      L.PushSubscriptionTestDocument,
+      {}
+    );
+    const data = response.pushSubscriptionTest;
+
+    return new PushSubscriptionTestPayload(this._request, data);
+  }
+}
+
+/**
+ * A fetchable RateLimitStatus Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class RateLimitStatusQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the RateLimitStatus query and return a RateLimitPayload
+   *
+   * @returns parsed response from RateLimitStatusQuery
+   */
+  public async fetch(): LinearFetch<RateLimitPayload> {
+    const response = await this._request<L.RateLimitStatusQuery, L.RateLimitStatusQueryVariables>(
+      L.RateLimitStatusDocument,
+      {}
+    );
+    const data = response.rateLimitStatus;
+
+    return new RateLimitPayload(this._request, data);
+  }
+}
+
+/**
+ * A fetchable Roadmap Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class RoadmapQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Roadmap query and return a Roadmap
+   *
+   * @param id - required id to pass to roadmap
+   * @returns parsed response from RoadmapQuery
+   */
+  public async fetch(id: string): LinearFetch<Roadmap> {
+    const response = await this._request<L.RoadmapQuery, L.RoadmapQueryVariables>(L.RoadmapDocument, {
+      id,
+    });
+    const data = response.roadmap;
+
+    return new Roadmap(this._request, data);
+  }
+}
+
+/**
+ * A fetchable RoadmapToProject Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class RoadmapToProjectQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the RoadmapToProject query and return a RoadmapToProject
+   *
+   * @param id - required id to pass to roadmapToProject
+   * @returns parsed response from RoadmapToProjectQuery
+   */
+  public async fetch(id: string): LinearFetch<RoadmapToProject> {
+    const response = await this._request<L.RoadmapToProjectQuery, L.RoadmapToProjectQueryVariables>(
+      L.RoadmapToProjectDocument,
+      {
+        id,
+      }
+    );
+    const data = response.roadmapToProject;
+
+    return new RoadmapToProject(this._request, data);
+  }
+}
+
+/**
+ * A fetchable RoadmapToProjects Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class RoadmapToProjectsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the RoadmapToProjects query and return a RoadmapToProjectConnection
+   *
+   * @param variables - variables to pass into the RoadmapToProjectsQuery
+   * @returns parsed response from RoadmapToProjectsQuery
+   */
+  public async fetch(variables?: L.RoadmapToProjectsQueryVariables): LinearFetch<RoadmapToProjectConnection> {
+    const response = await this._request<L.RoadmapToProjectsQuery, L.RoadmapToProjectsQueryVariables>(
+      L.RoadmapToProjectsDocument,
+      variables
+    );
+    const data = response.roadmapToProjects;
+
+    return new RoadmapToProjectConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable Roadmaps Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class RoadmapsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Roadmaps query and return a RoadmapConnection
+   *
+   * @param variables - variables to pass into the RoadmapsQuery
+   * @returns parsed response from RoadmapsQuery
+   */
+  public async fetch(variables?: L.RoadmapsQueryVariables): LinearFetch<RoadmapConnection> {
+    const response = await this._request<L.RoadmapsQuery, L.RoadmapsQueryVariables>(L.RoadmapsDocument, variables);
+    const data = response.roadmaps;
+
+    return new RoadmapConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable SsoUrlFromEmail Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class SsoUrlFromEmailQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the SsoUrlFromEmail query and return a SsoUrlFromEmailResponse
+   *
+   * @param email - required email to pass to ssoUrlFromEmail
+   * @param variables - variables without 'email' to pass into the SsoUrlFromEmailQuery
+   * @returns parsed response from SsoUrlFromEmailQuery
+   */
+  public async fetch(
+    email: string,
+    variables?: Omit<L.SsoUrlFromEmailQueryVariables, "email">
+  ): LinearFetch<SsoUrlFromEmailResponse> {
+    const response = await this._request<L.SsoUrlFromEmailQuery, L.SsoUrlFromEmailQueryVariables>(
+      L.SsoUrlFromEmailDocument,
+      {
+        email,
+        ...variables,
+      }
+    );
+    const data = response.ssoUrlFromEmail;
+
+    return new SsoUrlFromEmailResponse(this._request, data);
+  }
+}
+
+/**
+ * A fetchable Team Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class TeamQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Team query and return a Team
+   *
+   * @param id - required id to pass to team
+   * @returns parsed response from TeamQuery
+   */
+  public async fetch(id: string): LinearFetch<Team> {
+    const response = await this._request<L.TeamQuery, L.TeamQueryVariables>(L.TeamDocument, {
+      id,
+    });
+    const data = response.team;
+
+    return new Team(this._request, data);
+  }
+}
+
+/**
+ * A fetchable TeamMembership Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class TeamMembershipQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the TeamMembership query and return a TeamMembership
+   *
+   * @param id - required id to pass to teamMembership
+   * @returns parsed response from TeamMembershipQuery
+   */
+  public async fetch(id: string): LinearFetch<TeamMembership> {
+    const response = await this._request<L.TeamMembershipQuery, L.TeamMembershipQueryVariables>(
+      L.TeamMembershipDocument,
+      {
+        id,
+      }
+    );
+    const data = response.teamMembership;
+
+    return new TeamMembership(this._request, data);
+  }
+}
+
+/**
+ * A fetchable TeamMemberships Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class TeamMembershipsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the TeamMemberships query and return a TeamMembershipConnection
+   *
+   * @param variables - variables to pass into the TeamMembershipsQuery
+   * @returns parsed response from TeamMembershipsQuery
+   */
+  public async fetch(variables?: L.TeamMembershipsQueryVariables): LinearFetch<TeamMembershipConnection> {
+    const response = await this._request<L.TeamMembershipsQuery, L.TeamMembershipsQueryVariables>(
+      L.TeamMembershipsDocument,
+      variables
+    );
+    const data = response.teamMemberships;
+
+    return new TeamMembershipConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable Teams Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class TeamsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Teams query and return a TeamConnection
+   *
+   * @param variables - variables to pass into the TeamsQuery
+   * @returns parsed response from TeamsQuery
+   */
+  public async fetch(variables?: L.TeamsQueryVariables): LinearFetch<TeamConnection> {
+    const response = await this._request<L.TeamsQuery, L.TeamsQueryVariables>(L.TeamsDocument, variables);
+    const data = response.teams;
+
+    return new TeamConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable Template Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class TemplateQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Template query and return a Template
+   *
+   * @param id - required id to pass to template
+   * @returns parsed response from TemplateQuery
+   */
+  public async fetch(id: string): LinearFetch<Template> {
+    const response = await this._request<L.TemplateQuery, L.TemplateQueryVariables>(L.TemplateDocument, {
+      id,
+    });
+    const data = response.template;
+
+    return new Template(this._request, data);
+  }
+}
+
+/**
+ * A fetchable Templates Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class TemplatesQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Templates query and return a Template list
+   *
+   * @returns parsed response from TemplatesQuery
+   */
+  public async fetch(): LinearFetch<Template[]> {
+    const response = await this._request<L.TemplatesQuery, L.TemplatesQueryVariables>(L.TemplatesDocument, {});
+    const data = response.templates;
+
+    return data.map(node => {
+      return new Template(this._request, node);
+    });
+  }
+}
+
+/**
+ * A fetchable User Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class UserQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the User query and return a User
+   *
+   * @param id - required id to pass to user
+   * @returns parsed response from UserQuery
+   */
+  public async fetch(id: string): LinearFetch<User> {
+    const response = await this._request<L.UserQuery, L.UserQueryVariables>(L.UserDocument, {
+      id,
+    });
+    const data = response.user;
+
+    return new User(this._request, data);
+  }
+}
+
+/**
+ * A fetchable UserSettings Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class UserSettingsQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the UserSettings query and return a UserSettings
+   *
+   * @returns parsed response from UserSettingsQuery
+   */
+  public async fetch(): LinearFetch<UserSettings> {
+    const response = await this._request<L.UserSettingsQuery, L.UserSettingsQueryVariables>(L.UserSettingsDocument, {});
+    const data = response.userSettings;
+
+    return new UserSettings(this._request, data);
+  }
+}
+
+/**
+ * A fetchable Users Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class UsersQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Users query and return a UserConnection
+   *
+   * @param variables - variables to pass into the UsersQuery
+   * @returns parsed response from UsersQuery
+   */
+  public async fetch(variables?: L.UsersQueryVariables): LinearFetch<UserConnection> {
+    const response = await this._request<L.UsersQuery, L.UsersQueryVariables>(L.UsersDocument, variables);
+    const data = response.users;
+
+    return new UserConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable Viewer Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class ViewerQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Viewer query and return a User
+   *
+   * @returns parsed response from ViewerQuery
+   */
+  public async fetch(): LinearFetch<User> {
+    const response = await this._request<L.ViewerQuery, L.ViewerQueryVariables>(L.ViewerDocument, {});
+    const data = response.viewer;
+
+    return new User(this._request, data);
+  }
+}
+
+/**
+ * A fetchable Webhook Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class WebhookQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Webhook query and return a Webhook
+   *
+   * @param id - required id to pass to webhook
+   * @returns parsed response from WebhookQuery
+   */
+  public async fetch(id: string): LinearFetch<Webhook> {
+    const response = await this._request<L.WebhookQuery, L.WebhookQueryVariables>(L.WebhookDocument, {
+      id,
+    });
+    const data = response.webhook;
+
+    return new Webhook(this._request, data);
+  }
+}
+
+/**
+ * A fetchable Webhooks Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class WebhooksQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the Webhooks query and return a WebhookConnection
+   *
+   * @param variables - variables to pass into the WebhooksQuery
+   * @returns parsed response from WebhooksQuery
+   */
+  public async fetch(variables?: L.WebhooksQueryVariables): LinearFetch<WebhookConnection> {
+    const response = await this._request<L.WebhooksQuery, L.WebhooksQueryVariables>(L.WebhooksDocument, variables);
+    const data = response.webhooks;
+
+    return new WebhookConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
+  }
+}
+
+/**
+ * A fetchable WorkflowState Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class WorkflowStateQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the WorkflowState query and return a WorkflowState
+   *
+   * @param id - required id to pass to workflowState
+   * @returns parsed response from WorkflowStateQuery
+   */
+  public async fetch(id: string): LinearFetch<WorkflowState> {
+    const response = await this._request<L.WorkflowStateQuery, L.WorkflowStateQueryVariables>(L.WorkflowStateDocument, {
+      id,
+    });
+    const data = response.workflowState;
+
+    return new WorkflowState(this._request, data);
+  }
+}
+
+/**
+ * A fetchable WorkflowStates Query
+ *
+ * @param request - function to call the graphql client
+ */
+export class WorkflowStatesQuery extends Request {
+  public constructor(request: LinearRequest) {
+    super(request);
+  }
+
+  /**
+   * Call the WorkflowStates query and return a WorkflowStateConnection
+   *
+   * @param variables - variables to pass into the WorkflowStatesQuery
+   * @returns parsed response from WorkflowStatesQuery
+   */
+  public async fetch(variables?: L.WorkflowStatesQueryVariables): LinearFetch<WorkflowStateConnection> {
+    const response = await this._request<L.WorkflowStatesQuery, L.WorkflowStatesQueryVariables>(
+      L.WorkflowStatesDocument,
+      variables
+    );
+    const data = response.workflowStates;
+
+    return new WorkflowStateConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
   }
 }
 
@@ -16345,55 +16327,6 @@ export class IssueVcsBranchSearch_SubscribersQuery extends Request {
 }
 
 /**
- * A fetchable Milestone_Projects Query
- *
- * @param request - function to call the graphql client
- * @param id - required id to pass to milestone
- * @param variables - variables without 'id' to pass into the Milestone_ProjectsQuery
- */
-export class Milestone_ProjectsQuery extends Request {
-  private _id: string;
-  private _variables?: Omit<L.Milestone_ProjectsQueryVariables, "id">;
-
-  public constructor(request: LinearRequest, id: string, variables?: Omit<L.Milestone_ProjectsQueryVariables, "id">) {
-    super(request);
-    this._id = id;
-    this._variables = variables;
-  }
-
-  /**
-   * Call the Milestone_Projects query and return a ProjectConnection
-   *
-   * @param variables - variables without 'id' to pass into the Milestone_ProjectsQuery
-   * @returns parsed response from Milestone_ProjectsQuery
-   */
-  public async fetch(variables?: Omit<L.Milestone_ProjectsQueryVariables, "id">): LinearFetch<ProjectConnection> {
-    const response = await this._request<L.Milestone_ProjectsQuery, L.Milestone_ProjectsQueryVariables>(
-      L.Milestone_ProjectsDocument,
-      {
-        id: this._id,
-        ...this._variables,
-        ...variables,
-      }
-    );
-    const data = response.milestone.projects;
-
-    return new ProjectConnection(
-      this._request,
-      connection =>
-        this.fetch(
-          defaultConnection({
-            ...this._variables,
-            ...variables,
-            ...connection,
-          })
-        ),
-      data
-    );
-  }
-}
-
-/**
  * A fetchable Organization_Integrations Query
  *
  * @param request - function to call the graphql client
@@ -16669,38 +16602,6 @@ export class Project_DocumentsQuery extends Request {
         ),
       data
     );
-  }
-}
-
-/**
- * A fetchable Project_Initiative Query
- *
- * @param request - function to call the graphql client
- * @param id - required id to pass to project
- */
-export class Project_InitiativeQuery extends Request {
-  private _id: string;
-
-  public constructor(request: LinearRequest, id: string) {
-    super(request);
-    this._id = id;
-  }
-
-  /**
-   * Call the Project_Initiative query and return a Initiative
-   *
-   * @returns parsed response from Project_InitiativeQuery
-   */
-  public async fetch(): LinearFetch<Initiative | undefined> {
-    const response = await this._request<L.Project_InitiativeQuery, L.Project_InitiativeQueryVariables>(
-      L.Project_InitiativeDocument,
-      {
-        id: this._id,
-      }
-    );
-    const data = response.project.initiative;
-
-    return data ? new Initiative(this._request, data) : undefined;
   }
 }
 
@@ -17834,732 +17735,6 @@ export class LinearSdk extends Request {
   }
 
   /**
-   * All teams you the user can administrate. Administrable teams are teams whose settings the user can change, but to whose issues the user doesn't necessarily have access to.
-   *
-   * @param variables - variables to pass into the AdministrableTeamsQuery
-   * @returns TeamConnection
-   */
-  public administrableTeams(variables?: L.AdministrableTeamsQueryVariables): LinearFetch<TeamConnection> {
-    return new AdministrableTeamsQuery(this._request).fetch(variables);
-  }
-  /**
-   * All API keys for the user.
-   *
-   * @param variables - variables to pass into the ApiKeysQuery
-   * @returns ApiKeyConnection
-   */
-  public apiKeys(variables?: L.ApiKeysQueryVariables): LinearFetch<ApiKeyConnection> {
-    return new ApiKeysQuery(this._request).fetch(variables);
-  }
-  /**
-   * Get basic information for an application.
-   *
-   * @param clientId - required clientId to pass to applicationInfo
-   * @returns Application
-   */
-  public applicationInfo(clientId: string): LinearFetch<Application> {
-    return new ApplicationInfoQuery(this._request).fetch(clientId);
-  }
-  /**
-   * Get information for an application and whether a user has approved it for the given scopes.
-   *
-   * @param clientId - required clientId to pass to applicationWithAuthorization
-   * @param scope - required scope to pass to applicationWithAuthorization
-   * @param variables - variables without 'clientId', 'scope' to pass into the ApplicationWithAuthorizationQuery
-   * @returns UserAuthorizedApplication
-   */
-  public applicationWithAuthorization(
-    clientId: string,
-    scope: string[],
-    variables?: Omit<L.ApplicationWithAuthorizationQueryVariables, "clientId" | "scope">
-  ): LinearFetch<UserAuthorizedApplication> {
-    return new ApplicationWithAuthorizationQuery(this._request).fetch(clientId, scope, variables);
-  }
-  /**
-   * One specific issue attachment.
-   * [Deprecated] 'url' can no longer be used as the 'id' parameter. Use 'attachmentsForUrl' instead
-   *
-   * @param id - required id to pass to attachment
-   * @returns Attachment
-   */
-  public attachment(id: string): LinearFetch<Attachment> {
-    return new AttachmentQuery(this._request).fetch(id);
-  }
-  /**
-   * Query an issue by its associated attachment, and its id.
-   *
-   * @param id - required id to pass to attachmentIssue
-   * @returns Issue
-   */
-  public attachmentIssue(id: string): LinearFetch<Issue> {
-    return new AttachmentIssueQuery(this._request).fetch(id);
-  }
-  /**
-   * All issue attachments.
-   *
-   * To get attachments for a given URL, use `attachmentsForURL` query.
-   *
-   * @param variables - variables to pass into the AttachmentsQuery
-   * @returns AttachmentConnection
-   */
-  public attachments(variables?: L.AttachmentsQueryVariables): LinearFetch<AttachmentConnection> {
-    return new AttachmentsQuery(this._request).fetch(variables);
-  }
-  /**
-   * Returns issue attachments for a given `url`.
-   *
-   * @param url - required url to pass to attachmentsForURL
-   * @param variables - variables without 'url' to pass into the AttachmentsForUrlQuery
-   * @returns AttachmentConnection
-   */
-  public attachmentsForURL(
-    url: string,
-    variables?: Omit<L.AttachmentsForUrlQueryVariables, "url">
-  ): LinearFetch<AttachmentConnection> {
-    return new AttachmentsForUrlQuery(this._request).fetch(url, variables);
-  }
-  /**
-   * All audit log entries.
-   *
-   * @param variables - variables to pass into the AuditEntriesQuery
-   * @returns AuditEntryConnection
-   */
-  public auditEntries(variables?: L.AuditEntriesQueryVariables): LinearFetch<AuditEntryConnection> {
-    return new AuditEntriesQuery(this._request).fetch(variables);
-  }
-  /**
-   * List of audit entry types.
-   *
-   * @returns AuditEntryType[]
-   */
-  public get auditEntryTypes(): LinearFetch<AuditEntryType[]> {
-    return new AuditEntryTypesQuery(this._request).fetch();
-  }
-  /**
-   * Fetch users belonging to this user account.
-   *
-   * @returns AuthResolverResponse
-   */
-  public get availableUsers(): LinearFetch<AuthResolverResponse> {
-    return new AvailableUsersQuery(this._request).fetch();
-  }
-  /**
-   * A specific comment.
-   *
-   * @param id - required id to pass to comment
-   * @returns Comment
-   */
-  public comment(id: string): LinearFetch<Comment> {
-    return new CommentQuery(this._request).fetch(id);
-  }
-  /**
-   * All comments.
-   *
-   * @param variables - variables to pass into the CommentsQuery
-   * @returns CommentConnection
-   */
-  public comments(variables?: L.CommentsQueryVariables): LinearFetch<CommentConnection> {
-    return new CommentsQuery(this._request).fetch(variables);
-  }
-  /**
-   * One specific custom view.
-   *
-   * @param id - required id to pass to customView
-   * @returns CustomView
-   */
-  public customView(id: string): LinearFetch<CustomView> {
-    return new CustomViewQuery(this._request).fetch(id);
-  }
-  /**
-   * Custom views for the user.
-   *
-   * @param variables - variables to pass into the CustomViewsQuery
-   * @returns CustomViewConnection
-   */
-  public customViews(variables?: L.CustomViewsQueryVariables): LinearFetch<CustomViewConnection> {
-    return new CustomViewsQuery(this._request).fetch(variables);
-  }
-  /**
-   * One specific cycle.
-   *
-   * @param id - required id to pass to cycle
-   * @returns Cycle
-   */
-  public cycle(id: string): LinearFetch<Cycle> {
-    return new CycleQuery(this._request).fetch(id);
-  }
-  /**
-   * All cycles.
-   *
-   * @param variables - variables to pass into the CyclesQuery
-   * @returns CycleConnection
-   */
-  public cycles(variables?: L.CyclesQueryVariables): LinearFetch<CycleConnection> {
-    return new CyclesQuery(this._request).fetch(variables);
-  }
-  /**
-   * One specific document.
-   *
-   * @param id - required id to pass to document
-   * @returns Document
-   */
-  public document(id: string): LinearFetch<Document> {
-    return new DocumentQuery(this._request).fetch(id);
-  }
-  /**
-   * All documents for the project.
-   *
-   * @param variables - variables to pass into the DocumentsQuery
-   * @returns DocumentConnection
-   */
-  public documents(variables?: L.DocumentsQueryVariables): LinearFetch<DocumentConnection> {
-    return new DocumentsQuery(this._request).fetch(variables);
-  }
-  /**
-   * A specific emoji.
-   *
-   * @param id - required id to pass to emoji
-   * @returns Emoji
-   */
-  public emoji(id: string): LinearFetch<Emoji> {
-    return new EmojiQuery(this._request).fetch(id);
-  }
-  /**
-   * All custom emojis.
-   *
-   * @param variables - variables to pass into the EmojisQuery
-   * @returns EmojiConnection
-   */
-  public emojis(variables?: L.EmojisQueryVariables): LinearFetch<EmojiConnection> {
-    return new EmojisQuery(this._request).fetch(variables);
-  }
-  /**
-   * One specific favorite.
-   *
-   * @param id - required id to pass to favorite
-   * @returns Favorite
-   */
-  public favorite(id: string): LinearFetch<Favorite> {
-    return new FavoriteQuery(this._request).fetch(id);
-  }
-  /**
-   * The user's favorites.
-   *
-   * @param variables - variables to pass into the FavoritesQuery
-   * @returns FavoriteConnection
-   */
-  public favorites(variables?: L.FavoritesQueryVariables): LinearFetch<FavoriteConnection> {
-    return new FavoritesQuery(this._request).fetch(variables);
-  }
-  /**
-   * Fetch Figma screenshot and other information with file and node identifiers.
-   *
-   * @param fileId - required fileId to pass to figmaEmbedInfo
-   * @param variables - variables without 'fileId' to pass into the FigmaEmbedInfoQuery
-   * @returns FigmaEmbedPayload
-   */
-  public figmaEmbedInfo(
-    fileId: string,
-    variables?: Omit<L.FigmaEmbedInfoQueryVariables, "fileId">
-  ): LinearFetch<FigmaEmbedPayload> {
-    return new FigmaEmbedInfoQuery(this._request).fetch(fileId, variables);
-  }
-  /**
-   * One specific integration.
-   *
-   * @param id - required id to pass to integration
-   * @returns Integration
-   */
-  public integration(id: string): LinearFetch<Integration> {
-    return new IntegrationQuery(this._request).fetch(id);
-  }
-  /**
-   * One specific integrationTemplate.
-   *
-   * @param id - required id to pass to integrationTemplate
-   * @returns IntegrationTemplate
-   */
-  public integrationTemplate(id: string): LinearFetch<IntegrationTemplate> {
-    return new IntegrationTemplateQuery(this._request).fetch(id);
-  }
-  /**
-   * Template and integration connections.
-   *
-   * @param variables - variables to pass into the IntegrationTemplatesQuery
-   * @returns IntegrationTemplateConnection
-   */
-  public integrationTemplates(
-    variables?: L.IntegrationTemplatesQueryVariables
-  ): LinearFetch<IntegrationTemplateConnection> {
-    return new IntegrationTemplatesQuery(this._request).fetch(variables);
-  }
-  /**
-   * All integrations.
-   *
-   * @param variables - variables to pass into the IntegrationsQuery
-   * @returns IntegrationConnection
-   */
-  public integrations(variables?: L.IntegrationsQueryVariables): LinearFetch<IntegrationConnection> {
-    return new IntegrationsQuery(this._request).fetch(variables);
-  }
-  /**
-   * One specific set of settings.
-   *
-   * @param id - required id to pass to integrationsSettings
-   * @returns IntegrationsSettings
-   */
-  public integrationsSettings(id: string): LinearFetch<IntegrationsSettings> {
-    return new IntegrationsSettingsQuery(this._request).fetch(id);
-  }
-  /**
-   * One specific issue.
-   *
-   * @param id - required id to pass to issue
-   * @returns Issue
-   */
-  public issue(id: string): LinearFetch<Issue> {
-    return new IssueQuery(this._request).fetch(id);
-  }
-  /**
-   * Fetches the GitHub token, completing the OAuth flow.
-   *
-   * @param code - required code to pass to issueImportFinishGithubOAuth
-   * @returns GithubOAuthTokenPayload
-   */
-  public issueImportFinishGithubOAuth(code: string): LinearFetch<GithubOAuthTokenPayload> {
-    return new IssueImportFinishGithubOAuthQuery(this._request).fetch(code);
-  }
-  /**
-   * One specific label.
-   *
-   * @param id - required id to pass to issueLabel
-   * @returns IssueLabel
-   */
-  public issueLabel(id: string): LinearFetch<IssueLabel> {
-    return new IssueLabelQuery(this._request).fetch(id);
-  }
-  /**
-   * All issue labels.
-   *
-   * @param variables - variables to pass into the IssueLabelsQuery
-   * @returns IssueLabelConnection
-   */
-  public issueLabels(variables?: L.IssueLabelsQueryVariables): LinearFetch<IssueLabelConnection> {
-    return new IssueLabelsQuery(this._request).fetch(variables);
-  }
-  /**
-   * Issue priority values and corresponding labels.
-   *
-   * @returns IssuePriorityValue[]
-   */
-  public get issuePriorityValues(): LinearFetch<IssuePriorityValue[]> {
-    return new IssuePriorityValuesQuery(this._request).fetch();
-  }
-  /**
-   * One specific issue relation.
-   *
-   * @param id - required id to pass to issueRelation
-   * @returns IssueRelation
-   */
-  public issueRelation(id: string): LinearFetch<IssueRelation> {
-    return new IssueRelationQuery(this._request).fetch(id);
-  }
-  /**
-   * All issue relationships.
-   *
-   * @param variables - variables to pass into the IssueRelationsQuery
-   * @returns IssueRelationConnection
-   */
-  public issueRelations(variables?: L.IssueRelationsQueryVariables): LinearFetch<IssueRelationConnection> {
-    return new IssueRelationsQuery(this._request).fetch(variables);
-  }
-  /**
-   * Find issue based on the VCS branch name.
-   *
-   * @param branchName - required branchName to pass to issueVcsBranchSearch
-   * @returns Issue
-   */
-  public issueVcsBranchSearch(branchName: string): LinearFetch<Issue | undefined> {
-    return new IssueVcsBranchSearchQuery(this._request).fetch(branchName);
-  }
-  /**
-   * All issues.
-   *
-   * @param variables - variables to pass into the IssuesQuery
-   * @returns IssueConnection
-   */
-  public issues(variables?: L.IssuesQueryVariables): LinearFetch<IssueConnection> {
-    return new IssuesQuery(this._request).fetch(variables);
-  }
-  /**
-   * One specific milestone.
-   *
-   * @param id - required id to pass to milestone
-   * @returns Milestone
-   */
-  public milestone(id: string): LinearFetch<Milestone> {
-    return new MilestoneQuery(this._request).fetch(id);
-  }
-  /**
-   * All milestones.
-   *
-   * @param variables - variables to pass into the MilestonesQuery
-   * @returns MilestoneConnection
-   */
-  public milestones(variables?: L.MilestonesQueryVariables): LinearFetch<MilestoneConnection> {
-    return new MilestonesQuery(this._request).fetch(variables);
-  }
-  /**
-   * One specific notification.
-   *
-   * @param id - required id to pass to notification
-   * @returns Notification
-   */
-  public notification(
-    id: string
-  ): LinearFetch<IssueNotification | OauthClientApprovalNotification | ProjectNotification | Notification> {
-    return new NotificationQuery(this._request).fetch(id);
-  }
-  /**
-   * One specific notification subscription.
-   *
-   * @param id - required id to pass to notificationSubscription
-   * @returns NotificationSubscription
-   */
-  public notificationSubscription(
-    id: string
-  ): LinearFetch<ProjectNotificationSubscription | TeamNotificationSubscription | NotificationSubscription> {
-    return new NotificationSubscriptionQuery(this._request).fetch(id);
-  }
-  /**
-   * The user's notification subscriptions.
-   *
-   * @param variables - variables to pass into the NotificationSubscriptionsQuery
-   * @returns NotificationSubscriptionConnection
-   */
-  public notificationSubscriptions(
-    variables?: L.NotificationSubscriptionsQueryVariables
-  ): LinearFetch<NotificationSubscriptionConnection> {
-    return new NotificationSubscriptionsQuery(this._request).fetch(variables);
-  }
-  /**
-   * All notifications.
-   *
-   * @param variables - variables to pass into the NotificationsQuery
-   * @returns NotificationConnection
-   */
-  public notifications(variables?: L.NotificationsQueryVariables): LinearFetch<NotificationConnection> {
-    return new NotificationsQuery(this._request).fetch(variables);
-  }
-  /**
-   * The user's organization.
-   *
-   * @returns Organization
-   */
-  public get organization(): LinearFetch<Organization> {
-    return new OrganizationQuery(this._request).fetch();
-  }
-  /**
-   * Does the organization exist.
-   *
-   * @param urlKey - required urlKey to pass to organizationExists
-   * @returns OrganizationExistsPayload
-   */
-  public organizationExists(urlKey: string): LinearFetch<OrganizationExistsPayload> {
-    return new OrganizationExistsQuery(this._request).fetch(urlKey);
-  }
-  /**
-   * One specific organization invite.
-   *
-   * @param id - required id to pass to organizationInvite
-   * @returns OrganizationInvite
-   */
-  public organizationInvite(id: string): LinearFetch<OrganizationInvite> {
-    return new OrganizationInviteQuery(this._request).fetch(id);
-  }
-  /**
-   * One specific organization invite.
-   *
-   * @param id - required id to pass to organizationInviteDetails
-   * @returns OrganizationInviteDetailsPayload
-   */
-  public organizationInviteDetails(id: string): LinearFetch<OrganizationInviteDetailsPayload> {
-    return new OrganizationInviteDetailsQuery(this._request).fetch(id);
-  }
-  /**
-   * All invites for the organization.
-   *
-   * @param variables - variables to pass into the OrganizationInvitesQuery
-   * @returns OrganizationInviteConnection
-   */
-  public organizationInvites(
-    variables?: L.OrganizationInvitesQueryVariables
-  ): LinearFetch<OrganizationInviteConnection> {
-    return new OrganizationInvitesQuery(this._request).fetch(variables);
-  }
-  /**
-   * One specific project.
-   *
-   * @param id - required id to pass to project
-   * @returns Project
-   */
-  public project(id: string): LinearFetch<Project> {
-    return new ProjectQuery(this._request).fetch(id);
-  }
-  /**
-   * One specific project link.
-   *
-   * @param id - required id to pass to projectLink
-   * @returns ProjectLink
-   */
-  public projectLink(id: string): LinearFetch<ProjectLink> {
-    return new ProjectLinkQuery(this._request).fetch(id);
-  }
-  /**
-   * All links for the project.
-   *
-   * @param variables - variables to pass into the ProjectLinksQuery
-   * @returns ProjectLinkConnection
-   */
-  public projectLinks(variables?: L.ProjectLinksQueryVariables): LinearFetch<ProjectLinkConnection> {
-    return new ProjectLinksQuery(this._request).fetch(variables);
-  }
-  /**
-   * A specific project update.
-   *
-   * @param id - required id to pass to projectUpdate
-   * @returns ProjectUpdate
-   */
-  public projectUpdate(id: string): LinearFetch<ProjectUpdate> {
-    return new ProjectUpdateQuery(this._request).fetch(id);
-  }
-  /**
-   * A specific interaction on a project update.
-   *
-   * @param id - required id to pass to projectUpdateInteraction
-   * @returns ProjectUpdateInteraction
-   */
-  public projectUpdateInteraction(id: string): LinearFetch<ProjectUpdateInteraction> {
-    return new ProjectUpdateInteractionQuery(this._request).fetch(id);
-  }
-  /**
-   * All interactions on project updates.
-   *
-   * @param variables - variables to pass into the ProjectUpdateInteractionsQuery
-   * @returns ProjectUpdateInteractionConnection
-   */
-  public projectUpdateInteractions(
-    variables?: L.ProjectUpdateInteractionsQueryVariables
-  ): LinearFetch<ProjectUpdateInteractionConnection> {
-    return new ProjectUpdateInteractionsQuery(this._request).fetch(variables);
-  }
-  /**
-   * All project updates.
-   *
-   * @param variables - variables to pass into the ProjectUpdatesQuery
-   * @returns ProjectUpdateConnection
-   */
-  public projectUpdates(variables?: L.ProjectUpdatesQueryVariables): LinearFetch<ProjectUpdateConnection> {
-    return new ProjectUpdatesQuery(this._request).fetch(variables);
-  }
-  /**
-   * All projects.
-   *
-   * @param variables - variables to pass into the ProjectsQuery
-   * @returns ProjectConnection
-   */
-  public projects(variables?: L.ProjectsQueryVariables): LinearFetch<ProjectConnection> {
-    return new ProjectsQuery(this._request).fetch(variables);
-  }
-  /**
-   * Sends a test push message.
-   *
-   * @returns PushSubscriptionTestPayload
-   */
-  public get pushSubscriptionTest(): LinearFetch<PushSubscriptionTestPayload> {
-    return new PushSubscriptionTestQuery(this._request).fetch();
-  }
-  /**
-   * The status of the rate limiter.
-   *
-   * @returns RateLimitPayload
-   */
-  public get rateLimitStatus(): LinearFetch<RateLimitPayload> {
-    return new RateLimitStatusQuery(this._request).fetch();
-  }
-  /**
-   * One specific roadmap.
-   *
-   * @param id - required id to pass to roadmap
-   * @returns Roadmap
-   */
-  public roadmap(id: string): LinearFetch<Roadmap> {
-    return new RoadmapQuery(this._request).fetch(id);
-  }
-  /**
-   * One specific roadmapToProject.
-   *
-   * @param id - required id to pass to roadmapToProject
-   * @returns RoadmapToProject
-   */
-  public roadmapToProject(id: string): LinearFetch<RoadmapToProject> {
-    return new RoadmapToProjectQuery(this._request).fetch(id);
-  }
-  /**
-   * Custom views for the user.
-   *
-   * @param variables - variables to pass into the RoadmapToProjectsQuery
-   * @returns RoadmapToProjectConnection
-   */
-  public roadmapToProjects(variables?: L.RoadmapToProjectsQueryVariables): LinearFetch<RoadmapToProjectConnection> {
-    return new RoadmapToProjectsQuery(this._request).fetch(variables);
-  }
-  /**
-   * All roadmaps in the workspace.
-   *
-   * @param variables - variables to pass into the RoadmapsQuery
-   * @returns RoadmapConnection
-   */
-  public roadmaps(variables?: L.RoadmapsQueryVariables): LinearFetch<RoadmapConnection> {
-    return new RoadmapsQuery(this._request).fetch(variables);
-  }
-  /**
-   * Fetch SSO login URL for the email provided.
-   *
-   * @param email - required email to pass to ssoUrlFromEmail
-   * @param variables - variables without 'email' to pass into the SsoUrlFromEmailQuery
-   * @returns SsoUrlFromEmailResponse
-   */
-  public ssoUrlFromEmail(
-    email: string,
-    variables?: Omit<L.SsoUrlFromEmailQueryVariables, "email">
-  ): LinearFetch<SsoUrlFromEmailResponse> {
-    return new SsoUrlFromEmailQuery(this._request).fetch(email, variables);
-  }
-  /**
-   * One specific team.
-   *
-   * @param id - required id to pass to team
-   * @returns Team
-   */
-  public team(id: string): LinearFetch<Team> {
-    return new TeamQuery(this._request).fetch(id);
-  }
-  /**
-   * One specific team membership.
-   *
-   * @param id - required id to pass to teamMembership
-   * @returns TeamMembership
-   */
-  public teamMembership(id: string): LinearFetch<TeamMembership> {
-    return new TeamMembershipQuery(this._request).fetch(id);
-  }
-  /**
-   * All team memberships.
-   *
-   * @param variables - variables to pass into the TeamMembershipsQuery
-   * @returns TeamMembershipConnection
-   */
-  public teamMemberships(variables?: L.TeamMembershipsQueryVariables): LinearFetch<TeamMembershipConnection> {
-    return new TeamMembershipsQuery(this._request).fetch(variables);
-  }
-  /**
-   * All teams whose issues can be accessed by the user. This might be different from `administrableTeams`, which also includes teams whose settings can be changed by the user.
-   *
-   * @param variables - variables to pass into the TeamsQuery
-   * @returns TeamConnection
-   */
-  public teams(variables?: L.TeamsQueryVariables): LinearFetch<TeamConnection> {
-    return new TeamsQuery(this._request).fetch(variables);
-  }
-  /**
-   * A specific template.
-   *
-   * @param id - required id to pass to template
-   * @returns Template
-   */
-  public template(id: string): LinearFetch<Template> {
-    return new TemplateQuery(this._request).fetch(id);
-  }
-  /**
-   * All templates from all users.
-   *
-   * @returns Template[]
-   */
-  public get templates(): LinearFetch<Template[]> {
-    return new TemplatesQuery(this._request).fetch();
-  }
-  /**
-   * One specific user.
-   *
-   * @param id - required id to pass to user
-   * @returns User
-   */
-  public user(id: string): LinearFetch<User> {
-    return new UserQuery(this._request).fetch(id);
-  }
-  /**
-   * The user's settings.
-   *
-   * @returns UserSettings
-   */
-  public get userSettings(): LinearFetch<UserSettings> {
-    return new UserSettingsQuery(this._request).fetch();
-  }
-  /**
-   * All users for the organization.
-   *
-   * @param variables - variables to pass into the UsersQuery
-   * @returns UserConnection
-   */
-  public users(variables?: L.UsersQueryVariables): LinearFetch<UserConnection> {
-    return new UsersQuery(this._request).fetch(variables);
-  }
-  /**
-   * The currently authenticated user.
-   *
-   * @returns User
-   */
-  public get viewer(): LinearFetch<User> {
-    return new ViewerQuery(this._request).fetch();
-  }
-  /**
-   * A specific webhook.
-   *
-   * @param id - required id to pass to webhook
-   * @returns Webhook
-   */
-  public webhook(id: string): LinearFetch<Webhook> {
-    return new WebhookQuery(this._request).fetch(id);
-  }
-  /**
-   * All webhooks.
-   *
-   * @param variables - variables to pass into the WebhooksQuery
-   * @returns WebhookConnection
-   */
-  public webhooks(variables?: L.WebhooksQueryVariables): LinearFetch<WebhookConnection> {
-    return new WebhooksQuery(this._request).fetch(variables);
-  }
-  /**
-   * One specific state.
-   *
-   * @param id - required id to pass to workflowState
-   * @returns WorkflowState
-   */
-  public workflowState(id: string): LinearFetch<WorkflowState> {
-    return new WorkflowStateQuery(this._request).fetch(id);
-  }
-  /**
-   * All issue workflow states.
-   *
-   * @param variables - variables to pass into the WorkflowStatesQuery
-   * @returns WorkflowStateConnection
-   */
-  public workflowStates(variables?: L.WorkflowStatesQueryVariables): LinearFetch<WorkflowStateConnection> {
-    return new WorkflowStatesQuery(this._request).fetch(variables);
-  }
-  /**
    * Creates an integration api key for Airbyte to connect with Linear
    *
    * @param input - required input to pass to airbyteIntegrationConnect
@@ -19520,43 +18695,6 @@ export class LinearSdk extends Request {
     return new LogoutMutation(this._request).fetch();
   }
   /**
-   * Migrates milestones to roadmaps
-   *
-   * @param input - required input to pass to migrateMilestonesToRoadmaps
-   * @returns MilestoneMigrationPayload
-   */
-  public migrateMilestonesToRoadmaps(input: L.MilestonesMigrateInput): LinearFetch<MilestoneMigrationPayload> {
-    return new MigrateMilestonesToRoadmapsMutation(this._request).fetch(input);
-  }
-  /**
-   * Creates a new milestone.
-   *
-   * @param input - required input to pass to createMilestone
-   * @returns MilestonePayload
-   */
-  public createMilestone(input: L.MilestoneCreateInput): LinearFetch<MilestonePayload> {
-    return new CreateMilestoneMutation(this._request).fetch(input);
-  }
-  /**
-   * Deletes a milestone.
-   *
-   * @param id - required id to pass to deleteMilestone
-   * @returns ArchivePayload
-   */
-  public deleteMilestone(id: string): LinearFetch<ArchivePayload> {
-    return new DeleteMilestoneMutation(this._request).fetch(id);
-  }
-  /**
-   * Updates a milestone.
-   *
-   * @param id - required id to pass to updateMilestone
-   * @param input - required input to pass to updateMilestone
-   * @returns MilestonePayload
-   */
-  public updateMilestone(id: string, input: L.MilestoneUpdateInput): LinearFetch<MilestonePayload> {
-    return new UpdateMilestoneMutation(this._request).fetch(id, input);
-  }
-  /**
    * Archives a notification.
    *
    * @param id - required id to pass to archiveNotification
@@ -19745,6 +18883,37 @@ export class LinearSdk extends Request {
    */
   public updateProjectLink(id: string, input: L.ProjectLinkUpdateInput): LinearFetch<ProjectLinkPayload> {
     return new UpdateProjectLinkMutation(this._request).fetch(id, input);
+  }
+  /**
+   * Creates a new project milestone.
+   *
+   * @param input - required input to pass to createProjectMilestone
+   * @returns ProjectMilestonePayload
+   */
+  public createProjectMilestone(input: L.ProjectMilestoneCreateInput): LinearFetch<ProjectMilestonePayload> {
+    return new CreateProjectMilestoneMutation(this._request).fetch(input);
+  }
+  /**
+   * Deletes a project milestone.
+   *
+   * @param id - required id to pass to deleteProjectMilestone
+   * @returns ArchivePayload
+   */
+  public deleteProjectMilestone(id: string): LinearFetch<ArchivePayload> {
+    return new DeleteProjectMilestoneMutation(this._request).fetch(id);
+  }
+  /**
+   * Updates a project milestone.
+   *
+   * @param id - required id to pass to updateProjectMilestone
+   * @param input - required input to pass to updateProjectMilestone
+   * @returns ProjectMilestonePayload
+   */
+  public updateProjectMilestone(
+    id: string,
+    input: L.ProjectMilestoneUpdateInput
+  ): LinearFetch<ProjectMilestonePayload> {
+    return new UpdateProjectMilestoneMutation(this._request).fetch(id, input);
   }
   /**
    * Unarchives a project.
@@ -20268,5 +19437,731 @@ export class LinearSdk extends Request {
    */
   public updateWorkflowState(id: string, input: L.WorkflowStateUpdateInput): LinearFetch<WorkflowStatePayload> {
     return new UpdateWorkflowStateMutation(this._request).fetch(id, input);
+  }
+  /**
+   * One specific project milestone.
+   *
+   * @param id - required id to pass to ProjectMilestone
+   * @returns ProjectMilestone
+   */
+  public ProjectMilestone(id: string): LinearFetch<ProjectMilestone> {
+    return new ProjectMilestoneQuery(this._request).fetch(id);
+  }
+  /**
+   * All milestones for the project.
+   *
+   * @param variables - variables to pass into the ProjectMilestonesQuery
+   * @returns ProjectMilestoneConnection
+   */
+  public ProjectMilestones(variables?: L.ProjectMilestonesQueryVariables): LinearFetch<ProjectMilestoneConnection> {
+    return new ProjectMilestonesQuery(this._request).fetch(variables);
+  }
+  /**
+   * All teams you the user can administrate. Administrable teams are teams whose settings the user can change, but to whose issues the user doesn't necessarily have access to.
+   *
+   * @param variables - variables to pass into the AdministrableTeamsQuery
+   * @returns TeamConnection
+   */
+  public administrableTeams(variables?: L.AdministrableTeamsQueryVariables): LinearFetch<TeamConnection> {
+    return new AdministrableTeamsQuery(this._request).fetch(variables);
+  }
+  /**
+   * All API keys for the user.
+   *
+   * @param variables - variables to pass into the ApiKeysQuery
+   * @returns ApiKeyConnection
+   */
+  public apiKeys(variables?: L.ApiKeysQueryVariables): LinearFetch<ApiKeyConnection> {
+    return new ApiKeysQuery(this._request).fetch(variables);
+  }
+  /**
+   * Get basic information for an application.
+   *
+   * @param clientId - required clientId to pass to applicationInfo
+   * @returns Application
+   */
+  public applicationInfo(clientId: string): LinearFetch<Application> {
+    return new ApplicationInfoQuery(this._request).fetch(clientId);
+  }
+  /**
+   * Get information for an application and whether a user has approved it for the given scopes.
+   *
+   * @param clientId - required clientId to pass to applicationWithAuthorization
+   * @param scope - required scope to pass to applicationWithAuthorization
+   * @param variables - variables without 'clientId', 'scope' to pass into the ApplicationWithAuthorizationQuery
+   * @returns UserAuthorizedApplication
+   */
+  public applicationWithAuthorization(
+    clientId: string,
+    scope: string[],
+    variables?: Omit<L.ApplicationWithAuthorizationQueryVariables, "clientId" | "scope">
+  ): LinearFetch<UserAuthorizedApplication> {
+    return new ApplicationWithAuthorizationQuery(this._request).fetch(clientId, scope, variables);
+  }
+  /**
+   * One specific issue attachment.
+   * [Deprecated] 'url' can no longer be used as the 'id' parameter. Use 'attachmentsForUrl' instead
+   *
+   * @param id - required id to pass to attachment
+   * @returns Attachment
+   */
+  public attachment(id: string): LinearFetch<Attachment> {
+    return new AttachmentQuery(this._request).fetch(id);
+  }
+  /**
+   * Query an issue by its associated attachment, and its id.
+   *
+   * @param id - required id to pass to attachmentIssue
+   * @returns Issue
+   */
+  public attachmentIssue(id: string): LinearFetch<Issue> {
+    return new AttachmentIssueQuery(this._request).fetch(id);
+  }
+  /**
+   * All issue attachments.
+   *
+   * To get attachments for a given URL, use `attachmentsForURL` query.
+   *
+   * @param variables - variables to pass into the AttachmentsQuery
+   * @returns AttachmentConnection
+   */
+  public attachments(variables?: L.AttachmentsQueryVariables): LinearFetch<AttachmentConnection> {
+    return new AttachmentsQuery(this._request).fetch(variables);
+  }
+  /**
+   * Returns issue attachments for a given `url`.
+   *
+   * @param url - required url to pass to attachmentsForURL
+   * @param variables - variables without 'url' to pass into the AttachmentsForUrlQuery
+   * @returns AttachmentConnection
+   */
+  public attachmentsForURL(
+    url: string,
+    variables?: Omit<L.AttachmentsForUrlQueryVariables, "url">
+  ): LinearFetch<AttachmentConnection> {
+    return new AttachmentsForUrlQuery(this._request).fetch(url, variables);
+  }
+  /**
+   * All audit log entries.
+   *
+   * @param variables - variables to pass into the AuditEntriesQuery
+   * @returns AuditEntryConnection
+   */
+  public auditEntries(variables?: L.AuditEntriesQueryVariables): LinearFetch<AuditEntryConnection> {
+    return new AuditEntriesQuery(this._request).fetch(variables);
+  }
+  /**
+   * List of audit entry types.
+   *
+   * @returns AuditEntryType[]
+   */
+  public get auditEntryTypes(): LinearFetch<AuditEntryType[]> {
+    return new AuditEntryTypesQuery(this._request).fetch();
+  }
+  /**
+   * Fetch users belonging to this user account.
+   *
+   * @returns AuthResolverResponse
+   */
+  public get availableUsers(): LinearFetch<AuthResolverResponse> {
+    return new AvailableUsersQuery(this._request).fetch();
+  }
+  /**
+   * A specific comment.
+   *
+   * @param id - required id to pass to comment
+   * @returns Comment
+   */
+  public comment(id: string): LinearFetch<Comment> {
+    return new CommentQuery(this._request).fetch(id);
+  }
+  /**
+   * All comments.
+   *
+   * @param variables - variables to pass into the CommentsQuery
+   * @returns CommentConnection
+   */
+  public comments(variables?: L.CommentsQueryVariables): LinearFetch<CommentConnection> {
+    return new CommentsQuery(this._request).fetch(variables);
+  }
+  /**
+   * One specific custom view.
+   *
+   * @param id - required id to pass to customView
+   * @returns CustomView
+   */
+  public customView(id: string): LinearFetch<CustomView> {
+    return new CustomViewQuery(this._request).fetch(id);
+  }
+  /**
+   * Custom views for the user.
+   *
+   * @param variables - variables to pass into the CustomViewsQuery
+   * @returns CustomViewConnection
+   */
+  public customViews(variables?: L.CustomViewsQueryVariables): LinearFetch<CustomViewConnection> {
+    return new CustomViewsQuery(this._request).fetch(variables);
+  }
+  /**
+   * One specific cycle.
+   *
+   * @param id - required id to pass to cycle
+   * @returns Cycle
+   */
+  public cycle(id: string): LinearFetch<Cycle> {
+    return new CycleQuery(this._request).fetch(id);
+  }
+  /**
+   * All cycles.
+   *
+   * @param variables - variables to pass into the CyclesQuery
+   * @returns CycleConnection
+   */
+  public cycles(variables?: L.CyclesQueryVariables): LinearFetch<CycleConnection> {
+    return new CyclesQuery(this._request).fetch(variables);
+  }
+  /**
+   * One specific document.
+   *
+   * @param id - required id to pass to document
+   * @returns Document
+   */
+  public document(id: string): LinearFetch<Document> {
+    return new DocumentQuery(this._request).fetch(id);
+  }
+  /**
+   * All documents for the project.
+   *
+   * @param variables - variables to pass into the DocumentsQuery
+   * @returns DocumentConnection
+   */
+  public documents(variables?: L.DocumentsQueryVariables): LinearFetch<DocumentConnection> {
+    return new DocumentsQuery(this._request).fetch(variables);
+  }
+  /**
+   * A specific emoji.
+   *
+   * @param id - required id to pass to emoji
+   * @returns Emoji
+   */
+  public emoji(id: string): LinearFetch<Emoji> {
+    return new EmojiQuery(this._request).fetch(id);
+  }
+  /**
+   * All custom emojis.
+   *
+   * @param variables - variables to pass into the EmojisQuery
+   * @returns EmojiConnection
+   */
+  public emojis(variables?: L.EmojisQueryVariables): LinearFetch<EmojiConnection> {
+    return new EmojisQuery(this._request).fetch(variables);
+  }
+  /**
+   * One specific favorite.
+   *
+   * @param id - required id to pass to favorite
+   * @returns Favorite
+   */
+  public favorite(id: string): LinearFetch<Favorite> {
+    return new FavoriteQuery(this._request).fetch(id);
+  }
+  /**
+   * The user's favorites.
+   *
+   * @param variables - variables to pass into the FavoritesQuery
+   * @returns FavoriteConnection
+   */
+  public favorites(variables?: L.FavoritesQueryVariables): LinearFetch<FavoriteConnection> {
+    return new FavoritesQuery(this._request).fetch(variables);
+  }
+  /**
+   * Fetch Figma screenshot and other information with file and node identifiers.
+   *
+   * @param fileId - required fileId to pass to figmaEmbedInfo
+   * @param variables - variables without 'fileId' to pass into the FigmaEmbedInfoQuery
+   * @returns FigmaEmbedPayload
+   */
+  public figmaEmbedInfo(
+    fileId: string,
+    variables?: Omit<L.FigmaEmbedInfoQueryVariables, "fileId">
+  ): LinearFetch<FigmaEmbedPayload> {
+    return new FigmaEmbedInfoQuery(this._request).fetch(fileId, variables);
+  }
+  /**
+   * One specific integration.
+   *
+   * @param id - required id to pass to integration
+   * @returns Integration
+   */
+  public integration(id: string): LinearFetch<Integration> {
+    return new IntegrationQuery(this._request).fetch(id);
+  }
+  /**
+   * One specific integrationTemplate.
+   *
+   * @param id - required id to pass to integrationTemplate
+   * @returns IntegrationTemplate
+   */
+  public integrationTemplate(id: string): LinearFetch<IntegrationTemplate> {
+    return new IntegrationTemplateQuery(this._request).fetch(id);
+  }
+  /**
+   * Template and integration connections.
+   *
+   * @param variables - variables to pass into the IntegrationTemplatesQuery
+   * @returns IntegrationTemplateConnection
+   */
+  public integrationTemplates(
+    variables?: L.IntegrationTemplatesQueryVariables
+  ): LinearFetch<IntegrationTemplateConnection> {
+    return new IntegrationTemplatesQuery(this._request).fetch(variables);
+  }
+  /**
+   * All integrations.
+   *
+   * @param variables - variables to pass into the IntegrationsQuery
+   * @returns IntegrationConnection
+   */
+  public integrations(variables?: L.IntegrationsQueryVariables): LinearFetch<IntegrationConnection> {
+    return new IntegrationsQuery(this._request).fetch(variables);
+  }
+  /**
+   * One specific set of settings.
+   *
+   * @param id - required id to pass to integrationsSettings
+   * @returns IntegrationsSettings
+   */
+  public integrationsSettings(id: string): LinearFetch<IntegrationsSettings> {
+    return new IntegrationsSettingsQuery(this._request).fetch(id);
+  }
+  /**
+   * One specific issue.
+   *
+   * @param id - required id to pass to issue
+   * @returns Issue
+   */
+  public issue(id: string): LinearFetch<Issue> {
+    return new IssueQuery(this._request).fetch(id);
+  }
+  /**
+   * Fetches the GitHub token, completing the OAuth flow.
+   *
+   * @param code - required code to pass to issueImportFinishGithubOAuth
+   * @returns GithubOAuthTokenPayload
+   */
+  public issueImportFinishGithubOAuth(code: string): LinearFetch<GithubOAuthTokenPayload> {
+    return new IssueImportFinishGithubOAuthQuery(this._request).fetch(code);
+  }
+  /**
+   * One specific label.
+   *
+   * @param id - required id to pass to issueLabel
+   * @returns IssueLabel
+   */
+  public issueLabel(id: string): LinearFetch<IssueLabel> {
+    return new IssueLabelQuery(this._request).fetch(id);
+  }
+  /**
+   * All issue labels.
+   *
+   * @param variables - variables to pass into the IssueLabelsQuery
+   * @returns IssueLabelConnection
+   */
+  public issueLabels(variables?: L.IssueLabelsQueryVariables): LinearFetch<IssueLabelConnection> {
+    return new IssueLabelsQuery(this._request).fetch(variables);
+  }
+  /**
+   * Issue priority values and corresponding labels.
+   *
+   * @returns IssuePriorityValue[]
+   */
+  public get issuePriorityValues(): LinearFetch<IssuePriorityValue[]> {
+    return new IssuePriorityValuesQuery(this._request).fetch();
+  }
+  /**
+   * One specific issue relation.
+   *
+   * @param id - required id to pass to issueRelation
+   * @returns IssueRelation
+   */
+  public issueRelation(id: string): LinearFetch<IssueRelation> {
+    return new IssueRelationQuery(this._request).fetch(id);
+  }
+  /**
+   * All issue relationships.
+   *
+   * @param variables - variables to pass into the IssueRelationsQuery
+   * @returns IssueRelationConnection
+   */
+  public issueRelations(variables?: L.IssueRelationsQueryVariables): LinearFetch<IssueRelationConnection> {
+    return new IssueRelationsQuery(this._request).fetch(variables);
+  }
+  /**
+   * Find issue based on the VCS branch name.
+   *
+   * @param branchName - required branchName to pass to issueVcsBranchSearch
+   * @returns Issue
+   */
+  public issueVcsBranchSearch(branchName: string): LinearFetch<Issue | undefined> {
+    return new IssueVcsBranchSearchQuery(this._request).fetch(branchName);
+  }
+  /**
+   * All issues.
+   *
+   * @param variables - variables to pass into the IssuesQuery
+   * @returns IssueConnection
+   */
+  public issues(variables?: L.IssuesQueryVariables): LinearFetch<IssueConnection> {
+    return new IssuesQuery(this._request).fetch(variables);
+  }
+  /**
+   * One specific notification.
+   *
+   * @param id - required id to pass to notification
+   * @returns Notification
+   */
+  public notification(
+    id: string
+  ): LinearFetch<IssueNotification | OauthClientApprovalNotification | ProjectNotification | Notification> {
+    return new NotificationQuery(this._request).fetch(id);
+  }
+  /**
+   * One specific notification subscription.
+   *
+   * @param id - required id to pass to notificationSubscription
+   * @returns NotificationSubscription
+   */
+  public notificationSubscription(
+    id: string
+  ): LinearFetch<ProjectNotificationSubscription | TeamNotificationSubscription | NotificationSubscription> {
+    return new NotificationSubscriptionQuery(this._request).fetch(id);
+  }
+  /**
+   * The user's notification subscriptions.
+   *
+   * @param variables - variables to pass into the NotificationSubscriptionsQuery
+   * @returns NotificationSubscriptionConnection
+   */
+  public notificationSubscriptions(
+    variables?: L.NotificationSubscriptionsQueryVariables
+  ): LinearFetch<NotificationSubscriptionConnection> {
+    return new NotificationSubscriptionsQuery(this._request).fetch(variables);
+  }
+  /**
+   * All notifications.
+   *
+   * @param variables - variables to pass into the NotificationsQuery
+   * @returns NotificationConnection
+   */
+  public notifications(variables?: L.NotificationsQueryVariables): LinearFetch<NotificationConnection> {
+    return new NotificationsQuery(this._request).fetch(variables);
+  }
+  /**
+   * The user's organization.
+   *
+   * @returns Organization
+   */
+  public get organization(): LinearFetch<Organization> {
+    return new OrganizationQuery(this._request).fetch();
+  }
+  /**
+   * Does the organization exist.
+   *
+   * @param urlKey - required urlKey to pass to organizationExists
+   * @returns OrganizationExistsPayload
+   */
+  public organizationExists(urlKey: string): LinearFetch<OrganizationExistsPayload> {
+    return new OrganizationExistsQuery(this._request).fetch(urlKey);
+  }
+  /**
+   * One specific organization invite.
+   *
+   * @param id - required id to pass to organizationInvite
+   * @returns OrganizationInvite
+   */
+  public organizationInvite(id: string): LinearFetch<OrganizationInvite> {
+    return new OrganizationInviteQuery(this._request).fetch(id);
+  }
+  /**
+   * One specific organization invite.
+   *
+   * @param id - required id to pass to organizationInviteDetails
+   * @returns OrganizationInviteDetailsPayload
+   */
+  public organizationInviteDetails(id: string): LinearFetch<OrganizationInviteDetailsPayload> {
+    return new OrganizationInviteDetailsQuery(this._request).fetch(id);
+  }
+  /**
+   * All invites for the organization.
+   *
+   * @param variables - variables to pass into the OrganizationInvitesQuery
+   * @returns OrganizationInviteConnection
+   */
+  public organizationInvites(
+    variables?: L.OrganizationInvitesQueryVariables
+  ): LinearFetch<OrganizationInviteConnection> {
+    return new OrganizationInvitesQuery(this._request).fetch(variables);
+  }
+  /**
+   * One specific project.
+   *
+   * @param id - required id to pass to project
+   * @returns Project
+   */
+  public project(id: string): LinearFetch<Project> {
+    return new ProjectQuery(this._request).fetch(id);
+  }
+  /**
+   * One specific project link.
+   *
+   * @param id - required id to pass to projectLink
+   * @returns ProjectLink
+   */
+  public projectLink(id: string): LinearFetch<ProjectLink> {
+    return new ProjectLinkQuery(this._request).fetch(id);
+  }
+  /**
+   * All links for the project.
+   *
+   * @param variables - variables to pass into the ProjectLinksQuery
+   * @returns ProjectLinkConnection
+   */
+  public projectLinks(variables?: L.ProjectLinksQueryVariables): LinearFetch<ProjectLinkConnection> {
+    return new ProjectLinksQuery(this._request).fetch(variables);
+  }
+  /**
+   * A specific project update.
+   *
+   * @param id - required id to pass to projectUpdate
+   * @returns ProjectUpdate
+   */
+  public projectUpdate(id: string): LinearFetch<ProjectUpdate> {
+    return new ProjectUpdateQuery(this._request).fetch(id);
+  }
+  /**
+   * A specific interaction on a project update.
+   *
+   * @param id - required id to pass to projectUpdateInteraction
+   * @returns ProjectUpdateInteraction
+   */
+  public projectUpdateInteraction(id: string): LinearFetch<ProjectUpdateInteraction> {
+    return new ProjectUpdateInteractionQuery(this._request).fetch(id);
+  }
+  /**
+   * All interactions on project updates.
+   *
+   * @param variables - variables to pass into the ProjectUpdateInteractionsQuery
+   * @returns ProjectUpdateInteractionConnection
+   */
+  public projectUpdateInteractions(
+    variables?: L.ProjectUpdateInteractionsQueryVariables
+  ): LinearFetch<ProjectUpdateInteractionConnection> {
+    return new ProjectUpdateInteractionsQuery(this._request).fetch(variables);
+  }
+  /**
+   * All project updates.
+   *
+   * @param variables - variables to pass into the ProjectUpdatesQuery
+   * @returns ProjectUpdateConnection
+   */
+  public projectUpdates(variables?: L.ProjectUpdatesQueryVariables): LinearFetch<ProjectUpdateConnection> {
+    return new ProjectUpdatesQuery(this._request).fetch(variables);
+  }
+  /**
+   * All projects.
+   *
+   * @param variables - variables to pass into the ProjectsQuery
+   * @returns ProjectConnection
+   */
+  public projects(variables?: L.ProjectsQueryVariables): LinearFetch<ProjectConnection> {
+    return new ProjectsQuery(this._request).fetch(variables);
+  }
+  /**
+   * Sends a test push message.
+   *
+   * @returns PushSubscriptionTestPayload
+   */
+  public get pushSubscriptionTest(): LinearFetch<PushSubscriptionTestPayload> {
+    return new PushSubscriptionTestQuery(this._request).fetch();
+  }
+  /**
+   * The status of the rate limiter.
+   *
+   * @returns RateLimitPayload
+   */
+  public get rateLimitStatus(): LinearFetch<RateLimitPayload> {
+    return new RateLimitStatusQuery(this._request).fetch();
+  }
+  /**
+   * One specific roadmap.
+   *
+   * @param id - required id to pass to roadmap
+   * @returns Roadmap
+   */
+  public roadmap(id: string): LinearFetch<Roadmap> {
+    return new RoadmapQuery(this._request).fetch(id);
+  }
+  /**
+   * One specific roadmapToProject.
+   *
+   * @param id - required id to pass to roadmapToProject
+   * @returns RoadmapToProject
+   */
+  public roadmapToProject(id: string): LinearFetch<RoadmapToProject> {
+    return new RoadmapToProjectQuery(this._request).fetch(id);
+  }
+  /**
+   * Custom views for the user.
+   *
+   * @param variables - variables to pass into the RoadmapToProjectsQuery
+   * @returns RoadmapToProjectConnection
+   */
+  public roadmapToProjects(variables?: L.RoadmapToProjectsQueryVariables): LinearFetch<RoadmapToProjectConnection> {
+    return new RoadmapToProjectsQuery(this._request).fetch(variables);
+  }
+  /**
+   * All roadmaps in the workspace.
+   *
+   * @param variables - variables to pass into the RoadmapsQuery
+   * @returns RoadmapConnection
+   */
+  public roadmaps(variables?: L.RoadmapsQueryVariables): LinearFetch<RoadmapConnection> {
+    return new RoadmapsQuery(this._request).fetch(variables);
+  }
+  /**
+   * Fetch SSO login URL for the email provided.
+   *
+   * @param email - required email to pass to ssoUrlFromEmail
+   * @param variables - variables without 'email' to pass into the SsoUrlFromEmailQuery
+   * @returns SsoUrlFromEmailResponse
+   */
+  public ssoUrlFromEmail(
+    email: string,
+    variables?: Omit<L.SsoUrlFromEmailQueryVariables, "email">
+  ): LinearFetch<SsoUrlFromEmailResponse> {
+    return new SsoUrlFromEmailQuery(this._request).fetch(email, variables);
+  }
+  /**
+   * One specific team.
+   *
+   * @param id - required id to pass to team
+   * @returns Team
+   */
+  public team(id: string): LinearFetch<Team> {
+    return new TeamQuery(this._request).fetch(id);
+  }
+  /**
+   * One specific team membership.
+   *
+   * @param id - required id to pass to teamMembership
+   * @returns TeamMembership
+   */
+  public teamMembership(id: string): LinearFetch<TeamMembership> {
+    return new TeamMembershipQuery(this._request).fetch(id);
+  }
+  /**
+   * All team memberships.
+   *
+   * @param variables - variables to pass into the TeamMembershipsQuery
+   * @returns TeamMembershipConnection
+   */
+  public teamMemberships(variables?: L.TeamMembershipsQueryVariables): LinearFetch<TeamMembershipConnection> {
+    return new TeamMembershipsQuery(this._request).fetch(variables);
+  }
+  /**
+   * All teams whose issues can be accessed by the user. This might be different from `administrableTeams`, which also includes teams whose settings can be changed by the user.
+   *
+   * @param variables - variables to pass into the TeamsQuery
+   * @returns TeamConnection
+   */
+  public teams(variables?: L.TeamsQueryVariables): LinearFetch<TeamConnection> {
+    return new TeamsQuery(this._request).fetch(variables);
+  }
+  /**
+   * A specific template.
+   *
+   * @param id - required id to pass to template
+   * @returns Template
+   */
+  public template(id: string): LinearFetch<Template> {
+    return new TemplateQuery(this._request).fetch(id);
+  }
+  /**
+   * All templates from all users.
+   *
+   * @returns Template[]
+   */
+  public get templates(): LinearFetch<Template[]> {
+    return new TemplatesQuery(this._request).fetch();
+  }
+  /**
+   * One specific user.
+   *
+   * @param id - required id to pass to user
+   * @returns User
+   */
+  public user(id: string): LinearFetch<User> {
+    return new UserQuery(this._request).fetch(id);
+  }
+  /**
+   * The user's settings.
+   *
+   * @returns UserSettings
+   */
+  public get userSettings(): LinearFetch<UserSettings> {
+    return new UserSettingsQuery(this._request).fetch();
+  }
+  /**
+   * All users for the organization.
+   *
+   * @param variables - variables to pass into the UsersQuery
+   * @returns UserConnection
+   */
+  public users(variables?: L.UsersQueryVariables): LinearFetch<UserConnection> {
+    return new UsersQuery(this._request).fetch(variables);
+  }
+  /**
+   * The currently authenticated user.
+   *
+   * @returns User
+   */
+  public get viewer(): LinearFetch<User> {
+    return new ViewerQuery(this._request).fetch();
+  }
+  /**
+   * A specific webhook.
+   *
+   * @param id - required id to pass to webhook
+   * @returns Webhook
+   */
+  public webhook(id: string): LinearFetch<Webhook> {
+    return new WebhookQuery(this._request).fetch(id);
+  }
+  /**
+   * All webhooks.
+   *
+   * @param variables - variables to pass into the WebhooksQuery
+   * @returns WebhookConnection
+   */
+  public webhooks(variables?: L.WebhooksQueryVariables): LinearFetch<WebhookConnection> {
+    return new WebhooksQuery(this._request).fetch(variables);
+  }
+  /**
+   * One specific state.
+   *
+   * @param id - required id to pass to workflowState
+   * @returns WorkflowState
+   */
+  public workflowState(id: string): LinearFetch<WorkflowState> {
+    return new WorkflowStateQuery(this._request).fetch(id);
+  }
+  /**
+   * All issue workflow states.
+   *
+   * @param variables - variables to pass into the WorkflowStatesQuery
+   * @returns WorkflowStateConnection
+   */
+  public workflowStates(variables?: L.WorkflowStatesQueryVariables): LinearFetch<WorkflowStateConnection> {
+    return new WorkflowStatesQuery(this._request).fetch(variables);
   }
 }

--- a/packages/sdk/src/_tests/_generated.test.ts
+++ b/packages/sdk/src/_tests/_generated.test.ts
@@ -19,6 +19,43 @@ describe("generated", () => {
     stopClient();
   });
 
+  /** Test all ProjectMilestone queries */
+  describe("ProjectMilestones", () => {
+    let _ProjectMilestone: L.ProjectMilestone | undefined;
+    let _ProjectMilestone_id: string | undefined;
+
+    /** Test the root connection query for the ProjectMilestone */
+    it("ProjectMilestones", async () => {
+      const ProjectMilestones: L.ProjectMilestoneConnection | undefined = await client.ProjectMilestones();
+      const ProjectMilestone = ProjectMilestones?.nodes?.[0];
+      _ProjectMilestone_id = ProjectMilestone?.id;
+      expect(ProjectMilestones instanceof L.ProjectMilestoneConnection);
+    });
+
+    /** Test the root query for a single ProjectMilestone */
+    it("ProjectMilestone", async () => {
+      if (_ProjectMilestone_id) {
+        const ProjectMilestone: L.ProjectMilestone | undefined = await client.ProjectMilestone(_ProjectMilestone_id);
+        _ProjectMilestone = ProjectMilestone;
+        expect(ProjectMilestone instanceof L.ProjectMilestone);
+      } else {
+        console.warn(
+          "codegen-doc:print: No first ProjectMilestone found in connection - cannot test ProjectMilestone query"
+        );
+      }
+    });
+
+    /** Test the ProjectMilestone.project query for L.Project */
+    it("ProjectMilestone.project", async () => {
+      if (_ProjectMilestone) {
+        const ProjectMilestone_project: L.Project | undefined = await _ProjectMilestone.project;
+        expect(ProjectMilestone_project instanceof L.Project);
+      } else {
+        console.warn("codegen-doc:print: No ProjectMilestone found - cannot test ProjectMilestone.project query");
+      }
+    });
+  });
+
   /** Test all Team queries */
   describe("AdministrableTeams", () => {
     let _team: L.Team | undefined;
@@ -1495,51 +1532,6 @@ describe("generated", () => {
     });
   });
 
-  /** Test all Milestone queries */
-  describe("Milestones", () => {
-    let _milestone: L.Milestone | undefined;
-    let _milestone_id: string | undefined;
-
-    /** Test the root connection query for the Milestone */
-    it("milestones", async () => {
-      const milestones: L.MilestoneConnection | undefined = await client.milestones();
-      const milestone = milestones?.nodes?.[0];
-      _milestone_id = milestone?.id;
-      expect(milestones instanceof L.MilestoneConnection);
-    });
-
-    /** Test the root query for a single Milestone */
-    it("milestone", async () => {
-      if (_milestone_id) {
-        const milestone: L.Milestone | undefined = await client.milestone(_milestone_id);
-        _milestone = milestone;
-        expect(milestone instanceof L.Milestone);
-      } else {
-        console.warn("codegen-doc:print: No first Milestone found in connection - cannot test milestone query");
-      }
-    });
-
-    /** Test the milestone connection query for the Project */
-    it("milestone.projects", async () => {
-      if (_milestone) {
-        const projects: L.ProjectConnection | undefined = await _milestone.projects();
-        expect(projects instanceof L.ProjectConnection);
-      } else {
-        console.warn("codegen-doc:print: No milestone found - cannot test _milestone.projects query");
-      }
-    });
-
-    /** Test the milestone.organization query for L.Organization */
-    it("milestone.organization", async () => {
-      if (_milestone) {
-        const milestone_organization: L.Organization | undefined = await _milestone.organization;
-        expect(milestone_organization instanceof L.Organization);
-      } else {
-        console.warn("codegen-doc:print: No Milestone found - cannot test milestone.organization query");
-      }
-    });
-  });
-
   /** Test all NotificationSubscription queries */
   describe("NotificationSubscriptions", () => {
     let _notificationSubscription:
@@ -2000,16 +1992,6 @@ describe("generated", () => {
       }
     });
 
-    /** Test the project model query for Project_Initiative */
-    it("project.initiative", async () => {
-      if (_project) {
-        const initiative: L.Initiative | undefined = _project.initiative;
-        expect(initiative instanceof L.Initiative);
-      } else {
-        console.warn("codegen-doc:print: No project found - cannot test _project.initiative query");
-      }
-    });
-
     /** Test the project connection query for the Issue */
     it("project.issues", async () => {
       if (_project) {
@@ -2097,16 +2079,6 @@ describe("generated", () => {
         expect(project_lead instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Project found - cannot test project.lead query");
-      }
-    });
-
-    /** Test the project.milestone query for L.Milestone */
-    it("project.milestone", async () => {
-      if (_project) {
-        const project_milestone: L.Milestone | undefined = await _project.milestone;
-        expect(project_milestone instanceof L.Milestone);
-      } else {
-        console.warn("codegen-doc:print: No Project found - cannot test project.milestone query");
       }
     });
   });

--- a/packages/sdk/src/schema.graphql
+++ b/packages/sdk/src/schema.graphql
@@ -247,7 +247,7 @@ input AttachmentCollectionFilter {
   """
   Comparator for the source type.
   """
-  sourceType: NestedStringComparator
+  sourceType: SourceTypeComparator
   """
   Comparator for the subtitle.
   """
@@ -354,7 +354,7 @@ input AttachmentFilter {
   """
   Comparator for the source type.
   """
-  sourceType: NestedStringComparator
+  sourceType: SourceTypeComparator
   """
   Comparator for the subtitle.
   """
@@ -443,6 +443,10 @@ type AuditEntry implements Node {
   Additional metadata related to the audit entry.
   """
   metadata: JSONObject
+  """
+  The organization the audit log belongs to.
+  """
+  organization: Organization
   """
   Additional information related to the request which performed the action.
   """
@@ -670,7 +674,7 @@ type Comment implements Node {
   """
   issue: Issue!
   """
-  The parent of the comment.
+  The parent comment under which the current comment is nested.
   """
   parent: Comment
   """
@@ -771,6 +775,10 @@ input CommentCreateInput {
   """
   displayIconUrl: String
   """
+  Flag to prevent auto subscription to the issue the comment is created on.
+  """
+  doNotSubscribeToIssue: Boolean
+  """
   The identifier in UUID v4 format. If none is provided, the backend will generate one.
   """
   id: String
@@ -779,7 +787,7 @@ input CommentCreateInput {
   """
   issueId: String!
   """
-  [Internal] The parent under which to nest the comment.
+  The parent comment under which to nest a current comment.
   """
   parentId: String
 }
@@ -2397,64 +2405,6 @@ type ImageUploadFromUrlPayload {
 }
 
 """
-A initiative that contains projects.
-"""
-type Initiative implements Node {
-  """
-  The time at which the entity was archived. Null if the entity has not been archived.
-  """
-  archivedAt: DateTime
-  """
-  The time at which the entity was created.
-  """
-  createdAt: DateTime!
-  """
-  The initiative's description.
-  """
-  description: String
-  """
-  The unique identifier of the entity.
-  """
-  id: ID!
-  """
-  The name of the initiative.
-  """
-  name: String!
-  """
-  The organization that the initiative belongs to.
-  """
-  organization: Organization!
-  """
-  The sort order for the initiative.
-  """
-  sortOrder: Float!
-  """
-  The estimated completion date of the initiative.
-  """
-  targetDate: TimelessDate
-  """
-  The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
-      for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
-      been updated after creation.
-  """
-  updatedAt: DateTime!
-}
-
-type InitiativeConnection {
-  edges: [InitiativeEdge!]!
-  nodes: [Initiative!]!
-  pageInfo: PageInfo!
-}
-
-type InitiativeEdge {
-  """
-  Used in `before` and `after` args
-  """
-  cursor: String!
-  node: Initiative!
-}
-
-"""
 An integration with an external service.
 """
 type Integration implements Node {
@@ -2634,6 +2584,7 @@ type IntegrationSettings {
   googleSheets: GoogleSheetsSettings
   intercom: IntercomSettings
   jira: JiraSettings
+  notion: NotionSettings
   sentry: SentrySettings
   slackOrgProjectUpdatesPost: SlackPostSettings
   slackPost: SlackPostSettings
@@ -2647,6 +2598,7 @@ input IntegrationSettingsInput {
   googleSheets: GoogleSheetsSettingsInput
   intercom: IntercomSettingsInput
   jira: JiraSettingsInput
+  notion: NotionSettingsInput
   sentry: SentrySettingsInput
   slackOrgProjectUpdatesPost: SlackPostSettingsInput
   slackPost: SlackPostSettingsInput
@@ -2751,6 +2703,10 @@ type IntegrationsSettings implements Node {
   """
   project: Project
   """
+  Whether to send a Slack message when a new issue is added to triage.
+  """
+  slackIssueAddedToTriage: Boolean
+  """
   Whether to send a Slack message when a new issue is created for the project or the team.
   """
   slackIssueCreated: Boolean
@@ -2758,6 +2714,14 @@ type IntegrationsSettings implements Node {
   Whether to send a Slack message when a comment is created on any of the project or team's issues.
   """
   slackIssueNewComment: Boolean
+  """
+  Whether to send a Slack message when an SLA is breached
+  """
+  slackIssueSlaBreached: Boolean
+  """
+  Whether to send a Slack message when an SLA is at high risk
+  """
+  slackIssueSlaHighRisk: Boolean
   """
   Whether to send a Slack message when any of the project or team's issues has a change in status.
   """
@@ -2770,10 +2734,6 @@ type IntegrationsSettings implements Node {
   Whether to send a Slack message when a project update is created.
   """
   slackProjectUpdateCreated: Boolean
-  """
-  Whether to send a new project update to milestone Slack channels.
-  """
-  slackProjectUpdateCreatedToMilestone: Boolean
   """
   Whether to send a new project update to team Slack channels.
   """
@@ -2810,6 +2770,10 @@ input IntegrationsSettingsCreateInput {
   """
   projectId: String
   """
+  Whether to send a Slack message when a new issue is added to triage.
+  """
+  slackIssueAddedToTriage: Boolean
+  """
   Whether to send a Slack message when a new issue is created for the project or the team.
   """
   slackIssueCreated: Boolean
@@ -2817,6 +2781,14 @@ input IntegrationsSettingsCreateInput {
   Whether to send a Slack message when a comment is created on any of the project or team's issues.
   """
   slackIssueNewComment: Boolean
+  """
+  Whether to receive notification when an SLA has breached on Slack.
+  """
+  slackIssueSlaBreached: Boolean
+  """
+  Whether to send a Slack message when an SLA is at high risk
+  """
+  slackIssueSlaHighRisk: Boolean
   """
   Whether to send a Slack message when any of the project or team's issues has a change in status.
   """
@@ -2829,10 +2801,6 @@ input IntegrationsSettingsCreateInput {
   Whether to send a Slack message when a project update is created.
   """
   slackProjectUpdateCreated: Boolean
-  """
-  Whether to send a Slack message when a project update is created to milestone channels.
-  """
-  slackProjectUpdateCreatedToMilestone: Boolean
   """
   Whether to send a Slack message when a project update is created to team channels.
   """
@@ -2872,6 +2840,10 @@ type IntegrationsSettingsPayload {
 
 input IntegrationsSettingsUpdateInput {
   """
+  Whether to send a Slack message when a new issue is added to triage.
+  """
+  slackIssueAddedToTriage: Boolean
+  """
   Whether to send a Slack message when a new issue is created for the project or the team.
   """
   slackIssueCreated: Boolean
@@ -2879,6 +2851,14 @@ input IntegrationsSettingsUpdateInput {
   Whether to send a Slack message when a comment is created on any of the project or team's issues.
   """
   slackIssueNewComment: Boolean
+  """
+  Whether to receive notification when an SLA has breached on Slack.
+  """
+  slackIssueSlaBreached: Boolean
+  """
+  Whether to send a Slack message when an SLA is at high risk
+  """
+  slackIssueSlaHighRisk: Boolean
   """
   Whether to send a Slack message when any of the project or team's issues has a change in status.
   """
@@ -2891,10 +2871,6 @@ input IntegrationsSettingsUpdateInput {
   Whether to send a Slack message when a project update is created.
   """
   slackProjectUpdateCreated: Boolean
-  """
-  Whether to send a Slack message when a project update is created to milestone channels.
-  """
-  slackProjectUpdateCreatedToMilestone: Boolean
   """
   Whether to send a Slack message when a project update is created to team channels.
   """
@@ -3275,6 +3251,10 @@ type Issue implements Node {
   """
   project: Project
   """
+  [ALPHA] The projectMilestone that the issue is associated with.
+  """
+  projectMilestone: ProjectMilestone
+  """
   Relations associated with this issue.
   """
   relations(
@@ -3304,6 +3284,14 @@ type Issue implements Node {
     orderBy: PaginationOrderBy
   ): IssueRelationConnection!
   """
+  [Internal] The time at which the issue's SLA will breach.
+  """
+  slaBreachesAt: DateTime
+  """
+  [Internal] The time at which the issue's SLA began.
+  """
+  slaStartedAt: DateTime
+  """
   The user who snoozed the issue.
   """
   snoozedBy: User
@@ -3319,6 +3307,10 @@ type Issue implements Node {
   The time at which the issue was moved into started state.
   """
   startedAt: DateTime
+  """
+  The time at which the issue entered triage.
+  """
+  startedTriageAt: DateTime
   """
   The workflow state that the issue is associated with.
   """
@@ -3528,6 +3520,10 @@ input IssueCollectionFilter {
   """
   searchableContent: ContentComparator
   """
+  Comparator for the issues sla status.
+  """
+  slaStatus: SlaStatusComparator
+  """
   Filters that the issues snoozer must satisfy.
   """
   snoozedBy: NullableUserFilter
@@ -3633,6 +3629,10 @@ input IssueCreateInput {
   """
   projectId: String
   """
+  [ALPHA] The project milestone associated with the issue.
+  """
+  projectMilestoneId: String
+  """
   The comment the issue is referencing.
   """
   referenceCommentId: String
@@ -3660,6 +3660,98 @@ input IssueCreateInput {
   The title of the issue.
   """
   title: String!
+}
+
+"""
+[Internal] A draft issue.
+"""
+type IssueDraft implements Node {
+  """
+  The time at which the entity was archived. Null if the entity has not been archived.
+  """
+  archivedAt: DateTime
+  """
+  The user assigned to the draft.
+  """
+  assigneeId: String
+  """
+  Serialized array of JSONs representing attachments.
+  """
+  attachments: JSONObject!
+  """
+  The time at which the entity was created.
+  """
+  createdAt: DateTime!
+  """
+  The user who created the draft.
+  """
+  creator: User!
+  """
+  The cycle associated with the draft.
+  """
+  cycleId: String
+  """
+  The draft's description in markdown format.
+  """
+  description: String
+  """
+  [Internal] The draft's description as a Prosemirror document.
+  """
+  descriptionData: JSON
+  """
+  The date at which the issue would be due.
+  """
+  dueDate: TimelessDate
+  """
+  The estimate of the complexity of the draft.
+  """
+  estimate: Float
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  """
+  The parent draft of the draft.
+  """
+  parent: IssueDraft
+  """
+  The parent issue of the draft.
+  """
+  parentIssue: Issue
+  """
+  The priority of the draft.
+  """
+  priority: Float!
+  """
+  Label for the priority.
+  """
+  priorityLabel: String!
+  """
+  The project associated with the draft.
+  """
+  projectId: String
+  """
+  The workflow state associated with the draft.
+  """
+  stateId: String!
+  """
+  The order of items in the sub-draft list. Only set if the draft has `parent` set.
+  """
+  subIssueSortOrder: Float
+  """
+  The team associated with the draft.
+  """
+  teamId: String!
+  """
+  The draft's title.
+  """
+  title: String!
+  """
+  The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+      for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+      been updated after creation.
+  """
+  updatedAt: DateTime!
 }
 
 type IssueEdge {
@@ -3783,6 +3875,10 @@ input IssueFilter {
   """
   searchableContent: ContentComparator
   """
+  Comparator for the issues sla status.
+  """
+  slaStatus: SlaStatusComparator
+  """
   Filters that the issues snoozer must satisfy.
   """
   snoozedBy: NullableUserFilter
@@ -3856,6 +3952,10 @@ type IssueHistory implements Node {
   Whether the issue was auto-closed.
   """
   autoClosed: Boolean
+  """
+  [Internal] Serialized JSON representing changes for certain non-relational properties.
+  """
+  changes: JSONObject
   """
   The time at which the entity was created.
   """
@@ -4702,6 +4802,14 @@ input IssueUpdateInput {
   """
   projectId: String
   """
+  [ALPHA] The project milestone associated with the issue.
+  """
+  projectMilestoneId: String
+  """
+  [Internal] The timestamp at which an issue will be considered in breach of SLA.
+  """
+  slaBreachesAt: DateTime
+  """
   The identifier of the user who snoozed the issue.
   """
   snoozedById: String
@@ -4865,184 +4973,6 @@ type LogoutResponse {
   success: Boolean!
 }
 
-"""
-A milestone that contains projects.
-"""
-type Milestone implements Node {
-  """
-  The time at which the entity was archived. Null if the entity has not been archived.
-  """
-  archivedAt: DateTime
-  """
-  The time at which the entity was created.
-  """
-  createdAt: DateTime!
-  """
-  [ALPHA] The milestone's description.
-  """
-  description: String
-  """
-  The unique identifier of the entity.
-  """
-  id: ID!
-  """
-  The name of the milestone.
-  """
-  name: String!
-  """
-  The organization that the milestone belongs to.
-  """
-  organization: Organization!
-  """
-  Projects associated with the milestone.
-  """
-  projects(
-    """
-    A cursor to be used with first for forward pagination
-    """
-    after: String
-    """
-    A cursor to be used with last for backward pagination.
-    """
-    before: String
-    """
-    Filter returned projects.
-    """
-    filter: ProjectFilter
-    """
-    The number of items to forward paginate (used with after). Defaults to 50.
-    """
-    first: Int
-    """
-    Should archived resources be included (default: false)
-    """
-    includeArchived: Boolean
-    """
-    The number of items to backward paginate (used with before). Defaults to 50.
-    """
-    last: Int
-    """
-    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
-    """
-    orderBy: PaginationOrderBy
-  ): ProjectConnection! @deprecated(reason: "Milestones will be removed. Use roadmaps instead.")
-  """
-  The sort order for the milestone.
-  """
-  sortOrder: Float!
-  """
-  [ALPHA] The estimated completion date of the initiative.
-  """
-  targetDate: TimelessDate
-  """
-  The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
-      for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
-      been updated after creation.
-  """
-  updatedAt: DateTime!
-}
-
-type MilestoneConnection {
-  edges: [MilestoneEdge!]!
-  nodes: [Milestone!]!
-  pageInfo: PageInfo!
-}
-
-input MilestoneCreateInput {
-  """
-  [ALPHA] The description for the milestone.
-  """
-  description: String
-  """
-  The identifier in UUID v4 format. If none is provided, the backend will generate one.
-  """
-  id: String
-  """
-  The name of the milestone.
-  """
-  name: String!
-  """
-  The sort order of the milestone.
-  """
-  sortOrder: Float
-  """
-  [ALPHA] The planned target date of the milestone.
-  """
-  targetDate: TimelessDate
-  """
-  [ALPHA] The identifiers of the teams this milestone is associated with.
-  """
-  teamIds: [String!]
-}
-
-type MilestoneEdge {
-  """
-  Used in `before` and `after` args
-  """
-  cursor: String!
-  node: Milestone!
-}
-
-type MilestoneMigrationPayload {
-  """
-  The identifier of the last sync operation.
-  """
-  lastSyncId: Float!
-  """
-  Whether the operation was successful.
-  """
-  success: Boolean!
-}
-
-type MilestonePayload {
-  """
-  The identifier of the last sync operation.
-  """
-  lastSyncId: Float!
-  """
-  The milesteone that was created or updated.
-  """
-  milestone: Milestone
-  """
-  Whether the operation was successful.
-  """
-  success: Boolean!
-}
-
-input MilestoneUpdateInput {
-  """
-  [ALPHA] The description for the milestone.
-  """
-  description: String
-  """
-  The name of the milestone.
-  """
-  name: String
-  """
-  The sort order of the milestone.
-  """
-  sortOrder: Float
-  """
-  [ALPHA] The planned target date of the milestone.
-  """
-  targetDate: TimelessDate
-  """
-  [ALPHA] The identifiers of the teams this milestone is associated with.
-  """
-  teamIds: [String!]
-}
-
-input MilestonesMigrateInput {
-  """
-  IDs of the milestones to delete.
-  """
-  milestonesToDelete: [String!]
-  """
-  IDs of the milestones to migrate.
-  """
-  milestonesToMigrate: [String!]
-}
-
 type Mutation {
   """
   Creates an integration api key for Airbyte to connect with Linear
@@ -5162,6 +5092,10 @@ type Mutation {
   Link any url to an issue.
   """
   attachmentLinkURL(
+    """
+    The id for the attachment.
+    """
+    id: String
     """
     The issue for which to link the url.
     """
@@ -5867,6 +5801,19 @@ type Mutation {
     id: String!
   ): ArchivePayload!
   """
+  [INTERNAL] Updates an issue description from the Front app to handle Front attachments correctly.
+  """
+  issueDescriptionUpdateFromFront(
+    """
+    Description to update the issue with.
+    """
+    description: String!
+    """
+    The identifier of the issue to update.
+    """
+    id: String!
+  ): IssuePayload!
+  """
   Kicks off an Asana import job.
   """
   issueImportCreateAsana(
@@ -6207,46 +6154,6 @@ type Mutation {
   """
   logout: LogoutResponse!
   """
-  Migrates milestones to roadmaps
-  """
-  migrateMilestonesToRoadmaps(
-    """
-    Ids for milestones to migrate and milestones to delete
-    """
-    input: MilestonesMigrateInput!
-  ): MilestoneMigrationPayload!
-  """
-  Creates a new milestone.
-  """
-  milestoneCreate(
-    """
-    The issue object to create.
-    """
-    input: MilestoneCreateInput!
-  ): MilestonePayload! @deprecated(reason: "Milestones will be removed. Use roadmaps instead.")
-  """
-  Deletes a milestone.
-  """
-  milestoneDelete(
-    """
-    The identifier of the milestone to delete.
-    """
-    id: String!
-  ): ArchivePayload! @deprecated(reason: "Milestones will be removed. Use roadmaps instead.")
-  """
-  Updates a milestone.
-  """
-  milestoneUpdate(
-    """
-    The identifier of the milestone to update.
-    """
-    id: String!
-    """
-    A partial milestone object to update the milestone with.
-    """
-    input: MilestoneUpdateInput!
-  ): MilestonePayload! @deprecated(reason: "Milestones will be removed. Use roadmaps instead.")
-  """
   Archives a notification.
   """
   notificationArchive(
@@ -6463,6 +6370,37 @@ type Mutation {
     """
     input: ProjectLinkUpdateInput!
   ): ProjectLinkPayload!
+  """
+  Creates a new project milestone.
+  """
+  projectMilestoneCreate(
+    """
+    The project milestone to create.
+    """
+    input: ProjectMilestoneCreateInput!
+  ): ProjectMilestonePayload!
+  """
+  Deletes a project milestone.
+  """
+  projectMilestoneDelete(
+    """
+    The identifier of the project milestone to delete.
+    """
+    id: String!
+  ): ArchivePayload!
+  """
+  Updates a project milestone.
+  """
+  projectMilestoneUpdate(
+    """
+    The identifier of the project milestone to update. Also the identifier from the URL is accepted.
+    """
+    id: String!
+    """
+    A partial object to update the project milestone with.
+    """
+    input: ProjectMilestoneUpdateInput!
+  ): ProjectMilestonePayload!
   """
   Unarchives a project.
   """
@@ -6775,45 +6713,6 @@ type Mutation {
     input: TemplateUpdateInput!
   ): TemplatePayload!
   """
-  [INTERNAL] Cancels an ongoing email change for the user account
-  """
-  userAccountEmailChangeCancel(
-    """
-    The id of the user account to cancel the change for.
-    """
-    id: String!
-  ): UserAccountEmailVerificationPayload!
-  """
-  [INTERNAL] Creates an email verification challenge from the app for a user account that wants to change email.
-  """
-  userAccountEmailChangeCreate(
-    """
-    [INTERNAL] Whether an existing account exists for the new email address.
-    """
-    hasExistingAccount: Boolean!
-    """
-    [INTERNAL] The identifier of the user account that wants to change email.
-    """
-    id: String!
-    """
-    [INTERNAL] The new email address the user wants to use.
-    """
-    newEmail: String!
-  ): UserAccountEmailVerificationPayload!
-  """
-  [INTERNAL] Verifies the email address and code for a user account that wants to change email.
-  """
-  userAccountEmailChangeVerifyCode(
-    """
-    [INTERNAL] The code to verify.
-    """
-    code: String!
-    """
-    [INTERNAL] The email to verify.
-    """
-    email: String!
-  ): UserAccountEmailChangeVerifyCodePayload!
-  """
   Makes user a regular user. Can only be called by an admin.
   """
   userDemoteAdmin(
@@ -7059,68 +6958,6 @@ type Mutation {
   ): WorkflowStatePayload!
 }
 
-"""
-Comparator for strings.
-"""
-input NestedStringComparator {
-  """
-  Contains constraint. Matches any values that contain the given string.
-  """
-  contains: String
-  """
-  Contains case insensitive constraint. Matches any values that contain the given string case insensitive.
-  """
-  containsIgnoreCase: String
-  """
-  Ends with constraint. Matches any values that end with the given string.
-  """
-  endsWith: String
-  """
-  Equals constraint.
-  """
-  eq: String
-  """
-  Equals case insensitive. Matches any values that matches the given string case insensitive.
-  """
-  eqIgnoreCase: String
-  """
-  In-array constraint.
-  """
-  in: [String!]
-  """
-  Not-equals constraint.
-  """
-  neq: String
-  """
-  Not-equals case insensitive. Matches any values that don't match the given string case insensitive.
-  """
-  neqIgnoreCase: String
-  """
-  Not-in-array constraint.
-  """
-  nin: [String!]
-  """
-  Doesn't contain constraint. Matches any values that don't contain the given string.
-  """
-  notContains: String
-  """
-  Doesn't contain case insensitive constraint. Matches any values that don't contain the given string case insensitive.
-  """
-  notContainsIgnoreCase: String
-  """
-  Doesn't end with constraint. Matches any values that don't end with the given string.
-  """
-  notEndsWith: String
-  """
-  Doesn't start with constraint. Matches any values that don't start with the given string.
-  """
-  notStartsWith: String
-  """
-  Starts with constraint. Matches any values that start with the given string.
-  """
-  startsWith: String
-}
-
 interface Node {
   """
   The unique identifier of the entity.
@@ -7273,6 +7110,10 @@ input NotificationSubscriptionCreateInput {
   The identifier of the team to subscribe to.
   """
   teamId: String
+  """
+  The types of notifications of the team subscription.
+  """
+  teamNotificationSubscriptionTypes: [String!]
 }
 
 type NotificationSubscriptionEdge {
@@ -7302,7 +7143,11 @@ input NotificationSubscriptionUpdateInput {
   """
   The type of the project subscription.
   """
-  projectNotificationSubscriptionType: ProjectNotificationSubscriptionType!
+  projectNotificationSubscriptionType: ProjectNotificationSubscriptionType
+  """
+  The types of notifications of the team subscription.
+  """
+  teamNotificationSubscriptionTypes: [String!]
 }
 
 input NotificationUpdateInput {
@@ -7318,6 +7163,31 @@ input NotificationUpdateInput {
   The time until a notification will be snoozed. After that it will appear in the inbox again.
   """
   snoozedUntilAt: DateTime
+}
+
+"""
+Notion specific settings.
+"""
+type NotionSettings {
+  """
+  The ID of the Notion workspace being connected.
+  """
+  workspaceId: String!
+  """
+  The name of the Notion workspace being connected.
+  """
+  workspaceName: String!
+}
+
+input NotionSettingsInput {
+  """
+  The ID of the Notion workspace being connected.
+  """
+  workspaceId: String!
+  """
+  The name of the Notion workspace being connected.
+  """
+  workspaceName: String!
 }
 
 """
@@ -7556,6 +7426,10 @@ input NullableIssueFilter {
   [Internal] Comparator for the issues content.
   """
   searchableContent: ContentComparator
+  """
+  Comparator for the issues sla status.
+  """
+  slaStatus: SlaStatusComparator
   """
   Filters that the issues snoozer must satisfy.
   """
@@ -8745,7 +8619,7 @@ type PaidSubscription implements Node {
   """
   seats: Float!
   """
-  The maximum number of seats that can be added to the subscription.
+  The maximum number of seats that will be billed in the subscription.
   """
   seatsMaximum: Float
   """
@@ -8762,6 +8636,38 @@ type PaidSubscription implements Node {
       been updated after creation.
   """
   updatedAt: DateTime!
+}
+
+"""
+A personal note for a user
+"""
+type PersonalNote implements Node {
+  """
+  The time at which the entity was archived. Null if the entity has not been archived.
+  """
+  archivedAt: DateTime
+  """
+  The note content as JSON.
+  """
+  contentData: JSONObject
+  """
+  The time at which the entity was created.
+  """
+  createdAt: DateTime!
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  """
+  The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+      for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+      been updated after creation.
+  """
+  updatedAt: DateTime!
+  """
+  The user that owns the note.
+  """
+  user: User!
 }
 
 """
@@ -8853,10 +8759,6 @@ type Project implements Node {
   The number of in progress estimation points after each week.
   """
   inProgressScopeHistory: [Float!]!
-  """
-  The initiative that this project is associated with.
-  """
-  initiative: Initiative
   """
   Settings for all integrations associated with that project.
   """
@@ -8969,10 +8871,6 @@ type Project implements Node {
     orderBy: PaginationOrderBy
   ): UserConnection!
   """
-  The milestone that this project is associated with.
-  """
-  milestone: Milestone @deprecated(reason: "Milestones will be removed. Use roadmaps instead.")
-  """
   The project's name.
   """
   name: String!
@@ -8980,6 +8878,35 @@ type Project implements Node {
   The overall progress of the project. This is the (completed estimate points + 0.25 * in progress estimate points) / total estimate points.
   """
   progress: Float!
+  """
+  [ALPHA] Milestones associated with the project.
+  """
+  projectMilestones(
+    """
+    A cursor to be used with first for forward pagination
+    """
+    after: String
+    """
+    A cursor to be used with last for backward pagination.
+    """
+    before: String
+    """
+    The number of items to forward paginate (used with after). Defaults to 50.
+    """
+    first: Int
+    """
+    Should archived resources be included (default: false)
+    """
+    includeArchived: Boolean
+    """
+    The number of items to backward paginate (used with before). Defaults to 50.
+    """
+    last: Int
+    """
+    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+    """
+    orderBy: PaginationOrderBy
+  ): ProjectMilestoneConnection!
   """
   The time until which project update reminders are paused.
   """
@@ -9038,7 +8965,7 @@ type Project implements Node {
   """
   slugId: String!
   """
-  The sort order for the project within its milestone/initiative.
+  The sort order for the project within the organizion.
   """
   sortOrder: Float!
   """
@@ -9215,10 +9142,6 @@ input ProjectCreateInput {
   The identifiers of the members of this project.
   """
   memberIds: [String!]
-  """
-  The identifier of the milestone to associate the project with.
-  """
-  milestoneId: String
   """
   The name of the project.
   """
@@ -9416,6 +9339,117 @@ input ProjectLinkUpdateInput {
   The URL of the link.
   """
   url: String
+}
+
+"""
+A milestone for a project.
+"""
+type ProjectMilestone implements Node {
+  """
+  The time at which the entity was archived. Null if the entity has not been archived.
+  """
+  archivedAt: DateTime
+  """
+  The time at which the entity was created.
+  """
+  createdAt: DateTime!
+  """
+  The description of the project milestone.
+  """
+  description: String
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  """
+  The name of the project milestone.
+  """
+  name: String!
+  """
+  The project of the milestone.
+  """
+  project: Project!
+  """
+  The planned completion date of the milestone.
+  """
+  targetDate: TimelessDate
+  """
+  The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+      for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+      been updated after creation.
+  """
+  updatedAt: DateTime!
+}
+
+type ProjectMilestoneConnection {
+  edges: [ProjectMilestoneEdge!]!
+  nodes: [ProjectMilestone!]!
+  pageInfo: PageInfo!
+}
+
+input ProjectMilestoneCreateInput {
+  """
+  The description of the project milestone.
+  """
+  description: String
+  """
+  The identifier in UUID v4 format. If none is provided, the backend will generate one.
+  """
+  id: String
+  """
+  The name of the project milestone.
+  """
+  name: String!
+  """
+  Related project for the project milestone.
+  """
+  projectId: String!
+  """
+  The planned target date of the project milestone.
+  """
+  targetDate: TimelessDate
+}
+
+type ProjectMilestoneEdge {
+  """
+  Used in `before` and `after` args
+  """
+  cursor: String!
+  node: ProjectMilestone!
+}
+
+type ProjectMilestonePayload {
+  """
+  The identifier of the last sync operation.
+  """
+  lastSyncId: Float!
+  """
+  The project milestone that was created or updated.
+  """
+  projectMilestone: ProjectMilestone!
+  """
+  Whether the operation was successful.
+  """
+  success: Boolean!
+}
+
+input ProjectMilestoneUpdateInput {
+  """
+  The description of the project milestone.
+  """
+  description: String
+  """
+  The name of the project milestone.
+  """
+  name: String
+  """
+  Related project for the project milestone.
+  """
+  projectId: String
+  """
+  The planned target date of the project milestone.
+  """
+  targetDate: TimelessDate
 }
 
 """
@@ -9674,10 +9708,6 @@ input ProjectUpdateInput {
   The identifiers of the members of this project.
   """
   memberIds: [String!]
-  """
-  The identifier of the milestone to associate the project with.
-  """
-  milestoneId: String
   """
   The name of the project.
   """
@@ -9995,6 +10025,39 @@ enum PushSubscriptionType {
 }
 
 type Query {
+  """
+  One specific project milestone.
+  """
+  ProjectMilestone(id: String!): ProjectMilestone!
+  """
+  All milestones for the project.
+  """
+  ProjectMilestones(
+    """
+    A cursor to be used with first for forward pagination
+    """
+    after: String
+    """
+    A cursor to be used with last for backward pagination.
+    """
+    before: String
+    """
+    The number of items to forward paginate (used with after). Defaults to 50.
+    """
+    first: Int
+    """
+    Should archived resources be included (default: false)
+    """
+    includeArchived: Boolean
+    """
+    The number of items to backward paginate (used with before). Defaults to 50.
+    """
+    last: Int
+    """
+    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+    """
+    orderBy: PaginationOrderBy
+  ): ProjectMilestoneConnection!
   """
   All teams you the user can administrate. Administrable teams are teams whose settings the user can change, but to whose issues the user doesn't necessarily have access to.
   """
@@ -10727,39 +10790,6 @@ type Query {
     orderBy: PaginationOrderBy
   ): IssueConnection!
   """
-  One specific milestone.
-  """
-  milestone(id: String!): Milestone! @deprecated(reason: "Milestones will be removed. Use roadmaps instead.")
-  """
-  All milestones.
-  """
-  milestones(
-    """
-    A cursor to be used with first for forward pagination
-    """
-    after: String
-    """
-    A cursor to be used with last for backward pagination.
-    """
-    before: String
-    """
-    The number of items to forward paginate (used with after). Defaults to 50.
-    """
-    first: Int
-    """
-    Should archived resources be included (default: false)
-    """
-    includeArchived: Boolean
-    """
-    The number of items to backward paginate (used with before). Defaults to 50.
-    """
-    last: Int
-    """
-    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
-    """
-    orderBy: PaginationOrderBy
-  ): MilestoneConnection! @deprecated(reason: "Milestones will be removed. Use roadmaps instead.")
-  """
   One specific notification.
   """
   notification(id: String!): Notification!
@@ -11204,15 +11234,6 @@ type Query {
     """
     id: String!
   ): User!
-  """
-  [INTERNAL] Checks if there's a currently active email verification challenge for a user account.
-  """
-  userAccountEmailChangeFind(
-    """
-    [INTERNAL] The email of the user account.
-    """
-    email: String!
-  ): UserAccountEmailChangeFindPayload!
   """
   Finds a user account by email.
   """
@@ -11751,7 +11772,7 @@ input RoadmapToProjectCreateInput {
   """
   roadmapId: String!
   """
-  The sort order for the project within its milestone.
+  The sort order for the project within its organization.
   """
   sortOrder: Float
 }
@@ -11781,7 +11802,7 @@ type RoadmapToProjectPayload {
 
 input RoadmapToProjectUpdateInput {
   """
-  The sort order for the project within its milestone.
+  The sort order for the project within its organization.
   """
   sortOrder: Float
 }
@@ -11936,6 +11957,40 @@ input SentrySettingsInput {
   organizationSlug: String!
 }
 
+enum SlaStatus {
+  Breached
+  Completed
+  HighRisk
+  LowRisk
+  MediumRisk
+}
+
+"""
+Comparator for sla status.
+"""
+input SlaStatusComparator {
+  """
+  Equals constraint.
+  """
+  eq: SlaStatus
+  """
+  In-array constraint.
+  """
+  in: [SlaStatus!]
+  """
+  Not-equals constraint.
+  """
+  neq: SlaStatus
+  """
+  Not-in-array constraint.
+  """
+  nin: [SlaStatus!]
+  """
+  Null constraint. Matches any non-null values if the given value is false, otherwise it matches null values.
+  """
+  null: Boolean
+}
+
 """
 Slack notification specific settings.
 """
@@ -11949,6 +12004,68 @@ input SlackPostSettingsInput {
   channel: String!
   channelId: String!
   configurationUrl: String!
+}
+
+"""
+Comparator for `sourceType` field.
+"""
+input SourceTypeComparator {
+  """
+  Contains constraint. Matches any values that contain the given string.
+  """
+  contains: String
+  """
+  Contains case insensitive constraint. Matches any values that contain the given string case insensitive.
+  """
+  containsIgnoreCase: String
+  """
+  Ends with constraint. Matches any values that end with the given string.
+  """
+  endsWith: String
+  """
+  Equals constraint.
+  """
+  eq: String
+  """
+  Equals case insensitive. Matches any values that matches the given string case insensitive.
+  """
+  eqIgnoreCase: String
+  """
+  In-array constraint.
+  """
+  in: [String!]
+  """
+  Not-equals constraint.
+  """
+  neq: String
+  """
+  Not-equals case insensitive. Matches any values that don't match the given string case insensitive.
+  """
+  neqIgnoreCase: String
+  """
+  Not-in-array constraint.
+  """
+  nin: [String!]
+  """
+  Doesn't contain constraint. Matches any values that don't contain the given string.
+  """
+  notContains: String
+  """
+  Doesn't contain case insensitive constraint. Matches any values that don't contain the given string case insensitive.
+  """
+  notContainsIgnoreCase: String
+  """
+  Doesn't end with constraint. Matches any values that don't end with the given string.
+  """
+  notEndsWith: String
+  """
+  Doesn't start with constraint. Matches any values that don't start with the given string.
+  """
+  notStartsWith: String
+  """
+  Starts with constraint. Matches any values that start with the given string.
+  """
+  startsWith: String
 }
 
 type SsoUrlFromEmailResponse {
@@ -12419,6 +12536,10 @@ type Team implements Node {
     orderBy: PaginationOrderBy
   ): ProjectConnection!
   """
+  Whether an issue needs to have a priority set before leaving triage
+  """
+  requirePriorityToLeaveTriage: Boolean!
+  """
   The workflow state into which issues are moved when a review has been requested for the PR.
   """
   reviewWorkflowState: WorkflowState
@@ -12672,6 +12793,10 @@ input TeamCreateInput {
   Internal. Whether the team is private or not.
   """
   private: Boolean
+  """
+  Whether an issue needs to have a priority set before leaving triage.
+  """
+  requirePriorityToLeaveTriage: Boolean
   """
   The timezone of the team.
   """
@@ -13016,6 +13141,10 @@ input TeamUpdateInput {
   """
   private: Boolean
   """
+  Whether an issue needs to have a priority set before leaving triage.
+  """
+  requirePriorityToLeaveTriage: Boolean
+  """
   The workflow state into which issues are moved when a review has been requested for the PR.
   """
   reviewWorkflowStateId: String
@@ -13300,6 +13429,10 @@ input UpdateOrganizationInput {
   Whether the organization is using roadmap.
   """
   roadmapEnabled: Boolean
+  """
+  Internal. Whether SLA's have been enabled for the organization.
+  """
+  slaEnabled: Boolean
   """
   The URL key of the organization.
   """
@@ -13717,52 +13850,6 @@ type UserAccountEmailChange {
   The time at which the model was updated.
   """
   updatedAt: DateTime!
-}
-
-"""
-[INTERNAL] Result of searching for a verification challenge for a user account.
-"""
-type UserAccountEmailChangeFindPayload {
-  """
-  [INTERNAL] Whether there is a currently active change.
-  """
-  hasChangeActive: Boolean!
-  """
-  The identifier of the last sync operation.
-  """
-  lastSyncId: Float!
-}
-
-"""
-[INTERNAL] Result of verifying an email and code.
-"""
-type UserAccountEmailChangeVerifyCodePayload {
-  """
-  [INTERNAL] Reason why the operation was not successful.
-  """
-  failureReason: Float
-  """
-  [INTERNAL] Whether the operation was successful.
-  """
-  success: Boolean!
-}
-
-"""
-[INTERNAL] Result of creating or cancelling a verification challenge for email change.
-"""
-type UserAccountEmailVerificationPayload {
-  """
-  [INTERNAL] Reason why the operation was not successful.
-  """
-  failureReason: Float
-  """
-  The identifier of the last sync operation.
-  """
-  lastSyncId: Float!
-  """
-  [INTERNAL] Whether the operation was successful.
-  """
-  success: Boolean!
 }
 
 """
@@ -14256,8 +14343,10 @@ enum ViewType {
   inbox
   label
   myIssues
+  myIssuesActivity
   myIssuesCreatedByMe
   myIssuesSubscribedTo
+  myIssuesTouchedByMe
   project
   projects
   projectsAll
@@ -14418,13 +14507,17 @@ input WebhookUpdateInput {
 }
 
 """
-The conditions to match different events, which need to be true for workflow to be started.
+A condition to match for the workflow to be triggered.
 """
-input WorkflowConditions {
+input WorkflowCondition {
   """
-  The conditions to match triggers based on issue (creation, update, deletion).
+  Trigger the workflow when an issue matches the filter. Can only be used when the trigger type is `Issue`.
   """
-  issue: WorkflowEntityPropertyMatcher!
+  issueFilter: IssueFilter
+  """
+  Triggers the workflow when a project matches the filter. Can only be used when the trigger type is `Project`.
+  """
+  projectFilter: ProjectFilter
 }
 
 type WorkflowDefinition implements Node {
@@ -14437,7 +14530,7 @@ type WorkflowDefinition implements Node {
   """
   archivedAt: DateTime
   """
-  One or more conditions that need to be true for workflow to be triggered.
+  The conditions that need to be match for the workflow to be triggered.
   """
   conditions: JSONObject!
   """
@@ -14449,10 +14542,14 @@ type WorkflowDefinition implements Node {
   """
   creator: User!
   """
-  The workflow description.
+  The description of the workflow.
   """
   description: String
   enabled: Boolean!
+  """
+  The name of the group that the workflow belongs to.
+  """
+  groupName: String
   """
   The unique identifier of the entity.
   """
@@ -14462,23 +14559,27 @@ type WorkflowDefinition implements Node {
   """
   name: String!
   """
-  The organization where workflow was created.
-  """
-  organization: Organization!
-  """
   Cron schedule which is used to execute the workflow. Only applicable for cron based workflows.
   """
   schedule: JSONObject!
   """
-  The team associated with the workflow.
+  The sort order of the workflow definition within its siblings.
   """
-  team: Team!
+  sortOrder: String!
   """
-  The type of the trigger that kicks off the workflow.
+  The team associated with the workflow. If not set, the workflow is associated with the entire organization.
   """
-  trigger: WorkflowTriggerType!
+  team: Team
   """
-  The type of the workflow
+  The type of the event that triggers off the workflow.
+  """
+  trigger: WorkflowTrigger!
+  """
+  The object type (e.g. Issue) that triggers this workflow.
+  """
+  triggerType: WorkflowTriggerType!
+  """
+  The type of the workflow.
   """
   type: WorkflowType!
   """
@@ -14489,30 +14590,18 @@ type WorkflowDefinition implements Node {
   updatedAt: DateTime!
 }
 
-"""
-Object to provide conditions to match an entity change.
-"""
-input WorkflowEntityPropertyMatcher {
+type WorkflowDefinitionConnection {
+  edges: [WorkflowDefinitionEdge!]!
+  nodes: [WorkflowDefinition!]!
+  pageInfo: PageInfo!
+}
+
+type WorkflowDefinitionEdge {
   """
-  The optional list of property matchers that all have to match.
+  Used in `before` and `after` args
   """
-  and: [WorkflowEntityPropertyMatcher!]
-  """
-  The initial value of the property to match.
-  """
-  fromValue: String
-  """
-  The optional list of property matchers where at least one have to match.
-  """
-  or: [WorkflowEntityPropertyMatcher!]
-  """
-  The property to check for matching.
-  """
-  property: String!
-  """
-  The new value of the property to match.
-  """
-  toValue: String
+  cursor: String!
+  node: WorkflowDefinition!
 }
 
 """
@@ -14725,16 +14814,24 @@ input WorkflowStateUpdateInput {
   position: Float
 }
 
-enum WorkflowTriggerType {
+enum WorkflowTrigger {
   cron
-  issueCreated
-  issueDeleted
-  issueUpdated
+  entityCreated
+  entityCreatedOrUpdated
+  entityRemoved
+  entityUnarchived
+  entityUpdated
+}
+
+enum WorkflowTriggerType {
+  issue
+  project
 }
 
 enum WorkflowType {
   custom
   recurringIssue
+  sla
 }
 
 """

--- a/packages/sdk/src/schema.json
+++ b/packages/sdk/src/schema.json
@@ -1063,7 +1063,7 @@
             "description": "Comparator for the source type.",
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "NestedStringComparator",
+              "name": "SourceTypeComparator",
               "ofType": null
             },
             "defaultValue": null,
@@ -1519,7 +1519,7 @@
             "description": "Comparator for the source type.",
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "NestedStringComparator",
+              "name": "SourceTypeComparator",
               "ofType": null
             },
             "defaultValue": null,
@@ -1770,6 +1770,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organization",
+            "description": "The organization the audit log belongs to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Organization",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -2521,7 +2533,7 @@
           },
           {
             "name": "parent",
-            "description": "The parent of the comment.",
+            "description": "The parent comment under which the current comment is nested.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -3020,7 +3032,7 @@
           },
           {
             "name": "parentId",
-            "description": "[Internal] The parent under which to nest the comment.",
+            "description": "The parent comment under which to nest a current comment.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -3060,6 +3072,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "doNotSubscribeToIssue",
+            "description": "Flag to prevent auto subscription to the issue the comment is created on.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "defaultValue": null,
@@ -9143,273 +9167,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "Initiative",
-        "description": "A initiative that contains projects.",
-        "fields": [
-          {
-            "name": "id",
-            "description": "The unique identifier of the entity.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "createdAt",
-            "description": "The time at which the entity was created.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatedAt",
-            "description": "The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those\n    for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't\n    been updated after creation.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "archivedAt",
-            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": "The name of the initiative.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "organization",
-            "description": "The organization that the initiative belongs to.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Organization",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sortOrder",
-            "description": "The sort order for the initiative.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": "The initiative's description.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "targetDate",
-            "description": "The estimated completion date of the initiative.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "TimelessDate",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "Node",
-            "ofType": null
-          }
-        ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "InitiativeConnection",
-        "description": null,
-        "fields": [
-          {
-            "name": "edges",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "InitiativeEdge",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "nodes",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Initiative",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pageInfo",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PageInfo",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "InitiativeEdge",
-        "description": null,
-        "fields": [
-          {
-            "name": "node",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Initiative",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cursor",
-            "description": "Used in `before` and `after` args",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "Integration",
         "description": "An integration with an external service.",
         "fields": [
@@ -10254,6 +10011,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "notion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "NotionSettings",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -10381,6 +10150,18 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "JiraSettingsInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notion",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "NotionSettingsInput",
               "ofType": null
             },
             "defaultValue": null,
@@ -10871,8 +10652,8 @@
             "deprecationReason": null
           },
           {
-            "name": "slackProjectUpdateCreatedToMilestone",
-            "description": "Whether to send a new project update to milestone Slack channels.",
+            "name": "slackProjectUpdateCreatedToWorkspace",
+            "description": "Whether to send a new project update to workspace Slack channel.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -10883,8 +10664,32 @@
             "deprecationReason": null
           },
           {
-            "name": "slackProjectUpdateCreatedToWorkspace",
-            "description": "Whether to send a new project update to workspace Slack channel.",
+            "name": "slackIssueAddedToTriage",
+            "description": "Whether to send a Slack message when a new issue is added to triage.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slackIssueSlaHighRisk",
+            "description": "Whether to send a Slack message when an SLA is at high risk",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slackIssueSlaBreached",
+            "description": "Whether to send a Slack message when an SLA is breached",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -11084,8 +10889,8 @@
             "deprecationReason": null
           },
           {
-            "name": "slackProjectUpdateCreatedToMilestone",
-            "description": "Whether to send a Slack message when a project update is created to milestone channels.",
+            "name": "slackProjectUpdateCreatedToWorkspace",
+            "description": "Whether to send a Slack message when a project update is created to workspace channel.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -11096,8 +10901,32 @@
             "deprecationReason": null
           },
           {
-            "name": "slackProjectUpdateCreatedToWorkspace",
-            "description": "Whether to send a Slack message when a project update is created to workspace channel.",
+            "name": "slackIssueAddedToTriage",
+            "description": "Whether to send a Slack message when a new issue is added to triage.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slackIssueSlaHighRisk",
+            "description": "Whether to send a Slack message when an SLA is at high risk",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slackIssueSlaBreached",
+            "description": "Whether to receive notification when an SLA has breached on Slack.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -11329,8 +11158,8 @@
             "deprecationReason": null
           },
           {
-            "name": "slackProjectUpdateCreatedToMilestone",
-            "description": "Whether to send a Slack message when a project update is created to milestone channels.",
+            "name": "slackProjectUpdateCreatedToWorkspace",
+            "description": "Whether to send a Slack message when a project update is created to workspace channel.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -11341,8 +11170,32 @@
             "deprecationReason": null
           },
           {
-            "name": "slackProjectUpdateCreatedToWorkspace",
-            "description": "Whether to send a Slack message when a project update is created to workspace channel.",
+            "name": "slackIssueAddedToTriage",
+            "description": "Whether to send a Slack message when a new issue is added to triage.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slackIssueSlaHighRisk",
+            "description": "Whether to send a Slack message when an SLA is at high risk",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slackIssueSlaBreached",
+            "description": "Whether to receive notification when an SLA has breached on Slack.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -11693,6 +11546,18 @@
             "deprecationReason": null
           },
           {
+            "name": "startedTriageAt",
+            "description": "The time at which the issue entered triage.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "triagedAt",
             "description": "The time at which the issue left triage.",
             "args": [],
@@ -11747,6 +11612,30 @@
             "type": {
               "kind": "SCALAR",
               "name": "TimelessDate",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slaStartedAt",
+            "description": "[Internal] The time at which the issue's SLA began.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slaBreachesAt",
+            "description": "[Internal] The time at which the issue's SLA will breach.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
               "ofType": null
             },
             "isDeprecated": false,
@@ -11811,6 +11700,18 @@
             "type": {
               "kind": "OBJECT",
               "name": "Project",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectMilestone",
+            "description": "[ALPHA] The projectMilestone that the issue is associated with.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ProjectMilestone",
               "ofType": null
             },
             "isDeprecated": false,
@@ -13363,6 +13264,18 @@
             "deprecationReason": null
           },
           {
+            "name": "slaStatus",
+            "description": "Comparator for the issues sla status.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "SlaStatusComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "and",
             "description": "Compound filters, all of which need to be matched by the issue.",
             "type": {
@@ -13705,6 +13618,18 @@
             "deprecationReason": null
           },
           {
+            "name": "projectMilestoneId",
+            "description": "[ALPHA] The project milestone associated with the issue.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "stateId",
             "description": "The team state of the issue.",
             "type": {
@@ -13814,6 +13739,315 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "IssueDraft",
+        "description": "[Internal] A draft issue.",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time at which the entity was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those\n    for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't\n    been updated after creation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archivedAt",
+            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": "The draft's title.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "The draft's description in markdown format.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "priority",
+            "description": "The priority of the draft.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "estimate",
+            "description": "The estimate of the complexity of the draft.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dueDate",
+            "description": "The date at which the issue would be due.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "TimelessDate",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "teamId",
+            "description": "The team associated with the draft.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cycleId",
+            "description": "The cycle associated with the draft.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectId",
+            "description": "The project associated with the draft.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "creator",
+            "description": "The user who created the draft.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "assigneeId",
+            "description": "The user assigned to the draft.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stateId",
+            "description": "The workflow state associated with the draft.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "parent",
+            "description": "The parent draft of the draft.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "IssueDraft",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "parentIssue",
+            "description": "The parent issue of the draft.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Issue",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subIssueSortOrder",
+            "description": "The order of items in the sub-draft list. Only set if the draft has `parent` set.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "priorityLabel",
+            "description": "Label for the priority.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "descriptionData",
+            "description": "[Internal] The draft's description as a Prosemirror document.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSON",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "attachments",
+            "description": "Serialized array of JSONs representing attachments.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSONObject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -14256,6 +14490,18 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "RelationExistsComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slaStatus",
+            "description": "Comparator for the issues sla status.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "SlaStatusComparator",
               "ofType": null
             },
             "defaultValue": null,
@@ -14971,6 +15217,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "TimelessDate",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "changes",
+            "description": "[Internal] Serialized JSON representing changes for certain non-relational properties.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
               "ofType": null
             },
             "isDeprecated": false,
@@ -17459,6 +17717,18 @@
             "deprecationReason": null
           },
           {
+            "name": "projectMilestoneId",
+            "description": "[ALPHA] The project milestone associated with the issue.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "stateId",
             "description": "The team state of the issue.",
             "type": {
@@ -17524,6 +17794,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slaBreachesAt",
+            "description": "[Internal] The timestamp at which an issue will be considered in breach of SLA.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
               "ofType": null
             },
             "defaultValue": null,
@@ -18020,697 +18302,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "Milestone",
-        "description": "A milestone that contains projects.",
-        "fields": [
-          {
-            "name": "id",
-            "description": "The unique identifier of the entity.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "createdAt",
-            "description": "The time at which the entity was created.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatedAt",
-            "description": "The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those\n    for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't\n    been updated after creation.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "archivedAt",
-            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": "The name of the milestone.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "organization",
-            "description": "The organization that the milestone belongs to.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Organization",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sortOrder",
-            "description": "The sort order for the milestone.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": "[ALPHA] The milestone's description.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "targetDate",
-            "description": "[ALPHA] The estimated completion date of the initiative.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "TimelessDate",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "projects",
-            "description": "Projects associated with the milestone.",
-            "args": [
-              {
-                "name": "filter",
-                "description": "Filter returned projects.",
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "ProjectFilter",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "before",
-                "description": "A cursor to be used with last for backward pagination.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "after",
-                "description": "A cursor to be used with first for forward pagination",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "first",
-                "description": "The number of items to forward paginate (used with after). Defaults to 50.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "last",
-                "description": "The number of items to backward paginate (used with before). Defaults to 50.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "includeArchived",
-                "description": "Should archived resources be included (default: false)",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "orderBy",
-                "description": "By which field should the pagination order by. Available options are createdAt (default) and updatedAt.",
-                "type": {
-                  "kind": "ENUM",
-                  "name": "PaginationOrderBy",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ProjectConnection",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Milestones will be removed. Use roadmaps instead."
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "Node",
-            "ofType": null
-          }
-        ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "MilestoneConnection",
-        "description": null,
-        "fields": [
-          {
-            "name": "edges",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "MilestoneEdge",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "nodes",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Milestone",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pageInfo",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PageInfo",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "MilestoneCreateInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "id",
-            "description": "The identifier in UUID v4 format. If none is provided, the backend will generate one.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": "The name of the milestone.",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sortOrder",
-            "description": "The sort order of the milestone.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": "[ALPHA] The description for the milestone.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "targetDate",
-            "description": "[ALPHA] The planned target date of the milestone.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "TimelessDate",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "teamIds",
-            "description": "[ALPHA] The identifiers of the teams this milestone is associated with.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "MilestoneEdge",
-        "description": null,
-        "fields": [
-          {
-            "name": "node",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Milestone",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "cursor",
-            "description": "Used in `before` and `after` args",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "MilestoneMigrationPayload",
-        "description": null,
-        "fields": [
-          {
-            "name": "lastSyncId",
-            "description": "The identifier of the last sync operation.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": "Whether the operation was successful.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "MilestonePayload",
-        "description": null,
-        "fields": [
-          {
-            "name": "lastSyncId",
-            "description": "The identifier of the last sync operation.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "milestone",
-            "description": "The milesteone that was created or updated.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Milestone",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": "Whether the operation was successful.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "MilestoneUpdateInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "name",
-            "description": "The name of the milestone.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sortOrder",
-            "description": "The sort order of the milestone.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": "[ALPHA] The description for the milestone.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "targetDate",
-            "description": "[ALPHA] The planned target date of the milestone.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "TimelessDate",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "teamIds",
-            "description": "[ALPHA] The identifiers of the teams this milestone is associated with.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "MilestonesMigrateInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "milestonesToMigrate",
-            "description": "IDs of the milestones to migrate.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "milestonesToDelete",
-            "description": "IDs of the milestones to delete.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "Mutation",
         "description": null,
         "fields": [
@@ -18902,6 +18493,18 @@
               {
                 "name": "title",
                 "description": "The title to use for the attachment.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "id",
+                "description": "The id for the attachment.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -21458,24 +21061,8 @@
             "description": "Integrates the organization with Zendesk.",
             "args": [
               {
-                "name": "redirectUri",
-                "description": "The Zendesk OAuth redirect URI.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "scope",
-                "description": "The Zendesk OAuth scopes.",
+                "name": "subdomain",
+                "description": "The Zendesk installation subdomain.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21506,8 +21093,24 @@
                 "deprecationReason": null
               },
               {
-                "name": "subdomain",
-                "description": "The Zendesk installation subdomain.",
+                "name": "scope",
+                "description": "The Zendesk OAuth scopes.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "redirectUri",
+                "description": "The Zendesk OAuth redirect URI.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -23014,51 +22617,18 @@
             "deprecationReason": null
           },
           {
-            "name": "milestoneCreate",
-            "description": "Creates a new milestone.",
+            "name": "issueDescriptionUpdateFromFront",
+            "description": "[INTERNAL] Updates an issue description from the Front app to handle Front attachments correctly.",
             "args": [
               {
-                "name": "input",
-                "description": "The issue object to create.",
+                "name": "description",
+                "description": "Description to update the issue with. ",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "MilestoneCreateInput",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "MilestonePayload",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Milestones will be removed. Use roadmaps instead."
-          },
-          {
-            "name": "milestoneUpdate",
-            "description": "Updates a milestone.",
-            "args": [
-              {
-                "name": "input",
-                "description": "A partial milestone object to update the milestone with.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "MilestoneUpdateInput",
+                    "kind": "SCALAR",
+                    "name": "String",
                     "ofType": null
                   }
                 },
@@ -23068,7 +22638,7 @@
               },
               {
                 "name": "id",
-                "description": "The identifier of the milestone to update.",
+                "description": "The identifier of the issue to update.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -23088,73 +22658,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "MilestonePayload",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Milestones will be removed. Use roadmaps instead."
-          },
-          {
-            "name": "milestoneDelete",
-            "description": "Deletes a milestone.",
-            "args": [
-              {
-                "name": "id",
-                "description": "The identifier of the milestone to delete.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ArchivePayload",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Milestones will be removed. Use roadmaps instead."
-          },
-          {
-            "name": "migrateMilestonesToRoadmaps",
-            "description": "Migrates milestones to roadmaps",
-            "args": [
-              {
-                "name": "input",
-                "description": "Ids for milestones to migrate and milestones to delete",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "MilestonesMigrateInput",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "MilestoneMigrationPayload",
+                "name": "IssuePayload",
                 "ofType": null
               }
             },
@@ -23870,6 +23374,121 @@
               {
                 "name": "id",
                 "description": "The identifier of the project link to delete.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ArchivePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectMilestoneCreate",
+            "description": "Creates a new project milestone.",
+            "args": [
+              {
+                "name": "input",
+                "description": "The project milestone to create.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectMilestoneCreateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProjectMilestonePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectMilestoneUpdate",
+            "description": "Updates a project milestone.",
+            "args": [
+              {
+                "name": "input",
+                "description": "A partial object to update the project milestone with.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ProjectMilestoneUpdateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "id",
+                "description": "The identifier of the project milestone to update. Also the identifier from the URL is accepted.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProjectMilestonePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectMilestoneDelete",
+            "description": "Deletes a project milestone.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The identifier of the project milestone to delete.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -25081,153 +24700,6 @@
             "deprecationReason": null
           },
           {
-            "name": "userAccountEmailChangeVerifyCode",
-            "description": "[INTERNAL] Verifies the email address and code for a user account that wants to change email.",
-            "args": [
-              {
-                "name": "code",
-                "description": "[INTERNAL] The code to verify.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "email",
-                "description": "[INTERNAL] The email to verify.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "UserAccountEmailChangeVerifyCodePayload",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "userAccountEmailChangeCreate",
-            "description": "[INTERNAL] Creates an email verification challenge from the app for a user account that wants to change email.",
-            "args": [
-              {
-                "name": "hasExistingAccount",
-                "description": "[INTERNAL] Whether an existing account exists for the new email address.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "newEmail",
-                "description": "[INTERNAL] The new email address the user wants to use.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "id",
-                "description": "[INTERNAL] The identifier of the user account that wants to change email.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "UserAccountEmailVerificationPayload",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "userAccountEmailChangeCancel",
-            "description": "[INTERNAL] Cancels an ongoing email change for the user account",
-            "args": [
-              {
-                "name": "id",
-                "description": "The id of the user account to cancel the change for.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "UserAccountEmailVerificationPayload",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "userUpdate",
             "description": "Updates a user. Only available to organization admins and the user themselves.",
             "args": [
@@ -26142,201 +25614,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "NestedStringComparator",
-        "description": "Comparator for strings.",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "eq",
-            "description": "Equals constraint.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "neq",
-            "description": "Not-equals constraint.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "in",
-            "description": "In-array constraint.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "nin",
-            "description": "Not-in-array constraint.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "eqIgnoreCase",
-            "description": "Equals case insensitive. Matches any values that matches the given string case insensitive.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "neqIgnoreCase",
-            "description": "Not-equals case insensitive. Matches any values that don't match the given string case insensitive.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "startsWith",
-            "description": "Starts with constraint. Matches any values that start with the given string.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "notStartsWith",
-            "description": "Doesn't start with constraint. Matches any values that don't start with the given string.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "endsWith",
-            "description": "Ends with constraint. Matches any values that end with the given string.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "notEndsWith",
-            "description": "Doesn't end with constraint. Matches any values that don't end with the given string.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "contains",
-            "description": "Contains constraint. Matches any values that contain the given string.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "containsIgnoreCase",
-            "description": "Contains case insensitive constraint. Matches any values that contain the given string case insensitive.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "notContains",
-            "description": "Doesn't contain constraint. Matches any values that don't contain the given string.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "notContainsIgnoreCase",
-            "description": "Doesn't contain case insensitive constraint. Matches any values that don't contain the given string case insensitive.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "INTERFACE",
         "name": "Node",
         "description": null,
@@ -26409,11 +25686,6 @@
           },
           {
             "kind": "OBJECT",
-            "name": "Initiative",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
             "name": "Integration",
             "ofType": null
           },
@@ -26439,6 +25711,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "IssueDraft",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "IssueHistory",
             "ofType": null
           },
@@ -26460,11 +25737,6 @@
           {
             "kind": "OBJECT",
             "name": "IssueRelation",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "Milestone",
             "ofType": null
           },
           {
@@ -26504,12 +25776,22 @@
           },
           {
             "kind": "OBJECT",
+            "name": "PersonalNote",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "Project",
             "ofType": null
           },
           {
             "kind": "OBJECT",
             "name": "ProjectLink",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ProjectMilestone",
             "ofType": null
           },
           {
@@ -27248,6 +26530,26 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "teamNotificationSubscriptionTypes",
+            "description": "The types of notifications of the team subscription.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -27366,12 +26668,28 @@
             "name": "projectNotificationSubscriptionType",
             "description": "The type of the project subscription.",
             "type": {
-              "kind": "NON_NULL",
+              "kind": "ENUM",
+              "name": "ProjectNotificationSubscriptionType",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "teamNotificationSubscriptionTypes",
+            "description": "The types of notifications of the team subscription.",
+            "type": {
+              "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "ENUM",
-                "name": "ProjectNotificationSubscriptionType",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               }
             },
             "defaultValue": null,
@@ -27420,6 +26738,92 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "NotionSettings",
+        "description": "Notion specific settings.",
+        "fields": [
+          {
+            "name": "workspaceId",
+            "description": "The ID of the Notion workspace being connected.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workspaceName",
+            "description": "The name of the Notion workspace being connected.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "NotionSettingsInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "workspaceId",
+            "description": "The ID of the Notion workspace being connected.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workspaceName",
+            "description": "The name of the Notion workspace being connected.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -28204,6 +27608,18 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "RelationExistsComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slaStatus",
+            "description": "Comparator for the issues sla status.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "SlaStatusComparator",
               "ofType": null
             },
             "defaultValue": null,
@@ -32259,7 +31675,7 @@
           },
           {
             "name": "seatsMaximum",
-            "description": "The maximum number of seats that can be added to the subscription.",
+            "description": "The maximum number of seats that will be billed in the subscription.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32328,6 +31744,111 @@
             "type": {
               "kind": "SCALAR",
               "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PersonalNote",
+        "description": "A personal note for a user",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time at which the entity was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those\n    for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't\n    been updated after creation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archivedAt",
+            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user",
+            "description": "The user that owns the note.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contentData",
+            "description": "The note content as JSON.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
               "ofType": null
             },
             "isDeprecated": false,
@@ -32531,30 +32052,6 @@
             "deprecationReason": null
           },
           {
-            "name": "milestone",
-            "description": "The milestone that this project is associated with.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Milestone",
-              "ofType": null
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Milestones will be removed. Use roadmaps instead."
-          },
-          {
-            "name": "initiative",
-            "description": "The initiative that this project is associated with.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Initiative",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "projectUpdateRemindersPausedUntilAt",
             "description": "The time until which project update reminders are paused.",
             "args": [],
@@ -32640,7 +32137,7 @@
           },
           {
             "name": "sortOrder",
-            "description": "The sort order for the project within its milestone/initiative.",
+            "description": "The sort order for the project within the organizion.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33236,6 +32733,95 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "DocumentConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectMilestones",
+            "description": "[ALPHA] Milestones associated with the project.",
+            "args": [
+              {
+                "name": "before",
+                "description": "A cursor to be used with last for backward pagination.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "after",
+                "description": "A cursor to be used with first for forward pagination",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": "The number of items to forward paginate (used with after). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "The number of items to backward paginate (used with before). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "includeArchived",
+                "description": "Should archived resources be included (default: false)",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "By which field should the pagination order by. Available options are createdAt (default) and updatedAt.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "PaginationOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProjectMilestoneConnection",
                 "ofType": null
               }
             },
@@ -33879,18 +33465,6 @@
           {
             "name": "description",
             "description": "The description for the project.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "milestoneId",
-            "description": "The identifier of the milestone to associate the project with.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -34669,6 +34243,454 @@
           {
             "name": "label",
             "description": "The label for the link.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProjectMilestone",
+        "description": "A milestone for a project.",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time at which the entity was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those\n    for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't\n    been updated after creation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archivedAt",
+            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "The name of the project milestone.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "The description of the project milestone.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "targetDate",
+            "description": "The planned completion date of the milestone.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "TimelessDate",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project",
+            "description": "The project of the milestone.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Project",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProjectMilestoneConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProjectMilestoneEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProjectMilestone",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProjectMilestoneCreateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": "The identifier in UUID v4 format. If none is provided, the backend will generate one.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "The name of the project milestone.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "The description of the project milestone.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "targetDate",
+            "description": "The planned target date of the project milestone.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "TimelessDate",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectId",
+            "description": "Related project for the project milestone.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProjectMilestoneEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProjectMilestone",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cursor",
+            "description": "Used in `before` and `after` args",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProjectMilestonePayload",
+        "description": null,
+        "fields": [
+          {
+            "name": "lastSyncId",
+            "description": "The identifier of the last sync operation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectMilestone",
+            "description": "The project milestone that was created or updated.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProjectMilestone",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "success",
+            "description": "Whether the operation was successful.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProjectMilestoneUpdateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "name",
+            "description": "The name of the project milestone.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "The description of the project milestone.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "targetDate",
+            "description": "The planned target date of the project milestone.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "TimelessDate",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectId",
+            "description": "Related project for the project milestone.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -35561,18 +35583,6 @@
           {
             "name": "description",
             "description": "The description for the project.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "milestoneId",
-            "description": "The identifier of the milestone to associate the project with.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -39745,128 +39755,6 @@
             "deprecationReason": null
           },
           {
-            "name": "milestones",
-            "description": "All milestones.",
-            "args": [
-              {
-                "name": "before",
-                "description": "A cursor to be used with last for backward pagination.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "after",
-                "description": "A cursor to be used with first for forward pagination",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "first",
-                "description": "The number of items to forward paginate (used with after). Defaults to 50.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "last",
-                "description": "The number of items to backward paginate (used with before). Defaults to 50.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "includeArchived",
-                "description": "Should archived resources be included (default: false)",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "orderBy",
-                "description": "By which field should the pagination order by. Available options are createdAt (default) and updatedAt.",
-                "type": {
-                  "kind": "ENUM",
-                  "name": "PaginationOrderBy",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "MilestoneConnection",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Milestones will be removed. Use roadmaps instead."
-          },
-          {
-            "name": "milestone",
-            "description": "One specific milestone.",
-            "args": [
-              {
-                "name": "id",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Milestone",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Milestones will be removed. Use roadmaps instead."
-          },
-          {
             "name": "notifications",
             "description": "All notifications.",
             "args": [
@@ -40463,6 +40351,128 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "ProjectLink",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ProjectMilestones",
+            "description": "All milestones for the project.",
+            "args": [
+              {
+                "name": "before",
+                "description": "A cursor to be used with last for backward pagination.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "after",
+                "description": "A cursor to be used with first for forward pagination",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": "The number of items to forward paginate (used with after). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "The number of items to backward paginate (used with before). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "includeArchived",
+                "description": "Should archived resources be included (default: false)",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "By which field should the pagination order by. Available options are createdAt (default) and updatedAt.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "PaginationOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProjectMilestoneConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ProjectMilestone",
+            "description": "One specific project milestone.",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProjectMilestone",
                 "ofType": null
               }
             },
@@ -41442,39 +41452,6 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "Template",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "userAccountEmailChangeFind",
-            "description": "[INTERNAL] Checks if there's a currently active email verification challenge for a user account.",
-            "args": [
-              {
-                "name": "email",
-                "description": "[INTERNAL] The email of the user account.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "UserAccountEmailChangeFindPayload",
                 "ofType": null
               }
             },
@@ -43544,7 +43521,7 @@
           },
           {
             "name": "sortOrder",
-            "description": "The sort order for the project within its milestone.",
+            "description": "The sort order for the project within its organization.",
             "type": {
               "kind": "SCALAR",
               "name": "Float",
@@ -43669,7 +43646,7 @@
         "inputFields": [
           {
             "name": "sortOrder",
-            "description": "The sort order for the project within its milestone.",
+            "description": "The sort order for the project within its organization.",
             "type": {
               "kind": "SCALAR",
               "name": "Float",
@@ -44170,6 +44147,134 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "SlaStatus",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "Breached",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "HighRisk",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MediumRisk",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "LowRisk",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "Completed",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SlaStatusComparator",
+        "description": "Comparator for sla status.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "eq",
+            "description": "Equals constraint.",
+            "type": {
+              "kind": "ENUM",
+              "name": "SlaStatus",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "neq",
+            "description": "Not-equals constraint.",
+            "type": {
+              "kind": "ENUM",
+              "name": "SlaStatus",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "in",
+            "description": "In-array constraint.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SlaStatus",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nin",
+            "description": "Not-in-array constraint.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SlaStatus",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "null",
+            "description": "Null constraint. Matches any non-null values if the given value is false, otherwise it matches null values.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "SlackPostSettings",
         "description": "Slack notification specific settings.",
@@ -44277,6 +44382,201 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SourceTypeComparator",
+        "description": "Comparator for `sourceType` field.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "eq",
+            "description": "Equals constraint.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "neq",
+            "description": "Not-equals constraint.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "in",
+            "description": "In-array constraint.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nin",
+            "description": "Not-in-array constraint.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eqIgnoreCase",
+            "description": "Equals case insensitive. Matches any values that matches the given string case insensitive.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "neqIgnoreCase",
+            "description": "Not-equals case insensitive. Matches any values that don't match the given string case insensitive.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startsWith",
+            "description": "Starts with constraint. Matches any values that start with the given string.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notStartsWith",
+            "description": "Doesn't start with constraint. Matches any values that don't start with the given string.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endsWith",
+            "description": "Ends with constraint. Matches any values that end with the given string.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notEndsWith",
+            "description": "Doesn't end with constraint. Matches any values that don't end with the given string.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contains",
+            "description": "Contains constraint. Matches any values that contain the given string.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "containsIgnoreCase",
+            "description": "Contains case insensitive constraint. Matches any values that contain the given string case insensitive.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notContains",
+            "description": "Doesn't contain constraint. Matches any values that don't contain the given string.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notContainsIgnoreCase",
+            "description": "Doesn't contain case insensitive constraint. Matches any values that don't contain the given string case insensitive.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -45051,6 +45351,22 @@
           {
             "name": "triageEnabled",
             "description": "Whether triage mode is enabled for the team or not.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requirePriorityToLeaveTriage",
+            "description": "Whether an issue needs to have a priority set before leaving triage",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -46531,6 +46847,18 @@
             "deprecationReason": null
           },
           {
+            "name": "requirePriorityToLeaveTriage",
+            "description": "Whether an issue needs to have a priority set before leaving triage.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "timezone",
             "description": "The timezone of the team.",
             "type": {
@@ -47922,6 +48250,18 @@
             "deprecationReason": null
           },
           {
+            "name": "requirePriorityToLeaveTriage",
+            "description": "Whether an issue needs to have a priority set before leaving triage.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "defaultIssueStateId",
             "description": "Default status for newly created issues.",
             "type": {
@@ -48901,6 +49241,18 @@
                   "ofType": null
                 }
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slaEnabled",
+            "description": "Internal. Whether SLA's have been enabled for the organization.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -50299,143 +50651,6 @@
             "type": {
               "kind": "SCALAR",
               "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "UserAccountEmailChangeFindPayload",
-        "description": "[INTERNAL] Result of searching for a verification challenge for a user account.",
-        "fields": [
-          {
-            "name": "lastSyncId",
-            "description": "The identifier of the last sync operation.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasChangeActive",
-            "description": "[INTERNAL] Whether there is a currently active change.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "UserAccountEmailChangeVerifyCodePayload",
-        "description": "[INTERNAL] Result of verifying an email and code.",
-        "fields": [
-          {
-            "name": "success",
-            "description": "[INTERNAL] Whether the operation was successful.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "failureReason",
-            "description": "[INTERNAL] Reason why the operation was not successful.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "UserAccountEmailVerificationPayload",
-        "description": "[INTERNAL] Result of creating or cancelling a verification challenge for email change.",
-        "fields": [
-          {
-            "name": "lastSyncId",
-            "description": "The identifier of the last sync operation.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": "[INTERNAL] Whether the operation was successful.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "failureReason",
-            "description": "[INTERNAL] Reason why the operation was not successful.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
               "ofType": null
             },
             "isDeprecated": false,
@@ -52247,6 +52462,18 @@
             "deprecationReason": null
           },
           {
+            "name": "myIssuesTouchedByMe",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "myIssuesActivity",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "userProfile",
             "description": null,
             "isDeprecated": false,
@@ -52967,21 +53194,29 @@
       },
       {
         "kind": "INPUT_OBJECT",
-        "name": "WorkflowConditions",
-        "description": "The conditions to match different events, which need to be true for workflow to be started.",
+        "name": "WorkflowCondition",
+        "description": "A condition to match for the workflow to be triggered.",
         "fields": null,
         "inputFields": [
           {
-            "name": "issue",
-            "description": "The conditions to match triggers based on issue (creation, update, deletion).",
+            "name": "issueFilter",
+            "description": "Trigger the workflow when an issue matches the filter. Can only be used when the trigger type is `Issue`.",
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "INPUT_OBJECT",
-                "name": "WorkflowEntityPropertyMatcher",
-                "ofType": null
-              }
+              "kind": "INPUT_OBJECT",
+              "name": "IssueFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectFilter",
+            "description": "Triggers the workflow when a project matches the filter. Can only be used when the trigger type is `Project`.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ProjectFilter",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -53074,8 +53309,20 @@
             "deprecationReason": null
           },
           {
+            "name": "groupName",
+            "description": "The name of the group that the workflow belongs to.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "description",
-            "description": "The workflow description.",
+            "description": "The description of the workflow.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -53087,7 +53334,7 @@
           },
           {
             "name": "type",
-            "description": "The type of the workflow",
+            "description": "The type of the workflow.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -53103,7 +53350,23 @@
           },
           {
             "name": "trigger",
-            "description": "The type of the trigger that kicks off the workflow.",
+            "description": "The type of the event that triggers off the workflow.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "WorkflowTrigger",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "triggerType",
+            "description": "The object type (e.g. Issue) that triggers this workflow.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -53111,6 +53374,22 @@
               "ofType": {
                 "kind": "ENUM",
                 "name": "WorkflowTriggerType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "conditions",
+            "description": "The conditions that need to be match for the workflow to be triggered.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSONObject",
                 "ofType": null
               }
             },
@@ -53134,33 +53413,13 @@
             "deprecationReason": null
           },
           {
-            "name": "organization",
-            "description": "The organization where workflow was created.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Organization",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "team",
-            "description": "The team associated with the workflow.",
+            "description": "The team associated with the workflow. If not set, the workflow is associated with the entire organization.",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Team",
-                "ofType": null
-              }
+              "kind": "OBJECT",
+              "name": "Team",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -53175,22 +53434,6 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "User",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "conditions",
-            "description": "One or more conditions that need to be true for workflow to be triggered.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "JSONObject",
                 "ofType": null
               }
             },
@@ -53228,6 +53471,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "sortOrder",
+            "description": "The sort order of the workflow definition within its siblings.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -53242,14 +53501,105 @@
         "possibleTypes": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "WorkflowEntityPropertyMatcher",
-        "description": "Object to provide conditions to match an entity change.",
-        "fields": null,
-        "inputFields": [
+        "kind": "OBJECT",
+        "name": "WorkflowDefinitionConnection",
+        "description": null,
+        "fields": [
           {
-            "name": "property",
-            "description": "The property to check for matching.",
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkflowDefinitionEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkflowDefinition",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowDefinitionEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDefinition",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cursor",
+            "description": "Used in `before` and `after` args",
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -53259,76 +53609,12 @@
                 "ofType": null
               }
             },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "fromValue",
-            "description": "The initial value of the property to match.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "toValue",
-            "description": "The new value of the property to match.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "and",
-            "description": "The optional list of property matchers that all have to match.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "WorkflowEntityPropertyMatcher",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "or",
-            "description": "The optional list of property matchers where at least one have to match.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "WorkflowEntityPropertyMatcher",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
         ],
-        "interfaces": null,
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -54110,7 +54396,7 @@
       },
       {
         "kind": "ENUM",
-        "name": "WorkflowTriggerType",
+        "name": "WorkflowTrigger",
         "description": null,
         "fields": null,
         "inputFields": null,
@@ -54123,19 +54409,54 @@
             "deprecationReason": null
           },
           {
-            "name": "issueCreated",
+            "name": "entityCreated",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "issueUpdated",
+            "name": "entityUpdated",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "issueDeleted",
+            "name": "entityCreatedOrUpdated",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "entityRemoved",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "entityUnarchived",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "WorkflowTriggerType",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "issue",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -54153,6 +54474,12 @@
         "enumValues": [
           {
             "name": "recurringIssue",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sla",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null


### PR DESCRIPTION
Adds configuration to skip some comment annotated fields during test generation. This is the same configuration that is used when generating the SDK code.

```
config:
  skipComments:
    - "[Internal]"
    - "[INTERNAL]"
    - "[ALPHA]"
```