### PR TITLE
feat: add LinearWebhooks class to help work with Linear webhooks

### DIFF
--- a/.changeset/serious-kiwis-wink.md
+++ b/.changeset/serious-kiwis-wink.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": minor
+---
+
+Add new Webhooks helper class

--- a/packages/sdk/src/_tests/LinearWebhooks.test.ts
+++ b/packages/sdk/src/_tests/LinearWebhooks.test.ts
@@ -1,0 +1,57 @@
+import { LINEAR_WEBHOOK_TS_FIELD, LinearWebhooks } from "../webhooks";
+import crypto from "crypto";
+
+describe("webhooks", () => {
+  let parsedBody = {};
+  let rawBody: Buffer;
+  let requestBody = {};
+
+  beforeEach(() => {
+    requestBody = {
+      action: "create",
+      data: {
+        id: "2174add1-f7c8-44e3-bbf3-2d60b5ea8bc9",
+        createdAt: "2020-01-23T12:53:18.084Z",
+        updatedAt: "2020-01-23T12:53:18.084Z",
+        archivedAt: null,
+        body: "Indeed, I think this is definitely an improvement over the previous version.",
+        edited: false,
+        issueId: "539068e2-ae88-4d09-bd75-22eb4a59612f",
+        userId: "aacdca22-6266-4c0a-ab3c-8fa70a26765c",
+      },
+      type: "Comment",
+      url: "https://linear.app/issue/LIN-1778/foo-bar#comment-77217de3-fb52-4dad-bb9a-b356beb93de8",
+      createdAt: "2020-01-23T12:53:18.084Z",
+      webhookTimestamp: 1677611643000,
+    };
+
+    rawBody = Buffer.from(JSON.stringify(requestBody));
+    parsedBody = JSON.parse(rawBody.toString());
+  });
+
+  it("incorrect signature, should fail verification", async () => {
+    const webhook = new LinearWebhooks("SECRET");
+    const signature = crypto.createHmac("sha256", "WRONG_SECRET").update(rawBody).digest("hex");
+    expect(() => webhook.verify(rawBody, signature, parsedBody[LINEAR_WEBHOOK_TS_FIELD])).toThrowError(
+      "Invalid webhook signature"
+    );
+  });
+
+  it("correct signature, incorrect timestamp should fail verification", async () => {
+    const webhook = new LinearWebhooks("SECRET");
+    const signature = crypto.createHmac("sha256", "SECRET").update(rawBody).digest("hex");
+    expect(() => webhook.verify(rawBody, signature, parsedBody[LINEAR_WEBHOOK_TS_FIELD])).toThrowError(
+      "Invalid webhook timestamp"
+    );
+  });
+
+  it("correct signature, correct timestamp should pass verification", async () => {
+    requestBody["webhookTimestamp"] = new Date().getTime();
+    rawBody = Buffer.from(JSON.stringify(requestBody));
+    parsedBody = JSON.parse(rawBody.toString());
+
+    const webhook = new LinearWebhooks("SECRET");
+    const signature = crypto.createHmac("sha256", "SECRET").update(rawBody).digest("hex");
+    expect(() => webhook.verify(rawBody, signature, parsedBody[LINEAR_WEBHOOK_TS_FIELD])).toBeTruthy();
+  });
+});

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -6,3 +6,4 @@ export * from "./graphql-client";
 export * from "./types";
 export * as LinearDocument from "./_generated_documents";
 export * from "./_generated_sdk";
+export * from "./webhooks";

--- a/packages/sdk/src/webhooks.ts
+++ b/packages/sdk/src/webhooks.ts
@@ -1,0 +1,38 @@
+import crypto from "crypto";
+
+export const LINEAR_WEBHOOK_SIGNATURE_HEADER = "linear-signature";
+export const LINEAR_WEBHOOK_TS_FIELD = "webhookTimestamp";
+
+/**
+ * Provides helper functions to work with Linear webhooks
+ */
+export class LinearWebhooks {
+  public constructor(private secret: string) {}
+
+  /**
+   * Verify the webhook signature
+   * @param rawBody The webhook request raw body.
+   * @param signature The signature to verify.
+   * @param timestamp The `webhookTimestamp` field from the request parsed body.
+   */
+  public verify(rawBody: Buffer, signature: string, timestamp: number): boolean {
+    const verificationBuffer = Buffer.from(crypto.createHmac("sha256", this.secret).update(rawBody).digest("hex"));
+    const signatureBuffer = Buffer.from(signature);
+
+    if (verificationBuffer.length !== signatureBuffer.length) {
+      throw new Error("Invalid webhook signature");
+    }
+
+    if (!crypto.timingSafeEqual(verificationBuffer, signatureBuffer)) {
+      throw new Error("Invalid webhook signature");
+    }
+
+    const timeDiff = Math.abs(new Date().getTime() - timestamp);
+    // Throw error if more than one minute delta between provided ts and current time
+    if (timeDiff > 1000 * 60) {
+      throw new Error("Invalid webhook timestamp");
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
This PR introduces a new `Webhooks` aimed at dealing with Linear Webhooks.

Its first method is a helper to verify the HMAC signatures. See https://developers.linear.app/docs/graphql/webhooks#securing-webhooks for documentation