### PR TITLE
Support mapping Trello lists to statuses, importing archived cards as archived in Linear

### DIFF
--- a/packages/import/src/cli.ts
+++ b/packages/import/src/cli.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import chalk from "chalk";
 import * as inquirer from "inquirer";
+import { importIssues } from "./importIssues";
 import { asanaCsvImport } from "./importers/asanaCsv";
 import { githubImport } from "./importers/github";
 import { jiraCsvImport } from "./importers/jiraCsv";
@@ -9,7 +10,6 @@ import { linearCsvImporter } from "./importers/linearCsv";
 import { pivotalCsvImport } from "./importers/pivotalCsv";
 import { shortcutCsvImport } from "./importers/shortcutCsv";
 import { trelloJsonImport } from "./importers/trelloJson";
-import { importIssues } from "./importIssues";
 import { ImportAnswers } from "./types";
 
 inquirer.registerPrompt("filePath", require("inquirer-file-path"));

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { LinearClient } from "@linear/sdk";
-import { format } from "date-fns";
 import chalk from "chalk";
+import { format } from "date-fns";
 import * as inquirer from "inquirer";
 import _ from "lodash";
 import { Comment, Importer, ImportResult } from "./types";
@@ -270,7 +270,7 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
 
     const formattedDueDate = issue.dueDate ? format(issue.dueDate, "yyyy-MM-dd") : undefined;
 
-    await client.createIssue({
+    const createdIssue = await client.createIssue({
       teamId,
       projectId: projectId as unknown as string,
       title: issue.title,
@@ -281,6 +281,10 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
       assigneeId,
       dueDate: formattedDueDate,
     });
+
+    if (issue.archived) {
+      await (await createdIssue.issue)?.archive();
+    }
   }
 
   console.info(chalk.green(`${importer.name} issues imported to your team: https://linear.app/team/${teamKey}/all`));

--- a/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
+++ b/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
@@ -146,6 +146,7 @@ export class TrelloJsonImporter implements Importer {
         labels,
         comments: comments[card.id],
         status: this.mapListsToStatuses ? cardList?.name : undefined,
+        archived: card.closed || cardList?.closed,
       });
 
       const allLabels = card.labels.map(label => ({

--- a/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
+++ b/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
@@ -24,6 +24,7 @@ interface TrelloCard {
 
 interface TrelloList {
   id: string;
+  name: string;
   closed: boolean;
 }
 
@@ -50,8 +51,14 @@ interface TrelloCommentAction {
 }
 
 export class TrelloJsonImporter implements Importer {
-  public constructor(filePath: string, discardArchivedCards: boolean, discardArchivedLists: boolean) {
+  public constructor(
+    filePath: string,
+    mapListsToStatuses: boolean,
+    discardArchivedCards: boolean,
+    discardArchivedLists: boolean
+  ) {
     this.filePath = filePath;
+    this.mapListsToStatuses = mapListsToStatuses;
     this.discardArchivedCards = discardArchivedCards;
     this.discardArchivedLists = discardArchivedLists;
   }
@@ -101,6 +108,8 @@ export class TrelloJsonImporter implements Importer {
       }
     }
 
+    const trelloLists = data.lists as TrelloList[];
+
     for (const card of data.cards as TrelloCard[]) {
       const url = card.shortUrl;
       const mdDesc = card.desc;
@@ -115,6 +124,7 @@ export class TrelloJsonImporter implements Importer {
       const formattedAttachments = card.attachments
         .map(attachment => `[${attachment.name}](${attachment.url})`)
         .join("\n");
+      const cardList = trelloLists.find(list => list.id === card.idList);
 
       const description = `${mdDesc}${formattedChecklist && `\n${formattedChecklist}`}${
         formattedAttachments && `\n\nAttachments:\n${formattedAttachments}`
@@ -125,10 +135,7 @@ export class TrelloJsonImporter implements Importer {
         continue;
       }
 
-      if (
-        this.discardArchivedLists &&
-        (data.lists as TrelloList[]).find(list => list.id === card.idList && list.closed)
-      ) {
+      if (this.discardArchivedLists && cardList?.closed) {
         continue;
       }
 
@@ -138,6 +145,7 @@ export class TrelloJsonImporter implements Importer {
         url,
         labels,
         comments: comments[card.id],
+        status: this.mapListsToStatuses ? cardList?.name : undefined,
       });
 
       const allLabels = card.labels.map(label => ({
@@ -158,6 +166,7 @@ export class TrelloJsonImporter implements Importer {
 
   // -- Private interface
   private filePath: string;
+  private mapListsToStatuses: boolean;
   private discardArchivedCards: boolean;
   private discardArchivedLists: boolean;
 }

--- a/packages/import/src/importers/trelloJson/index.ts
+++ b/packages/import/src/importers/trelloJson/index.ts
@@ -8,6 +8,7 @@ export const trelloJsonImport = async (): Promise<Importer> => {
   const answers = await inquirer.prompt<TrelloImportAnswers>(questions);
   const trelloImporter = new TrelloJsonImporter(
     answers.trelloFilePath,
+    answers.mapListsToStatuses,
     answers.discardArchivedCards,
     answers.discardArchivedLists
   );
@@ -16,6 +17,7 @@ export const trelloJsonImport = async (): Promise<Importer> => {
 
 interface TrelloImportAnswers {
   trelloFilePath: string;
+  mapListsToStatuses: boolean;
   discardArchivedCards: boolean;
   discardArchivedLists: boolean;
 }
@@ -26,6 +28,12 @@ const questions = [
     type: "filePath",
     name: "trelloFilePath",
     message: "Select your exported JSON file of Trello cards",
+  },
+  {
+    type: "confirm",
+    name: "mapListsToStatuses",
+    message: "Would you like to map Trello lists to statuses?",
+    default: true,
   },
   {
     type: "confirm",

--- a/packages/import/src/types.ts
+++ b/packages/import/src/types.ts
@@ -24,6 +24,8 @@ export interface Issue {
   completedAt?: Date;
   /** When the issue was started. */
   startedAt?: Date;
+  /** Whether issue is archived */
+  archived?: boolean;
 }
 
 /** Issue comment */


### PR DESCRIPTION
This PR enables users to (optionally) map Trello lists to statuses in Linear. It reuses the existing logic for mapping statuses, by providing the list name in the `Issue.status` field.

I've also introduced a new `Issue.archived` field to allow for imported tasks to be actually as 'archived' within Linear after import, instead of importing archived tasks as active. This is currently only implemented for Trello cards.