### PR TITLE
fix: fix faulty assignee import

### DIFF
--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -284,11 +284,12 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
       : undefined;
 
     const assigneeId: string | undefined =
-      existingAssigneeId || importAnswers.selfAssign
+      existingAssigneeId ||
+      (importAnswers.selfAssign
         ? viewer
         : !!importAnswers.targetAssignee && importAnswers.targetAssignee.length > 0
         ? importAnswers.targetAssignee
-        : undefined;
+        : undefined);
 
     const formattedDueDate = issue.dueDate ? format(issue.dueDate, "yyyy-MM-dd") : undefined;
 


### PR DESCRIPTION
Due to precedence of || operator being higher than that of ?: ([MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence#table)) assignees of imported tasks were invalid.
Effectively, it was
```typescript
const assigneeId: string | undefined =
      (existingAssigneeId || importAnswers.selfAssign)
        ? viewer
        : !!importAnswers.targetAssignee && importAnswers.targetAssignee.length > 0
        ? importAnswers.targetAssignee
        : undefined;
``` 