### PR TITLE
feat: check if Connection type is valid or not

### DIFF
--- a/.changeset/late-pumas-whisper.md
+++ b/.changeset/late-pumas-whisper.md
@@ -1,0 +1,6 @@
+---
+"@linear/codegen-doc": minor
+"@linear/codegen-sdk": minor
+---
+
+Check if Connection type is valid or not

--- a/packages/codegen-doc/src/fragment-visitor.ts
+++ b/packages/codegen-doc/src/fragment-visitor.ts
@@ -58,7 +58,7 @@ export class FragmentVisitor {
       const node = _node as unknown as NamedFields<ObjectTypeDefinitionNode>;
 
       /** Process non empty object definitions */
-      if (isValidObject(this._context, node)) {
+      if (isValidObject(this._context, node, this._fragments)) {
         /** Record fragment on context */
         this._fragments = [...this._fragments, node];
 

--- a/packages/codegen-doc/src/fragment.ts
+++ b/packages/codegen-doc/src/fragment.ts
@@ -4,9 +4,9 @@ import {
   ObjectTypeDefinitionNode,
   OperationTypeDefinitionNode,
 } from "graphql";
-import { isEdge, isOperationRoot } from "./object";
+import { getObjectName, isConnection, isEdge, isOperationRoot } from "./object";
 import { printTypescriptType } from "./print";
-import { Named, NamedFields, PluginContext } from "./types";
+import { Fragment, Named, NamedFields, PluginContext } from "./types";
 
 /**
  * Get the fragment object type matching the name arg
@@ -25,8 +25,24 @@ export function findFragment(
 /**
  * Check whether this object has valid content and is not a connection, edge, root or has a skip comment.
  */
-export function isValidObject(context: PluginContext, fragment: NamedFields<ObjectTypeDefinitionNode>): boolean {
+export function isValidObject(
+  context: PluginContext,
+  fragment: NamedFields<ObjectTypeDefinitionNode>,
+  previousFragments: Fragment[]
+): boolean {
   const hasFields = (fragment.fields ?? []).filter(Boolean).length;
   const skipComment = context.config.skipComments?.some(comment => fragment.description?.value.includes(comment));
-  return Boolean(hasFields && !isEdge(fragment) && !isOperationRoot(context, fragment) && !skipComment);
+  const skip = Boolean(hasFields && !isEdge(fragment) && !isOperationRoot(context, fragment) && !skipComment);
+
+  const connection = isConnection(fragment);
+  if (connection) {
+    // Check we have accepted a fragment for the type of this connection
+    const rootTypeName = getObjectName(fragment).replace("Connection", "");
+    const hasSkippedRootType = !previousFragments.some(f => f.name === rootTypeName);
+    if (hasSkippedRootType) {
+      return false;
+    }
+  }
+
+  return skip;
 }

--- a/packages/codegen-doc/src/object.ts
+++ b/packages/codegen-doc/src/object.ts
@@ -34,7 +34,7 @@ export function findInterface(
  * Get the string value of the object name
  */
 export function getObjectName(
-  object: ObjectTypeDefinitionNode | NamedFields<ObjectTypeDefinitionNode> | string
+  object: ObjectTypeDefinitionNode | NamedFields<ObjectTypeDefinitionNode> | InterfaceTypeDefinitionNode | string
 ): string {
   return typeof object === "string" ? object : typeof object.name === "string" ? object.name : object.name.value;
 }
@@ -43,7 +43,7 @@ export function getObjectName(
  * Is the object a connection type
  */
 export function isConnection(
-  object?: ObjectTypeDefinitionNode | NamedFields<ObjectTypeDefinitionNode> | string
+  object?: ObjectTypeDefinitionNode | NamedFields<ObjectTypeDefinitionNode> | InterfaceTypeDefinitionNode | string
 ): boolean {
   return object ? getObjectName(object).endsWith("Connection") : false;
 }

--- a/packages/codegen-sdk/src/constants.ts
+++ b/packages/codegen-sdk/src/constants.ts
@@ -26,6 +26,7 @@ export const Sdk = {
   RESPONSE_TYPE: "Response",
   SDK_CLASS: "LinearSdk",
   UNDEFINED: "undefined",
+  UNKNOWN_MODEL: "UnknownModel",
   VARIABLE_NAME: "variables",
   VARIABLE_TYPE: "Variables",
 };

--- a/packages/codegen-sdk/src/parse-operation.ts
+++ b/packages/codegen-sdk/src/parse-operation.ts
@@ -109,7 +109,7 @@ export function parseOperations(
 
     /** Find a matching model */
     const model = models.find(b => b.name === fragment?.name.value);
-    const modelName = model?.name ?? "UNKNOWN_MODEL";
+    const modelName = model?.name ?? Sdk.UNKNOWN_MODEL;
 
     /** Find a parent operation */
     const parentSdkKey = sdkPath.slice(0, -1).join("_");

--- a/packages/codegen-sdk/src/print-connection.ts
+++ b/packages/codegen-sdk/src/print-connection.ts
@@ -27,6 +27,15 @@ export function isConnectionModel(model?: SdkModel): boolean {
     : false;
 }
 
+/** Determines whether this connection model is valid by ensuring
+ * the entity it is referring to has been considered valid as well.
+ * @param model The model that is being checked
+ */
+export function isValidConnectionModel(context: SdkPluginContext, sdkModel: SdkModel): boolean {
+  const rootType = sdkModel?.name.replace("Connection", "");
+  return context.models?.some(model => model.name === rootType);
+}
+
 /**
  * Print an abstract class for identifying connection models
  */

--- a/packages/codegen-sdk/src/print-model.ts
+++ b/packages/codegen-sdk/src/print-model.ts
@@ -14,7 +14,7 @@ import {
 } from "@linear/codegen-doc";
 import { Sdk } from "./constants";
 import { findMutations, getMutationTypeFromPrefixedName } from "./mutation";
-import { isConnectionModel, printConnectionModel } from "./print-connection";
+import { isConnectionModel, isValidConnectionModel, printConnectionModel } from "./print-connection";
 import { getRequestArg } from "./print-request";
 import { printModelScalar } from "./print-scalar";
 import { SdkModel, SdkModelField, SdkPluginContext } from "./types";
@@ -44,7 +44,11 @@ function printModel(context: SdkPluginContext, model: SdkModel): string {
 
   /** Handle connection models separately */
   if (isConnectionModel(model)) {
-    return printConnectionModel(context, model);
+    if (isValidConnectionModel(context, model)) {
+      return printConnectionModel(context, model);
+    } else {
+      return "";
+    }
   }
 
   const args = getArgList([

--- a/packages/codegen-sdk/src/print-operation.ts
+++ b/packages/codegen-sdk/src/print-operation.ts
@@ -19,7 +19,12 @@ import { SdkOperation, SdkPluginContext } from "./types";
  */
 export function printOperations(context: SdkPluginContext): string {
   const returnTypes = Object.values(context.sdkDefinitions).reduce<string[]>((acc, definition) => {
-    return [...acc, ...definition.operations.map(operation => printOperation(context, operation))];
+    return [
+      ...acc,
+      ...definition.operations
+        .filter(operation => operation.print.model !== Sdk.UNKNOWN_MODEL)
+        .map(operation => printOperation(context, operation)),
+    ];
   }, []);
 
   return printLines(returnTypes);

--- a/packages/codegen-sdk/src/print-sdk.ts
+++ b/packages/codegen-sdk/src/print-sdk.ts
@@ -9,7 +9,9 @@ import { SdkOperation, SdkPluginContext } from "./types";
 export function printSdk(context: SdkPluginContext): string {
   const rootOperations = context.sdkDefinitions[""];
 
-  const operations = printLines(rootOperations.operations.map(printSdkOperation));
+  const operations = printLines(
+    rootOperations.operations.filter(operation => operation.print.model !== Sdk.UNKNOWN_MODEL).map(printSdkOperation)
+  );
 
   const args = getArgList([getRequestArg()]);
 


### PR DESCRIPTION
The `schema` Github action is currently breaking, preventing future SDK releases. The reason for failure is 

```
    GraphQLDocumentError: Unknown fragment "ExternalUser".
```

It comes from the fact that we have marked `ExternalUser` entity as [ALPHA]. Some operations are not annotated with the same comment though. Also, the schema contains one type related to `ExternalUser`: `ExternalUserConnection`, for which it's not possible to write an annotation.

This PR intends to skip generating objects that are related to a model being marked as skipped:
 - The Connection model linked to the model
 - Queries that are meant to return the model