### PR TITLE
feat: add support for workspace-level labels and label groups

### DIFF
--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -167,14 +167,25 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
 
   const teamInfo = await client.team(teamId);
 
-  const issueLabels = await teamInfo?.labels();
+  const teamLabels = await teamInfo?.labels();
+  const workspaceLabels = await (await client.organization).labels();
+  const existingLabels = [...(teamLabels?.nodes ?? []), ...(workspaceLabels?.nodes ?? [])];
   const workflowStates = await teamInfo?.states();
 
   const existingLabelMap = {} as { [name: string]: string };
-  for (const label of issueLabels?.nodes ?? []) {
+  const existingLabelGroupsMap = {} as { [name: string]: string };
+
+  for (const label of existingLabels) {
     const labelName = label.name?.toLowerCase();
-    if (labelName && label.id && !existingLabelMap[labelName]) {
-      existingLabelMap[labelName] = label.id;
+    const children = await label.children();
+    if (children?.nodes?.length > 0) {
+      if (labelName && label.id && !existingLabelGroupsMap[labelName]) {
+        existingLabelGroupsMap[labelName] = label.id;
+      }
+    } else {
+      if (labelName && label.id && !existingLabelMap[labelName]) {
+        existingLabelMap[labelName] = label.id;
+      }
     }
   }
 
@@ -184,8 +195,19 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
   const labelMapping = {} as { [id: string]: string };
   for (const labelId of Object.keys(importData.labels)) {
     const label = importData.labels[labelId];
-    const labelName = _.truncate(label.name.trim(), { length: 20 });
-    let actualLabelId = existingLabelMap[labelName.toLowerCase()];
+    let labelName = _.truncate(label.name.trim(), { length: 20 });
+
+    // Check if this label matches with an existing group label
+    let actualLabelId: string | undefined = existingLabelGroupsMap[labelName.toLowerCase()];
+
+    if (actualLabelId) {
+      // This label has matched with an existing group label. We cannot re-use the label as-is, it will be renamed.
+      actualLabelId = undefined;
+      labelName = `${labelName} (imported)`;
+    }
+
+    // Check if this label matches with an existing label
+    actualLabelId = existingLabelMap[labelName.toLowerCase()];
 
     if (!actualLabelId) {
       const labelResponse = await client.createIssueLabel({


### PR DESCRIPTION
The CLI importer currently doesn't support workspace-level or group labels. If any label in the import set conflicts with one of these, the importer crashes. This PR adds support for these:

 - Pull list of workspace-level labels alongside team-level labels to check for potential conflict
 - Check if existing labels are label groups. In the event of a match, we cannot use the group as a leaf label. Instead of picking the first label of the group, we default to renaming the label to `label (imported)`. This is inline with the behavior of the in-app importers.

There are no unit tests on this package. A sample CSV file is provided
[test_20230824_031624.csv](https://github.com/linear/linear/files/12425206/test_20230824_031624.csv)
