### PR TITLE
chore: downgrade chalk to 4.x

### DIFF
--- a/.changeset/strange-dryers-sort.md
+++ b/.changeset/strange-dryers-sort.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": patch
+---
+
+Downgrade chalk to 4.x

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@linear/sdk": "^7.0.0",
-    "chalk": "5.3.0",
+    "chalk": "4.1.2",
     "csvtojson": "2.0.10",
     "date-fns": "^2.19.0",
     "inquirer": "7.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,10 +4242,13 @@ chalk@4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"
-  integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
+chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
@@ -4266,14 +4269,6 @@ chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 change-case-all@1.0.14:
   version "1.0.14"


### PR DESCRIPTION
Chalk was recently upgraded from 4.x to 5.x by dependabot in #339.

As Chalk 5.x is now a [pure](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) ESM package, it cannot be used in a CommonJS project.

```
var chalk = require('chalk');
            ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/guillaumelachaud/.nvm/versions/node/v18.12.1/lib/node_modules/@linear/import/node_modules/chalk/source/index.js from /Users/guillaumelachaud/.nvm/versions/node/v18.12.1/lib/node_modules/@linear/import/dist/cli.js not supported.
Instead change the require of index.js in /Users/guillaumelachaud/.nvm/versions/node/v18.12.1/lib/node_modules/@linear/import/dist/cli.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/Users/guillaumelachaud/.nvm/versions/node/v18.12.1/lib/node_modules/@linear/import/dist/cli.js:3:13)
    at Object.<anonymous> (/Users/guillaumelachaud/.nvm/versions/node/v18.12.1/lib/node_modules/@linear/import/bin/linear-import.js:10:1) {
  code: 'ERR_REQUIRE_ESM'
}

Node.js v18.12.1
```

Until we upgrade the CLI to be an ESM project, we can revert back to Chalk 4.x to make sure the CLI keeps working.