### PR TITLE
feat: follow semver for schema related SDK bumps

### DIFF
--- a/.changeset/purple-lies-warn.md
+++ b/.changeset/purple-lies-warn.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": patch
+---
+
+Follow semver for API changes

--- a/packages/sdk/scripts/generate-schema-changeset.ts
+++ b/packages/sdk/scripts/generate-schema-changeset.ts
@@ -13,9 +13,16 @@ const levelOrder = {
   [CriticalityLevel.NonBreaking]: 0,
 };
 
+const criticalityToSemver = {
+  [CriticalityLevel.Breaking]: "major",
+  [CriticalityLevel.Dangerous]: "minor",
+  [CriticalityLevel.NonBreaking]: "patch",
+};
+
 const filename = path.resolve(`../../.changeset/_generated_schema_${Math.ceil(Math.random() * 100000000)}.md`);
 
-const changeset = printLines(["---", '"@linear/sdk": minor', "---"]);
+const changeset = (criticality: CriticalityLevel) =>
+  printLines(["---", `"@linear/sdk": ${criticalityToSemver[criticality]}`, "---"]);
 
 /**
  * Generate a changeset file by diffing the current schema with the master branch
@@ -44,7 +51,7 @@ async function generateSchemaChangeset() {
     await promisify(writeFile)(
       filename,
       printLines([
-        changeset,
+        changeset(changes[0].criticality.level),
         "\n",
         changes
           .map(


### PR DESCRIPTION
Currently, the `schema` action will generate a changeset that will always result in a `minor` sdk bump, regardless of whether the schema changes are breaking or not. (Example: #306)

If there is a breaking API change, than it will result in an SDK breaking change, which means we should bump sdk package accordingly, by bumping to the highest criticality included in the changeset.