### PR TITLE
Add `--version` argument to CLI importer

### DIFF
--- a/.changeset/lovely-goats-deliver.md
+++ b/.changeset/lovely-goats-deliver.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": minor
+---
+
+Add --version command argument

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,7 +93,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ["**/docs/**/*.js"],
+      files: ["**/docs/**/*.js", "**/bin/**/*.js"],
       rules: {
         "no-console": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",

--- a/packages/import/bin/linear-import.js
+++ b/packages/import/bin/linear-import.js
@@ -1,3 +1,10 @@
 #!/usr/bin/env node
 
+if (process.argv.length > 2) {
+  if (process.argv[2] === "--version") {
+    console.log(require("../package.json").version);
+    process.exit(0);
+  }
+}
+
 require("../dist/cli");


### PR DESCRIPTION
Adds a CLI argument `--version` to print out current version number of the CLI importer, for support purposes.