### PR TITLE
chore: add explicit permissions to `dependencies` job

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -5,6 +5,11 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+  checks: write
+  pull-requests: write
+
 jobs:
   dependencies:
     name: Dependencies


### PR DESCRIPTION
Following #390, the `dependencies` job now builds and tests successfully! It now fails at the last step, when trying to create a PR:

```
Pushing pull request branch to 'origin/dependencies'
  /usr/bin/git push --force-with-lease origin HEAD:refs/heads/dependencies
  remote: Permission to linear/linear.git denied to github-actions[bot].
  fatal: unable to access 'https://github.com/linear/linear/': The requested URL returned error: 403
  Error: The process '/usr/bin/git' failed with exit code 128
```

This PR adds the same permissions that are being used in other jobs.