### PR TITLE
fix: do not re-use query for connection fields

### DIFF
--- a/.changeset/quick-vans-compare.md
+++ b/.changeset/quick-vans-compare.md
@@ -1,0 +1,5 @@
+---
+"@linear/codegen-doc": patch
+---
+
+fix: do not re-use query for connection fields

--- a/packages/codegen-doc/src/constants.ts
+++ b/packages/codegen-doc/src/constants.ts
@@ -1,4 +1,5 @@
 export const Doc = {
+  CONNECTION_FIELDS: ["pageInfo", "nodes", "edges"],
   MUTATION_TYPES: [
     "update",
     "archive",

--- a/packages/codegen-doc/src/print-operation.ts
+++ b/packages/codegen-doc/src/print-operation.ts
@@ -154,7 +154,7 @@ export function printOperations(
           /** No need to go further than scalar fields */
           isScalarField(context, field) ||
           /** No need to go further if the field is within a connection */
-          ["pageInfo", "nodes"].includes(field.name.value) ||
+          Doc.CONNECTION_FIELDS.includes(field.name.value) ||
           /** No need to go further if this returns a list */
           reduceListType(field.type) ||
           /** No need to go further if we can get this field from a root query */

--- a/packages/codegen-doc/src/query.ts
+++ b/packages/codegen-doc/src/query.ts
@@ -1,5 +1,6 @@
 import { FieldDefinitionNode } from "graphql";
 import { getRequiredArgs } from "./args";
+import { Doc } from "./constants";
 import { Named, PluginContext } from "./types";
 import { nodeHasSkipComment, reduceListType, reduceTypeName } from "./utils";
 
@@ -15,7 +16,7 @@ export function findQuery(
   const fieldName = typeof field.name === "string" ? field.name : field.name.value;
 
   /** Ignore queries for connections and lists */
-  if (type?.endsWith("Connection")) {
+  if (type?.endsWith("Connection") || Doc.CONNECTION_FIELDS.includes(fieldName)) {
     return undefined;
   }
 

--- a/packages/sdk/src/_generated_documents.graphql
+++ b/packages/sdk/src/_generated_documents.graphql
@@ -4511,6 +4511,9 @@ fragment TeamPayload on TeamPayload {
 
 fragment TemplateConnection on TemplateConnection {
   __typename
+  nodes {
+    ...Template
+  }
   pageInfo {
     ...PageInfo
   }

--- a/packages/sdk/src/_generated_documents.ts
+++ b/packages/sdk/src/_generated_documents.ts
@@ -13150,6 +13150,7 @@ export type TeamPayloadFragment = { __typename: "TeamPayload" } & Pick<TeamPaylo
   };
 
 export type TemplateConnectionFragment = { __typename: "TemplateConnection" } & {
+  nodes: Array<{ __typename?: "Template" } & TemplateFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
@@ -18116,54 +18117,6 @@ export const TeamNotificationSubscriptionFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<TeamNotificationSubscriptionFragment, unknown>;
-export const TemplateFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "Template" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Template" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "templateData" } },
-          { kind: "Field", name: { kind: "Name", value: "description" } },
-          { kind: "Field", name: { kind: "Name", value: "type" } },
-          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
-          { kind: "Field", name: { kind: "Name", value: "name" } },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "team" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
-            },
-          },
-          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
-          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
-          { kind: "Field", name: { kind: "Name", value: "id" } },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "creator" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
-            },
-          },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "lastUpdatedBy" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
-            },
-          },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<TemplateFragment, unknown>;
 export const UserAccountFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -24321,6 +24274,54 @@ export const TeamPayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<TeamPayloadFragment, unknown>;
+export const TemplateFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "Template" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Template" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "templateData" } },
+          { kind: "Field", name: { kind: "Name", value: "description" } },
+          { kind: "Field", name: { kind: "Name", value: "type" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "team" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "creator" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "lastUpdatedBy" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<TemplateFragment, unknown>;
 export const TemplateConnectionFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -24332,6 +24333,14 @@ export const TemplateConnectionFragmentDoc = {
         kind: "SelectionSet",
         selections: [
           { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "nodes" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "Template" } }],
+            },
+          },
           {
             kind: "Field",
             name: { kind: "Name", value: "pageInfo" },
@@ -32249,6 +32258,7 @@ export const Organization_TemplatesDocument = {
       },
     },
     ...TemplateConnectionFragmentDoc.definitions,
+    ...TemplateFragmentDoc.definitions,
     ...PageInfoFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<Organization_TemplatesQuery, Organization_TemplatesQueryVariables>;
@@ -36286,6 +36296,7 @@ export const Team_TemplatesDocument = {
       },
     },
     ...TemplateConnectionFragmentDoc.definitions,
+    ...TemplateFragmentDoc.definitions,
     ...PageInfoFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<Team_TemplatesQuery, Team_TemplatesQueryVariables>;

--- a/packages/sdk/src/_generated_sdk.ts
+++ b/packages/sdk/src/_generated_sdk.ts
@@ -8080,17 +8080,21 @@ export class Template extends Request {
  * TemplateConnection model
  *
  * @param request - function to call the graphql client
- * @param data - L.TemplateConnectionFragment response data
+ * @param fetch - function to trigger a refetch of this TemplateConnection model
+ * @param data - TemplateConnection response data
  */
-export class TemplateConnection extends Request {
-  public constructor(request: LinearRequest, data: L.TemplateConnectionFragment) {
-    super(request);
-    this.pageInfo = new PageInfo(request, data.pageInfo);
-  }
-
-  public pageInfo: PageInfo;
-  public get nodes(): LinearFetch<Template[]> {
-    return new TemplatesQuery(this._request).fetch();
+export class TemplateConnection extends Connection<Template> {
+  public constructor(
+    request: LinearRequest,
+    fetch: (connection?: LinearConnectionVariables) => LinearFetch<LinearConnection<Template> | undefined>,
+    data: L.TemplateConnectionFragment
+  ) {
+    super(
+      request,
+      fetch,
+      data.nodes.map(node => new Template(request, node)),
+      new PageInfo(request, data.pageInfo)
+    );
   }
 }
 /**
@@ -19812,7 +19816,18 @@ export class Organization_TemplatesQuery extends Request {
     );
     const data = response.organization.templates;
 
-    return new TemplateConnection(this._request, data);
+    return new TemplateConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...this._variables,
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
   }
 }
 
@@ -20748,7 +20763,18 @@ export class Team_TemplatesQuery extends Request {
     );
     const data = response.team.templates;
 
-    return new TemplateConnection(this._request, data);
+    return new TemplateConnection(
+      this._request,
+      connection =>
+        this.fetch(
+          defaultConnection({
+            ...this._variables,
+            ...variables,
+            ...connection,
+          })
+        ),
+      data
+    );
   }
 }
 

--- a/packages/sdk/src/_tests/_generated.test.ts
+++ b/packages/sdk/src/_tests/_generated.test.ts
@@ -113,7 +113,7 @@ describe("generated", () => {
       }
     });
 
-    /** Test the team model query for Team_Templates */
+    /** Test the team connection query for the Template */
     it("team.templates", async () => {
       if (_team) {
         const templates: L.TemplateConnection | undefined = await _team.templates();
@@ -2279,7 +2279,7 @@ describe("generated", () => {
       }
     });
 
-    /** Test the organization model query for Organization_Templates */
+    /** Test the organization connection query for the Template */
     it("organization.templates", async () => {
       if (_organization) {
         const templates: L.TemplateConnection | undefined = await _organization.templates();
@@ -3013,7 +3013,7 @@ describe("generated", () => {
       }
     });
 
-    /** Test the team model query for Team_Templates */
+    /** Test the team connection query for the Template */
     it("team.templates", async () => {
       if (_team) {
         const templates: L.TemplateConnection | undefined = await _team.templates();


### PR DESCRIPTION
Query `archivedTeams` has the same return type (`[Team!]!`) as the `nodes` field of `TeamConnection`. This confuses the `codegen-doc` plugin that would then print an incomplete `TeamConnection` fragment. This PR adds an exception to this mechanism for connection's fields.

It turns out it was already broken for the TemplateConnection (through query `templatesForIntegration`) but no tests actually attempt to traverse the nodes of connections. It's probably something we should consider adding to the suite of auto generated tests. `TeamConnection` leads to some build failures as it's being actively and explicitly used in the CLI importer and the README/bundle tests of the SDK. 