### PR TITLE
chore: pin graphql-faker to rc.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "express": "^4.17.3",
     "get-port": "^5.1.1",
     "graphql": "^15.4.0",
-    "graphql-faker": "^2.0.0-rc.23",
+    "graphql-faker": "2.0.0-rc.25",
     "husky": "^4.3.8",
     "jest": "^26.6.3",
     "lerna": "7.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6218,7 +6218,7 @@ graphql-config@^3.3.0:
     minimatch "3.0.4"
     string-env-interpolation "1.0.1"
 
-graphql-faker@^2.0.0-rc.23:
+graphql-faker@2.0.0-rc.25:
   version "2.0.0-rc.25"
   resolved "https://registry.yarnpkg.com/graphql-faker/-/graphql-faker-2.0.0-rc.25.tgz#74d2cce58b0610deed9a0323e1d147cb8a756702"
   integrity sha512-tMSBRA/+aC988v66j95fxP1yzcVIXmc+KutspxrogvNSlMq314NE4omQyuY1FGD+RnOPMvy7p3nYgO30AKfVtA==


### PR DESCRIPTION
The `graphql-faker` package has been revived after 2 years without updates. Unfortunately, the 2.0.0 release has not been done properly and the package doesn't install. 

This PR intends to pin `graphql-faker` to `2.0.0-rc-25`  until https://github.com/graphql-kit/graphql-faker/issues/196 is resolved in order to fix the `dependencies` GH job.
