### PR TITLE
feat: add support for workspace-level labels and label groups

### DIFF
--- a/.changeset/mighty-vans-marry.md
+++ b/.changeset/mighty-vans-marry.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": minor
+---
+
+Add support for workspace-level and group labels

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -178,7 +178,7 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
   for (const label of existingLabels) {
     const labelName = label.name?.toLowerCase();
     const children = await label.children();
-    if(children?.nodes?.length > 0) {
+    if (children?.nodes?.length > 0) {
       if (labelName && label.id && !existingLabelGroupsMap[labelName]) {
         existingLabelGroupsMap[labelName] = label.id;
       }
@@ -196,14 +196,17 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
   for (const labelId of Object.keys(importData.labels)) {
     const label = importData.labels[labelId];
     let labelName = _.truncate(label.name.trim(), { length: 20 });
+
+    // Check if this label matches with an existing group label
     let actualLabelId: string | undefined = existingLabelGroupsMap[labelName.toLowerCase()];
 
-    if(actualLabelId) {
-      //This label has matched with an existing group label. We cannot re-use the label as-is.
+    if (actualLabelId) {
+      // This label has matched with an existing group label. We cannot re-use the label as-is, it will be renamed.
       actualLabelId = undefined;
       labelName = `${labelName} (imported)`;
     }
 
+    // Check if this label matches with an existing label
     actualLabelId = existingLabelMap[labelName.toLowerCase()];
 
     if (!actualLabelId) {


### PR DESCRIPTION
The CLI importer currently doesn't support workspace-level or group labels. If any label in the import set conflicts with one of these, the importer crashes. This PR adds support for these:

 - Pull list of workspace-level labels alongside team-level labels to check for potential conflict
 - Check if existing labels are label groups. In the event of a match, we cannot use the group as a leaf label. Instead of picking the first label of the group, we default to renaming the label to `label (imported)`. This is inline with the behavior of the in-app importers.

There are no unit tests on this package. A sample CSV file is provided
[test_20230824_031624.csv](https://github.com/linear/linear/files/12425206/test_20230824_031624.csv)
