### PR TITLE
fix: use dedupeFragments with all codegen plugins

### DIFF
--- a/.changeset/mean-pugs-appear.md
+++ b/.changeset/mean-pugs-appear.md
@@ -1,0 +1,7 @@
+---
+"@linear/codegen-doc": minor
+"@linear/codegen-sdk": minor
+"@linear/codegen-test": minor
+---
+
+Use dedupeFragments option

--- a/packages/sdk/codegen.doc.yml
+++ b/packages/sdk/codegen.doc.yml
@@ -11,6 +11,7 @@ config:
   skipFields:
     - integrationResource
     - integrationResources
+  dedupeFragments: true
 generates:
   src/_generated_documents.graphql:
     plugins:

--- a/packages/sdk/codegen.sdk.yml
+++ b/packages/sdk/codegen.sdk.yml
@@ -6,6 +6,7 @@ hooks:
     - prettier --write
 config:
   documentFile: ./_generated_documents
+  dedupeFragments: true
   skipComments:
     - "[Internal]"
     - "[INTERNAL]"

--- a/packages/sdk/codegen.test.yml
+++ b/packages/sdk/codegen.test.yml
@@ -5,6 +5,7 @@ hooks:
   afterOneFileWrite:
     - prettier --write
 config:
+  dedupeFragments: true
   skipComments:
     - "[Internal]"
     - "[INTERNAL]"


### PR DESCRIPTION
The SDK currently cannot be upgraded to the latest schema. It builds correctly, but the tests fail when trying query a user's notifications with the following error:

```
    There can be only one fragment named "ActorBot".
```

This is happening because we have introduced `ActorBot` as a new type for a field on a type that's an implementation of an interface (Notification):

<details>
<summary>Notification Fragment</summary>

```graphql
# A notification sent to a user.
fragment Notification on Notification {
  __typename
  # Notification type
  type
  # The bot that caused the notification.
  botActor {
    ...ActorBot
  }
  # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
  #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
  #     been updated after creation.
  updatedAt
  # The time at when an email reminder for this notification was sent to the user. Null, if no email
  #     reminder has been sent.
  emailedAt
  # The time at when the user marked the notification as read. Null, if the the user hasn't read the notification
  readAt
  # The time at which a notification was unsnoozed..
  unsnoozedAt
  # The time at which the entity was archived. Null if the entity has not been archived.
  archivedAt
  # The time at which the entity was created.
  createdAt
  # The time until a notification will be snoozed. After that it will appear in the inbox again.
  snoozedUntilAt
  # The unique identifier of the entity.
  id
  # The user that caused the notification.
  actor {
    id
  }
  # The user that received the notification.
  user {
    id
  }

  ... on IssueNotification {
    ...IssueNotification.  <-- This one also has an ActorBot fragment
  }

  ... on OauthClientApprovalNotification {
    ...OauthClientApprovalNotification <-- This one also has an ActorBot fragment
  }

  ... on ProjectNotification {
    ...ProjectNotification <-- This one also has an ActorBot fragment
  }
}
```
</details>

This fragment is valid. But the codegen plugin will generate a typescript document that will lead to the following query, which is not valid:

<details>
<summary>Notification Query</summary>

```graphql
query notifications($after: String, $before: String, $first: Int, $includeArchived: Boolean, $last: Int, $orderBy: PaginationOrderBy) {
  notifications(
    after: $after
    before: $before
    first: $first
    includeArchived: $includeArchived
    last: $last
    orderBy: $orderBy
  ) {
    ...NotificationConnection
  }
}

fragment NotificationConnection on NotificationConnection {
  __typename
  nodes {
    ...Notification
  }
  pageInfo {
    ...PageInfo
  }
}

fragment Notification on Notification {
  __typename
  type
  updatedAt
  emailedAt
  readAt
  unsnoozedAt
  archivedAt
  createdAt
  snoozedUntilAt
  id
  actor {
    id
  }
  user {
    id
  }
  ... on IssueNotification {
    ...IssueNotification
  }
  ... on OauthClientApprovalNotification {
    ...OauthClientApprovalNotification
  }
  ... on ProjectNotification {
    ...ProjectNotification
  }
}

fragment IssueNotification on IssueNotification {
  __typename
  reactionEmoji
  type
  botActor {
    ...ActorBot
  }
  comment {
    id
  }
  issue {
    id
  }
  updatedAt
  team {
    id
  }
  emailedAt
  readAt
  unsnoozedAt
  archivedAt
  createdAt
  snoozedUntilAt
  id
  actor {
    id
  }
  user {
    id
  }
}

fragment ActorBot on ActorBot {
  __typename
  avatarUrl
  name
  userDisplayName
  subType
  type
  id
}

fragment OauthClientApprovalNotification on OauthClientApprovalNotification {
  __typename
  type
  oauthClientApproval {
    ...OauthClientApproval
  }
  botActor {
    ...ActorBot
  }
  updatedAt
  emailedAt
  readAt
  unsnoozedAt
  archivedAt
  createdAt
  snoozedUntilAt
  id
  actor {
    id
  }
  user {
    id
  }
}

fragment OauthClientApproval on OauthClientApproval {
  __typename
  updatedAt
  requesterId
  responderId
  requestReason
  denyReason
  scopes
  archivedAt
  createdAt
  id
  oauthClientId
}

fragment ActorBot on ActorBot {
  __typename
  avatarUrl
  name
  userDisplayName
  subType
  type
  id
}

fragment ProjectNotification on ProjectNotification {
  __typename
  type
  botActor {
    ...ActorBot
  }
  updatedAt
  project {
    id
  }
  projectUpdate {
    id
  }
  emailedAt
  readAt
  unsnoozedAt
  archivedAt
  createdAt
  snoozedUntilAt
  id
  actor {
    id
  }
  user {
    id
  }
}

fragment ActorBot on ActorBot {
  __typename
  avatarUrl
  name
  userDisplayName
  subType
  type
  id
}

fragment PageInfo on PageInfo {
  __typename
  startCursor
  endCursor
  hasPreviousPage
  hasNextPage
}
```

</details>

as there are multiple fragment named `ActorBot`. 
This is actually a problem common enough that there's an option in `graphql-code-generator` to automatically dedupe these fragments.

This PR sets it on to true in all 3 codegen packages to ensure consistent behavior across the whole generation flow.