### PR TITLE
Workaround to handle schema with duplicate queries

### DIFF
--- a/.changeset/sixty-geckos-promise.md
+++ b/.changeset/sixty-geckos-promise.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": patch
+---
+
+override naming convention to allow support of duplicate queries

--- a/packages/sdk/codegen.sdk.yml
+++ b/packages/sdk/codegen.sdk.yml
@@ -20,6 +20,8 @@ generates:
       - typescript
       - typescript-operations
       - typed-document-node
+    config:
+      namingConvention: './naming-override#case'
   src/_generated_sdk.ts:
     plugins:
       - "@linear/codegen-sdk"

--- a/packages/sdk/naming-override/index.js
+++ b/packages/sdk/naming-override/index.js
@@ -1,0 +1,10 @@
+var changeCaseAll = require("change-case-all");
+
+exports.case = (type) => {
+    if(type.includes("ProjectMilestoneQuery") || type.includes("ProjectMilestonesQuery")) {
+        console.log("will not touch:", type)
+         return "ProjectMilestoneQueryDoNotUse";
+    }
+    console.log("Will pascal case:", type)
+    return changeCaseAll.pascalCase(type)
+}

--- a/packages/sdk/naming-override/index.js
+++ b/packages/sdk/naming-override/index.js
@@ -1,10 +1,19 @@
-var changeCaseAll = require("change-case-all");
+const changeCaseAll = require("change-case-all");
+
+// Sometimes we have two queries with the same case. If we do, add the query names here (PascalCased), and we'll perform
+// deduplication on their query args to allow the SDK to build by suffixing additional types with the same name with a
+// counter.
+const duplicateQueries = ["ProjectMilestone", "ProjectMilestones"];
+
+// Object containing counters of how many times we've seen each DuplicateQueryNameArgs type.
+const deduplicate = Object.fromEntries(duplicateQueries.map(query => [`Query${query}Args`, 0]));
 
 exports.case = (type) => {
-    if(type.includes("ProjectMilestoneQuery") || type.includes("ProjectMilestonesQuery")) {
-        console.log("will not touch:", type)
-         return "ProjectMilestoneQueryDoNotUse";
+  if (type in deduplicate) {
+    if (deduplicate[type] > 0) {
+      type = type + deduplicate[type];
     }
-    console.log("Will pascal case:", type)
-    return changeCaseAll.pascalCase(type)
+    deduplicate[type] += 1
+  }
+  return changeCaseAll.pascalCase(type)
 }


### PR DESCRIPTION
This PR introduces a hack relying on `graphql-coden`'s `typescript` plugin's option to override naming convention for different types. This allows to generate a valid `_generated_document.ts` despite the schema containing two queries that only differ by their case

From @smcgivern:
> We want to replace the `ProjectMilestone(s)?` query with
`projectMilestone(s)?`. To do this, we'll have a period where both
queries are in our API schema, which generates duplicate type names and
fails to build.

> As a hack, to work around this, we can simply append a counter to those
known-duplicate type names when we encounter them for the (N > 0)-th
time, and so let the SDK build. The types are identical otherwise so
there's no functional difference, just a bit of noise in the generated
output.
