### PR TITLE
docs(changeset): fix: increase mock server start delay

### DIFF
--- a/.changeset/grumpy-peaches-confess.md
+++ b/.changeset/grumpy-peaches-confess.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": patch
+---
+
+fix: increase mock server start delay

--- a/packages/sdk/src/_tests/test-client.ts
+++ b/packages/sdk/src/_tests/test-client.ts
@@ -39,7 +39,7 @@ export async function startClient(Client: typeof LinearClient = LinearClient): P
     }
 
     /** Wait for mock server to start */
-    await sleep(1000);
+    await sleep(5000);
 
     /** Create Linear client with mock server endpoint */
     return new Client({


### PR DESCRIPTION
That's not a great looking fix but it's probably best for now.

Tests start a mock GraphQL server in a separate process. We don't have a good way to know when this server is ready to accept connections. 1s is definitely a bit short as even on my laptop, it will fail from time to time with:

```
Request to http://localhost:42195/graphql failed, reason: connect ECONNREFUSED 127.0.0.1:42195
```

So it's an even tighter window on the low CPU GH Actions.