### PR TITLE
fix: explicit permissions for more GA scopes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,15 +6,16 @@ on:
       - master
   workflow_dispatch:
 
-permissions:
-  contents: write
-  checks: write
-  pull-requests: write
-
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+      checks: write
+      pull-requests: write
+      statuses: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
The `release` GitHub action is now failing:

```
Error: GitHub Actions is not permitted to create or approve pull requests.
    at /home/runner/work/_actions/changesets/action/master/dist/index.js:718:926
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Object.m [as runVersion] (/home/runner/work/_actions/changesets/action/master/dist/index.js:1058:5104)
    at async /home/runner/work/_actions/changesets/action/master/dist/index.js:1060:2297 {
```

Adding explicit permissions for more scope as the new GITHUB_TOKEN seems to be less permissive. Unfortunately, there is no word about permissions in the official [documentation](https://github.com/changesets/action) so there might be a bit of trial and error.