### PR TITLE
fix: node-version bump to 18

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -15,10 +15,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use node 14
+      - name: Use node 18
         uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "18"
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
Follow-up on #370. Also bumping version here in the action itself.