### PR TITLE
Add support for root query with all optional args

### DIFF
--- a/.changeset/_generated_schema_15229433.md
+++ b/.changeset/_generated_schema_15229433.md
@@ -1,0 +1,656 @@
+---
+"@linear/sdk": major
+---
+
+
+feat(schema): [breaking] Type 'AuthCreateOrJoinOrganizationResponse' was removed (AuthCreateOrJoinOrganizationResponse)
+
+feat(schema): [breaking] Type 'SamlConfiguration' was removed (SamlConfiguration)
+
+feat(schema): [breaking] Type 'SamlConfigurationInput' was removed (SamlConfigurationInput)
+
+feat(schema): [breaking] Type 'SamlConfigurationPayload' was removed (SamlConfigurationPayload)
+
+feat(schema): [breaking] Field 'ActorBot.id' changed type from 'ID!' to 'ID' (ActorBot.id)
+
+feat(schema): [breaking] Input field 'label' was added to input object type 'AuthApiKeyCreateInput' (AuthApiKeyCreateInput.label)
+
+feat(schema): [breaking] Field 'GitAutomationState.branchPattern' changed type from 'String!' to 'String' (GitAutomationState.branchPattern)
+
+feat(schema): [breaking] Field 'OauthToken.id' changed type from 'ID!' to 'Float!' (OauthToken.id)
+
+feat(schema): [breaking] Field 'ProjectUpdate.diff' changed type from 'JSON' to 'JSONObject' (ProjectUpdate.diff)
+
+feat(schema): [breaking] Field 'ProjectMilestone' (deprecated) was removed from object type 'Query' (Query.ProjectMilestone)
+
+feat(schema): [breaking] Field 'ProjectMilestones' (deprecated) was removed from object type 'Query' (Query.ProjectMilestones)
+
+feat(schema): [breaking] Field 'automationStates' was removed from object type 'Team' (Team.automationStates)
+
+feat(schema): [dangerous] Input field 'quotedText' was added to input object type 'CommentCreateInput' (CommentCreateInput.quotedText)
+
+feat(schema): [dangerous] Input field 'quotedText' was added to input object type 'CommentUpdateInput' (CommentUpdateInput.quotedText)
+
+feat(schema): [dangerous] Input field 'projectId' was added to input object type 'CustomViewCreateInput' (CustomViewCreateInput.projectId)
+
+feat(schema): [dangerous] Input field 'projectId' was added to input object type 'CustomViewUpdateInput' (CustomViewUpdateInput.projectId)
+
+feat(schema): [dangerous] Input field 'document' was added to input object type 'DocumentContentFilter' (DocumentContentFilter.document)
+
+feat(schema): [dangerous] Input field 'project' was added to input object type 'DocumentContentFilter' (DocumentContentFilter.project)
+
+feat(schema): [dangerous] Input field 'initiativeId' was added to input object type 'FavoriteCreateInput' (FavoriteCreateInput.initiativeId)
+
+feat(schema): [dangerous] Input field 'targetBranchId' was added to input object type 'GitAutomationStateCreateInput' (GitAutomationStateCreateInput.targetBranchId)
+
+feat(schema): [dangerous] Input field 'targetBranchId' was added to input object type 'GitAutomationStateUpdateInput' (GitAutomationStateUpdateInput.targetBranchId)
+
+feat(schema): [dangerous] Input field 'updateMetadata' was added to input object type 'JiraUpdateInput' (JiraUpdateInput.updateMetadata)
+
+feat(schema): [dangerous] Argument 'title: String' added to field 'Mutation.attachmentLinkDiscord' (Mutation.attachmentLinkDiscord.title)
+
+feat(schema): [dangerous] Argument 'title: String' added to field 'Mutation.attachmentLinkFront' (Mutation.attachmentLinkFront.title)
+
+feat(schema): [dangerous] Argument 'title: String' added to field 'Mutation.attachmentLinkGitHubIssue' (Mutation.attachmentLinkGitHubIssue.title)
+
+feat(schema): [dangerous] Argument 'title: String' added to field 'Mutation.attachmentLinkGitHubPR' (Mutation.attachmentLinkGitHubPR.title)
+
+feat(schema): [dangerous] Argument 'title: String' added to field 'Mutation.attachmentLinkGitLabMR' (Mutation.attachmentLinkGitLabMR.title)
+
+feat(schema): [dangerous] Argument 'title: String' added to field 'Mutation.attachmentLinkIntercom' (Mutation.attachmentLinkIntercom.title)
+
+feat(schema): [dangerous] Argument 'title: String' added to field 'Mutation.attachmentLinkZendesk' (Mutation.attachmentLinkZendesk.title)
+
+feat(schema): [dangerous] Input field 'document' was added to input object type 'NullableDocumentContentFilter' (NullableDocumentContentFilter.document)
+
+feat(schema): [dangerous] Input field 'project' was added to input object type 'NullableDocumentContentFilter' (NullableDocumentContentFilter.project)
+
+feat(schema): [dangerous] Argument 'filter: DocumentFilter' added to field 'Project.documents' (Project.documents.filter)
+
+feat(schema): [dangerous] Argument 'filter: ProjectMilestoneFilter' added to field 'Project.projectMilestones' (Project.projectMilestones.filter)
+
+feat(schema): [dangerous] Input field 'statusId' was added to input object type 'ProjectCreateInput' (ProjectCreateInput.statusId)
+
+feat(schema): [dangerous] Argument 'filter: DocumentFilter' added to field 'ProjectSearchResult.documents' (ProjectSearchResult.documents.filter)
+
+feat(schema): [dangerous] Argument 'filter: ProjectMilestoneFilter' added to field 'ProjectSearchResult.projectMilestones' (ProjectSearchResult.projectMilestones.filter)
+
+feat(schema): [dangerous] Input field 'statusId' was added to input object type 'ProjectUpdateInput' (ProjectUpdateInput.statusId)
+
+feat(schema): [dangerous] Argument 'hash: String' added to field 'Query.comment' (Query.comment.hash)
+
+feat(schema): [dangerous] Argument 'issueId: String' added to field 'Query.comment' (Query.comment.issueId)
+
+feat(schema): [dangerous] Argument 'filter: DocumentFilter' added to field 'Query.documents' (Query.documents.filter)
+
+feat(schema): [dangerous] Input field 'bidirectional' was added to input object type 'TeamRepoMappingInput' (TeamRepoMappingInput.bidirectional)
+
+feat(schema): [dangerous] Input field 'default' was added to input object type 'TeamRepoMappingInput' (TeamRepoMappingInput.default)
+
+feat(schema): [dangerous] Input field 'cycleEnabledStartDate' was added to input object type 'TeamUpdateInput' (TeamUpdateInput.cycleEnabledStartDate)
+
+feat(schema): [dangerous] Input field 'initiativeId' was added to input object type 'ViewPreferencesCreateInput' (ViewPreferencesCreateInput.initiativeId)
+
+feat(schema): [dangerous] Enum value 'initiative' was added to enum 'ViewType' (ViewType.initiative)
+
+feat(schema): [dangerous] Enum value 'initiatives' was added to enum 'ViewType' (ViewType.initiatives)
+
+feat(schema): [non_breaking] Type 'AuthOrganizationInvite' was added (AuthOrganizationInvite)
+
+feat(schema): [non_breaking] Type 'DataRecovery' was added (DataRecovery)
+
+feat(schema): [non_breaking] Type 'DocumentCollectionFilter' was added (DocumentCollectionFilter)
+
+feat(schema): [non_breaking] Type 'DocumentFilter' was added (DocumentFilter)
+
+feat(schema): [non_breaking] Type 'EmailIntakeAddressCreateInput' was added (EmailIntakeAddressCreateInput)
+
+feat(schema): [non_breaking] Type 'EmailIntakeAddressPayload' was added (EmailIntakeAddressPayload)
+
+feat(schema): [non_breaking] Type 'EmailIntakeAddressUpdateInput' was added (EmailIntakeAddressUpdateInput)
+
+feat(schema): [non_breaking] Type 'Facet' was added (Facet)
+
+feat(schema): [non_breaking] Type 'FacetConnection' was added (FacetConnection)
+
+feat(schema): [non_breaking] Type 'FacetEdge' was added (FacetEdge)
+
+feat(schema): [non_breaking] Type 'GitAutomationTargetBranch' was added (GitAutomationTargetBranch)
+
+feat(schema): [non_breaking] Type 'GitAutomationTargetBranchCreateInput' was added (GitAutomationTargetBranchCreateInput)
+
+feat(schema): [non_breaking] Type 'GitAutomationTargetBranchPayload' was added (GitAutomationTargetBranchPayload)
+
+feat(schema): [non_breaking] Type 'GitAutomationTargetBranchUpdateInput' was added (GitAutomationTargetBranchUpdateInput)
+
+feat(schema): [non_breaking] Type 'Initiative' was added (Initiative)
+
+feat(schema): [non_breaking] Type 'InitiativeArchivePayload' was added (InitiativeArchivePayload)
+
+feat(schema): [non_breaking] Type 'InitiativeConnection' was added (InitiativeConnection)
+
+feat(schema): [non_breaking] Type 'InitiativeCreateInput' was added (InitiativeCreateInput)
+
+feat(schema): [non_breaking] Type 'InitiativeEdge' was added (InitiativeEdge)
+
+feat(schema): [non_breaking] Type 'InitiativePayload' was added (InitiativePayload)
+
+feat(schema): [non_breaking] Type 'InitiativeToProject' was added (InitiativeToProject)
+
+feat(schema): [non_breaking] Type 'InitiativeToProjectConnection' was added (InitiativeToProjectConnection)
+
+feat(schema): [non_breaking] Type 'InitiativeToProjectCreateInput' was added (InitiativeToProjectCreateInput)
+
+feat(schema): [non_breaking] Type 'InitiativeToProjectEdge' was added (InitiativeToProjectEdge)
+
+feat(schema): [non_breaking] Type 'InitiativeToProjectPayload' was added (InitiativeToProjectPayload)
+
+feat(schema): [non_breaking] Type 'InitiativeToProjectUpdateInput' was added (InitiativeToProjectUpdateInput)
+
+feat(schema): [non_breaking] Type 'InitiativeUpdateInput' was added (InitiativeUpdateInput)
+
+feat(schema): [non_breaking] Type 'IntegrationHasScopesPayload' was added (IntegrationHasScopesPayload)
+
+feat(schema): [non_breaking] Type 'NullableDocumentFilter' was added (NullableDocumentFilter)
+
+feat(schema): [non_breaking] Type 'ProjectStatus' was added (ProjectStatus)
+
+feat(schema): [non_breaking] Type 'ProjectStatusConnection' was added (ProjectStatusConnection)
+
+feat(schema): [non_breaking] Type 'ProjectStatusEdge' was added (ProjectStatusEdge)
+
+feat(schema): [non_breaking] Type 'ProjectStatusType' was added (ProjectStatusType)
+
+feat(schema): [non_breaking] Type 'TimeSchedule' was added (TimeSchedule)
+
+feat(schema): [non_breaking] Type 'TimeScheduleConnection' was added (TimeScheduleConnection)
+
+feat(schema): [non_breaking] Type 'TimeScheduleEdge' was added (TimeScheduleEdge)
+
+feat(schema): [non_breaking] Type 'TimeScheduleEntry' was added (TimeScheduleEntry)
+
+feat(schema): [non_breaking] Field 'AttachmentSourcesPayload.sources' description changed from 'A unique list of all source types used in this workspace' to 'A unique list of all source types used in this workspace.' (AttachmentSourcesPayload.sources)
+
+feat(schema): [non_breaking] Field 'releaseChannel' was added to object type 'AuthOrganization' (AuthOrganization.releaseChannel)
+
+feat(schema): [non_breaking] Field 'serviceId' was added to object type 'AuthOrganization' (AuthOrganization.serviceId)
+
+feat(schema): [non_breaking] Field 'authType' was added to object type 'AuthOrganizationDomain' (AuthOrganizationDomain.authType)
+
+feat(schema): [non_breaking] Field 'claimed' was added to object type 'AuthOrganizationDomain' (AuthOrganizationDomain.claimed)
+
+feat(schema): [non_breaking] Field 'name' was added to object type 'AuthOrganizationDomain' (AuthOrganizationDomain.name)
+
+feat(schema): [non_breaking] Field 'organizationId' was added to object type 'AuthOrganizationDomain' (AuthOrganizationDomain.organizationId)
+
+feat(schema): [non_breaking] Field 'verified' was added to object type 'AuthOrganizationDomain' (AuthOrganizationDomain.verified)
+
+feat(schema): [non_breaking] Field 'AuthResolverResponse.availableOrganizations' description changed from 'Organizations this account has access to, but is not yet a member.' to 'List of organizations allowing this user account to join automatically.' (AuthResolverResponse.availableOrganizations)
+
+feat(schema): [non_breaking] Field 'AuthResolverResponse.email' changed type from 'String' to 'String!' (AuthResolverResponse.email)
+
+feat(schema): [non_breaking] Field 'AuthResolverResponse.lockedOrganizations' description changed from 'List of organizations this user account is part of but are currently locked because of the current auth service.' to 'List of organization available to this user account but locked due to the current auth method.' (AuthResolverResponse.lockedOrganizations)
+
+feat(schema): [non_breaking] Field 'AuthResolverResponse.token' description changed from 'JWT token for authentication of the account.' to 'Application token.' (AuthResolverResponse.token)
+
+feat(schema): [non_breaking] Field 'AuthResolverResponse.token' is deprecated (AuthResolverResponse.token)
+
+feat(schema): [non_breaking] Field 'AuthResolverResponse.token' has deprecation reason 'Deprecated and not used anymore. Never populated.' (AuthResolverResponse.token)
+
+feat(schema): [non_breaking] Field 'AuthResolverResponse.users' description changed from 'Users belonging to this account.' to 'List of active users that belong to the user account.' (AuthResolverResponse.users)
+
+feat(schema): [non_breaking] Field 'userAccountId' was added to object type 'AuthUser' (AuthUser.userAccountId)
+
+feat(schema): [non_breaking] Description 'Authentication session information' on type 'AuthenticationSessionResponse' has changed to 'Authentication session information.' (AuthenticationSessionResponse)
+
+feat(schema): [non_breaking] Field 'quotedText' was added to object type 'Comment' (Comment.quotedText)
+
+feat(schema): [non_breaking] Field 'Comment.botActor' description changed from 'The bot that created the comment' to 'The bot that created the comment.' (Comment.botActor)
+
+feat(schema): [non_breaking] Field 'Comment.reactionData' description changed from 'Emoji reaction summary, grouped by emoji type' to 'Emoji reaction summary, grouped by emoji type.' (Comment.reactionData)
+
+feat(schema): [non_breaking] Input field 'CommentCreateInput.projectUpdateId' description changed from 'The prject update to associate the comment with.' to 'The project update to associate the comment with.' (CommentCreateInput.projectUpdateId)
+
+feat(schema): [non_breaking] Description '[INTERNAL] Input for sending a message to the Linear Sales team' on type 'ContactSalesCreateInput' has changed to '[INTERNAL] Input for sending a message to the Linear Sales team.' (ContactSalesCreateInput)
+
+feat(schema): [non_breaking] Field 'issues' was added to object type 'CustomView' (CustomView.issues)
+
+feat(schema): [non_breaking] Field 'CustomView.projectFilterData' description changed from '[ALPHA] The filter applied to projects in the custom view.' to 'The filter applied to projects in the custom view.' (CustomView.projectFilterData)
+
+feat(schema): [non_breaking] Field 'CustomView.updatedBy' description changed from '[ALPHA] The user who last updated the custom view.' to 'The user who last updated the custom view.' (CustomView.updatedBy)
+
+feat(schema): [non_breaking] Input field 'CustomViewCreateInput.projectFilterData' description changed from '[ALPHA] The project filter applied to issues in the custom view.' to 'The project filter applied to issues in the custom view.' (CustomViewCreateInput.projectFilterData)
+
+feat(schema): [non_breaking] Field 'CustomViewNotificationSubscription.active' description changed from 'Whether the subscription is active or not' to 'Whether the subscription is active or not.' (CustomViewNotificationSubscription.active)
+
+feat(schema): [non_breaking] Input field 'CustomViewUpdateInput.projectFilterData' description changed from '[ALPHA] The project filter applied to issues in the custom view.' to 'The project filter applied to issues in the custom view.' (CustomViewUpdateInput.projectFilterData)
+
+feat(schema): [non_breaking] Field 'CycleNotificationSubscription.active' description changed from 'Whether the subscription is active or not' to 'Whether the subscription is active or not.' (CycleNotificationSubscription.active)
+
+feat(schema): [non_breaking] Input field 'CycleShiftAllInput.daysToShift' description changed from 'The number of days to shift the cycles by.' to '[DEPRECATED] The number of days to shift the cycles by.' (CycleShiftAllInput.daysToShift)
+
+feat(schema): [non_breaking] Input field 'CycleShiftAllInput.id' description changed from 'The cycle id at which to start the shift.' to '[DEPRECATED] The cycle id at which to start the shift.' (CycleShiftAllInput.id)
+
+feat(schema): [non_breaking] Object type 'CycleShiftAllInput' has description '[DEPRECATED] Input for shifting all cycles by a certain number of days. Mutation is now deprecated.' (CycleShiftAllInput)
+
+feat(schema): [non_breaking] Field 'contentState' was added to object type 'Document' (Document.contentState)
+
+feat(schema): [non_breaking] Field 'Document.contentData' description changed from 'The documents content as a Prosemirror document.' to '[Internal] The documents content as a Prosemirror document.' (Document.contentData)
+
+feat(schema): [non_breaking] Field 'DocumentContent.contentData' is deprecated (DocumentContent.contentData)
+
+feat(schema): [non_breaking] Field 'DocumentContent.contentData' has deprecation reason 'Use `contentState` instead' (DocumentContent.contentData)
+
+feat(schema): [non_breaking] Field 'DocumentContent.restoredAt' description changed from 'The time at which the document content was restored from a previous version' to 'The time at which the document content was restored from a previous version.' (DocumentContent.restoredAt)
+
+feat(schema): [non_breaking] Field 'DocumentContentHistory.contentDataSnapshotAt' description changed from 'The timestamp associated with the DocumentContent when it was originally saved' to 'The timestamp associated with the DocumentContent when it was originally saved.' (DocumentContentHistory.contentDataSnapshotAt)
+
+feat(schema): [non_breaking] Description 'A document content history for a document' on type 'DocumentContentHistory' has changed to 'A document content history for a document.' (DocumentContentHistory)
+
+feat(schema): [non_breaking] Field 'contentState' was added to object type 'DocumentSearchResult' (DocumentSearchResult.contentState)
+
+feat(schema): [non_breaking] Field 'DocumentSearchResult.contentData' description changed from 'The documents content as a Prosemirror document.' to '[Internal] The documents content as a Prosemirror document.' (DocumentSearchResult.contentData)
+
+feat(schema): [non_breaking] Field 'DocumentSearchResult.metadata' description changed from 'Metadata related to search result' to 'Metadata related to search result.' (DocumentSearchResult.metadata)
+
+feat(schema): [non_breaking] Field 'organization' was added to object type 'EmailIntakeAddress' (EmailIntakeAddress.organization)
+
+feat(schema): [non_breaking] Field 'template' was added to object type 'EmailIntakeAddress' (EmailIntakeAddress.template)
+
+feat(schema): [non_breaking] Description 'An email address that can be used for submitting issues' on type 'EmailIntakeAddress' has changed to 'An email address that can be used for submitting issues.' (EmailIntakeAddress)
+
+feat(schema): [non_breaking] Description '[ALPHA] An external authenticated (e.g., through Slack) user which doesn't have a Linear account, but can create and update entities in Linear from the external system that authenticated them.' on type 'ExternalUser' has changed to 'An external authenticated (e.g., through Slack) user which doesn't have a Linear account, but can create and update entities in Linear from the external system that authenticated them.' (ExternalUser)
+
+feat(schema): [non_breaking] Field 'targetBranch' was added to object type 'GitAutomationState' (GitAutomationState.targetBranch)
+
+feat(schema): [non_breaking] Field 'GitAutomationState.branchPattern' description changed from 'The target branch, if null, the automation will be triggered on any branch.' to '[DEPRECATED] The target branch, if null, the automation will be triggered on any branch.' (GitAutomationState.branchPattern)
+
+feat(schema): [non_breaking] Field 'GitAutomationState.branchPattern' is deprecated (GitAutomationState.branchPattern)
+
+feat(schema): [non_breaking] Field 'GitAutomationState.branchPattern' has deprecation reason 'Use targetBranch instead.' (GitAutomationState.branchPattern)
+
+feat(schema): [non_breaking] Input field 'GitAutomationStateCreateInput.branchPattern' description changed from 'The target branch pattern. If null, all branches are targeted.' to '[DEPRECATED] The target branch pattern. If null, all branches are targeted.' (GitAutomationStateCreateInput.branchPattern)
+
+feat(schema): [non_breaking] Input field 'GitAutomationStateUpdateInput.branchPattern' description changed from 'The target branch pattern. If null, all branches are targeted.' to '[DEPRECATED] The target branch pattern. If null, all branches are targeted.' (GitAutomationStateUpdateInput.branchPattern)
+
+feat(schema): [non_breaking] Field 'GitHubPersonalSettings.login' description changed from 'The GitHub user's name' to 'The GitHub user's name.' (GitHubPersonalSettings.login)
+
+feat(schema): [non_breaking] Input field 'GitHubPersonalSettingsInput.login' description changed from 'The GitHub user's name' to 'The GitHub user's name.' (GitHubPersonalSettingsInput.login)
+
+feat(schema): [non_breaking] Field 'GitHubSettings.orgAvatarUrl' description changed from 'The avatar URL for the GitHub organization' to 'The avatar URL for the GitHub organization.' (GitHubSettings.orgAvatarUrl)
+
+feat(schema): [non_breaking] Field 'GitHubSettings.orgLogin' description changed from 'The GitHub organization's name' to 'The GitHub organization's name.' (GitHubSettings.orgLogin)
+
+feat(schema): [non_breaking] Field 'GitHubSettings.repositories' description changed from 'The names of the repositories connected for the GitHub integration' to 'The names of the repositories connected for the GitHub integration.' (GitHubSettings.repositories)
+
+feat(schema): [non_breaking] Field 'GitHubSettings.repositoriesMapping' description changed from 'Mapping of team to repository for syncing' to 'Mapping of team to repository for syncing.' (GitHubSettings.repositoriesMapping)
+
+feat(schema): [non_breaking] Input field 'GitHubSettingsInput.orgAvatarUrl' description changed from 'The avatar URL for the GitHub organization' to 'The avatar URL for the GitHub organization.' (GitHubSettingsInput.orgAvatarUrl)
+
+feat(schema): [non_breaking] Input field 'GitHubSettingsInput.orgLogin' description changed from 'The GitHub organization's name' to 'The GitHub organization's name.' (GitHubSettingsInput.orgLogin)
+
+feat(schema): [non_breaking] Input field 'GitHubSettingsInput.repositories' description changed from 'The names of the repositories connected for the GitHub integration' to 'The names of the repositories connected for the GitHub integration.' (GitHubSettingsInput.repositories)
+
+feat(schema): [non_breaking] Input field 'GitHubSettingsInput.repositoriesMapping' description changed from 'Mapping of team to repository for syncing' to 'Mapping of team to repository for syncing.' (GitHubSettingsInput.repositoriesMapping)
+
+feat(schema): [non_breaking] Field 'GitLabSettings.expiresAt' description changed from 'The ISO timestamp the GitLab access token expires' to 'The ISO timestamp the GitLab access token expires.' (GitLabSettings.expiresAt)
+
+feat(schema): [non_breaking] Field 'GitLabSettings.readonly' description changed from 'Whether the token is limited to a read-only scope' to 'Whether the token is limited to a read-only scope.' (GitLabSettings.readonly)
+
+feat(schema): [non_breaking] Field 'GitLabSettings.url' description changed from 'The self-hosted URL of the GitLab instance' to 'The self-hosted URL of the GitLab instance.' (GitLabSettings.url)
+
+feat(schema): [non_breaking] Input field 'GitLabSettingsInput.expiresAt' description changed from 'The ISO timestamp the GitLab access token expires' to 'The ISO timestamp the GitLab access token expires.' (GitLabSettingsInput.expiresAt)
+
+feat(schema): [non_breaking] Input field 'GitLabSettingsInput.readonly' description changed from 'Whether the token is limited to a read-only scope' to 'Whether the token is limited to a read-only scope.' (GitLabSettingsInput.readonly)
+
+feat(schema): [non_breaking] Input field 'GitLabSettingsInput.url' description changed from 'The self-hosted URL of the GitLab instance' to 'The self-hosted URL of the GitLab instance.' (GitLabSettingsInput.url)
+
+feat(schema): [non_breaking] Input field 'GoogleUserAccountAuthInput.inviteLink' description changed from 'An optional invite link for an organization.' to 'An optional invite link for an organization used to populate available organizations.' (GoogleUserAccountAuthInput.inviteLink)
+
+feat(schema): [non_breaking] Description 'The integration resource's settings' on type 'IntegrationSettings' has changed to 'The integration resource's settings.' (IntegrationSettings)
+
+feat(schema): [non_breaking] Description 'Join table between templates and integrations' on type 'IntegrationTemplate' has changed to 'Join table between templates and integrations.' (IntegrationTemplate)
+
+feat(schema): [non_breaking] Field 'IntegrationsSettings.slackIssueSlaBreached' description changed from 'Whether to send a Slack message when an SLA is breached' to 'Whether to send a Slack message when an SLA is breached.' (IntegrationsSettings.slackIssueSlaBreached)
+
+feat(schema): [non_breaking] Field 'IntegrationsSettings.slackIssueSlaHighRisk' description changed from 'Whether to send a Slack message when an SLA is at high risk' to 'Whether to send a Slack message when an SLA is at high risk.' (IntegrationsSettings.slackIssueSlaHighRisk)
+
+feat(schema): [non_breaking] Input field 'IntegrationsSettingsCreateInput.slackIssueSlaHighRisk' description changed from 'Whether to send a Slack message when an SLA is at high risk' to 'Whether to send a Slack message when an SLA is at high risk.' (IntegrationsSettingsCreateInput.slackIssueSlaHighRisk)
+
+feat(schema): [non_breaking] Input field 'IntegrationsSettingsUpdateInput.slackIssueSlaHighRisk' description changed from 'Whether to send a Slack message when an SLA is at high risk' to 'Whether to send a Slack message when an SLA is at high risk.' (IntegrationsSettingsUpdateInput.slackIssueSlaHighRisk)
+
+feat(schema): [non_breaking] Field 'descriptionState' was added to object type 'Issue' (Issue.descriptionState)
+
+feat(schema): [non_breaking] Field 'Issue.externalUserCreator' description changed from '[ALPHA] The external user who created the issue.' to 'The external user who created the issue.' (Issue.externalUserCreator)
+
+feat(schema): [non_breaking] Input field 'IssueCreateInput.preserveSortOrderOnCreate' description changed from 'Whether the passed sort order should be preserved' to 'Whether the passed sort order should be preserved.' (IssueCreateInput.preserveSortOrderOnCreate)
+
+feat(schema): [non_breaking] Field 'IssueHistory.botActor' description changed from 'The bot that performed the action' to 'The bot that performed the action.' (IssueHistory.botActor)
+
+feat(schema): [non_breaking] Field 'IssueHistory.fromDueDate' description changed from 'What the due date was changed from' to 'What the due date was changed from.' (IssueHistory.fromDueDate)
+
+feat(schema): [non_breaking] Field 'IssueHistory.toDueDate' description changed from 'What the due date was changed to' to 'What the due date was changed to.' (IssueHistory.toDueDate)
+
+feat(schema): [non_breaking] Field 'IssueImport.errorMetadata' description changed from 'Error code and metadata, if one has occurred during the import' to 'Error code and metadata, if one has occurred during the import.' (IssueImport.errorMetadata)
+
+feat(schema): [non_breaking] Field 'IssueImport.teamName' description changed from 'New team's name in cases when teamId not set' to 'New team's name in cases when teamId not set.' (IssueImport.teamName)
+
+feat(schema): [non_breaking] Description 'An import job for data from an external service' on type 'IssueImport' has changed to 'An import job for data from an external service.' (IssueImport)
+
+feat(schema): [non_breaking] Input field 'IssueImportMappingInput.epics' description changed from 'The mapping configuration for epics' to 'The mapping configuration for epics.' (IssueImportMappingInput.epics)
+
+feat(schema): [non_breaking] Input field 'IssueImportMappingInput.users' description changed from 'The mapping configuration for users' to 'The mapping configuration for users.' (IssueImportMappingInput.users)
+
+feat(schema): [non_breaking] Input field 'IssueImportMappingInput.workflowStates' description changed from 'The mapping configuration for workflow states' to 'The mapping configuration for workflow states.' (IssueImportMappingInput.workflowStates)
+
+feat(schema): [non_breaking] Description 'Issue import mapping input' on type 'IssueImportMappingInput' has changed to 'Issue import mapping input.' (IssueImportMappingInput)
+
+feat(schema): [non_breaking] Field 'IssueNotification.team' description changed from 'The team related to the notification.' to 'The team related to the issue notification.' (IssueNotification.team)
+
+feat(schema): [non_breaking] Field 'IssueNotification.type' description changed from 'Notification type' to 'Notification type.' (IssueNotification.type)
+
+feat(schema): [non_breaking] Description 'An issue related notification' on type 'IssueNotification' has changed to 'An issue related notification.' (IssueNotification)
+
+feat(schema): [non_breaking] Description 'Issue relation history's payload' on type 'IssueRelationHistoryPayload' has changed to 'Issue relation history's payload.' (IssueRelationHistoryPayload)
+
+feat(schema): [non_breaking] Field 'descriptionState' was added to object type 'IssueSearchResult' (IssueSearchResult.descriptionState)
+
+feat(schema): [non_breaking] Field 'IssueSearchResult.externalUserCreator' description changed from '[ALPHA] The external user who created the issue.' to 'The external user who created the issue.' (IssueSearchResult.externalUserCreator)
+
+feat(schema): [non_breaking] Field 'IssueSearchResult.metadata' description changed from 'Metadata related to search result' to 'Metadata related to search result.' (IssueSearchResult.metadata)
+
+feat(schema): [non_breaking] Input field 'JiraUpdateInput.id' description changed from 'The id of the integration to update' to 'The id of the integration to update.' (JiraUpdateInput.id)
+
+feat(schema): [non_breaking] Input field 'JiraUpdateInput.updateProjects' description changed from 'Whether to refresh Jira Projects for the integration' to 'Whether to refresh Jira Projects for the integration.' (JiraUpdateInput.updateProjects)
+
+feat(schema): [non_breaking] Field 'LabelNotificationSubscription.active' description changed from 'Whether the subscription is active or not' to 'Whether the subscription is active or not.' (LabelNotificationSubscription.active)
+
+feat(schema): [non_breaking] Field 'emailIntakeAddressCreate' was added to object type 'Mutation' (Mutation.emailIntakeAddressCreate)
+
+feat(schema): [non_breaking] Field 'emailIntakeAddressDelete' was added to object type 'Mutation' (Mutation.emailIntakeAddressDelete)
+
+feat(schema): [non_breaking] Field 'emailIntakeAddressRotate' was added to object type 'Mutation' (Mutation.emailIntakeAddressRotate)
+
+feat(schema): [non_breaking] Field 'emailIntakeAddressUpdate' was added to object type 'Mutation' (Mutation.emailIntakeAddressUpdate)
+
+feat(schema): [non_breaking] Field 'gitAutomationTargetBranchCreate' was added to object type 'Mutation' (Mutation.gitAutomationTargetBranchCreate)
+
+feat(schema): [non_breaking] Field 'gitAutomationTargetBranchDelete' was added to object type 'Mutation' (Mutation.gitAutomationTargetBranchDelete)
+
+feat(schema): [non_breaking] Field 'gitAutomationTargetBranchUpdate' was added to object type 'Mutation' (Mutation.gitAutomationTargetBranchUpdate)
+
+feat(schema): [non_breaking] Field 'initiativeArchive' was added to object type 'Mutation' (Mutation.initiativeArchive)
+
+feat(schema): [non_breaking] Field 'initiativeCreate' was added to object type 'Mutation' (Mutation.initiativeCreate)
+
+feat(schema): [non_breaking] Field 'initiativeDelete' was added to object type 'Mutation' (Mutation.initiativeDelete)
+
+feat(schema): [non_breaking] Field 'initiativeToProjectCreate' was added to object type 'Mutation' (Mutation.initiativeToProjectCreate)
+
+feat(schema): [non_breaking] Field 'initiativeToProjectDelete' was added to object type 'Mutation' (Mutation.initiativeToProjectDelete)
+
+feat(schema): [non_breaking] Field 'initiativeToProjectUpdate' was added to object type 'Mutation' (Mutation.initiativeToProjectUpdate)
+
+feat(schema): [non_breaking] Field 'initiativeUnarchive' was added to object type 'Mutation' (Mutation.initiativeUnarchive)
+
+feat(schema): [non_breaking] Field 'initiativeUpdate' was added to object type 'Mutation' (Mutation.initiativeUpdate)
+
+feat(schema): [non_breaking] Field 'integrationArchive' was added to object type 'Mutation' (Mutation.integrationArchive)
+
+feat(schema): [non_breaking] Field 'Mutation.airbyteIntegrationConnect' description changed from 'Creates an integration api key for Airbyte to connect with Linear' to 'Creates an integration api key for Airbyte to connect with Linear.' (Mutation.airbyteIntegrationConnect)
+
+feat(schema): [non_breaking] Description for argument 'id' on field 'Mutation.attachmentLinkDiscord' changed from 'Optional attachment ID that may be provided through the API' to 'Optional attachment ID that may be provided through the API.' (Mutation.attachmentLinkDiscord.id)
+
+feat(schema): [non_breaking] Description for argument 'id' on field 'Mutation.attachmentLinkFront' changed from 'Optional attachment ID that may be provided through the API' to 'Optional attachment ID that may be provided through the API.' (Mutation.attachmentLinkFront.id)
+
+feat(schema): [non_breaking] Description for argument 'id' on field 'Mutation.attachmentLinkGitHubIssue' changed from 'Optional attachment ID that may be provided through the API' to 'Optional attachment ID that may be provided through the API.' (Mutation.attachmentLinkGitHubIssue.id)
+
+feat(schema): [non_breaking] Description for argument 'id' on field 'Mutation.attachmentLinkGitHubPR' changed from 'Optional attachment ID that may be provided through the API' to 'Optional attachment ID that may be provided through the API.' (Mutation.attachmentLinkGitHubPR.id)
+
+feat(schema): [non_breaking] Description for argument 'id' on field 'Mutation.attachmentLinkGitLabMR' changed from 'Optional attachment ID that may be provided through the API' to 'Optional attachment ID that may be provided through the API.' (Mutation.attachmentLinkGitLabMR.id)
+
+feat(schema): [non_breaking] Description for argument 'projectPathWithNamespace' on field 'Mutation.attachmentLinkGitLabMR' changed from 'The path name to the project including any (sub)groups. E.g. linear/main/client' to 'The path name to the project including any (sub)groups. E.g. linear/main/client.' (Mutation.attachmentLinkGitLabMR.projectPathWithNamespace)
+
+feat(schema): [non_breaking] Description for argument 'id' on field 'Mutation.attachmentLinkIntercom' changed from 'Optional attachment ID that may be provided through the API' to 'Optional attachment ID that may be provided through the API.' (Mutation.attachmentLinkIntercom.id)
+
+feat(schema): [non_breaking] Description for argument 'id' on field 'Mutation.attachmentLinkSlack' changed from 'Optional attachment ID that may be provided through the API' to 'Optional attachment ID that may be provided through the API.' (Mutation.attachmentLinkSlack.id)
+
+feat(schema): [non_breaking] Description for argument 'title' on field 'Mutation.attachmentLinkSlack' changed from 'Optional title that may be provided through the API' to 'The title to use for the attachment.' (Mutation.attachmentLinkSlack.title)
+
+feat(schema): [non_breaking] Description for argument 'id' on field 'Mutation.attachmentLinkZendesk' changed from 'Optional attachment ID that may be provided through the API' to 'Optional attachment ID that may be provided through the API.' (Mutation.attachmentLinkZendesk.id)
+
+feat(schema): [non_breaking] Field 'Mutation.cycleShiftAll' description changed from 'Shifts all cycles starts by a certain number of weeks.' to '[DEPRECATED] Shifts all cycles starts by a certain number of weeks.' (Mutation.cycleShiftAll)
+
+feat(schema): [non_breaking] Description for argument 'gitlabUrl' on field 'Mutation.integrationGitlabConnect' changed from 'The URL of the GitLab installation' to 'The URL of the GitLab installation.' (Mutation.integrationGitlabConnect.gitlabUrl)
+
+feat(schema): [non_breaking] Field 'Mutation.integrationJiraUpdate' description changed from '[INTERNAL] Updates a Jira Integration' to '[INTERNAL] Updates a Jira Integration.' (Mutation.integrationJiraUpdate)
+
+feat(schema): [non_breaking] Description for argument 'input' on field 'Mutation.integrationJiraUpdate' changed from 'Jira integration update input' to 'Jira integration update input.' (Mutation.integrationJiraUpdate.input)
+
+feat(schema): [non_breaking] Field 'Mutation.integrationSlackAsks' description changed from 'Integrates the organization with the Slack Asks app' to 'Integrates the organization with the Slack Asks app.' (Mutation.integrationSlackAsks)
+
+feat(schema): [non_breaking] Description for argument 'trash' on field 'Mutation.issueArchive' changed from 'Whether to trash the issue' to 'Whether to trash the issue.' (Mutation.issueArchive.trash)
+
+feat(schema): [non_breaking] Description for argument 'trash' on field 'Mutation.projectArchive' changed from 'Whether to trash the project' to 'Whether to trash the project.' (Mutation.projectArchive.trash)
+
+feat(schema): [non_breaking] Description for argument 'service' on field 'Mutation.userExternalUserDisconnect' changed from 'The external service to disconnect' to 'The external service to disconnect.' (Mutation.userExternalUserDisconnect.service)
+
+feat(schema): [non_breaking] Description for argument 'operation' on field 'Mutation.userFlagUpdate' changed from 'Flag operation to perform' to 'Flag operation to perform.' (Mutation.userFlagUpdate.operation)
+
+feat(schema): [non_breaking] Field 'Notification.type' description changed from 'Notification type' to 'Notification type.' (Notification.type)
+
+feat(schema): [non_breaking] Field 'NotificationSubscription.active' description changed from 'Whether the subscription is active or not' to 'Whether the subscription is active or not.' (NotificationSubscription.active)
+
+feat(schema): [non_breaking] Description 'The different requests statuses possible for an OAuth client approval request' on type 'OAuthClientApprovalStatus' has changed to 'The different requests statuses possible for an OAuth client approval request.' (OAuthClientApprovalStatus)
+
+feat(schema): [non_breaking] Field 'OauthClient.webhookUrl' description changed from 'Webhook URL' to 'Webhook URL.' (OauthClient.webhookUrl)
+
+feat(schema): [non_breaking] Field 'OauthClientApprovalNotification.type' description changed from 'Notification type' to 'Notification type.' (OauthClientApprovalNotification.type)
+
+feat(schema): [non_breaking] Description 'An oauth client approval related notification' on type 'OauthClientApprovalNotification' has changed to 'An oauth client approval related notification.' (OauthClientApprovalNotification)
+
+feat(schema): [non_breaking] Field 'client' was added to object type 'OauthToken' (OauthToken.client)
+
+feat(schema): [non_breaking] Field 'clientId' was added to object type 'OauthToken' (OauthToken.clientId)
+
+feat(schema): [non_breaking] Field 'revokedAt' was added to object type 'OauthToken' (OauthToken.revokedAt)
+
+feat(schema): [non_breaking] Field 'user' was added to object type 'OauthToken' (OauthToken.user)
+
+feat(schema): [non_breaking] Field 'userId' was added to object type 'OauthToken' (OauthToken.userId)
+
+feat(schema): [non_breaking] Field 'Organization.allowMembersToInvite' description changed from 'Whether member users are allowed to send invites' to 'Whether member users are allowed to send invites.' (Organization.allowMembersToInvite)
+
+feat(schema): [non_breaking] Field 'Organization.allowedAuthServices' description changed from 'Allowed authentication providers, empty array means all are allowed' to 'Allowed authentication providers, empty array means all are allowed.' (Organization.allowedAuthServices)
+
+feat(schema): [non_breaking] Field 'Organization.samlSettings' description changed from '[INTERNAL] SAML settings' to '[INTERNAL] SAML settings.' (Organization.samlSettings)
+
+feat(schema): [non_breaking] Field 'Organization.slaDayCount' description changed from 'Which day count to use for SLA calculations' to 'Which day count to use for SLA calculations.' (Organization.slaDayCount)
+
+feat(schema): [non_breaking] Field 'OrganizationAcceptedOrExpiredInviteDetailsPayload.status' description changed from 'The status of the invite' to 'The status of the invite.' (OrganizationAcceptedOrExpiredInviteDetailsPayload.status)
+
+feat(schema): [non_breaking] Field 'OrganizationDomain.authType' description changed from 'What type of auth is the domain used for' to 'What type of auth is the domain used for.' (OrganizationDomain.authType)
+
+feat(schema): [non_breaking] Field 'OrganizationDomain.name' description changed from 'Domain name' to 'Domain name.' (OrganizationDomain.name)
+
+feat(schema): [non_breaking] Field 'OrganizationDomain.verificationEmail' description changed from 'E-mail used to verify this domain' to 'E-mail used to verify this domain.' (OrganizationDomain.verificationEmail)
+
+feat(schema): [non_breaking] Field 'OrganizationDomain.verified' description changed from 'Is this domain verified' to 'Is this domain verified.' (OrganizationDomain.verified)
+
+feat(schema): [non_breaking] Field 'OrganizationInvite.acceptedAt' description changed from 'The time at which the invite was accepted. Null, if the invite hasn't been accepted' to 'The time at which the invite was accepted. Null, if the invite hasn't been accepted.' (OrganizationInvite.acceptedAt)
+
+feat(schema): [non_breaking] Field 'OrganizationInvite.expiresAt' description changed from 'The time at which the invite will be expiring. Null, if the invite shouldn't expire' to 'The time at which the invite will be expiring. Null, if the invite shouldn't expire.' (OrganizationInvite.expiresAt)
+
+feat(schema): [non_breaking] Input field 'OrganizationInviteCreateInput.metadata' description changed from '[INTERNAL] Optional metadata about the invite' to '[INTERNAL] Optional metadata about the invite.' (OrganizationInviteCreateInput.metadata)
+
+feat(schema): [non_breaking] Field 'OrganizationInviteFullDetailsPayload.email' description changed from 'The email of the invitee' to 'The email of the invitee.' (OrganizationInviteFullDetailsPayload.email)
+
+feat(schema): [non_breaking] Field 'OrganizationInviteFullDetailsPayload.inviter' description changed from 'The name of the inviter' to 'The name of the inviter.' (OrganizationInviteFullDetailsPayload.inviter)
+
+feat(schema): [non_breaking] Field 'OrganizationInviteFullDetailsPayload.status' description changed from 'The status of the invite' to 'The status of the invite.' (OrganizationInviteFullDetailsPayload.status)
+
+feat(schema): [non_breaking] Input field 'OrganizationUpdateInput.linearPreviewFlags' description changed from 'Linear Preview feature flags' to 'Linear Preview feature flags.' (OrganizationUpdateInput.linearPreviewFlags)
+
+feat(schema): [non_breaking] Field 'contentState' was added to object type 'Project' (Project.contentState)
+
+feat(schema): [non_breaking] Field 'descriptionState' was added to object type 'ProjectMilestone' (ProjectMilestone.descriptionState)
+
+feat(schema): [non_breaking] Field 'ProjectMilestone.descriptionData' is deprecated (ProjectMilestone.descriptionData)
+
+feat(schema): [non_breaking] Field 'ProjectMilestone.descriptionData' has deprecation reason 'Use `descriptionState` instead.' (ProjectMilestone.descriptionData)
+
+feat(schema): [non_breaking] Field 'ProjectNotification.type' description changed from 'Notification type' to 'Notification type.' (ProjectNotification.type)
+
+feat(schema): [non_breaking] Description 'A project related notification' on type 'ProjectNotification' has changed to 'A project related notification.' (ProjectNotification)
+
+feat(schema): [non_breaking] Field 'ProjectNotificationSubscription.active' description changed from 'Whether the subscription is active or not' to 'Whether the subscription is active or not.' (ProjectNotificationSubscription.active)
+
+feat(schema): [non_breaking] Field 'contentState' was added to object type 'ProjectSearchResult' (ProjectSearchResult.contentState)
+
+feat(schema): [non_breaking] Field 'ProjectSearchResult.metadata' description changed from 'Metadata related to search result' to 'Metadata related to search result.' (ProjectSearchResult.metadata)
+
+feat(schema): [non_breaking] Field 'bodyData' was added to object type 'ProjectUpdate' (ProjectUpdate.bodyData)
+
+feat(schema): [non_breaking] Field 'ProjectUpdate.isDiffHidden' description changed from '[ALPHA] Whether project update diff should be hidden' to 'Whether project update diff should be hidden.' (ProjectUpdate.isDiffHidden)
+
+feat(schema): [non_breaking] Input field 'ProjectUpdateCreateInput.isDiffHidden' description changed from '[ALPHA] Whether the diff between the current update and the previous one should be hidden.' to 'Whether the diff between the current update and the previous one should be hidden.' (ProjectUpdateCreateInput.isDiffHidden)
+
+feat(schema): [non_breaking] Input field 'ProjectUpdateUpdateInput.isDiffHidden' description changed from '[ALPHA] Whether the diff between the current update and the previous one should be hidden.' to 'Whether the diff between the current update and the previous one should be hidden.' (ProjectUpdateUpdateInput.isDiffHidden)
+
+feat(schema): [non_breaking] Input field 'PushSubscriptionCreateInput.type' description changed from 'Whether this is a subscription payload for Google Cloud Messaging or Apple Push Notification service' to 'Whether this is a subscription payload for Google Cloud Messaging or Apple Push Notification service.' (PushSubscriptionCreateInput.type)
+
+feat(schema): [non_breaking] Description 'The different push subscription types' on type 'PushSubscriptionType' has changed to 'The different push subscription types.' (PushSubscriptionType)
+
+feat(schema): [non_breaking] Field 'initiative' was added to object type 'Query' (Query.initiative)
+
+feat(schema): [non_breaking] Field 'initiativeToProject' was added to object type 'Query' (Query.initiativeToProject)
+
+feat(schema): [non_breaking] Field 'initiativeToProjects' was added to object type 'Query' (Query.initiativeToProjects)
+
+feat(schema): [non_breaking] Field 'initiatives' was added to object type 'Query' (Query.initiatives)
+
+feat(schema): [non_breaking] Field 'integrationHasScopes' was added to object type 'Query' (Query.integrationHasScopes)
+
+feat(schema): [non_breaking] Field 'Query.applicationInfoByIds' description changed from '[INTERNAL] Get basic information for a list of applications' to '[INTERNAL] Get basic information for a list of applications.' (Query.applicationInfoByIds)
+
+feat(schema): [non_breaking] Description for argument 'scope' on field 'Query.applicationWithAuthorization' changed from 'Scopes being requested by the application' to 'Scopes being requested by the application.' (Query.applicationWithAuthorization.scope)
+
+feat(schema): [non_breaking] Field 'Query.attachmentSources' description changed from '[Internal] Get a list of all unique attachment sources in the workspace' to '[Internal] Get a list of all unique attachment sources in the workspace.' (Query.attachmentSources)
+
+feat(schema): [non_breaking] Description for argument 'teamId' on field 'Query.attachmentSources' changed from '(optional) if provided will only return attachment sources for the given team' to '(optional) if provided will only return attachment sources for the given team.' (Query.attachmentSources.teamId)
+
+feat(schema): [non_breaking] Field 'Query.authorizedApplications' description changed from '[INTERNAL] Get all authorized applications for a user' to '[INTERNAL] Get all authorized applications for a user.' (Query.authorizedApplications)
+
+feat(schema): [non_breaking] Type for argument 'id' on field 'Query.comment' changed from 'String!' to 'String' (Query.comment.id)
+
+feat(schema): [non_breaking] Description for argument 'id' on field 'Query.emoji' changed from 'The identifier of the emoji to retrieve.' to 'The identifier or the name of the emoji to retrieve.' (Query.emoji.id)
+
+feat(schema): [non_breaking] Description for argument 'csvUrl' on field 'Query.issueImportCheckCSV' changed from 'CSV storage url' to 'CSV storage url.' (Query.issueImportCheckCSV.csvUrl)
+
+feat(schema): [non_breaking] Description for argument 'service' on field 'Query.issueImportCheckCSV' changed from 'The service the CSV containing data from' to 'The service the CSV containing data from.' (Query.issueImportCheckCSV.service)
+
+feat(schema): [non_breaking] Description for argument 'includeComments' on field 'Query.searchDocuments' changed from 'Should associated comments be searched (default: true)' to 'Should associated comments be searched (default: true).' (Query.searchDocuments.includeComments)
+
+feat(schema): [non_breaking] Description for argument 'teamId' on field 'Query.searchDocuments' changed from 'UUID of a team to use as a boost' to 'UUID of a team to use as a boost.' (Query.searchDocuments.teamId)
+
+feat(schema): [non_breaking] Description for argument 'includeComments' on field 'Query.searchIssues' changed from 'Should associated comments be searched (default: true)' to 'Should associated comments be searched (default: true).' (Query.searchIssues.includeComments)
+
+feat(schema): [non_breaking] Description for argument 'teamId' on field 'Query.searchIssues' changed from 'UUID of a team to use as a boost' to 'UUID of a team to use as a boost.' (Query.searchIssues.teamId)
+
+feat(schema): [non_breaking] Description for argument 'includeComments' on field 'Query.searchProjects' changed from 'Should associated comments be searched (default: true)' to 'Should associated comments be searched (default: true).' (Query.searchProjects.includeComments)
+
+feat(schema): [non_breaking] Description for argument 'teamId' on field 'Query.searchProjects' changed from 'UUID of a team to use as a boost' to 'UUID of a team to use as a boost.' (Query.searchProjects.teamId)
+
+feat(schema): [non_breaking] Description for argument 'integrationType' on field 'Query.templatesForIntegration' changed from 'The type of integration for which to return associated templates' to 'The type of integration for which to return associated templates.' (Query.templatesForIntegration.integrationType)
+
+feat(schema): [non_breaking] Field 'Query.workspaceAuthorizedApplications' description changed from '[INTERNAL] Get all authorized applications (with limited fields) for a workspace' to '[INTERNAL] Get all authorized applications (with limited fields) for a workspace.' (Query.workspaceAuthorizedApplications)
+
+feat(schema): [non_breaking] Input field 'ReactionCreateInput.id' description changed from 'The identifier in UUID v4 format. If none is provided, the backend will generate one' to 'The identifier in UUID v4 format. If none is provided, the backend will generate one.' (ReactionCreateInput.id)
+
+feat(schema): [non_breaking] Description 'Features release channel' on type 'ReleaseChannel' has changed to 'Features release channel.' (ReleaseChannel)
+
+feat(schema): [non_breaking] Input field 'RoadmapCreateInput.ownerId' description changed from 'The owner of the roadmap' to 'The owner of the roadmap.' (RoadmapCreateInput.ownerId)
+
+feat(schema): [non_breaking] Description 'Join table between projects and roadmaps' on type 'RoadmapToProject' has changed to 'Join table between projects and roadmaps.' (RoadmapToProject)
+
+feat(schema): [non_breaking] Input field 'RoadmapUpdateInput.ownerId' description changed from 'The owner of the roadmap' to 'The owner of the roadmap.' (RoadmapUpdateInput.ownerId)
+
+feat(schema): [non_breaking] Description 'Which day count to use for SLA calculations' on type 'SLADayCountType' has changed to 'Which day count to use for SLA calculations.' (SLADayCountType)
+
+feat(schema): [non_breaking] Field 'SlackAsksTeamSettings.hasDefaultAsk' description changed from 'Whether the default Asks template is enabled in the given channel for this team' to 'Whether the default Asks template is enabled in the given channel for this team.' (SlackAsksTeamSettings.hasDefaultAsk)
+
+feat(schema): [non_breaking] Description 'Tuple for mapping Slack channel IDs to names' on type 'SlackAsksTeamSettings' has changed to 'Tuple for mapping Slack channel IDs to names.' (SlackAsksTeamSettings)
+
+feat(schema): [non_breaking] Input field 'SlackAsksTeamSettingsInput.hasDefaultAsk' description changed from 'Whether the default Asks template is enabled in the given channel for this team' to 'Whether the default Asks template is enabled in the given channel for this team.' (SlackAsksTeamSettingsInput.hasDefaultAsk)
+
+feat(schema): [non_breaking] Field 'SlackChannelNameMapping.autoCreateOnBotMention' description changed from 'Whether or not @-mentioning the bot should automatically create an Ask with the message' to 'Whether or not @-mentioning the bot should automatically create an Ask with the message.' (SlackChannelNameMapping.autoCreateOnBotMention)
+
+feat(schema): [non_breaking] Field 'SlackChannelNameMapping.autoCreateOnEmoji' description changed from 'Whether or not using the :ticket: emoji in this channel should automatically create Asks' to 'Whether or not using the :ticket: emoji in this channel should automatically create Asks.' (SlackChannelNameMapping.autoCreateOnEmoji)
+
+feat(schema): [non_breaking] Field 'SlackChannelNameMapping.autoCreateOnMessage' description changed from 'Whether or not top-level messages in this channel should automatically create Asks' to 'Whether or not top-level messages in this channel should automatically create Asks.' (SlackChannelNameMapping.autoCreateOnMessage)
+
+feat(schema): [non_breaking] Field 'SlackChannelNameMapping.botAdded' description changed from 'Whether or not we the Linear Asks bot has been added to this Slack channel' to 'Whether or not we the Linear Asks bot has been added to this Slack channel.' (SlackChannelNameMapping.botAdded)
+
+feat(schema): [non_breaking] Field 'SlackChannelNameMapping.isPrivate' description changed from 'Whether or not the Slack channel is private' to 'Whether or not the Slack channel is private.' (SlackChannelNameMapping.isPrivate)
+
+feat(schema): [non_breaking] Field 'SlackChannelNameMapping.isShared' description changed from 'Whether or not the Slack channel is shared with an external org' to 'Whether or not the Slack channel is shared with an external org.' (SlackChannelNameMapping.isShared)
+
+feat(schema): [non_breaking] Field 'SlackChannelNameMapping.teams' description changed from 'Which teams are connected to the channel and settings for those teams' to 'Which teams are connected to the channel and settings for those teams.' (SlackChannelNameMapping.teams)
+
+feat(schema): [non_breaking] Description 'Object for mapping Slack channel IDs to names and other settings' on type 'SlackChannelNameMapping' has changed to 'Object for mapping Slack channel IDs to names and other settings.' (SlackChannelNameMapping)
+
+feat(schema): [non_breaking] Input field 'SlackChannelNameMappingInput.autoCreateOnBotMention' description changed from 'Whether or not @-mentioning the bot should automatically create an Ask with the message' to 'Whether or not @-mentioning the bot should automatically create an Ask with the message.' (SlackChannelNameMappingInput.autoCreateOnBotMention)
+
+feat(schema): [non_breaking] Input field 'SlackChannelNameMappingInput.autoCreateOnEmoji' description changed from 'Whether or not using the :ticket: emoji in this channel should automatically create Asks' to 'Whether or not using the :ticket: emoji in this channel should automatically create Asks.' (SlackChannelNameMappingInput.autoCreateOnEmoji)
+
+feat(schema): [non_breaking] Input field 'SlackChannelNameMappingInput.autoCreateOnMessage' description changed from 'Whether or not top-level messages in this channel should automatically create Asks' to 'Whether or not top-level messages in this channel should automatically create Asks.' (SlackChannelNameMappingInput.autoCreateOnMessage)
+
+feat(schema): [non_breaking] Input field 'SlackChannelNameMappingInput.botAdded' description changed from 'Whether or not we the Linear Asks bot has been added to this Slack channel' to 'Whether or not we the Linear Asks bot has been added to this Slack channel.' (SlackChannelNameMappingInput.botAdded)
+
+feat(schema): [non_breaking] Input field 'SlackChannelNameMappingInput.isPrivate' description changed from 'Whether or not the Slack channel is private' to 'Whether or not the Slack channel is private.' (SlackChannelNameMappingInput.isPrivate)
+
+feat(schema): [non_breaking] Input field 'SlackChannelNameMappingInput.isShared' description changed from 'Whether or not the Slack channel is shared with an external org' to 'Whether or not the Slack channel is shared with an external org.' (SlackChannelNameMappingInput.isShared)
+
+feat(schema): [non_breaking] Input field 'SlackChannelNameMappingInput.teams' description changed from 'Which teams are connected to the channel and settings for those teams' to 'Which teams are connected to the channel and settings for those teams.' (SlackChannelNameMappingInput.teams)
+
+feat(schema): [non_breaking] Field 'gitAutomationStates' was added to object type 'Team' (Team.gitAutomationStates)
+
+feat(schema): [non_breaking] Field 'Team.requirePriorityToLeaveTriage' description changed from 'Whether an issue needs to have a priority set before leaving triage' to 'Whether an issue needs to have a priority set before leaving triage.' (Team.requirePriorityToLeaveTriage)
+
+feat(schema): [non_breaking] Field 'TeamMembership.owner' description changed from 'Whether the user is the owner of the team' to 'Whether the user is the owner of the team.' (TeamMembership.owner)
+
+feat(schema): [non_breaking] Field 'TeamNotificationSubscription.active' description changed from 'Whether the subscription is active or not' to 'Whether the subscription is active or not.' (TeamNotificationSubscription.active)
+
+feat(schema): [non_breaking] Field 'bidirectional' was added to object type 'TeamRepoMapping' (TeamRepoMapping.bidirectional)
+
+feat(schema): [non_breaking] Field 'default' was added to object type 'TeamRepoMapping' (TeamRepoMapping.default)
+
+feat(schema): [non_breaking] Description 'Tuple for mapping Linear teams to GitHub repos.' on type 'TeamRepoMapping' has changed to 'Mapping of Linear teams to GitHub repos.' (TeamRepoMapping)
+
+feat(schema): [non_breaking] Input field 'TeamUpdateInput.cycleEnabledStartWeek' description changed from 'Whether the first cycle should start in the current or the next week.' to '[DEPRECATED] Whether the first cycle should start in the current or the next week.' (TeamUpdateInput.cycleEnabledStartWeek)
+
+feat(schema): [non_breaking] Field 'timeSchedule' was added to object type 'TriageResponsibility' (TriageResponsibility.timeSchedule)
+
+feat(schema): [non_breaking] Field 'UploadFile.assetUrl' description changed from 'The asset URL for the uploaded file. (assigned automatically)' to 'The asset URL for the uploaded file. (assigned automatically).' (UploadFile.assetUrl)
+
+feat(schema): [non_breaking] Field 'UploadFile.uploadUrl' description changed from 'The signed URL the for the uploaded file. (assigned automatically)' to 'The signed URL the for the uploaded file. (assigned automatically).' (UploadFile.uploadUrl)
+
+feat(schema): [non_breaking] Field 'authTokenLinkDisabled' was added to object type 'UserAccount' (UserAccount.authTokenLinkDisabled)
+
+feat(schema): [non_breaking] Field 'UserAuthorizedApplication.approvalErrorCode' description changed from 'Error associated with the application needing to be requested for approval in the workspace' to 'Error associated with the application needing to be requested for approval in the workspace.' (UserAuthorizedApplication.approvalErrorCode)
+
+feat(schema): [non_breaking] Description 'Operations that can be applied to UserFlagType' on type 'UserFlagUpdateOperation' has changed to 'Operations that can be applied to UserFlagType.' (UserFlagUpdateOperation)
+
+feat(schema): [non_breaking] Field 'UserNotificationSubscription.active' description changed from 'Whether the subscription is active or not' to 'Whether the subscription is active or not.' (UserNotificationSubscription.active)
+
+feat(schema): [non_breaking] Description 'The different permission roles available to users on an organization' on type 'UserRoleType' has changed to 'The different permission roles available to users on an organization.' (UserRoleType)
+
+feat(schema): [non_breaking] Field 'Webhook.label' description changed from 'Webhook label' to 'Webhook label.' (Webhook.label)
+
+feat(schema): [non_breaking] Field 'Webhook.url' description changed from 'Webhook URL' to 'Webhook URL.' (Webhook.url)
+
+feat(schema): [non_breaking] Description 'A webhook used to send HTTP notifications over data updates' on type 'Webhook' has changed to 'A webhook used to send HTTP notifications over data updates.' (Webhook)
+
+feat(schema): [non_breaking] Field 'WorkspaceAuthorizedApplication.memberships' description changed from 'UserIds and membership dates of everyone who has authorized the application with the set of scopes' to 'UserIds and membership dates of everyone who has authorized the application with the set of scopes.' (WorkspaceAuthorizedApplication.memberships)
+
+feat(schema): [non_breaking] Field 'WorkspaceAuthorizedApplication.totalMembers' description changed from 'Total number of members that authorized the application' to 'Total number of members that authorized the application.' (WorkspaceAuthorizedApplication.totalMembers)

--- a/.changeset/five-cycles-fly.md
+++ b/.changeset/five-cycles-fly.md
@@ -1,0 +1,8 @@
+---
+"@linear/codegen-test": major
+"@linear/codegen-doc": major
+"@linear/codegen-sdk": major
+"@linear/sdk": major
+---
+
+add support for root query with all optional args

--- a/.changeset/quick-vans-compare.md
+++ b/.changeset/quick-vans-compare.md
@@ -1,5 +1,0 @@
----
-"@linear/codegen-doc": patch
----
-
-fix: do not re-use query for connection fields

--- a/.changeset/quick-vans-compare.md
+++ b/.changeset/quick-vans-compare.md
@@ -1,0 +1,5 @@
+---
+"@linear/codegen-doc": patch
+---
+
+fix: do not re-use query for connection fields

--- a/packages/codegen-doc/src/fragment-visitor.ts
+++ b/packages/codegen-doc/src/fragment-visitor.ts
@@ -134,11 +134,13 @@ export class FragmentVisitor {
             .map(arg => arg.name.value)
             .sort();
 
+          // If the query has 0 required args, check if it has an optional id arg
           if (!queryRequiredArgs.length) {
             const optionalIdArg = query.arguments?.find(
               arg => arg.name.value === "id" && arg.type.kind !== Kind.NON_NULL_TYPE
             );
             if (optionalIdArg) {
+              // Use this as a required arg
               queryRequiredArgs.push(optionalIdArg.name.value);
             }
           }

--- a/packages/codegen-doc/src/fragment-visitor.ts
+++ b/packages/codegen-doc/src/fragment-visitor.ts
@@ -3,6 +3,7 @@ import {
   DocumentNode,
   FieldDefinitionNode,
   InterfaceTypeDefinitionNode,
+  Kind,
   ListTypeNode,
   NamedTypeNode,
   NameNode,
@@ -132,6 +133,15 @@ export class FragmentVisitor {
           const queryRequiredArgs = getRequiredArgs(query.arguments)
             .map(arg => arg.name.value)
             .sort();
+
+          if (!queryRequiredArgs.length) {
+            const optionalIdArg = query.arguments?.find(
+              arg => arg.name.value === "id" && arg.type.kind !== Kind.NON_NULL_TYPE
+            );
+            if (optionalIdArg) {
+              queryRequiredArgs.push(optionalIdArg.name.value);
+            }
+          }
 
           if (queryRequiredArgs.length) {
             return printLines([

--- a/packages/codegen-sdk/src/print-model.ts
+++ b/packages/codegen-sdk/src/print-model.ts
@@ -69,7 +69,8 @@ function printModel(context: SdkPluginContext, model: SdkModel): string {
         printDebug("fields.query"),
         printLines(
           model.fields.query.map(field =>
-            field.args.some(arg => !arg.optional)
+            field.args.some(arg => !arg.optional) ||
+            (field.args.every(arg => arg.optional) && !!field.args.find(arg => arg.name === "id"))
               ? `private _${field.name}${field.nonNull ? "" : "?"}: ${model.fragment}['${field.name}']`
               : undefined
           )

--- a/packages/codegen-sdk/src/print-model.ts
+++ b/packages/codegen-sdk/src/print-model.ts
@@ -113,7 +113,8 @@ function printModel(context: SdkPluginContext, model: SdkModel): string {
           printDebug("fields.query"),
           printLines(
             model.fields.query.map(field =>
-              field.args.some(arg => !arg.optional)
+              field.args.some(arg => !arg.optional) ||
+              (field.args.every(arg => arg.optional) && !!field.args.find(arg => arg.name === "id"))
                 ? printSet(
                     `this._${field.name}`,
                     `${Sdk.DATA_NAME}.${field.name}${field.nonNull ? "" : " ?? undefined"}`

--- a/packages/codegen-sdk/src/print-model.ts
+++ b/packages/codegen-sdk/src/print-model.ts
@@ -155,7 +155,11 @@ function printModel(context: SdkPluginContext, model: SdkModel): string {
           model.fields.query.map(field => {
             const typeName = printTypescriptType(context, field.node.type);
             const fieldQueryName = `${printPascal(field.query.name.value)}Query`;
-            const fieldQueryArgs = field.args?.map(arg => `this._${field.name}${field.nonNull ? "" : "?"}.${arg.name}`);
+            const allOptional = field.args.every(arg => arg.optional);
+            const optionalIdArg = field.args.find(arg => arg.name === "id" && arg.optional);
+            const fieldQueryArgs = (allOptional && optionalIdArg ? [optionalIdArg] : field.args)?.map(
+              arg => `this._${field.name}${field.nonNull ? "" : "?"}.${arg.name}`
+            );
 
             if (fieldQueryArgs.length) {
               const operationCall = `new ${fieldQueryName}(this._${Sdk.REQUEST_NAME}).${Sdk.FETCH_NAME}(${printList(

--- a/packages/codegen-sdk/src/print-model.ts
+++ b/packages/codegen-sdk/src/print-model.ts
@@ -163,9 +163,9 @@ function printModel(context: SdkPluginContext, model: SdkModel): string {
             );
 
             if (fieldQueryArgs.length) {
-              const operationCall = `new ${fieldQueryName}(this._${Sdk.REQUEST_NAME}).${Sdk.FETCH_NAME}(${printList(
-                fieldQueryArgs
-              )})`;
+              const operationCall = `new ${fieldQueryName}(this._${Sdk.REQUEST_NAME}).${Sdk.FETCH_NAME}(${
+                optionalIdArg ? `{${optionalIdArg.name}: ${fieldQueryArgs[0]}}` : printList(fieldQueryArgs)
+              })`;
               return printModelField(
                 field,
                 `public get ${field.name}(): ${Sdk.FETCH_TYPE}<${typeName}${

--- a/packages/codegen-test/src/print-test.ts
+++ b/packages/codegen-test/src/print-test.ts
@@ -223,6 +223,14 @@ function printConnectionQueryTest(context: SdkPluginContext, operation: SdkOpera
               ? printLines([
                   `const ${itemField} = ${fieldName}?.${Sdk.NODE_NAME}?.[0]`,
                   ...(itemArgs.map(arg => printSet(`_${itemField}_${arg.name}`, `${itemField}?.${arg.name}`)) ?? []),
+                  ...(optionalIdArg && itemArgs.length === 0
+                    ? [
+                        printSet(
+                          `_${itemField}_${optionalIdArg.variable.name.value}`,
+                          `${itemField}?.${optionalIdArg.variable.name.value}`
+                        ),
+                      ]
+                    : []),
                 ])
               : undefined,
             operation.print.list

--- a/packages/sdk/src/_generated_documents.graphql
+++ b/packages/sdk/src/_generated_documents.graphql
@@ -1,3 +1,26 @@
+# A Git target branch for which there are automations (GitAutomationState).
+fragment GitAutomationTargetBranch on GitAutomationTargetBranch {
+  __typename
+  # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+  #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+  #     been updated after creation.
+  updatedAt
+  # The target branch pattern.
+  branchPattern
+  # The team to which this Git target branch automation belongs.
+  team {
+    id
+  }
+  # The time at which the entity was archived. Null if the entity has not been archived.
+  archivedAt
+  # The time at which the entity was created.
+  createdAt
+  # The unique identifier of the entity.
+  id
+  # Whether the branch pattern is a regular expression.
+  isRegex
+}
+
 # A basic entity.
 fragment Entity on Entity {
   __typename
@@ -34,9 +57,9 @@ fragment Comment on Comment {
   __typename
   # Comment's URL.
   url
-  # Emoji reaction summary, grouped by emoji type
+  # Emoji reaction summary, grouped by emoji type.
   reactionData
-  # The bot that created the comment
+  # The bot that created the comment.
   botActor {
     ...ActorBot
   }
@@ -49,6 +72,10 @@ fragment Comment on Comment {
   # The document content that the comment is associated with.
   documentContent {
     ...DocumentContent
+  }
+  # The external user who wrote the comment.
+  externalUser {
+    id
   }
   # The issue that the comment is associated with.
   issue {
@@ -66,6 +93,8 @@ fragment Comment on Comment {
   projectUpdate {
     id
   }
+  # The text that this comment references. Only defined for inline comments.
+  quotedText
   # The time at which the entity was archived. Null if the entity has not been archived.
   archivedAt
   # The time at which the entity was created.
@@ -183,7 +212,7 @@ fragment CustomViewNotificationSubscription on CustomViewNotificationSubscriptio
   user {
     id
   }
-  # Whether the subscription is active or not
+  # Whether the subscription is active or not.
   active
 }
 
@@ -196,6 +225,8 @@ fragment CustomView on CustomView {
   description
   # The filter applied to issues in the custom view.
   filterData
+  # The filter applied to projects in the custom view.
+  projectFilterData
   # The filters applied to issues in the custom view.
   filters
   # The icon of the custom view.
@@ -220,6 +251,10 @@ fragment CustomView on CustomView {
   id
   # The user who created the custom view.
   creator {
+    id
+  }
+  # The user who last updated the custom view.
+  updatedBy {
     id
   }
   # The user who owns the custom view.
@@ -273,7 +308,7 @@ fragment CycleNotificationSubscription on CycleNotificationSubscription {
   user {
     id
   }
-  # Whether the subscription is active or not
+  # Whether the subscription is active or not.
   active
 }
 
@@ -304,7 +339,7 @@ fragment DocumentContent on DocumentContent {
   project {
     id
   }
-  # The time at which the document content was restored from a previous version
+  # The time at which the document content was restored from a previous version.
   restoredAt
   # The time at which the entity was archived. Null if the entity has not been archived.
   archivedAt
@@ -314,7 +349,7 @@ fragment DocumentContent on DocumentContent {
   id
 }
 
-# A document content history for a document
+# A document content history for a document.
 fragment DocumentContentHistory on DocumentContentHistory {
   __typename
   # IDs of actors whose edits went into this history item.
@@ -331,7 +366,7 @@ fragment DocumentContentHistory on DocumentContentHistory {
   archivedAt
   # The time at which the entity was created.
   createdAt
-  # The timestamp associated with the DocumentContent when it was originally saved
+  # The timestamp associated with the DocumentContent when it was originally saved.
   contentDataSnapshotAt
   # The unique identifier of the entity.
   id
@@ -346,8 +381,6 @@ fragment Document on Document {
   title
   # The document's unique URL slug.
   slugId
-  # The documents content as a Prosemirror document.
-  contentData
   # The documents content in markdown format.
   content
   # The icon of the document.
@@ -402,6 +435,15 @@ fragment CycleArchivePayload on CycleArchivePayload {
   entity {
     id
   }
+  # The identifier of the last sync operation.
+  lastSyncId
+  # Whether the operation was successful.
+  success
+}
+
+# A generic payload return from entity archive mutations.
+fragment InitiativeArchivePayload on InitiativeArchivePayload {
+  __typename
   # The identifier of the last sync operation.
   lastSyncId
   # Whether the operation was successful.
@@ -506,6 +548,10 @@ fragment ArchivePayload on ArchivePayload {
     ...DeletePayload
   }
 
+  ... on InitiativeArchivePayload {
+    ...InitiativeArchivePayload
+  }
+
   ... on IssueArchivePayload {
     ...IssueArchivePayload
   }
@@ -585,7 +631,7 @@ fragment LabelNotificationSubscription on LabelNotificationSubscription {
   user {
     id
   }
-  # Whether the subscription is active or not
+  # Whether the subscription is active or not.
   active
 }
 
@@ -619,11 +665,15 @@ fragment ProjectMilestone on ProjectMilestone {
 # A notification sent to a user.
 fragment Notification on Notification {
   __typename
-  # Notification type
+  # Notification type.
   type
   # The bot that caused the notification.
   botActor {
     ...ActorBot
+  }
+  # The external user that caused the notification.
+  externalUserActor {
+    id
   }
   # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
@@ -709,18 +759,22 @@ fragment ProjectNotificationSubscription on ProjectNotificationSubscription {
   user {
     id
   }
-  # Whether the subscription is active or not
+  # Whether the subscription is active or not.
   active
 }
 
-# A project related notification
+# A project related notification.
 fragment ProjectNotification on ProjectNotification {
   __typename
-  # Notification type
+  # Notification type.
   type
   # The bot that caused the notification.
   botActor {
     ...ActorBot
+  }
+  # The external user that caused the notification.
+  externalUserActor {
+    id
   }
   # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
@@ -892,7 +946,7 @@ fragment IssueHistory on IssueHistory {
   addedLabelIds
   # ID's of labels that were removed.
   removedLabelIds
-  # The bot that performed the action
+  # The bot that performed the action.
   botActor {
     ...ActorBot
   }
@@ -1004,9 +1058,9 @@ fragment IssueHistory on IssueHistory {
   actor {
     id
   }
-  # What the due date was changed from
+  # What the due date was changed from.
   fromDueDate
-  # What the due date was changed to
+  # What the due date was changed to.
   toDueDate
   # What the estimate was changed from.
   fromEstimate
@@ -1213,7 +1267,7 @@ fragment TeamNotificationSubscription on TeamNotificationSubscription {
   user {
     id
   }
-  # Whether the subscription is active or not
+  # Whether the subscription is active or not.
   active
 }
 
@@ -1240,6 +1294,10 @@ fragment TriageResponsibility on TriageResponsibility {
   archivedAt
   # The time at which the entity was created.
   createdAt
+  # The time schedule used for scheduling.
+  timeSchedule {
+    ...TimeSchedule
+  }
   # The unique identifier of the entity.
   id
 }
@@ -1279,6 +1337,35 @@ fragment Template on Template {
   }
 }
 
+# A time schedule.
+fragment TimeSchedule on TimeSchedule {
+  __typename
+  # The URL to the external schedule.
+  externalUrl
+  # The identifier of the Linear integration populating the schedule.
+  integration {
+    id
+  }
+  # The identifier of the external schedule.
+  externalId
+  # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+  #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+  #     been updated after creation.
+  updatedAt
+  # The name of the schedule.
+  name
+  # The schedule entries.
+  entries
+  # The time at which the entity was archived. Null if the entity has not been archived.
+  archivedAt
+  # The time at which the entity was created.
+  createdAt
+  # The unique identifier of the entity.
+  id
+  # User presentable error message, if an error occurred while updating the schedule.
+  error
+}
+
 # A trigger that updates the issue status according to Git automations.
 fragment GitAutomationState on GitAutomationState {
   __typename
@@ -1290,8 +1377,10 @@ fragment GitAutomationState on GitAutomationState {
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
   #     been updated after creation.
   updatedAt
-  # The target branch, if null, the automation will be triggered on any branch.
-  branchPattern
+  # The target branch associated to this automation state.
+  targetBranch {
+    ...GitAutomationTargetBranch
+  }
   # The team to which this automation state belongs.
   team {
     id
@@ -1302,6 +1391,8 @@ fragment GitAutomationState on GitAutomationState {
   createdAt
   # The unique identifier of the entity.
   id
+  # [DEPRECATED] The target branch, if null, the automation will be triggered on any branch.
+  branchPattern
 }
 
 # A update associated with an project.
@@ -1335,6 +1426,8 @@ fragment ProjectUpdate on ProjectUpdate {
   user {
     id
   }
+  # Whether project update diff should be hidden.
+  isDiffHidden
 }
 
 # A user account.
@@ -1354,6 +1447,8 @@ fragment UserAccount on UserAccount {
   email
   # The user's name.
   name
+  # Whether not to send email auth links in the email auth emails.
+  authTokenLinkDisabled
 }
 
 # A user notification subscription.
@@ -1399,7 +1494,7 @@ fragment UserNotificationSubscription on UserNotificationSubscription {
   subscriber {
     id
   }
-  # Whether the subscription is active or not
+  # Whether the subscription is active or not.
   active
 }
 
@@ -1418,6 +1513,8 @@ fragment AuthUser on AuthUser {
   email
   # The user's full name.
   name
+  # User account id the user belongs to.
+  userAccountId
   # Whether the user is active.
   active
   id
@@ -1491,7 +1588,7 @@ fragment PushSubscription on PushSubscription {
   id
 }
 
-# A webhook used to send HTTP notifications over data updates
+# A webhook used to send HTTP notifications over data updates.
 fragment Webhook on Webhook {
   __typename
   # Secret token for verifying the origin on the recipient side.
@@ -1516,9 +1613,9 @@ fragment Webhook on Webhook {
   creator {
     id
   }
-  # Webhook URL
+  # Webhook URL.
   url
-  # Webhook label
+  # Webhook label.
   label
   # Whether the Webhook is enabled for all public teams, including teams created after the webhook was created.
   allPublicTeams
@@ -1543,7 +1640,7 @@ fragment ApiKey on ApiKey {
   id
 }
 
-# An email address that can be used for submitting issues
+# An email address that can be used for submitting issues.
 fragment EmailIntakeAddress on EmailIntakeAddress {
   __typename
   # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
@@ -1552,6 +1649,10 @@ fragment EmailIntakeAddress on EmailIntakeAddress {
   updatedAt
   # The team that the email address is associated with.
   team {
+    id
+  }
+  # The template that the email address is associated with.
+  template {
     id
   }
   # The time at which the entity was archived. Null if the entity has not been archived.
@@ -1568,6 +1669,32 @@ fragment EmailIntakeAddress on EmailIntakeAddress {
   address
   # Whether the email address is enabled.
   enabled
+}
+
+# An external authenticated (e.g., through Slack) user which doesn't have a Linear account, but can
+# create and update entities in Linear from the external system that authenticated them.
+fragment ExternalUser on ExternalUser {
+  __typename
+  # An URL to the external user's avatar image.
+  avatarUrl
+  # The external user's display name. Unique within each organization. Can match the display name of an actual user.
+  displayName
+  # The external user's email address.
+  email
+  # The external user's full name.
+  name
+  # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+  #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+  #     been updated after creation.
+  updatedAt
+  # The last time the external user was seen interacting with Linear.
+  lastSeen
+  # The time at which the entity was archived. Null if the entity has not been archived.
+  archivedAt
+  # The time at which the entity was created.
+  createdAt
+  # The unique identifier of the entity.
+  id
 }
 
 # An external link for a project.
@@ -1599,16 +1726,16 @@ fragment ProjectLink on ProjectLink {
   }
 }
 
-# An import job for data from an external service
+# An import job for data from an external service.
 fragment IssueImport on IssueImport {
   __typename
   # Current step progress in % (0-100).
   progress
-  # Error code and metadata, if one has occurred during the import
+  # Error code and metadata, if one has occurred during the import.
   errorMetadata
   # File URL for the uploaded CSV for the import, if there is one.
   csvFileUrl
-  # New team's name in cases when teamId not set
+  # New team's name in cases when teamId not set.
   teamName
   # The data mapping configuration for the import job.
   mapping
@@ -1658,6 +1785,13 @@ fragment Integration on Integration {
 }
 
 # An invitation to the organization that has been sent via email.
+fragment AuthOrganizationInvite on AuthOrganizationInvite {
+  __typename
+  # The unique identifier of the entity.
+  id
+}
+
+# An invitation to the organization that has been sent via email.
 fragment OrganizationInvite on OrganizationInvite {
   __typename
   # Extra metadata associated with the organization invite.
@@ -1674,9 +1808,9 @@ fragment OrganizationInvite on OrganizationInvite {
   archivedAt
   # The time at which the entity was created.
   createdAt
-  # The time at which the invite was accepted. Null, if the invite hasn't been accepted
+  # The time at which the invite was accepted. Null, if the invite hasn't been accepted.
   acceptedAt
-  # The time at which the invite will be expiring. Null, if the invite shouldn't expire
+  # The time at which the invite will be expiring. Null, if the invite shouldn't expire.
   expiresAt
   # The unique identifier of the entity.
   id
@@ -1690,12 +1824,12 @@ fragment OrganizationInvite on OrganizationInvite {
   }
 }
 
-# An issue related notification
+# An issue related notification.
 fragment IssueNotification on IssueNotification {
   __typename
   # Name of the reaction emoji related to the notification.
   reactionEmoji
-  # Notification type
+  # Notification type.
   type
   # The bot that caused the notification.
   botActor {
@@ -1703,6 +1837,10 @@ fragment IssueNotification on IssueNotification {
   }
   # The comment related to the notification.
   comment {
+    id
+  }
+  # The external user that caused the notification.
+  externalUserActor {
     id
   }
   # The issue related to the notification.
@@ -1717,7 +1855,7 @@ fragment IssueNotification on IssueNotification {
   subscriptions {
     ...NotificationSubscription
   }
-  # The team related to the notification.
+  # The team related to the issue notification.
   team {
     id
   }
@@ -1777,6 +1915,10 @@ fragment Issue on Issue {
   dueDate
   # The estimate of the complexity of the issue..
   estimate
+  # The external user who created the issue.
+  externalUserCreator {
+    id
+  }
   # The issue's description in markdown format.
   description
   # The issue's title.
@@ -1859,10 +2001,10 @@ fragment Issue on Issue {
   }
 }
 
-# An oauth client approval related notification
+# An oauth client approval related notification.
 fragment OauthClientApprovalNotification on OauthClientApprovalNotification {
   __typename
-  # Notification type
+  # Notification type.
   type
   # The OAuth client approval request related to the notification.
   oauthClientApproval {
@@ -1871,6 +2013,10 @@ fragment OauthClientApprovalNotification on OauthClientApprovalNotification {
   # The bot that caused the notification.
   botActor {
     ...ActorBot
+  }
+  # The external user that caused the notification.
+  externalUserActor {
+    id
   }
   # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
@@ -1904,7 +2050,7 @@ fragment OauthClientApprovalNotification on OauthClientApprovalNotification {
 # An organization. Organizations are root-level objects that contain user accounts and teams.
 fragment Organization on Organization {
   __typename
-  # Allowed authentication providers, empty array means all are allowed
+  # Allowed authentication providers, empty array means all are allowed.
   allowedAuthServices
   # How git branches are formatted. If null, default formatting will be used.
   gitBranchFormat
@@ -1948,7 +2094,7 @@ fragment Organization on Organization {
   samlEnabled
   # Whether SCIM provisioning is enabled for organization.
   scimEnabled
-  # Whether member users are allowed to send invites
+  # Whether member users are allowed to send invites.
   allowMembersToInvite
   # Whether the Git integration linkback messages should be sent to private repositories.
   gitLinkbackMessagesEnabled
@@ -1965,6 +2111,8 @@ fragment AuthOrganization on AuthOrganization {
   allowedAuthServices
   # Previously used URL keys for the organization (last 3 are kept and redirected).
   previousUrlKeys
+  # The email domain or URL key for the organization.
+  serviceId
   # The organization's logo URL.
   logoUrl
   # The organization's name.
@@ -2095,7 +2243,7 @@ fragment Team on Team {
   defaultIssueEstimate
   # Where to move issues when changing state.
   setIssueSortOrderOnStateChange
-  # Whether an issue needs to have a priority set before leaving triage
+  # Whether an issue needs to have a priority set before leaving triage.
   requirePriorityToLeaveTriage
   # Whether issues without priority should be sorted first.
   issueOrderingNoPriorityFirst
@@ -2157,7 +2305,7 @@ fragment AuthOauthClientWithMemberships on AuthOauthClientWithMemberships {
   totalMembers
 }
 
-# Authentication session information
+# Authentication session information.
 fragment AuthenticationSessionResponse on AuthenticationSessionResponse {
   __typename
   # Client used for the session
@@ -2206,6 +2354,21 @@ fragment ArchiveResponse on ArchiveResponse {
   includesDependencies
 }
 
+# Data recovery.
+fragment DataRecovery on DataRecovery {
+  __typename
+  # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+  #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+  #     been updated after creation.
+  updatedAt
+  # The time at which the entity was archived. Null if the entity has not been archived.
+  archivedAt
+  # The time at which the entity was created.
+  createdAt
+  # The unique identifier of the entity.
+  id
+}
+
 # Defines the membership of a user to a team.
 fragment TeamMembership on TeamMembership {
   __typename
@@ -2229,18 +2392,18 @@ fragment TeamMembership on TeamMembership {
   user {
     id
   }
-  # Whether the user is the owner of the team
+  # Whether the user is the owner of the team.
   owner
 }
 
 # Defines the use of a domain by an organization.
 fragment OrganizationDomain on OrganizationDomain {
   __typename
-  # Domain name
+  # Domain name.
   name
-  # E-mail used to verify this domain
+  # E-mail used to verify this domain.
   verificationEmail
-  # Is this domain verified
+  # Is this domain verified.
   verified
   # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
@@ -2373,6 +2536,10 @@ fragment Attachment on Attachment {
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
   #     been updated after creation.
   updatedAt
+  # The non-Linear user who created the attachment.
+  externalUserCreator {
+    id
+  }
   # The time at which the entity was archived. Null if the entity has not been archived.
   archivedAt
   # The time at which the entity was created.
@@ -2381,7 +2548,7 @@ fragment Attachment on Attachment {
   id
 }
 
-# Issue relation history's payload
+# Issue relation history's payload.
 fragment IssueRelationHistoryPayload on IssueRelationHistoryPayload {
   __typename
   # The identifier of the related issue.
@@ -2412,7 +2579,7 @@ fragment JiraSettings on JiraSettings {
   isJiraServer
 }
 
-# Join table between projects and roadmaps
+# Join table between projects and roadmaps.
 fragment RoadmapToProject on RoadmapToProject {
   __typename
   # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
@@ -2437,7 +2604,7 @@ fragment RoadmapToProject on RoadmapToProject {
   id
 }
 
-# Join table between templates and integrations
+# Join table between templates and integrations.
 fragment IntegrationTemplate on IntegrationTemplate {
   __typename
   # ID of the foreign entity in the external integration this template is for, e.g., Slack channel ID.
@@ -2497,6 +2664,19 @@ fragment IssueLabel on IssueLabel {
   isGroup
 }
 
+# Mapping of Linear teams to GitHub repos.
+fragment TeamRepoMapping on TeamRepoMapping {
+  __typename
+  # The GitHub repo id.
+  gitHubRepoId
+  # The Linear team id to map to the given project.
+  linearTeamId
+  # Whether the sync for this mapping is bidirectional.
+  bidirectional
+  # Whether this mapping is the default one for issue creation.
+  default
+}
+
 # Metadata about a Jira project.
 fragment JiraProjectData on JiraProjectData {
   __typename
@@ -2522,22 +2702,22 @@ fragment PagerDutyScheduleInfo on PagerDutyScheduleInfo {
 # Metadata and settings for a GitHub Personal integration.
 fragment GitHubPersonalSettings on GitHubPersonalSettings {
   __typename
-  # The GitHub user's name
+  # The GitHub user's name.
   login
 }
 
 # Metadata and settings for a GitHub integration.
 fragment GitHubSettings on GitHubSettings {
   __typename
-  # Mapping of team to repository for syncing
+  # Mapping of team to repository for syncing.
   repositoriesMapping {
     ...TeamRepoMapping
   }
-  # The GitHub organization's name
+  # The GitHub organization's name.
   orgLogin
-  # The avatar URL for the GitHub organization
+  # The avatar URL for the GitHub organization.
   orgAvatarUrl
-  # The names of the repositories connected for the GitHub integration
+  # The names of the repositories connected for the GitHub integration.
   repositories {
     ...GitHubRepo
   }
@@ -2546,11 +2726,11 @@ fragment GitHubSettings on GitHubSettings {
 # Metadata and settings for a GitLab integration.
 fragment GitLabSettings on GitLabSettings {
   __typename
-  # The ISO timestamp the GitLab access token expires
+  # The ISO timestamp the GitLab access token expires.
   expiresAt
-  # The self-hosted URL of the GitLab instance
+  # The self-hosted URL of the GitLab instance.
   url
-  # Whether the token is limited to a read-only scope
+  # Whether the token is limited to a read-only scope.
   readonly
 }
 
@@ -2595,7 +2775,7 @@ fragment NotificationSubscription on NotificationSubscription {
   user {
     id
   }
-  # Whether the subscription is active or not
+  # Whether the subscription is active or not.
   active
 }
 
@@ -2643,7 +2823,7 @@ fragment OauthClient on OauthClient {
   }
   # Url of the developer.
   developerUrl
-  # Webhook URL
+  # Webhook URL.
   webhookUrl
   # Webhook secret token for verifying the origin on the recipient side.
   webhookSecret
@@ -2651,7 +2831,7 @@ fragment OauthClient on OauthClient {
   publicEnabled
 }
 
-# Object for mapping Slack channel IDs to names and other settings
+# Object for mapping Slack channel IDs to names and other settings.
 fragment SlackChannelNameMapping on SlackChannelNameMapping {
   __typename
   # The Slack channel ID.
@@ -2660,19 +2840,19 @@ fragment SlackChannelNameMapping on SlackChannelNameMapping {
   name
   # The optional template ID to use for Asks auto-created in this channel. If not set, auto-created Asks won't use any template.
   autoCreateTemplateId
-  # Whether or not @-mentioning the bot should automatically create an Ask with the message
+  # Whether or not @-mentioning the bot should automatically create an Ask with the message.
   autoCreateOnBotMention
-  # Whether or not the Slack channel is private
+  # Whether or not the Slack channel is private.
   isPrivate
-  # Whether or not the Slack channel is shared with an external org
+  # Whether or not the Slack channel is shared with an external org.
   isShared
-  # Whether or not top-level messages in this channel should automatically create Asks
+  # Whether or not top-level messages in this channel should automatically create Asks.
   autoCreateOnMessage
-  # Whether or not using the :ticket: emoji in this channel should automatically create Asks
+  # Whether or not using the :ticket: emoji in this channel should automatically create Asks.
   autoCreateOnEmoji
-  # Whether or not we the Linear Asks bot has been added to this Slack channel
+  # Whether or not we the Linear Asks bot has been added to this Slack channel.
   botAdded
-  # Which teams are connected to the channel and settings for those teams
+  # Which teams are connected to the channel and settings for those teams.
   teams {
     ...SlackAsksTeamSettings
   }
@@ -2681,13 +2861,13 @@ fragment SlackChannelNameMapping on SlackChannelNameMapping {
 # Object representing Google Cloud upload policy, plus additional data.
 fragment UploadFile on UploadFile {
   __typename
-  # The asset URL for the uploaded file. (assigned automatically)
+  # The asset URL for the uploaded file. (assigned automatically).
   assetUrl
   # The content type.
   contentType
   # The filename.
   filename
-  # The signed URL the for the uploaded file. (assigned automatically)
+  # The signed URL the for the uploaded file. (assigned automatically).
   uploadUrl
   # The size of the uploaded file.
   size
@@ -2712,7 +2892,7 @@ fragment UserAuthorizedApplication on UserAuthorizedApplication {
   __typename
   # Application name.
   name
-  # Error associated with the application needing to be requested for approval in the workspace
+  # Error associated with the application needing to be requested for approval in the workspace.
   approvalErrorCode
   # Image of the application.
   imageUrl
@@ -2866,9 +3046,9 @@ fragment IntegrationsSettings on IntegrationsSettings {
   slackIssueCreated
   # Whether to send a Slack message when a project update is created.
   slackProjectUpdateCreated
-  # Whether to send a Slack message when an SLA is at high risk
+  # Whether to send a Slack message when an SLA is at high risk.
   slackIssueSlaHighRisk
-  # Whether to send a Slack message when an SLA is breached
+  # Whether to send a Slack message when an SLA is breached.
   slackIssueSlaBreached
   # Whether to send a Slack message when any of the project or team's issues change to completed or cancelled.
   slackIssueStatusChangedDone
@@ -2880,7 +3060,7 @@ fragment IntegrationsSettings on IntegrationsSettings {
   slackProjectUpdateCreatedToWorkspace
 }
 
-# The integration resource's settings
+# The integration resource's settings.
 fragment IntegrationSettings on IntegrationSettings {
   __typename
   front {
@@ -2934,19 +3114,6 @@ fragment IntegrationSettings on IntegrationSettings {
   zendesk {
     ...ZendeskSettings
   }
-}
-
-# The organization's SAML configuration
-fragment SamlConfigurationPayload on SamlConfigurationPayload {
-  __typename
-  # Binding method for authentication call. Can be either `post` (default) or `redirect`.
-  ssoBinding
-  # Sign in endpoint URL for the identity provider.
-  ssoEndpoint
-  # The algorithm of the Signing Certificate. Can be one of `sha1`, `sha256` (default), or `sha512`.
-  ssoSignAlgo
-  # The issuer's custom entity ID.
-  issuerEntityId
 }
 
 # The paid subscription of an organization.
@@ -3024,21 +3191,12 @@ fragment JiraLinearMapping on JiraLinearMapping {
   default
 }
 
-# Tuple for mapping Linear teams to GitHub repos.
-fragment TeamRepoMapping on TeamRepoMapping {
-  __typename
-  # The GitHub repo id.
-  gitHubRepoId
-  # The Linear team id to map to the given project.
-  linearTeamId
-}
-
-# Tuple for mapping Slack channel IDs to names
+# Tuple for mapping Slack channel IDs to names.
 fragment SlackAsksTeamSettings on SlackAsksTeamSettings {
   __typename
   # The Linear team ID.
   id
-  # Whether the default Asks template is enabled in the given channel for this team
+  # Whether the default Asks template is enabled in the given channel for this team.
   hasDefaultAsk
 }
 
@@ -3281,7 +3439,7 @@ fragment AttachmentPayload on AttachmentPayload {
 
 fragment AttachmentSourcesPayload on AttachmentSourcesPayload {
   __typename
-  # A unique list of all source types used in this workspace
+  # A unique list of all source types used in this workspace.
   sources
 }
 
@@ -3317,23 +3475,6 @@ fragment AuthApiKeyPayload on AuthApiKeyPayload {
   }
   # Whether the operation was successful.
   success
-}
-
-fragment AuthCreateOrJoinOrganizationResponse on AuthCreateOrJoinOrganizationResponse {
-  __typename
-  authOrganization {
-    ...AuthOrganization
-  }
-  authUser {
-    ...AuthUser
-  }
-  grantDomainAccess
-  organization {
-    ...AuthOrganization
-  }
-  user {
-    ...AuthUser
-  }
 }
 
 fragment AuthIntegration on AuthIntegration {
@@ -3389,21 +3530,29 @@ fragment AuthOrganizationDomain on AuthOrganizationDomain {
   __typename
   # The unique identifier of the entity.
   id
+  claimed
+  name
+  organizationId
+  verified
 }
 
 fragment AuthResolverResponse on AuthResolverResponse {
   __typename
+  # Application token.
+  token
   # Email for the authenticated account.
   email
   # ID of the organization last accessed by the user.
   lastUsedOrganizationId
-  # JWT token for authentication of the account.
-  token
-  # List of organizations this user account is part of but are currently locked because of the current auth service.
+  # List of active users that belong to the user account.
+  users {
+    ...AuthUser
+  }
+  # List of organization available to this user account but locked due to the current auth method.
   lockedOrganizations {
     ...AuthOrganization
   }
-  # Organizations this account has access to, but is not yet a member.
+  # List of organizations allowing this user account to join automatically.
   availableOrganizations {
     ...AuthOrganization
   }
@@ -3411,10 +3560,6 @@ fragment AuthResolverResponse on AuthResolverResponse {
   allowDomainAccess
   # User account ID.
   id
-  # Users belonging to this account.
-  users {
-    ...AuthUser
-  }
 }
 
 fragment AuthSuccessPayload on AuthSuccessPayload {
@@ -3613,7 +3758,7 @@ fragment DocumentSearchPayload on DocumentSearchPayload {
 
 fragment DocumentSearchResult on DocumentSearchResult {
   __typename
-  # Metadata related to search result
+  # Metadata related to search result.
   metadata
   # The color of the icon.
   color
@@ -3621,8 +3766,6 @@ fragment DocumentSearchResult on DocumentSearchResult {
   title
   # The document's unique URL slug.
   slugId
-  # The documents content as a Prosemirror document.
-  contentData
   # The documents content in markdown format.
   content
   # The icon of the document.
@@ -3667,6 +3810,18 @@ fragment DocumentSearchResultConnection on DocumentSearchResultConnection {
   }
 }
 
+fragment EmailIntakeAddressPayload on EmailIntakeAddressPayload {
+  __typename
+  # The email address that was created or updated.
+  emailIntakeAddress {
+    ...EmailIntakeAddress
+  }
+  # The identifier of the last sync operation.
+  lastSyncId
+  # Whether the operation was successful.
+  success
+}
+
 fragment EmailUnsubscribePayload on EmailUnsubscribePayload {
   __typename
   # Whether the operation was successful.
@@ -3701,6 +3856,16 @@ fragment EmojiPayload on EmojiPayload {
   lastSyncId
   # Whether the operation was successful.
   success
+}
+
+fragment ExternalUserConnection on ExternalUserConnection {
+  __typename
+  nodes {
+    ...ExternalUser
+  }
+  pageInfo {
+    ...PageInfo
+  }
 }
 
 fragment FavoriteConnection on FavoriteConnection {
@@ -3755,6 +3920,18 @@ fragment GitAutomationStatePayload on GitAutomationStatePayload {
   success
 }
 
+fragment GitAutomationTargetBranchPayload on GitAutomationTargetBranchPayload {
+  __typename
+  # The Git target branch automation that was created or updated.
+  targetBranch {
+    ...GitAutomationTargetBranch
+  }
+  # The identifier of the last sync operation.
+  lastSyncId
+  # Whether the operation was successful.
+  success
+}
+
 fragment GitHubCommitIntegrationPayload on GitHubCommitIntegrationPayload {
   __typename
   # The identifier of the last sync operation.
@@ -3787,6 +3964,14 @@ fragment IntegrationConnection on IntegrationConnection {
   pageInfo {
     ...PageInfo
   }
+}
+
+fragment IntegrationHasScopesPayload on IntegrationHasScopesPayload {
+  __typename
+  # The missing scopes.
+  missingScopes
+  # Whether the integration has the required scopes.
+  hasAllScopes
 }
 
 fragment IntegrationPayload on IntegrationPayload {
@@ -4011,7 +4196,7 @@ fragment IssueSearchResult on IssueSearchResult {
   identifier
   # Label for the priority.
   priorityLabel
-  # Metadata related to search result
+  # Metadata related to search result.
   metadata
   # Previous identifiers of the issue if it has been moved between teams.
   previousIdentifiers
@@ -4031,6 +4216,10 @@ fragment IssueSearchResult on IssueSearchResult {
   dueDate
   # The estimate of the complexity of the issue..
   estimate
+  # The external user who created the issue.
+  externalUserCreator {
+    id
+  }
   # The issue's description in markdown format.
   description
   # The issue's title.
@@ -4203,8 +4392,20 @@ fragment OauthClientConnection on OauthClientConnection {
 
 fragment OauthToken on OauthToken {
   __typename
+  # Auth user who authorized the OAuth application.
+  user {
+    ...AuthUser
+  }
+  # Id of the user who authorized the OAuth application.
+  userId
+  # OAuth2 client for which the access token belongs to.
+  client {
+    ...AuthOauthClient
+  }
+  clientId
   createdAt
   id
+  revokedAt
 }
 
 fragment OrganizationCancelDeletePayload on OrganizationCancelDeletePayload {
@@ -4243,9 +4444,9 @@ fragment OrganizationInviteFullDetailsPayload on OrganizationInviteFullDetailsPa
   organizationId
   # Name of the workspace the invite is for.
   organizationName
-  # The email of the invitee
+  # The email of the invitee.
   email
-  # The name of the inviter
+  # The name of the inviter.
   inviter
   # URL of the workspace logo the invite is for.
   organizationLogoUrl
@@ -4387,7 +4588,7 @@ fragment ProjectSearchResult on ProjectSearchResult {
   __typename
   # A flag that indicates whether the project is in the trash bin.
   trashed
-  # Metadata related to search result
+  # Metadata related to search result.
   metadata
   # Project URL.
   url
@@ -4671,20 +4872,6 @@ fragment RoadmapToProjectPayload on RoadmapToProjectPayload {
   success
 }
 
-fragment SamlConfiguration on SamlConfiguration {
-  __typename
-  # Binding method for authentication call. Can be either `post` (default) or `redirect`.
-  ssoBinding
-  # Sign in endpoint URL for the identity provider.
-  ssoEndpoint
-  # The algorithm of the Signing Certificate. Can be one of `sha1`, `sha256` (default), or `sha512`.
-  ssoSignAlgo
-  # The issuer's custom entity ID.
-  issuerEntityId
-  # X.509 Signing Certificate in string form.
-  ssoSigningCert
-}
-
 fragment SlackChannelConnectPayload on SlackChannelConnectPayload {
   __typename
   # The identifier of the last sync operation.
@@ -4781,6 +4968,16 @@ fragment TemplatePayload on TemplatePayload {
   }
   # Whether the operation was successful.
   success
+}
+
+fragment TimeScheduleConnection on TimeScheduleConnection {
+  __typename
+  nodes {
+    ...TimeSchedule
+  }
+  pageInfo {
+    ...PageInfo
+  }
 }
 
 fragment TriageResponsibilityConnection on TriageResponsibilityConnection {
@@ -5106,7 +5303,7 @@ query applicationWithAuthorization(
   $clientId: String!
   # Redirect URI for the application.
   $redirectUri: String
-  # Scopes being requested by the application
+  # Scopes being requested by the application.
   $scope: [String!]!
 ) {
   applicationWithAuthorization(actor: $actor, clientId: $clientId, redirectUri: $redirectUri, scope: $scope) {
@@ -5507,19 +5704,27 @@ query availableUsers {
 }
 # A specific comment.
 query comment(
+  # The hash of the comment to retrieve, must be combined with an issueId.
+  $hash: String
   # The identifier of the comment to retrieve.
-  $id: String!
+  $id: String
+  # The issue for which to find the comment.
+  $issueId: String
 ) {
-  comment(id: $id) {
+  comment(hash: $hash, id: $id, issueId: $issueId) {
     ...Comment
   }
 }
-# The bot that created the comment
+# The bot that created the comment.
 query comment_botActor(
+  # The hash of the comment to retrieve, must be combined with an issueId.
+  $hash: String
   # The identifier of the comment to retrieve.
-  $id: String!
+  $id: String
+  # The issue for which to find the comment.
+  $issueId: String
 ) {
-  comment(id: $id) {
+  comment(hash: $hash, id: $id, issueId: $issueId) {
     botActor {
       ...ActorBot
     }
@@ -5527,8 +5732,12 @@ query comment_botActor(
 }
 # The children of the comment.
 query comment_children(
+  # The hash of the comment to retrieve, must be combined with an issueId.
+  $hash: String
   # The identifier of the comment to retrieve.
-  $id: String!
+  $id: String
+  # The issue for which to find the comment.
+  $issueId: String
   # A cursor to be used with first for forward pagination
   $after: String
   # A cursor to be used with last for backward pagination.
@@ -5544,7 +5753,7 @@ query comment_children(
   # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
   $orderBy: PaginationOrderBy
 ) {
-  comment(id: $id) {
+  comment(hash: $hash, id: $id, issueId: $issueId) {
     children(
       after: $after
       before: $before
@@ -5560,10 +5769,14 @@ query comment_children(
 }
 # The document content that the comment is associated with.
 query comment_documentContent(
+  # The hash of the comment to retrieve, must be combined with an issueId.
+  $hash: String
   # The identifier of the comment to retrieve.
-  $id: String!
+  $id: String
+  # The issue for which to find the comment.
+  $issueId: String
 ) {
-  comment(id: $id) {
+  comment(hash: $hash, id: $id, issueId: $issueId) {
     documentContent {
       ...DocumentContent
     }
@@ -5602,6 +5815,38 @@ query comments(
 query customView($id: String!) {
   customView(id: $id) {
     ...CustomView
+  }
+}
+# Issues associated with the custom view.
+query customView_issues(
+  $id: String!
+  # A cursor to be used with first for forward pagination
+  $after: String
+  # A cursor to be used with last for backward pagination.
+  $before: String
+  # Filter returned issues.
+  $filter: IssueFilter
+  # The number of items to forward paginate (used with after). Defaults to 50.
+  $first: Int
+  # Should archived resources be included (default: false)
+  $includeArchived: Boolean
+  # The number of items to backward paginate (used with before). Defaults to 50.
+  $last: Int
+  # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+  $orderBy: PaginationOrderBy
+) {
+  customView(id: $id) {
+    issues(
+      after: $after
+      before: $before
+      filter: $filter
+      first: $first
+      includeArchived: $includeArchived
+      last: $last
+      orderBy: $orderBy
+    ) {
+      ...IssueConnection
+    }
   }
 }
 # Whether a custom view has other subscribers than the current user in the organization.
@@ -5756,6 +6001,8 @@ query documents(
   $after: String
   # A cursor to be used with last for backward pagination.
   $before: String
+  # Filter returned documents.
+  $filter: DocumentFilter
   # The number of items to forward paginate (used with after). Defaults to 50.
   $first: Int
   # Should archived resources be included (default: false)
@@ -5768,6 +6015,7 @@ query documents(
   documents(
     after: $after
     before: $before
+    filter: $filter
     first: $first
     includeArchived: $includeArchived
     last: $last
@@ -5778,7 +6026,7 @@ query documents(
 }
 # A specific emoji.
 query emoji(
-  # The identifier of the emoji to retrieve.
+  # The identifier or the name of the emoji to retrieve.
   $id: String!
 ) {
   emoji(id: $id) {
@@ -5809,6 +6057,41 @@ query emojis(
     orderBy: $orderBy
   ) {
     ...EmojiConnection
+  }
+}
+# One specific external user.
+query externalUser(
+  # The identifier of the external user to retrieve.
+  $id: String!
+) {
+  externalUser(id: $id) {
+    ...ExternalUser
+  }
+}
+# All external users for the organization.
+query externalUsers(
+  # A cursor to be used with first for forward pagination
+  $after: String
+  # A cursor to be used with last for backward pagination.
+  $before: String
+  # The number of items to forward paginate (used with after). Defaults to 50.
+  $first: Int
+  # Should archived resources be included (default: false)
+  $includeArchived: Boolean
+  # The number of items to backward paginate (used with before). Defaults to 50.
+  $last: Int
+  # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+  $orderBy: PaginationOrderBy
+) {
+  externalUsers(
+    after: $after
+    before: $before
+    first: $first
+    includeArchived: $includeArchived
+    last: $last
+    orderBy: $orderBy
+  ) {
+    ...ExternalUserConnection
   }
 }
 # One specific favorite.
@@ -5876,6 +6159,17 @@ query favorites(
 query integration($id: String!) {
   integration(id: $id) {
     ...Integration
+  }
+}
+# Checks if the integration has all required scopes.
+query integrationHasScopes(
+  # The integration ID.
+  $integrationId: String!
+  # Required scopes.
+  $scopes: [String!]!
+) {
+  integrationHasScopes(integrationId: $integrationId, scopes: $scopes) {
+    ...IntegrationHasScopesPayload
   }
 }
 # One specific integrationTemplate.
@@ -6243,9 +6537,9 @@ query issueFilterSuggestion($prompt: String!) {
 }
 # Checks a CSV file validity against a specific import service.
 query issueImportCheckCSV(
-  # CSV storage url
+  # CSV storage url.
   $csvUrl: String!
-  # The service the CSV containing data from
+  # The service the CSV containing data from.
   $service: String!
 ) {
   issueImportCheckCSV(csvUrl: $csvUrl, service: $service) {
@@ -7016,6 +7310,8 @@ query project_documents(
   $after: String
   # A cursor to be used with last for backward pagination.
   $before: String
+  # Filter returned documents.
+  $filter: DocumentFilter
   # The number of items to forward paginate (used with after). Defaults to 50.
   $first: Int
   # Should archived resources be included (default: false)
@@ -7029,6 +7325,7 @@ query project_documents(
     documents(
       after: $after
       before: $before
+      filter: $filter
       first: $first
       includeArchived: $includeArchived
       last: $last
@@ -7141,6 +7438,8 @@ query project_projectMilestones(
   $after: String
   # A cursor to be used with last for backward pagination.
   $before: String
+  # Filter returned milestones.
+  $filter: ProjectMilestoneFilter
   # The number of items to forward paginate (used with after). Defaults to 50.
   $first: Int
   # Should archived resources be included (default: false)
@@ -7154,6 +7453,7 @@ query project_projectMilestones(
     projectMilestones(
       after: $after
       before: $before
+      filter: $filter
       first: $first
       includeArchived: $includeArchived
       last: $last
@@ -7522,13 +7822,13 @@ query searchDocuments(
   $first: Int
   # Should archived resources be included (default: false)
   $includeArchived: Boolean
-  # Should associated comments be searched (default: true)
+  # Should associated comments be searched (default: true).
   $includeComments: Boolean
   # The number of items to backward paginate (used with before). Defaults to 50.
   $last: Int
   # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
   $orderBy: PaginationOrderBy
-  # UUID of a team to use as a boost
+  # UUID of a team to use as a boost.
   $teamId: String
   # Search string to look for.
   $term: String!
@@ -7557,13 +7857,13 @@ query searchDocuments_archivePayload(
   $first: Int
   # Should archived resources be included (default: false)
   $includeArchived: Boolean
-  # Should associated comments be searched (default: true)
+  # Should associated comments be searched (default: true).
   $includeComments: Boolean
   # The number of items to backward paginate (used with before). Defaults to 50.
   $last: Int
   # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
   $orderBy: PaginationOrderBy
-  # UUID of a team to use as a boost
+  # UUID of a team to use as a boost.
   $teamId: String
   # Search string to look for.
   $term: String!
@@ -7596,13 +7896,13 @@ query searchIssues(
   $first: Int
   # Should archived resources be included (default: false)
   $includeArchived: Boolean
-  # Should associated comments be searched (default: true)
+  # Should associated comments be searched (default: true).
   $includeComments: Boolean
   # The number of items to backward paginate (used with before). Defaults to 50.
   $last: Int
   # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
   $orderBy: PaginationOrderBy
-  # UUID of a team to use as a boost
+  # UUID of a team to use as a boost.
   $teamId: String
   # Search string to look for.
   $term: String!
@@ -7634,13 +7934,13 @@ query searchIssues_archivePayload(
   $first: Int
   # Should archived resources be included (default: false)
   $includeArchived: Boolean
-  # Should associated comments be searched (default: true)
+  # Should associated comments be searched (default: true).
   $includeComments: Boolean
   # The number of items to backward paginate (used with before). Defaults to 50.
   $last: Int
   # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
   $orderBy: PaginationOrderBy
-  # UUID of a team to use as a boost
+  # UUID of a team to use as a boost.
   $teamId: String
   # Search string to look for.
   $term: String!
@@ -7672,13 +7972,13 @@ query searchProjects(
   $first: Int
   # Should archived resources be included (default: false)
   $includeArchived: Boolean
-  # Should associated comments be searched (default: true)
+  # Should associated comments be searched (default: true).
   $includeComments: Boolean
   # The number of items to backward paginate (used with before). Defaults to 50.
   $last: Int
   # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
   $orderBy: PaginationOrderBy
-  # UUID of a team to use as a boost
+  # UUID of a team to use as a boost.
   $teamId: String
   # Search string to look for.
   $term: String!
@@ -7707,13 +8007,13 @@ query searchProjects_archivePayload(
   $first: Int
   # Should archived resources be included (default: false)
   $includeArchived: Boolean
-  # Should associated comments be searched (default: true)
+  # Should associated comments be searched (default: true).
   $includeComments: Boolean
   # The number of items to backward paginate (used with before). Defaults to 50.
   $last: Int
   # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
   $orderBy: PaginationOrderBy
-  # UUID of a team to use as a boost
+  # UUID of a team to use as a boost.
   $teamId: String
   # Search string to look for.
   $term: String!
@@ -7751,35 +8051,6 @@ query team($id: String!) {
     ...Team
   }
 }
-# The automation states for the team.
-query team_automationStates(
-  $id: String!
-  # A cursor to be used with first for forward pagination
-  $after: String
-  # A cursor to be used with last for backward pagination.
-  $before: String
-  # The number of items to forward paginate (used with after). Defaults to 50.
-  $first: Int
-  # Should archived resources be included (default: false)
-  $includeArchived: Boolean
-  # The number of items to backward paginate (used with before). Defaults to 50.
-  $last: Int
-  # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
-  $orderBy: PaginationOrderBy
-) {
-  team(id: $id) {
-    automationStates(
-      after: $after
-      before: $before
-      first: $first
-      includeArchived: $includeArchived
-      last: $last
-      orderBy: $orderBy
-    ) {
-      ...GitAutomationStateConnection
-    }
-  }
-}
 # Cycles associated with the team.
 query team_cycles(
   $id: String!
@@ -7809,6 +8080,35 @@ query team_cycles(
       orderBy: $orderBy
     ) {
       ...CycleConnection
+    }
+  }
+}
+# The Git automation states for the team.
+query team_gitAutomationStates(
+  $id: String!
+  # A cursor to be used with first for forward pagination
+  $after: String
+  # A cursor to be used with last for backward pagination.
+  $before: String
+  # The number of items to forward paginate (used with after). Defaults to 50.
+  $first: Int
+  # Should archived resources be included (default: false)
+  $includeArchived: Boolean
+  # The number of items to backward paginate (used with before). Defaults to 50.
+  $last: Int
+  # By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+  $orderBy: PaginationOrderBy
+) {
+  team(id: $id) {
+    gitAutomationStates(
+      after: $after
+      before: $before
+      first: $first
+      includeArchived: $includeArchived
+      last: $last
+      orderBy: $orderBy
+    ) {
+      ...GitAutomationStateConnection
     }
   }
 }
@@ -8141,7 +8441,7 @@ query templates {
 }
 # Returns all templates that are associated with the integration type.
 query templatesForIntegration(
-  # The type of integration for which to return associated templates
+  # The type of integration for which to return associated templates.
   $integrationType: String!
 ) {
   templatesForIntegration(integrationType: $integrationType) {
@@ -8553,7 +8853,7 @@ query workflowStates(
     ...WorkflowStateConnection
   }
 }
-# Creates an integration api key for Airbyte to connect with Linear
+# Creates an integration api key for Airbyte to connect with Linear.
 mutation airbyteIntegrationConnect(
   # Airbyte integration settings.
   $input: AirbyteConfigurationInput!
@@ -8615,12 +8915,14 @@ mutation attachmentLinkDiscord(
   $createAsUser: String
   # Provide an external user avatar URL. Can only be used in conjunction with the `createAsUser` options. This option is only available to OAuth applications creating comments in `actor=application` mode.
   $displayIconUrl: String
-  # Optional attachment ID that may be provided through the API
+  # Optional attachment ID that may be provided through the API.
   $id: String
   # The issue for which to link the Discord message.
   $issueId: String!
   # The Discord message ID for the message to link.
   $messageId: String!
+  # The title to use for the attachment.
+  $title: String
   # The Discord message URL for the message to link.
   $url: String!
 ) {
@@ -8631,6 +8933,7 @@ mutation attachmentLinkDiscord(
     id: $id
     issueId: $issueId
     messageId: $messageId
+    title: $title
     url: $url
   ) {
     ...AttachmentPayload
@@ -8644,10 +8947,12 @@ mutation attachmentLinkFront(
   $createAsUser: String
   # Provide an external user avatar URL. Can only be used in conjunction with the `createAsUser` options. This option is only available to OAuth applications creating comments in `actor=application` mode.
   $displayIconUrl: String
-  # Optional attachment ID that may be provided through the API
+  # Optional attachment ID that may be provided through the API.
   $id: String
   # The issue for which to link the Front conversation.
   $issueId: String!
+  # The title to use for the attachment.
+  $title: String
 ) {
   attachmentLinkFront(
     conversationId: $conversationId
@@ -8655,6 +8960,7 @@ mutation attachmentLinkFront(
     displayIconUrl: $displayIconUrl
     id: $id
     issueId: $issueId
+    title: $title
   ) {
     ...FrontAttachmentPayload
   }
@@ -8665,10 +8971,12 @@ mutation attachmentLinkGitHubIssue(
   $createAsUser: String
   # Provide an external user avatar URL. Can only be used in conjunction with the `createAsUser` options. This option is only available to OAuth applications creating comments in `actor=application` mode.
   $displayIconUrl: String
-  # Optional attachment ID that may be provided through the API
+  # Optional attachment ID that may be provided through the API.
   $id: String
   # The Linear issue for which to link the GitHub issue.
   $issueId: String!
+  # The title to use for the attachment.
+  $title: String
   # The URL of the GitHub issue to link.
   $url: String!
 ) {
@@ -8677,6 +8985,7 @@ mutation attachmentLinkGitHubIssue(
     displayIconUrl: $displayIconUrl
     id: $id
     issueId: $issueId
+    title: $title
     url: $url
   ) {
     ...AttachmentPayload
@@ -8688,7 +8997,7 @@ mutation attachmentLinkGitHubPR(
   $createAsUser: String
   # Provide an external user avatar URL. Can only be used in conjunction with the `createAsUser` options. This option is only available to OAuth applications creating comments in `actor=application` mode.
   $displayIconUrl: String
-  # Optional attachment ID that may be provided through the API
+  # Optional attachment ID that may be provided through the API.
   $id: String
   # The issue for which to link the GitHub pull request.
   $issueId: String!
@@ -8698,6 +9007,8 @@ mutation attachmentLinkGitHubPR(
   $owner: String
   # The name of the GitHub repository.
   $repo: String
+  # The title to use for the attachment.
+  $title: String
   # The URL of the GitHub pull request to link.
   $url: String!
 ) {
@@ -8709,6 +9020,7 @@ mutation attachmentLinkGitHubPR(
     number: $number
     owner: $owner
     repo: $repo
+    title: $title
     url: $url
   ) {
     ...AttachmentPayload
@@ -8720,14 +9032,16 @@ mutation attachmentLinkGitLabMR(
   $createAsUser: String
   # Provide an external user avatar URL. Can only be used in conjunction with the `createAsUser` options. This option is only available to OAuth applications creating comments in `actor=application` mode.
   $displayIconUrl: String
-  # Optional attachment ID that may be provided through the API
+  # Optional attachment ID that may be provided through the API.
   $id: String
   # The issue for which to link the GitLab merge request.
   $issueId: String!
   # The GitLab merge request number to link.
   $number: Float!
-  # The path name to the project including any (sub)groups. E.g. linear/main/client
+  # The path name to the project including any (sub)groups. E.g. linear/main/client.
   $projectPathWithNamespace: String!
+  # The title to use for the attachment.
+  $title: String
   # The URL of the GitLab merge request to link.
   $url: String!
 ) {
@@ -8738,6 +9052,7 @@ mutation attachmentLinkGitLabMR(
     issueId: $issueId
     number: $number
     projectPathWithNamespace: $projectPathWithNamespace
+    title: $title
     url: $url
   ) {
     ...AttachmentPayload
@@ -8751,10 +9066,12 @@ mutation attachmentLinkIntercom(
   $createAsUser: String
   # Provide an external user avatar URL. Can only be used in conjunction with the `createAsUser` options. This option is only available to OAuth applications creating comments in `actor=application` mode.
   $displayIconUrl: String
-  # Optional attachment ID that may be provided through the API
+  # Optional attachment ID that may be provided through the API.
   $id: String
   # The issue for which to link the Intercom conversation.
   $issueId: String!
+  # The title to use for the attachment.
+  $title: String
 ) {
   attachmentLinkIntercom(
     conversationId: $conversationId
@@ -8762,6 +9079,7 @@ mutation attachmentLinkIntercom(
     displayIconUrl: $displayIconUrl
     id: $id
     issueId: $issueId
+    title: $title
   ) {
     ...AttachmentPayload
   }
@@ -8785,13 +9103,13 @@ mutation attachmentLinkSlack(
   $createAsUser: String
   # Provide an external user avatar URL. Can only be used in conjunction with the `createAsUser` options. This option is only available to OAuth applications creating comments in `actor=application` mode.
   $displayIconUrl: String
-  # Optional attachment ID that may be provided through the API
+  # Optional attachment ID that may be provided through the API.
   $id: String
   # The issue to which to link the Slack message.
   $issueId: String!
   # The latest timestamp for the Slack message.
   $latest: String!
-  # Optional title that may be provided through the API
+  # The title to use for the attachment.
   $title: String
   # Unique identifier of either a thread's parent message or a message in the thread.
   $ts: String
@@ -8844,12 +9162,14 @@ mutation attachmentLinkZendesk(
   $createAsUser: String
   # Provide an external user avatar URL. Can only be used in conjunction with the `createAsUser` options. This option is only available to OAuth applications creating comments in `actor=application` mode.
   $displayIconUrl: String
-  # Optional attachment ID that may be provided through the API
+  # Optional attachment ID that may be provided through the API.
   $id: String
   # The issue for which to link the Zendesk ticket.
   $issueId: String!
   # The Zendesk ticket ID to link.
   $ticketId: String!
+  # The title to use for the attachment.
+  $title: String
 ) {
   attachmentLinkZendesk(
     createAsUser: $createAsUser
@@ -8857,6 +9177,7 @@ mutation attachmentLinkZendesk(
     id: $id
     issueId: $issueId
     ticketId: $ticketId
+    title: $title
   ) {
     ...AttachmentPayload
   }
@@ -9013,7 +9334,7 @@ mutation createCycle(
     ...CyclePayload
   }
 }
-# Shifts all cycles starts by a certain number of weeks.
+# [DEPRECATED] Shifts all cycles starts by a certain number of weeks.
 mutation cycleShiftAll(
   # A partial cycle object to update the cycle with.
   $input: CycleShiftAllInput!
@@ -9060,6 +9381,44 @@ mutation updateDocument(
 ) {
   documentUpdate(id: $id, input: $input) {
     ...DocumentPayload
+  }
+}
+# Creates a new email intake address.
+mutation createEmailIntakeAddress(
+  # The email intake address object to create.
+  $input: EmailIntakeAddressCreateInput!
+) {
+  emailIntakeAddressCreate(input: $input) {
+    ...EmailIntakeAddressPayload
+  }
+}
+# Deletes an email intake address object.
+mutation deleteEmailIntakeAddress(
+  # The identifier of the email intake address to delete.
+  $id: String!
+) {
+  emailIntakeAddressDelete(id: $id) {
+    ...DeletePayload
+  }
+}
+# Rotates an existing email intake address.
+mutation emailIntakeAddressRotate(
+  # The identifier of the email intake address.
+  $id: String!
+) {
+  emailIntakeAddressRotate(id: $id) {
+    ...EmailIntakeAddressPayload
+  }
+}
+# Updates an existing email intake address.
+mutation updateEmailIntakeAddress(
+  # The identifier of the email intake address.
+  $id: String!
+  # The properties of the email intake address to update.
+  $input: EmailIntakeAddressUpdateInput!
+) {
+  emailIntakeAddressUpdate(id: $id, input: $input) {
+    ...EmailIntakeAddressPayload
   }
 }
 # Authenticates a user account via email and authentication token.
@@ -9189,6 +9548,35 @@ mutation updateGitAutomationState(
     ...GitAutomationStatePayload
   }
 }
+# Creates a Git target branch automation.
+mutation createGitAutomationTargetBranch(
+  # The Git target branch automation to create.
+  $input: GitAutomationTargetBranchCreateInput!
+) {
+  gitAutomationTargetBranchCreate(input: $input) {
+    ...GitAutomationTargetBranchPayload
+  }
+}
+# Archives a Git target branch automation.
+mutation deleteGitAutomationTargetBranch(
+  # The identifier of the Git target branch automation to archive.
+  $id: String!
+) {
+  gitAutomationTargetBranchDelete(id: $id) {
+    ...DeletePayload
+  }
+}
+# Updates an existing Git target branch automation.
+mutation updateGitAutomationTargetBranch(
+  # The identifier of the Git target branch automation to update.
+  $id: String!
+  # The updates.
+  $input: GitAutomationTargetBranchUpdateInput!
+) {
+  gitAutomationTargetBranchUpdate(id: $id, input: $input) {
+    ...GitAutomationTargetBranchPayload
+  }
+}
 # Authenticate user account through Google OAuth. This is the 2nd step of OAuth flow.
 mutation googleUserAccountAuth(
   # The data used for Google authentication.
@@ -9220,6 +9608,15 @@ mutation importFileUpload(
 ) {
   importFileUpload(contentType: $contentType, filename: $filename, metaData: $metaData, size: $size) {
     ...UploadPayload
+  }
+}
+# Archives an integration.
+mutation archiveIntegration(
+  # The identifier of the integration to archive.
+  $id: String!
+) {
+  integrationArchive(id: $id) {
+    ...DeletePayload
   }
 }
 # Connect a Slack channel to Asks.
@@ -9303,7 +9700,7 @@ mutation integrationGithubConnect(
 mutation integrationGitlabConnect(
   # The GitLab Access Token to connect with.
   $accessToken: String!
-  # The URL of the GitLab installation
+  # The URL of the GitLab installation.
   $gitlabUrl: String!
 ) {
   integrationGitlabConnect(accessToken: $accessToken, gitlabUrl: $gitlabUrl) {
@@ -9399,7 +9796,7 @@ mutation integrationSlack(
     ...IntegrationPayload
   }
 }
-# Integrates the organization with the Slack Asks app
+# Integrates the organization with the Slack Asks app.
 mutation integrationSlackAsks(
   # The Slack OAuth code.
   $code: String!
@@ -9552,7 +9949,7 @@ mutation issueAddLabel(
 mutation archiveIssue(
   # The identifier of the issue to archive.
   $id: String!
-  # Whether to trash the issue
+  # Whether to trash the issue.
   $trash: Boolean
 ) {
   issueArchive(id: $id, trash: $trash) {
@@ -10145,7 +10542,7 @@ mutation updateOrganization(
 mutation archiveProject(
   # The identifier of the project to archive. Also the identifier from the URL is accepted.
   $id: String!
-  # Whether to trash the project
+  # Whether to trash the project.
   $trash: Boolean
 ) {
   projectArchive(id: $id, trash: $trash) {
@@ -10584,7 +10981,7 @@ mutation userDiscordConnect(
 }
 # Disconnects the external user from this Linear account.
 mutation userExternalUserDisconnect(
-  # The external service to disconnect
+  # The external service to disconnect.
   $service: String!
 ) {
   userExternalUserDisconnect(service: $service) {
@@ -10595,7 +10992,7 @@ mutation userExternalUserDisconnect(
 mutation updateUserFlag(
   # Settings flag to increment.
   $flag: UserFlagType!
-  # Flag operation to perform
+  # Flag operation to perform.
   $operation: UserFlagUpdateOperation!
 ) {
   userFlagUpdate(flag: $flag, operation: $operation) {

--- a/packages/sdk/src/_generated_documents.ts
+++ b/packages/sdk/src/_generated_documents.ts
@@ -27,7 +27,7 @@ export type ActorBot = {
   __typename?: "ActorBot";
   /** A url pointing to the avatar representing this bot. */
   avatarUrl?: Maybe<Scalars["String"]>;
-  id: Scalars["ID"];
+  id?: Maybe<Scalars["ID"]>;
   /** The display name of the bot. */
   name?: Maybe<Scalars["String"]>;
   /** The sub type of the bot. */
@@ -302,7 +302,7 @@ export type AttachmentPayload = {
 
 export type AttachmentSourcesPayload = {
   __typename?: "AttachmentSourcesPayload";
-  /** A unique list of all source types used in this workspace */
+  /** A unique list of all source types used in this workspace. */
   sources: Scalars["JSONObject"];
 };
 
@@ -400,6 +400,8 @@ export type AuthApiKeyCreateInput = {
   id?: Maybe<Scalars["String"]>;
   /** The API key value. */
   key: Scalars["String"];
+  /** The label for the API key. */
+  label: Scalars["String"];
 };
 
 export type AuthApiKeyPayload = {
@@ -408,15 +410,6 @@ export type AuthApiKeyPayload = {
   authApiKey: AuthApiKey;
   /** Whether the operation was successful. */
   success: Scalars["Boolean"];
-};
-
-export type AuthCreateOrJoinOrganizationResponse = {
-  __typename?: "AuthCreateOrJoinOrganizationResponse";
-  authOrganization: AuthOrganization;
-  authUser: AuthUser;
-  grantDomainAccess?: Maybe<Scalars["Boolean"]>;
-  organization: AuthOrganization;
-  user: AuthUser;
 };
 
 export type AuthIntegration = {
@@ -526,12 +519,16 @@ export type AuthOrganization = {
   name: Scalars["String"];
   /** Previously used URL keys for the organization (last 3 are kept and redirected). */
   previousUrlKeys: Array<Scalars["String"]>;
+  /** The feature release channel the organization belongs to. */
+  releaseChannel: ReleaseChannel;
   /** Whether SAML authentication is enabled for organization. */
   samlEnabled: Scalars["Boolean"];
   /** [INTERNAL] SAML settings */
   samlSettings?: Maybe<Scalars["JSONObject"]>;
   /** Whether SCIM provisioning is enabled for organization. */
   scimEnabled: Scalars["Boolean"];
+  /** The email domain or URL key for the organization. */
+  serviceId: Scalars["String"];
   /** The organization's unique URL key. */
   urlKey: Scalars["String"];
   userCount: Scalars["Float"];
@@ -539,6 +536,18 @@ export type AuthOrganization = {
 
 export type AuthOrganizationDomain = {
   __typename?: "AuthOrganizationDomain";
+  authType: OrganizationDomainAuthType;
+  claimed?: Maybe<Scalars["Boolean"]>;
+  /** The unique identifier of the entity. */
+  id: Scalars["ID"];
+  name: Scalars["String"];
+  organizationId: Scalars["String"];
+  verified: Scalars["Boolean"];
+};
+
+/** An invitation to the organization that has been sent via email. */
+export type AuthOrganizationInvite = {
+  __typename?: "AuthOrganizationInvite";
   /** The unique identifier of the entity. */
   id: Scalars["ID"];
 };
@@ -547,19 +556,22 @@ export type AuthResolverResponse = {
   __typename?: "AuthResolverResponse";
   /** Should the signup flow allow access for the domain. */
   allowDomainAccess?: Maybe<Scalars["Boolean"]>;
-  /** Organizations this account has access to, but is not yet a member. */
+  /** List of organizations allowing this user account to join automatically. */
   availableOrganizations?: Maybe<Array<AuthOrganization>>;
   /** Email for the authenticated account. */
-  email?: Maybe<Scalars["String"]>;
+  email: Scalars["String"];
   /** User account ID. */
   id: Scalars["String"];
   /** ID of the organization last accessed by the user. */
   lastUsedOrganizationId?: Maybe<Scalars["String"]>;
-  /** List of organizations this user account is part of but are currently locked because of the current auth service. */
+  /** List of organization available to this user account but locked due to the current auth method. */
   lockedOrganizations?: Maybe<Array<AuthOrganization>>;
-  /** JWT token for authentication of the account. */
+  /**
+   * Application token.
+   * @deprecated Deprecated and not used anymore. Never populated.
+   */
   token?: Maybe<Scalars["String"]>;
-  /** Users belonging to this account. */
+  /** List of active users that belong to the user account. */
   users: Array<AuthUser>;
 };
 
@@ -585,6 +597,8 @@ export type AuthUser = {
   name: Scalars["String"];
   /** Organization the user belongs to. */
   organization: AuthOrganization;
+  /** User account id the user belongs to. */
+  userAccountId: Scalars["String"];
 };
 
 /** User authentication session. */
@@ -623,7 +637,7 @@ export type AuthenticationSession = {
   userAgent?: Maybe<Scalars["String"]>;
 };
 
-/** Authentication session information */
+/** Authentication session information. */
 export type AuthenticationSessionResponse = {
   __typename?: "AuthenticationSessionResponse";
   /** Used web browser. */
@@ -716,7 +730,7 @@ export type Comment = Node & {
   body: Scalars["String"];
   /** [Internal] The comment content as a Prosemirror document. */
   bodyData: Scalars["String"];
-  /** The bot that created the comment */
+  /** The bot that created the comment. */
   botActor?: Maybe<ActorBot>;
   /** The children of the comment. */
   children: CommentConnection;
@@ -736,7 +750,9 @@ export type Comment = Node & {
   parent?: Maybe<Comment>;
   /** The project update that the comment is associated with. */
   projectUpdate?: Maybe<ProjectUpdate>;
-  /** Emoji reaction summary, grouped by emoji type */
+  /** The text that this comment references. Only defined for inline comments. */
+  quotedText?: Maybe<Scalars["String"]>;
+  /** Emoji reaction summary, grouped by emoji type. */
   reactionData: Scalars["JSONObject"];
   /** The time the resolvingUser resolved the thread. */
   resolvedAt?: Maybe<Scalars["DateTime"]>;
@@ -827,8 +843,10 @@ export type CommentCreateInput = {
   issueId?: Maybe<Scalars["String"]>;
   /** The parent comment under which to nest a current comment. */
   parentId?: Maybe<Scalars["String"]>;
-  /** The prject update to associate the comment with. */
+  /** The project update to associate the comment with. */
   projectUpdateId?: Maybe<Scalars["String"]>;
+  /** The text that this comment references. Only defined for inline comments. */
+  quotedText?: Maybe<Scalars["String"]>;
 };
 
 export type CommentEdge = {
@@ -877,6 +895,8 @@ export type CommentUpdateInput = {
   body?: Maybe<Scalars["String"]>;
   /** The comment content as a Prosemirror document. */
   bodyData?: Maybe<Scalars["JSON"]>;
+  /** The text that this comment references. Only defined for inline comments. */
+  quotedText?: Maybe<Scalars["String"]>;
   /** [INTERNAL] The child comment that resolves this thread. */
   resolvingCommentId?: Maybe<Scalars["String"]>;
   /** [INTERNAL] The user who resolved this thread. */
@@ -951,7 +971,7 @@ export type ContactPayload = {
   success: Scalars["Boolean"];
 };
 
-/** [INTERNAL] Input for sending a message to the Linear Sales team */
+/** [INTERNAL] Input for sending a message to the Linear Sales team. */
 export type ContactSalesCreateInput = {
   /** Size of the company. */
   companySize?: Maybe<Scalars["String"]>;
@@ -1028,6 +1048,8 @@ export type CustomView = Node & {
   icon?: Maybe<Scalars["String"]>;
   /** The unique identifier of the entity. */
   id: Scalars["ID"];
+  /** Issues associated with the custom view. */
+  issues: IssueConnection;
   /** The model name of the custom view. */
   modelName: Scalars["String"];
   /** The name of the custom view. */
@@ -1036,7 +1058,7 @@ export type CustomView = Node & {
   organization: Organization;
   /** The user who owns the custom view. */
   owner: User;
-  /** [ALPHA] The filter applied to projects in the custom view. */
+  /** The filter applied to projects in the custom view. */
   projectFilterData?: Maybe<Scalars["JSONObject"]>;
   /** Whether the custom view is shared with everyone in the organization. */
   shared: Scalars["Boolean"];
@@ -1048,8 +1070,19 @@ export type CustomView = Node & {
    *     been updated after creation.
    */
   updatedAt: Scalars["DateTime"];
-  /** [ALPHA] The user who last updated the custom view. */
+  /** The user who last updated the custom view. */
   updatedBy: User;
+};
+
+/** A custom view that has been saved by a user. */
+export type CustomViewIssuesArgs = {
+  after?: Maybe<Scalars["String"]>;
+  before?: Maybe<Scalars["String"]>;
+  filter?: Maybe<IssueFilter>;
+  first?: Maybe<Scalars["Int"]>;
+  includeArchived?: Maybe<Scalars["Boolean"]>;
+  last?: Maybe<Scalars["Int"]>;
+  orderBy?: Maybe<PaginationOrderBy>;
 };
 
 export type CustomViewConnection = {
@@ -1076,8 +1109,10 @@ export type CustomViewCreateInput = {
   name: Scalars["String"];
   /** The owner of the custom view. */
   ownerId?: Maybe<Scalars["String"]>;
-  /** [ALPHA] The project filter applied to issues in the custom view. */
+  /** The project filter applied to issues in the custom view. */
   projectFilterData?: Maybe<Scalars["JSONObject"]>;
+  /** [Internal] The id of the project associated with the custom view. */
+  projectId?: Maybe<Scalars["String"]>;
   /** Whether the custom view is shared with everyone in the organization. */
   shared?: Maybe<Scalars["Boolean"]>;
   /** The id of the team associated with the custom view. */
@@ -1102,7 +1137,7 @@ export type CustomViewNotificationSubscription = Entity &
   Node &
   NotificationSubscription & {
     __typename?: "CustomViewNotificationSubscription";
-    /** Whether the subscription is active or not */
+    /** Whether the subscription is active or not. */
     active: Scalars["Boolean"];
     /** The time at which the entity was archived. Null if the entity has not been archived. */
     archivedAt?: Maybe<Scalars["DateTime"]>;
@@ -1173,8 +1208,10 @@ export type CustomViewUpdateInput = {
   name?: Maybe<Scalars["String"]>;
   /** The owner of the custom view. */
   ownerId?: Maybe<Scalars["String"]>;
-  /** [ALPHA] The project filter applied to issues in the custom view. */
+  /** The project filter applied to issues in the custom view. */
   projectFilterData?: Maybe<Scalars["JSONObject"]>;
+  /** [Internal] The id of the project associated with the custom view. */
+  projectId?: Maybe<Scalars["String"]>;
   /** Whether the custom view is shared with everyone in the organization. */
   shared?: Maybe<Scalars["Boolean"]>;
   /** The id of the team associated with the custom view. */
@@ -1337,7 +1374,7 @@ export type CycleNotificationSubscription = Entity &
   Node &
   NotificationSubscription & {
     __typename?: "CycleNotificationSubscription";
-    /** Whether the subscription is active or not */
+    /** Whether the subscription is active or not. */
     active: Scalars["Boolean"];
     /** The time at which the entity was archived. Null if the entity has not been archived. */
     archivedAt?: Maybe<Scalars["DateTime"]>;
@@ -1383,10 +1420,11 @@ export type CyclePayload = {
   success: Scalars["Boolean"];
 };
 
+/** [DEPRECATED] Input for shifting all cycles by a certain number of days. Mutation is now deprecated. */
 export type CycleShiftAllInput = {
-  /** The number of days to shift the cycles by. */
+  /** [DEPRECATED] The number of days to shift the cycles by. */
   daysToShift: Scalars["Float"];
-  /** The cycle id at which to start the shift. */
+  /** [DEPRECATED] The cycle id at which to start the shift. */
   id: Scalars["String"];
 };
 
@@ -1401,6 +1439,23 @@ export type CycleUpdateInput = {
   name?: Maybe<Scalars["String"]>;
   /** The start date of the cycle. */
   startsAt?: Maybe<Scalars["DateTime"]>;
+};
+
+/** Data recovery. */
+export type DataRecovery = Node & {
+  __typename?: "DataRecovery";
+  /** The time at which the entity was archived. Null if the entity has not been archived. */
+  archivedAt?: Maybe<Scalars["DateTime"]>;
+  /** The time at which the entity was created. */
+  createdAt: Scalars["DateTime"];
+  /** The unique identifier of the entity. */
+  id: Scalars["ID"];
+  /**
+   * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+   *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+   *     been updated after creation.
+   */
+  updatedAt: Scalars["DateTime"];
 };
 
 /** Comparator for dates. */
@@ -1468,10 +1523,12 @@ export type Document = Node & {
   /** The documents content in markdown format. */
   content?: Maybe<Scalars["String"]>;
   /**
-   * The documents content as a Prosemirror document.
+   * [Internal] The documents content as a Prosemirror document.
    * @deprecated Use content instead.
    */
   contentData?: Maybe<Scalars["JSON"]>;
+  /** [Internal] The documents content as YJS state. */
+  contentState?: Maybe<Scalars["String"]>;
   /** The time at which the entity was created. */
   createdAt: Scalars["DateTime"];
   /** The user who created the document. */
@@ -1500,6 +1557,34 @@ export type Document = Node & {
   updatedBy: User;
 };
 
+/** Document filtering options. */
+export type DocumentCollectionFilter = {
+  /** Compound filters, all of which need to be matched by the document. */
+  and?: Maybe<Array<DocumentCollectionFilter>>;
+  /** Comparator for the created at date. */
+  createdAt?: Maybe<DateComparator>;
+  /** Filters that the document's creator must satisfy. */
+  creator?: Maybe<UserFilter>;
+  /** Filters that needs to be matched by all documents. */
+  every?: Maybe<DocumentFilter>;
+  /** Comparator for the identifier. */
+  id?: Maybe<IdComparator>;
+  /** Comparator for the collection length. */
+  length?: Maybe<NumberComparator>;
+  /** Compound filters, one of which need to be matched by the document. */
+  or?: Maybe<Array<DocumentCollectionFilter>>;
+  /** Filters that the document's project must satisfy. */
+  project?: Maybe<ProjectFilter>;
+  /** Comparator for the document slug ID. */
+  slugId?: Maybe<StringComparator>;
+  /** Filters that needs to be matched by some documents. */
+  some?: Maybe<DocumentFilter>;
+  /** Comparator for the document title. */
+  title?: Maybe<StringComparator>;
+  /** Comparator for the updated at date. */
+  updatedAt?: Maybe<DateComparator>;
+};
+
 export type DocumentConnection = {
   __typename?: "DocumentConnection";
   edges: Array<DocumentEdge>;
@@ -1514,7 +1599,10 @@ export type DocumentContent = Node & {
   archivedAt?: Maybe<Scalars["DateTime"]>;
   /** The document content in markdown format. */
   content?: Maybe<Scalars["String"]>;
-  /** [Internal] The document content as a Prosemirror document. */
+  /**
+   * [Internal] The document content as a Prosemirror document.
+   * @deprecated Use `contentState` instead
+   */
   contentData?: Maybe<Scalars["JSONObject"]>;
   /** The document content state as a base64 encoded string. */
   contentState?: Maybe<Scalars["String"]>;
@@ -1530,7 +1618,7 @@ export type DocumentContent = Node & {
   project?: Maybe<Project>;
   /** The project milestone that the content is associated with. */
   projectMilestone?: Maybe<ProjectMilestone>;
-  /** The time at which the document content was restored from a previous version */
+  /** The time at which the document content was restored from a previous version. */
   restoredAt?: Maybe<Scalars["DateTime"]>;
   /**
    * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
@@ -1544,13 +1632,17 @@ export type DocumentContent = Node & {
 export type DocumentContentFilter = {
   /** Comparator for the created at date. */
   createdAt?: Maybe<DateComparator>;
+  /** Filters that the document content document must satisfy. */
+  document?: Maybe<DocumentFilter>;
   /** Comparator for the identifier. */
   id?: Maybe<IdComparator>;
+  /** Filters that the document content project must satisfy. */
+  project?: Maybe<ProjectFilter>;
   /** Comparator for the updated at date. */
   updatedAt?: Maybe<DateComparator>;
 };
 
-/** A document content history for a document */
+/** A document content history for a document. */
 export type DocumentContentHistory = Node & {
   __typename?: "DocumentContentHistory";
   /** IDs of actors whose edits went into this history item. */
@@ -1559,7 +1651,7 @@ export type DocumentContentHistory = Node & {
   archivedAt?: Maybe<Scalars["DateTime"]>;
   /** [Internal] The document content as a Prosemirror document. */
   contentData?: Maybe<Scalars["JSONObject"]>;
-  /** The timestamp associated with the DocumentContent when it was originally saved */
+  /** The timestamp associated with the DocumentContent when it was originally saved. */
   contentDataSnapshotAt: Scalars["DateTime"];
   /** The time at which the entity was created. */
   createdAt: Scalars["DateTime"];
@@ -1625,6 +1717,28 @@ export type DocumentEdge = {
   node: Document;
 };
 
+/** Document filtering options. */
+export type DocumentFilter = {
+  /** Compound filters, all of which need to be matched by the document. */
+  and?: Maybe<Array<DocumentFilter>>;
+  /** Comparator for the created at date. */
+  createdAt?: Maybe<DateComparator>;
+  /** Filters that the document's creator must satisfy. */
+  creator?: Maybe<UserFilter>;
+  /** Comparator for the identifier. */
+  id?: Maybe<IdComparator>;
+  /** Compound filters, one of which need to be matched by the document. */
+  or?: Maybe<Array<DocumentFilter>>;
+  /** Filters that the document's project must satisfy. */
+  project?: Maybe<ProjectFilter>;
+  /** Comparator for the document slug ID. */
+  slugId?: Maybe<StringComparator>;
+  /** Comparator for the document title. */
+  title?: Maybe<StringComparator>;
+  /** Comparator for the updated at date. */
+  updatedAt?: Maybe<DateComparator>;
+};
+
 export type DocumentPayload = {
   __typename?: "DocumentPayload";
   /** The document that was created or updated. */
@@ -1655,10 +1769,12 @@ export type DocumentSearchResult = Node & {
   /** The documents content in markdown format. */
   content?: Maybe<Scalars["String"]>;
   /**
-   * The documents content as a Prosemirror document.
+   * [Internal] The documents content as a Prosemirror document.
    * @deprecated Use content instead.
    */
   contentData?: Maybe<Scalars["JSON"]>;
+  /** [Internal] The documents content as YJS state. */
+  contentState?: Maybe<Scalars["String"]>;
   /** The time at which the entity was created. */
   createdAt: Scalars["DateTime"];
   /** The user who created the document. */
@@ -1669,7 +1785,7 @@ export type DocumentSearchResult = Node & {
   id: Scalars["ID"];
   /** The last template that was applied to this document. */
   lastAppliedTemplate?: Maybe<Template>;
-  /** Metadata related to search result */
+  /** Metadata related to search result. */
   metadata: Scalars["JSONObject"];
   /** The project that the document is associated with. */
   project: Project;
@@ -1722,7 +1838,7 @@ export type DocumentUpdateInput = {
   title?: Maybe<Scalars["String"]>;
 };
 
-/** An email address that can be used for submitting issues */
+/** An email address that can be used for submitting issues. */
 export type EmailIntakeAddress = Node & {
   __typename?: "EmailIntakeAddress";
   /** Unique email address user name (before @) used for incoming email. */
@@ -1737,14 +1853,40 @@ export type EmailIntakeAddress = Node & {
   enabled: Scalars["Boolean"];
   /** The unique identifier of the entity. */
   id: Scalars["ID"];
+  /** The organization that the email address is associated with. */
+  organization: Organization;
   /** The team that the email address is associated with. */
   team: Team;
+  /** The template that the email address is associated with. */
+  template?: Maybe<Template>;
   /**
    * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
    *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   updatedAt: Scalars["DateTime"];
+};
+
+export type EmailIntakeAddressCreateInput = {
+  /** The identifier in UUID v4 format. If none is provided, the backend will generate one. */
+  id?: Maybe<Scalars["String"]>;
+  /** The identifier or key of the team this email address will intake issues for. */
+  teamId: Scalars["String"];
+};
+
+export type EmailIntakeAddressPayload = {
+  __typename?: "EmailIntakeAddressPayload";
+  /** The email address that was created or updated. */
+  emailIntakeAddress: EmailIntakeAddress;
+  /** The identifier of the last sync operation. */
+  lastSyncId: Scalars["Float"];
+  /** Whether the operation was successful. */
+  success: Scalars["Boolean"];
+};
+
+export type EmailIntakeAddressUpdateInput = {
+  /** Whether the email address is currently enabled. If set to false, the email address will be disabled and no longer accept incoming emails. */
+  enabled: Scalars["Boolean"];
 };
 
 export type EmailSubscribeInput = {
@@ -1896,7 +2038,7 @@ export type EstimateComparator = {
   or?: Maybe<Array<NullableNumberComparator>>;
 };
 
-/** [ALPHA] An external authenticated (e.g., through Slack) user which doesn't have a Linear account, but can create and update entities in Linear from the external system that authenticated them. */
+/** An external authenticated (e.g., through Slack) user which doesn't have a Linear account, but can create and update entities in Linear from the external system that authenticated them. */
 export type ExternalUser = Node & {
   __typename?: "ExternalUser";
   /** The time at which the entity was archived. Null if the entity has not been archived. */
@@ -1937,6 +2079,39 @@ export type ExternalUserEdge = {
   /** Used in `before` and `after` args */
   cursor: Scalars["String"];
   node: ExternalUser;
+};
+
+/** [ALPHA] A facet. Facets are joins between entities. A facet can tie a custom view to a project, or a a project to a roadmap for example. */
+export type Facet = Node & {
+  __typename?: "Facet";
+  /** The time at which the entity was archived. Null if the entity has not been archived. */
+  archivedAt?: Maybe<Scalars["DateTime"]>;
+  /** The time at which the entity was created. */
+  createdAt: Scalars["DateTime"];
+  /** The unique identifier of the entity. */
+  id: Scalars["ID"];
+  /** The sort order of the facet. */
+  sortOrder: Scalars["Float"];
+  /**
+   * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+   *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+   *     been updated after creation.
+   */
+  updatedAt: Scalars["DateTime"];
+};
+
+export type FacetConnection = {
+  __typename?: "FacetConnection";
+  edges: Array<FacetEdge>;
+  nodes: Array<Facet>;
+  pageInfo: PageInfo;
+};
+
+export type FacetEdge = {
+  __typename?: "FacetEdge";
+  /** Used in `before` and `after` args */
+  cursor: Scalars["String"];
+  node: Facet;
 };
 
 /** User favorites presented in the sidebar. */
@@ -2020,6 +2195,8 @@ export type FavoriteCreateInput = {
   folderName?: Maybe<Scalars["String"]>;
   /** The identifier. If none is provided, the backend will generate one. */
   id?: Maybe<Scalars["String"]>;
+  /** [INTERNAL] The identifier of the initiative to favorite. */
+  initiativeId?: Maybe<Scalars["String"]>;
   /** The identifier of the issue to favorite. */
   issueId?: Maybe<Scalars["String"]>;
   /** The identifier of the label to favorite. */
@@ -2111,8 +2288,11 @@ export type GitAutomationState = Node & {
   __typename?: "GitAutomationState";
   /** The time at which the entity was archived. Null if the entity has not been archived. */
   archivedAt?: Maybe<Scalars["DateTime"]>;
-  /** The target branch, if null, the automation will be triggered on any branch. */
-  branchPattern: Scalars["String"];
+  /**
+   * [DEPRECATED] The target branch, if null, the automation will be triggered on any branch.
+   * @deprecated Use targetBranch instead.
+   */
+  branchPattern?: Maybe<Scalars["String"]>;
   /** The time at which the entity was created. */
   createdAt: Scalars["DateTime"];
   /** The event that triggers the automation. */
@@ -2121,6 +2301,8 @@ export type GitAutomationState = Node & {
   id: Scalars["ID"];
   /** The associated workflow state. */
   state?: Maybe<WorkflowState>;
+  /** The target branch associated to this automation state. */
+  targetBranch?: Maybe<GitAutomationTargetBranch>;
   /** The team to which this automation state belongs. */
   team: Team;
   /**
@@ -2139,7 +2321,7 @@ export type GitAutomationStateConnection = {
 };
 
 export type GitAutomationStateCreateInput = {
-  /** The target branch pattern. If null, all branches are targeted. */
+  /** [DEPRECATED] The target branch pattern. If null, all branches are targeted. */
   branchPattern?: Maybe<Scalars["String"]>;
   /** The event that triggers the automation. */
   event: GitAutomationStates;
@@ -2147,6 +2329,8 @@ export type GitAutomationStateCreateInput = {
   id?: Maybe<Scalars["String"]>;
   /** The associated workflow state. If null, will override default behaviour and take no action. */
   stateId?: Maybe<Scalars["String"]>;
+  /** The associated target branch. If null, all branches are targeted. */
+  targetBranchId?: Maybe<Scalars["String"]>;
   /** The team associated with the automation state. */
   teamId: Scalars["String"];
 };
@@ -2169,12 +2353,14 @@ export type GitAutomationStatePayload = {
 };
 
 export type GitAutomationStateUpdateInput = {
-  /** The target branch pattern. If null, all branches are targeted. */
+  /** [DEPRECATED] The target branch pattern. If null, all branches are targeted. */
   branchPattern?: Maybe<Scalars["String"]>;
   /** The event that triggers the automation. */
   event?: Maybe<GitAutomationStates>;
   /** The associated workflow state. */
   stateId?: Maybe<Scalars["String"]>;
+  /** The associated target branch. If null, all branches are targeted. */
+  targetBranchId?: Maybe<Scalars["String"]>;
 };
 
 /** The various states of a pull/merge request. */
@@ -2185,6 +2371,69 @@ export enum GitAutomationStates {
   Review = "review",
   Start = "start",
 }
+
+/** A Git target branch for which there are automations (GitAutomationState). */
+export type GitAutomationTargetBranch = Node & {
+  __typename?: "GitAutomationTargetBranch";
+  /** The time at which the entity was archived. Null if the entity has not been archived. */
+  archivedAt?: Maybe<Scalars["DateTime"]>;
+  /** Automation states associated with the target branch. */
+  automationStates: GitAutomationStateConnection;
+  /** The target branch pattern. */
+  branchPattern: Scalars["String"];
+  /** The time at which the entity was created. */
+  createdAt: Scalars["DateTime"];
+  /** The unique identifier of the entity. */
+  id: Scalars["ID"];
+  /** Whether the branch pattern is a regular expression. */
+  isRegex: Scalars["Boolean"];
+  /** The team to which this Git target branch automation belongs. */
+  team: Team;
+  /**
+   * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+   *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+   *     been updated after creation.
+   */
+  updatedAt: Scalars["DateTime"];
+};
+
+/** A Git target branch for which there are automations (GitAutomationState). */
+export type GitAutomationTargetBranchAutomationStatesArgs = {
+  after?: Maybe<Scalars["String"]>;
+  before?: Maybe<Scalars["String"]>;
+  first?: Maybe<Scalars["Int"]>;
+  includeArchived?: Maybe<Scalars["Boolean"]>;
+  last?: Maybe<Scalars["Int"]>;
+  orderBy?: Maybe<PaginationOrderBy>;
+};
+
+export type GitAutomationTargetBranchCreateInput = {
+  /** The target branch pattern. */
+  branchPattern: Scalars["String"];
+  /** The identifier in UUID v4 format. If none is provided, the backend will generate one. */
+  id?: Maybe<Scalars["String"]>;
+  /** Whether the branch pattern is a regular expression. */
+  isRegex?: Maybe<Scalars["Boolean"]>;
+  /** The team associated with the Git target branch automation. */
+  teamId: Scalars["String"];
+};
+
+export type GitAutomationTargetBranchPayload = {
+  __typename?: "GitAutomationTargetBranchPayload";
+  /** The identifier of the last sync operation. */
+  lastSyncId: Scalars["Float"];
+  /** Whether the operation was successful. */
+  success: Scalars["Boolean"];
+  /** The Git target branch automation that was created or updated. */
+  targetBranch: GitAutomationTargetBranch;
+};
+
+export type GitAutomationTargetBranchUpdateInput = {
+  /** The target branch pattern. */
+  branchPattern?: Maybe<Scalars["String"]>;
+  /** Whether the branch pattern is a regular expression. */
+  isRegex?: Maybe<Scalars["Boolean"]>;
+};
 
 export type GitHubCommitIntegrationPayload = {
   __typename?: "GitHubCommitIntegrationPayload";
@@ -2201,12 +2450,12 @@ export type GitHubCommitIntegrationPayload = {
 /** Metadata and settings for a GitHub Personal integration. */
 export type GitHubPersonalSettings = {
   __typename?: "GitHubPersonalSettings";
-  /** The GitHub user's name */
+  /** The GitHub user's name. */
   login: Scalars["String"];
 };
 
 export type GitHubPersonalSettingsInput = {
-  /** The GitHub user's name */
+  /** The GitHub user's name. */
   login: Scalars["String"];
 };
 
@@ -2229,44 +2478,44 @@ export type GitHubRepoInput = {
 /** Metadata and settings for a GitHub integration. */
 export type GitHubSettings = {
   __typename?: "GitHubSettings";
-  /** The avatar URL for the GitHub organization */
+  /** The avatar URL for the GitHub organization. */
   orgAvatarUrl: Scalars["String"];
-  /** The GitHub organization's name */
+  /** The GitHub organization's name. */
   orgLogin: Scalars["String"];
-  /** The names of the repositories connected for the GitHub integration */
+  /** The names of the repositories connected for the GitHub integration. */
   repositories?: Maybe<Array<GitHubRepo>>;
-  /** Mapping of team to repository for syncing */
+  /** Mapping of team to repository for syncing. */
   repositoriesMapping?: Maybe<Array<TeamRepoMapping>>;
 };
 
 export type GitHubSettingsInput = {
-  /** The avatar URL for the GitHub organization */
+  /** The avatar URL for the GitHub organization. */
   orgAvatarUrl: Scalars["String"];
-  /** The GitHub organization's name */
+  /** The GitHub organization's name. */
   orgLogin: Scalars["String"];
-  /** The names of the repositories connected for the GitHub integration */
+  /** The names of the repositories connected for the GitHub integration. */
   repositories?: Maybe<Array<GitHubRepoInput>>;
-  /** Mapping of team to repository for syncing */
+  /** Mapping of team to repository for syncing. */
   repositoriesMapping?: Maybe<Array<TeamRepoMappingInput>>;
 };
 
 /** Metadata and settings for a GitLab integration. */
 export type GitLabSettings = {
   __typename?: "GitLabSettings";
-  /** The ISO timestamp the GitLab access token expires */
+  /** The ISO timestamp the GitLab access token expires. */
   expiresAt?: Maybe<Scalars["String"]>;
-  /** Whether the token is limited to a read-only scope */
+  /** Whether the token is limited to a read-only scope. */
   readonly?: Maybe<Scalars["Boolean"]>;
-  /** The self-hosted URL of the GitLab instance */
+  /** The self-hosted URL of the GitLab instance. */
   url?: Maybe<Scalars["String"]>;
 };
 
 export type GitLabSettingsInput = {
-  /** The ISO timestamp the GitLab access token expires */
+  /** The ISO timestamp the GitLab access token expires. */
   expiresAt?: Maybe<Scalars["String"]>;
-  /** Whether the token is limited to a read-only scope */
+  /** Whether the token is limited to a read-only scope. */
   readonly?: Maybe<Scalars["Boolean"]>;
-  /** The self-hosted URL of the GitLab instance */
+  /** The self-hosted URL of the GitLab instance. */
   url?: Maybe<Scalars["String"]>;
 };
 
@@ -2322,7 +2571,7 @@ export type GoogleSheetsSettingsInput = {
 export type GoogleUserAccountAuthInput = {
   /** Code returned from Google's OAuth flow. */
   code: Scalars["String"];
-  /** An optional invite link for an organization. */
+  /** An optional invite link for an organization used to populate available organizations. */
   inviteLink?: Maybe<Scalars["String"]>;
   /** The URI to redirect the user to. */
   redirectUri?: Maybe<Scalars["String"]>;
@@ -2354,6 +2603,190 @@ export type ImageUploadFromUrlPayload = {
   success: Scalars["Boolean"];
   /** The URL containing the image. */
   url?: Maybe<Scalars["String"]>;
+};
+
+/** [INTERNAL] An initiative to group projects. */
+export type Initiative = Node & {
+  __typename?: "Initiative";
+  /** The time at which the entity was archived. Null if the entity has not been archived. */
+  archivedAt?: Maybe<Scalars["DateTime"]>;
+  /** The initiative's color. */
+  color?: Maybe<Scalars["String"]>;
+  /** The time at which the entity was created. */
+  createdAt: Scalars["DateTime"];
+  /** The user who created the initiative. */
+  creator: User;
+  /** The description of the initiative. */
+  description?: Maybe<Scalars["String"]>;
+  /** The unique identifier of the entity. */
+  id: Scalars["ID"];
+  /** The name of the initiative. */
+  name: Scalars["String"];
+  /** The organization of the initiative. */
+  organization: Organization;
+  /** The user who owns the initiative. */
+  owner: User;
+  /** Projects associated with the initiative. */
+  projects: ProjectConnection;
+  /** The initiative's unique URL slug. */
+  slugId: Scalars["String"];
+  /** The sort order of the initiative within the organization. */
+  sortOrder: Scalars["Float"];
+  /** The estimated completion date of the initiative. */
+  targetDate?: Maybe<Scalars["TimelessDate"]>;
+  /** [INTERNAL] The resolution of the initiative's estimated completion date. */
+  targetDateResolution?: Maybe<DateResolutionType>;
+  /**
+   * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+   *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+   *     been updated after creation.
+   */
+  updatedAt: Scalars["DateTime"];
+};
+
+/** [INTERNAL] An initiative to group projects. */
+export type InitiativeProjectsArgs = {
+  after?: Maybe<Scalars["String"]>;
+  before?: Maybe<Scalars["String"]>;
+  filter?: Maybe<ProjectFilter>;
+  first?: Maybe<Scalars["Int"]>;
+  includeArchived?: Maybe<Scalars["Boolean"]>;
+  last?: Maybe<Scalars["Int"]>;
+  orderBy?: Maybe<PaginationOrderBy>;
+};
+
+/** A generic payload return from entity archive mutations. */
+export type InitiativeArchivePayload = ArchivePayload & {
+  __typename?: "InitiativeArchivePayload";
+  /** The archived/unarchived entity. Null if entity was deleted. */
+  entity?: Maybe<Initiative>;
+  /** The identifier of the last sync operation. */
+  lastSyncId: Scalars["Float"];
+  /** Whether the operation was successful. */
+  success: Scalars["Boolean"];
+};
+
+export type InitiativeConnection = {
+  __typename?: "InitiativeConnection";
+  edges: Array<InitiativeEdge>;
+  nodes: Array<Initiative>;
+  pageInfo: PageInfo;
+};
+
+/** [Internal] The properties of the initiative to create. */
+export type InitiativeCreateInput = {
+  /** The initiative's color. */
+  color?: Maybe<Scalars["String"]>;
+  /** The description of the initiative. */
+  description?: Maybe<Scalars["String"]>;
+  /** The identifier in UUID v4 format. If none is provided, the backend will generate one. */
+  id?: Maybe<Scalars["String"]>;
+  /** The name of the initiative. */
+  name: Scalars["String"];
+  /** The owner of the initiative. */
+  ownerId?: Maybe<Scalars["String"]>;
+  /** The sort order of the initiative within the organization. */
+  sortOrder?: Maybe<Scalars["Float"]>;
+};
+
+export type InitiativeEdge = {
+  __typename?: "InitiativeEdge";
+  /** Used in `before` and `after` args */
+  cursor: Scalars["String"];
+  node: Initiative;
+};
+
+/** [Internal] The payload returned by the initiative mutations. */
+export type InitiativePayload = {
+  __typename?: "InitiativePayload";
+  /** The initiative that was created or updated. */
+  initiative: Initiative;
+  /** The identifier of the last sync operation. */
+  lastSyncId: Scalars["Float"];
+  /** Whether the operation was successful. */
+  success: Scalars["Boolean"];
+};
+
+/** [INTERNAL] Join table between projects and initiatives. */
+export type InitiativeToProject = Node & {
+  __typename?: "InitiativeToProject";
+  /** The time at which the entity was archived. Null if the entity has not been archived. */
+  archivedAt?: Maybe<Scalars["DateTime"]>;
+  /** The time at which the entity was created. */
+  createdAt: Scalars["DateTime"];
+  /** The unique identifier of the entity. */
+  id: Scalars["ID"];
+  /** The initiative that the project is associated with. */
+  initiative: Initiative;
+  /** The project that the initiative is associated with. */
+  project: Project;
+  /** The sort order of the project within the initiative. */
+  sortOrder: Scalars["String"];
+  /**
+   * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+   *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+   *     been updated after creation.
+   */
+  updatedAt: Scalars["DateTime"];
+};
+
+export type InitiativeToProjectConnection = {
+  __typename?: "InitiativeToProjectConnection";
+  edges: Array<InitiativeToProjectEdge>;
+  nodes: Array<InitiativeToProject>;
+  pageInfo: PageInfo;
+};
+
+/** [INTERNAL] The properties of the initiativeToProject to create. */
+export type InitiativeToProjectCreateInput = {
+  /** The identifier in UUID v4 format. If none is provided, the backend will generate one. */
+  id?: Maybe<Scalars["String"]>;
+  /** The identifier of the initiative. */
+  initiativeId: Scalars["String"];
+  /** The identifier of the project. */
+  projectId: Scalars["String"];
+  /** The sort order for the project within its organization. */
+  sortOrder?: Maybe<Scalars["Float"]>;
+};
+
+export type InitiativeToProjectEdge = {
+  __typename?: "InitiativeToProjectEdge";
+  /** Used in `before` and `after` args */
+  cursor: Scalars["String"];
+  node: InitiativeToProject;
+};
+
+/** [INTERNAL] The result of a initiativeToProject mutation. */
+export type InitiativeToProjectPayload = {
+  __typename?: "InitiativeToProjectPayload";
+  /** The initiativeToProject that was created or updated. */
+  initiativeToProject: InitiativeToProject;
+  /** The identifier of the last sync operation. */
+  lastSyncId: Scalars["Float"];
+  /** Whether the operation was successful. */
+  success: Scalars["Boolean"];
+};
+
+/** [INTERNAL] The properties of the initiativeToProject to update. */
+export type InitiativeToProjectUpdateInput = {
+  /** The sort order for the project within its organization. */
+  sortOrder?: Maybe<Scalars["Float"]>;
+};
+
+/** [Internal] The properties of the initiative to update. */
+export type InitiativeUpdateInput = {
+  /** The initiative's color. */
+  color?: Maybe<Scalars["String"]>;
+  /** The description of the initiative. */
+  description?: Maybe<Scalars["String"]>;
+  /** The name of the initiative. */
+  name?: Maybe<Scalars["String"]>;
+  /** The owner of the initiative. */
+  ownerId?: Maybe<Scalars["String"]>;
+  /** The sort order of the initiative within the organization. */
+  sortOrder?: Maybe<Scalars["Float"]>;
+  /** The estimated completion date of the initiative. */
+  targetDate?: Maybe<Scalars["TimelessDate"]>;
 };
 
 /** An integration with an external service. */
@@ -2393,6 +2826,14 @@ export type IntegrationEdge = {
   /** Used in `before` and `after` args */
   cursor: Scalars["String"];
   node: Integration;
+};
+
+export type IntegrationHasScopesPayload = {
+  __typename?: "IntegrationHasScopesPayload";
+  /** Whether the integration has the required scopes. */
+  hasAllScopes: Scalars["Boolean"];
+  /** The missing scopes. */
+  missingScopes?: Maybe<Array<Scalars["String"]>>;
 };
 
 export type IntegrationPayload = {
@@ -2448,7 +2889,7 @@ export enum IntegrationService {
   Zendesk = "zendesk",
 }
 
-/** The integration resource's settings */
+/** The integration resource's settings. */
 export type IntegrationSettings = {
   __typename?: "IntegrationSettings";
   front?: Maybe<FrontSettings>;
@@ -2490,7 +2931,7 @@ export type IntegrationSettingsInput = {
   zendesk?: Maybe<ZendeskSettingsInput>;
 };
 
-/** Join table between templates and integrations */
+/** Join table between templates and integrations. */
 export type IntegrationTemplate = Node & {
   __typename?: "IntegrationTemplate";
   /** The time at which the entity was archived. Null if the entity has not been archived. */
@@ -2565,9 +3006,9 @@ export type IntegrationsSettings = Node & {
   slackIssueCreated?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when a comment is created on any of the project or team's issues. */
   slackIssueNewComment?: Maybe<Scalars["Boolean"]>;
-  /** Whether to send a Slack message when an SLA is breached */
+  /** Whether to send a Slack message when an SLA is breached. */
   slackIssueSlaBreached?: Maybe<Scalars["Boolean"]>;
-  /** Whether to send a Slack message when an SLA is at high risk */
+  /** Whether to send a Slack message when an SLA is at high risk. */
   slackIssueSlaHighRisk?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when any of the project or team's issues has a change in status. */
   slackIssueStatusChangedAll?: Maybe<Scalars["Boolean"]>;
@@ -2609,7 +3050,7 @@ export type IntegrationsSettingsCreateInput = {
   slackIssueNewComment?: Maybe<Scalars["Boolean"]>;
   /** Whether to receive notification when an SLA has breached on Slack. */
   slackIssueSlaBreached?: Maybe<Scalars["Boolean"]>;
-  /** Whether to send a Slack message when an SLA is at high risk */
+  /** Whether to send a Slack message when an SLA is at high risk. */
   slackIssueSlaHighRisk?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when any of the project or team's issues has a change in status. */
   slackIssueStatusChangedAll?: Maybe<Scalars["Boolean"]>;
@@ -2651,7 +3092,7 @@ export type IntegrationsSettingsUpdateInput = {
   slackIssueNewComment?: Maybe<Scalars["Boolean"]>;
   /** Whether to receive notification when an SLA has breached on Slack. */
   slackIssueSlaBreached?: Maybe<Scalars["Boolean"]>;
-  /** Whether to send a Slack message when an SLA is at high risk */
+  /** Whether to send a Slack message when an SLA is at high risk. */
   slackIssueSlaHighRisk?: Maybe<Scalars["Boolean"]>;
   /** Whether to send a Slack message when any of the project or team's issues has a change in status. */
   slackIssueStatusChangedAll?: Maybe<Scalars["Boolean"]>;
@@ -2738,11 +3179,13 @@ export type Issue = Node & {
    * @deprecated Use description instead.
    */
   descriptionData?: Maybe<Scalars["JSON"]>;
+  /** [Internal] The issue's description content as YJS state. */
+  descriptionState?: Maybe<Scalars["String"]>;
   /** The date at which the issue is due. */
   dueDate?: Maybe<Scalars["TimelessDate"]>;
   /** The estimate of the complexity of the issue.. */
   estimate?: Maybe<Scalars["Float"]>;
-  /** [ALPHA] The external user who created the issue. */
+  /** The external user who created the issue. */
   externalUserCreator?: Maybe<ExternalUser>;
   /** The users favorite associated with this issue. */
   favorite?: Maybe<Favorite>;
@@ -3049,7 +3492,7 @@ export type IssueCreateInput = {
   lastAppliedTemplateId?: Maybe<Scalars["String"]>;
   /** The identifier of the parent issue. */
   parentId?: Maybe<Scalars["String"]>;
-  /** Whether the passed sort order should be preserved */
+  /** Whether the passed sort order should be preserved. */
   preserveSortOrderOnCreate?: Maybe<Scalars["Boolean"]>;
   /** The priority of the issue. 0 = No priority, 1 = Urgent, 2 = High, 3 = Normal, 4 = Low. */
   priority?: Maybe<Scalars["Int"]>;
@@ -3249,7 +3692,7 @@ export type IssueHistory = Node & {
   autoArchived?: Maybe<Scalars["Boolean"]>;
   /** Whether the issue was auto-closed. */
   autoClosed?: Maybe<Scalars["Boolean"]>;
-  /** The bot that performed the action */
+  /** The bot that performed the action. */
   botActor?: Maybe<ActorBot>;
   /** [Internal] Serialized JSON representing changes for certain non-relational properties. */
   changes?: Maybe<Scalars["JSONObject"]>;
@@ -3263,7 +3706,7 @@ export type IssueHistory = Node & {
   fromCycle?: Maybe<Cycle>;
   /** The id of previous cycle of the issue. */
   fromCycleId?: Maybe<Scalars["String"]>;
-  /** What the due date was changed from */
+  /** What the due date was changed from. */
   fromDueDate?: Maybe<Scalars["TimelessDate"]>;
   /** What the estimate was changed from. */
   fromEstimate?: Maybe<Scalars["Float"]>;
@@ -3310,7 +3753,7 @@ export type IssueHistory = Node & {
   toCycle?: Maybe<Cycle>;
   /** The id of new cycle of the issue. */
   toCycleId?: Maybe<Scalars["String"]>;
-  /** What the due date was changed to */
+  /** What the due date was changed to. */
   toDueDate?: Maybe<Scalars["TimelessDate"]>;
   /** What the estimate was changed to. */
   toEstimate?: Maybe<Scalars["Float"]>;
@@ -3360,7 +3803,7 @@ export type IssueHistoryEdge = {
   node: IssueHistory;
 };
 
-/** An import job for data from an external service */
+/** An import job for data from an external service. */
 export type IssueImport = Node & {
   __typename?: "IssueImport";
   /** The time at which the entity was archived. Null if the entity has not been archived. */
@@ -3373,7 +3816,7 @@ export type IssueImport = Node & {
   csvFileUrl?: Maybe<Scalars["String"]>;
   /** User readable error message, if one has occurred during the import. */
   error?: Maybe<Scalars["String"]>;
-  /** Error code and metadata, if one has occurred during the import */
+  /** Error code and metadata, if one has occurred during the import. */
   errorMetadata?: Maybe<Scalars["JSONObject"]>;
   /** The unique identifier of the entity. */
   id: Scalars["ID"];
@@ -3385,7 +3828,7 @@ export type IssueImport = Node & {
   service: Scalars["String"];
   /** The status for the import job. */
   status: Scalars["String"];
-  /** New team's name in cases when teamId not set */
+  /** New team's name in cases when teamId not set. */
   teamName?: Maybe<Scalars["String"]>;
   /**
    * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
@@ -3411,13 +3854,13 @@ export type IssueImportDeletePayload = {
   success: Scalars["Boolean"];
 };
 
-/** Issue import mapping input */
+/** Issue import mapping input. */
 export type IssueImportMappingInput = {
-  /** The mapping configuration for epics */
+  /** The mapping configuration for epics. */
   epics?: Maybe<Scalars["JSONObject"]>;
-  /** The mapping configuration for users */
+  /** The mapping configuration for users. */
   users?: Maybe<Scalars["JSONObject"]>;
-  /** The mapping configuration for workflow states */
+  /** The mapping configuration for workflow states. */
   workflowStates?: Maybe<Scalars["JSONObject"]>;
 };
 
@@ -3595,7 +4038,7 @@ export type IssueLabelUpdateInput = {
   parentId?: Maybe<Scalars["String"]>;
 };
 
-/** An issue related notification */
+/** An issue related notification. */
 export type IssueNotification = Entity &
   Node &
   Notification & {
@@ -3629,9 +4072,9 @@ export type IssueNotification = Entity &
     snoozedUntilAt?: Maybe<Scalars["DateTime"]>;
     /** The subscriptions related to the notification. */
     subscriptions?: Maybe<Array<NotificationSubscription>>;
-    /** The team related to the notification. */
+    /** The team related to the issue notification. */
     team: Team;
-    /** Notification type */
+    /** Notification type. */
     type: Scalars["String"];
     /** The time at which a notification was unsnoozed.. */
     unsnoozedAt?: Maybe<Scalars["DateTime"]>;
@@ -3711,7 +4154,7 @@ export type IssueRelationEdge = {
   node: IssueRelation;
 };
 
-/** Issue relation history's payload */
+/** Issue relation history's payload. */
 export type IssueRelationHistoryPayload = {
   __typename?: "IssueRelationHistoryPayload";
   /** The identifier of the related issue. */
@@ -3801,11 +4244,13 @@ export type IssueSearchResult = Node & {
    * @deprecated Use description instead.
    */
   descriptionData?: Maybe<Scalars["JSON"]>;
+  /** [Internal] The issue's description content as YJS state. */
+  descriptionState?: Maybe<Scalars["String"]>;
   /** The date at which the issue is due. */
   dueDate?: Maybe<Scalars["TimelessDate"]>;
   /** The estimate of the complexity of the issue.. */
   estimate?: Maybe<Scalars["Float"]>;
-  /** [ALPHA] The external user who created the issue. */
+  /** The external user who created the issue. */
   externalUserCreator?: Maybe<ExternalUser>;
   /** The users favorite associated with this issue. */
   favorite?: Maybe<Favorite>;
@@ -3825,7 +4270,7 @@ export type IssueSearchResult = Node & {
   labels: IssueLabelConnection;
   /** The last template that was applied to this issue. */
   lastAppliedTemplate?: Maybe<Template>;
-  /** Metadata related to search result */
+  /** Metadata related to search result. */
   metadata: Scalars["JSONObject"];
   /** The issue's unique number. */
   number: Scalars["Float"];
@@ -4112,9 +4557,11 @@ export type JiraSettingsInput = {
 };
 
 export type JiraUpdateInput = {
-  /** The id of the integration to update */
+  /** The id of the integration to update. */
   id: Scalars["String"];
-  /** Whether to refresh Jira Projects for the integration */
+  /** Whether to refresh Jira metadata for the integration. */
+  updateMetadata?: Maybe<Scalars["Boolean"]>;
+  /** Whether to refresh Jira Projects for the integration. */
   updateProjects?: Maybe<Scalars["Boolean"]>;
 };
 
@@ -4130,7 +4577,7 @@ export type LabelNotificationSubscription = Entity &
   Node &
   NotificationSubscription & {
     __typename?: "LabelNotificationSubscription";
-    /** Whether the subscription is active or not */
+    /** Whether the subscription is active or not. */
     active: Scalars["Boolean"];
     /** The time at which the entity was archived. Null if the entity has not been archived. */
     archivedAt?: Maybe<Scalars["DateTime"]>;
@@ -4174,7 +4621,7 @@ export type LogoutResponse = {
 
 export type Mutation = {
   __typename?: "Mutation";
-  /** Creates an integration api key for Airbyte to connect with Linear */
+  /** Creates an integration api key for Airbyte to connect with Linear. */
   airbyteIntegrationConnect: IntegrationPayload;
   /** Creates a new API key. */
   apiKeyCreate: ApiKeyPayload;
@@ -4243,7 +4690,7 @@ export type Mutation = {
   cycleArchive: CycleArchivePayload;
   /** Creates a new cycle. */
   cycleCreate: CyclePayload;
-  /** Shifts all cycles starts by a certain number of weeks. */
+  /** [DEPRECATED] Shifts all cycles starts by a certain number of weeks. */
   cycleShiftAll: CyclePayload;
   /** Updates a cycle. */
   cycleUpdate: CyclePayload;
@@ -4253,6 +4700,14 @@ export type Mutation = {
   documentDelete: DeletePayload;
   /** Updates a document. */
   documentUpdate: DocumentPayload;
+  /** Creates a new email intake address. */
+  emailIntakeAddressCreate: EmailIntakeAddressPayload;
+  /** Deletes an email intake address object. */
+  emailIntakeAddressDelete: DeletePayload;
+  /** Rotates an existing email intake address. */
+  emailIntakeAddressRotate: EmailIntakeAddressPayload;
+  /** Updates an existing email intake address. */
+  emailIntakeAddressUpdate: EmailIntakeAddressPayload;
   /** [INTERNAL] Subscribes the email to the newsletter. */
   emailSubscribe: EmailSubscribePayload;
   /** Authenticates a user account via email and authentication token. */
@@ -4279,12 +4734,36 @@ export type Mutation = {
   gitAutomationStateDelete: DeletePayload;
   /** Updates an existing state. */
   gitAutomationStateUpdate: GitAutomationStatePayload;
+  /** Creates a Git target branch automation. */
+  gitAutomationTargetBranchCreate: GitAutomationTargetBranchPayload;
+  /** Archives a Git target branch automation. */
+  gitAutomationTargetBranchDelete: DeletePayload;
+  /** Updates an existing Git target branch automation. */
+  gitAutomationTargetBranchUpdate: GitAutomationTargetBranchPayload;
   /** Authenticate user account through Google OAuth. This is the 2nd step of OAuth flow. */
   googleUserAccountAuth: AuthResolverResponse;
   /** Upload an image from an URL to Linear. */
   imageUploadFromUrl: ImageUploadFromUrlPayload;
   /** XHR request payload to upload a file for import, directly to Linear's cloud storage. */
   importFileUpload: UploadPayload;
+  /** [Internal] Archives a initiative. */
+  initiativeArchive: InitiativeArchivePayload;
+  /** [Internal] Creates a new initiative. */
+  initiativeCreate: InitiativePayload;
+  /** [Internal] Deletes a initiative. */
+  initiativeDelete: DeletePayload;
+  /** [INTERNAL] Creates a new initiativeToProject join. */
+  initiativeToProjectCreate: InitiativeToProjectPayload;
+  /** [INTERNAL] Deletes a initiativeToProject. */
+  initiativeToProjectDelete: DeletePayload;
+  /** [INTERNAL] Updates a initiativeToProject. */
+  initiativeToProjectUpdate: InitiativeToProjectPayload;
+  /** [Internal] Unarchives a initiative. */
+  initiativeUnarchive: InitiativeArchivePayload;
+  /** [Internal] Updates a initiative. */
+  initiativeUpdate: InitiativePayload;
+  /** Archives an integration. */
+  integrationArchive: DeletePayload;
   /** Connect a Slack channel to Asks. */
   integrationAsksConnectChannel: AsksChannelConnectPayload;
   /** Deletes an integration. */
@@ -4318,7 +4797,7 @@ export type Mutation = {
   integrationIntercomSettingsUpdate: IntegrationPayload;
   /** Connect your Jira account to Linear. */
   integrationJiraPersonal: IntegrationPayload;
-  /** [INTERNAL] Updates a Jira Integration */
+  /** [INTERNAL] Updates a Jira Integration. */
   integrationJiraUpdate: IntegrationPayload;
   /**
    * Enables Loom integration for the organization.
@@ -4337,7 +4816,7 @@ export type Mutation = {
   integrationSettingsUpdate: IntegrationPayload;
   /** Integrates the organization with Slack. */
   integrationSlack: IntegrationPayload;
-  /** Integrates the organization with the Slack Asks app */
+  /** Integrates the organization with the Slack Asks app. */
   integrationSlackAsks: IntegrationPayload;
   /** Imports custom emojis from your Slack workspace. */
   integrationSlackImportEmojis: IntegrationPayload;
@@ -4642,6 +5121,7 @@ export type MutationAttachmentLinkDiscordArgs = {
   id?: Maybe<Scalars["String"]>;
   issueId: Scalars["String"];
   messageId: Scalars["String"];
+  title?: Maybe<Scalars["String"]>;
   url: Scalars["String"];
 };
 
@@ -4651,6 +5131,7 @@ export type MutationAttachmentLinkFrontArgs = {
   displayIconUrl?: Maybe<Scalars["String"]>;
   id?: Maybe<Scalars["String"]>;
   issueId: Scalars["String"];
+  title?: Maybe<Scalars["String"]>;
 };
 
 export type MutationAttachmentLinkGitHubIssueArgs = {
@@ -4658,6 +5139,7 @@ export type MutationAttachmentLinkGitHubIssueArgs = {
   displayIconUrl?: Maybe<Scalars["String"]>;
   id?: Maybe<Scalars["String"]>;
   issueId: Scalars["String"];
+  title?: Maybe<Scalars["String"]>;
   url: Scalars["String"];
 };
 
@@ -4669,6 +5151,7 @@ export type MutationAttachmentLinkGitHubPrArgs = {
   number?: Maybe<Scalars["Float"]>;
   owner?: Maybe<Scalars["String"]>;
   repo?: Maybe<Scalars["String"]>;
+  title?: Maybe<Scalars["String"]>;
   url: Scalars["String"];
 };
 
@@ -4679,6 +5162,7 @@ export type MutationAttachmentLinkGitLabMrArgs = {
   issueId: Scalars["String"];
   number: Scalars["Float"];
   projectPathWithNamespace: Scalars["String"];
+  title?: Maybe<Scalars["String"]>;
   url: Scalars["String"];
 };
 
@@ -4688,6 +5172,7 @@ export type MutationAttachmentLinkIntercomArgs = {
   displayIconUrl?: Maybe<Scalars["String"]>;
   id?: Maybe<Scalars["String"]>;
   issueId: Scalars["String"];
+  title?: Maybe<Scalars["String"]>;
 };
 
 export type MutationAttachmentLinkJiraIssueArgs = {
@@ -4722,6 +5207,7 @@ export type MutationAttachmentLinkZendeskArgs = {
   id?: Maybe<Scalars["String"]>;
   issueId: Scalars["String"];
   ticketId: Scalars["String"];
+  title?: Maybe<Scalars["String"]>;
 };
 
 export type MutationAttachmentUnsyncSlackArgs = {
@@ -4820,6 +5306,23 @@ export type MutationDocumentUpdateArgs = {
   input: DocumentUpdateInput;
 };
 
+export type MutationEmailIntakeAddressCreateArgs = {
+  input: EmailIntakeAddressCreateInput;
+};
+
+export type MutationEmailIntakeAddressDeleteArgs = {
+  id: Scalars["String"];
+};
+
+export type MutationEmailIntakeAddressRotateArgs = {
+  id: Scalars["String"];
+};
+
+export type MutationEmailIntakeAddressUpdateArgs = {
+  id: Scalars["String"];
+  input: EmailIntakeAddressUpdateInput;
+};
+
 export type MutationEmailSubscribeArgs = {
   input: EmailSubscribeInput;
 };
@@ -4878,6 +5381,19 @@ export type MutationGitAutomationStateUpdateArgs = {
   input: GitAutomationStateUpdateInput;
 };
 
+export type MutationGitAutomationTargetBranchCreateArgs = {
+  input: GitAutomationTargetBranchCreateInput;
+};
+
+export type MutationGitAutomationTargetBranchDeleteArgs = {
+  id: Scalars["String"];
+};
+
+export type MutationGitAutomationTargetBranchUpdateArgs = {
+  id: Scalars["String"];
+  input: GitAutomationTargetBranchUpdateInput;
+};
+
 export type MutationGoogleUserAccountAuthArgs = {
   input: GoogleUserAccountAuthInput;
 };
@@ -4891,6 +5407,44 @@ export type MutationImportFileUploadArgs = {
   filename: Scalars["String"];
   metaData?: Maybe<Scalars["JSON"]>;
   size: Scalars["Int"];
+};
+
+export type MutationInitiativeArchiveArgs = {
+  id: Scalars["String"];
+};
+
+export type MutationInitiativeCreateArgs = {
+  input: InitiativeCreateInput;
+};
+
+export type MutationInitiativeDeleteArgs = {
+  id: Scalars["String"];
+};
+
+export type MutationInitiativeToProjectCreateArgs = {
+  input: InitiativeToProjectCreateInput;
+};
+
+export type MutationInitiativeToProjectDeleteArgs = {
+  id: Scalars["String"];
+};
+
+export type MutationInitiativeToProjectUpdateArgs = {
+  id: Scalars["String"];
+  input: InitiativeToProjectUpdateInput;
+};
+
+export type MutationInitiativeUnarchiveArgs = {
+  id: Scalars["String"];
+};
+
+export type MutationInitiativeUpdateArgs = {
+  id: Scalars["String"];
+  input: InitiativeUpdateInput;
+};
+
+export type MutationIntegrationArchiveArgs = {
+  id: Scalars["String"];
 };
 
 export type MutationIntegrationAsksConnectChannelArgs = {
@@ -5612,7 +6166,7 @@ export type Notification = {
   readAt?: Maybe<Scalars["DateTime"]>;
   /** The time until a notification will be snoozed. After that it will appear in the inbox again. */
   snoozedUntilAt?: Maybe<Scalars["DateTime"]>;
-  /** Notification type */
+  /** Notification type. */
   type: Scalars["String"];
   /** The time at which a notification was unsnoozed.. */
   unsnoozedAt?: Maybe<Scalars["DateTime"]>;
@@ -5685,7 +6239,7 @@ export type NotificationPayload = {
 
 /** Notification subscriptions for models. */
 export type NotificationSubscription = {
-  /** Whether the subscription is active or not */
+  /** Whether the subscription is active or not. */
   active: Scalars["Boolean"];
   /** The time at which the entity was archived. Null if the entity has not been archived. */
   archivedAt?: Maybe<Scalars["DateTime"]>;
@@ -5866,8 +6420,36 @@ export type NullableDateComparator = {
 export type NullableDocumentContentFilter = {
   /** Comparator for the created at date. */
   createdAt?: Maybe<DateComparator>;
+  /** Filters that the document content document must satisfy. */
+  document?: Maybe<DocumentFilter>;
   /** Comparator for the identifier. */
   id?: Maybe<IdComparator>;
+  /** Filters that the document content project must satisfy. */
+  project?: Maybe<ProjectFilter>;
+  /** Comparator for the updated at date. */
+  updatedAt?: Maybe<DateComparator>;
+};
+
+/** Document filtering options. */
+export type NullableDocumentFilter = {
+  /** Compound filters, all of which need to be matched by the document. */
+  and?: Maybe<Array<NullableDocumentFilter>>;
+  /** Comparator for the created at date. */
+  createdAt?: Maybe<DateComparator>;
+  /** Filters that the document's creator must satisfy. */
+  creator?: Maybe<UserFilter>;
+  /** Comparator for the identifier. */
+  id?: Maybe<IdComparator>;
+  /** Filter based on the existence of the relation. */
+  null?: Maybe<Scalars["Boolean"]>;
+  /** Compound filters, one of which need to be matched by the document. */
+  or?: Maybe<Array<NullableDocumentFilter>>;
+  /** Filters that the document's project must satisfy. */
+  project?: Maybe<ProjectFilter>;
+  /** Comparator for the document slug ID. */
+  slugId?: Maybe<StringComparator>;
+  /** Comparator for the document title. */
+  title?: Maybe<StringComparator>;
   /** Comparator for the updated at date. */
   updatedAt?: Maybe<DateComparator>;
 };
@@ -6201,7 +6783,7 @@ export type NumberComparator = {
   nin?: Maybe<Array<Scalars["Float"]>>;
 };
 
-/** The different requests statuses possible for an OAuth client approval request */
+/** The different requests statuses possible for an OAuth client approval request. */
 export enum OAuthClientApprovalStatus {
   Approved = "approved",
   Denied = "denied",
@@ -6249,7 +6831,7 @@ export type OauthClient = Node & {
   webhookResourceTypes: Array<Scalars["String"]>;
   /** Webhook secret token for verifying the origin on the recipient side. */
   webhookSecret?: Maybe<Scalars["String"]>;
-  /** Webhook URL */
+  /** Webhook URL. */
   webhookUrl?: Maybe<Scalars["String"]>;
 };
 
@@ -6284,7 +6866,7 @@ export type OauthClientApproval = Node & {
   updatedAt: Scalars["DateTime"];
 };
 
-/** An oauth client approval related notification */
+/** An oauth client approval related notification. */
 export type OauthClientApprovalNotification = Entity &
   Node &
   Notification & {
@@ -6312,7 +6894,7 @@ export type OauthClientApprovalNotification = Entity &
     readAt?: Maybe<Scalars["DateTime"]>;
     /** The time until a notification will be snoozed. After that it will appear in the inbox again. */
     snoozedUntilAt?: Maybe<Scalars["DateTime"]>;
-    /** Notification type */
+    /** Notification type. */
     type: Scalars["String"];
     /** The time at which a notification was unsnoozed.. */
     unsnoozedAt?: Maybe<Scalars["DateTime"]>;
@@ -6342,8 +6924,16 @@ export type OauthClientEdge = {
 
 export type OauthToken = {
   __typename?: "OauthToken";
+  /** OAuth2 client for which the access token belongs to. */
+  client: AuthOauthClient;
+  clientId: Scalars["String"];
   createdAt: Scalars["DateTime"];
-  id: Scalars["ID"];
+  id: Scalars["Float"];
+  revokedAt?: Maybe<Scalars["DateTime"]>;
+  /** Auth user who authorized the OAuth application. */
+  user: AuthUser;
+  /** Id of the user who authorized the OAuth application. */
+  userId: Scalars["String"];
 };
 
 export type OnboardingCustomerSurvey = {
@@ -6354,9 +6944,9 @@ export type OnboardingCustomerSurvey = {
 /** An organization. Organizations are root-level objects that contain user accounts and teams. */
 export type Organization = Node & {
   __typename?: "Organization";
-  /** Whether member users are allowed to send invites */
+  /** Whether member users are allowed to send invites. */
   allowMembersToInvite?: Maybe<Scalars["Boolean"]>;
-  /** Allowed authentication providers, empty array means all are allowed */
+  /** Allowed authentication providers, empty array means all are allowed. */
   allowedAuthServices: Array<Scalars["String"]>;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
   archivedAt?: Maybe<Scalars["DateTime"]>;
@@ -6400,11 +6990,11 @@ export type Organization = Node & {
   roadmapEnabled: Scalars["Boolean"];
   /** Whether SAML authentication is enabled for organization. */
   samlEnabled: Scalars["Boolean"];
-  /** [INTERNAL] SAML settings */
+  /** [INTERNAL] SAML settings. */
   samlSettings?: Maybe<Scalars["JSONObject"]>;
   /** Whether SCIM provisioning is enabled for organization. */
   scimEnabled: Scalars["Boolean"];
-  /** Which day count to use for SLA calculations */
+  /** Which day count to use for SLA calculations. */
   slaDayCount: SlaDayCountType;
   /** The organization's subscription to a paid plan. */
   subscription?: Maybe<PaidSubscription>;
@@ -6483,7 +7073,7 @@ export type OrganizationUsersArgs = {
 
 export type OrganizationAcceptedOrExpiredInviteDetailsPayload = {
   __typename?: "OrganizationAcceptedOrExpiredInviteDetailsPayload";
-  /** The status of the invite */
+  /** The status of the invite. */
   status: OrganizationInviteStatus;
 };
 
@@ -6504,7 +7094,7 @@ export type OrganizationDomain = Node & {
   __typename?: "OrganizationDomain";
   /** The time at which the entity was archived. Null if the entity has not been archived. */
   archivedAt?: Maybe<Scalars["DateTime"]>;
-  /** What type of auth is the domain used for */
+  /** What type of auth is the domain used for. */
   authType: OrganizationDomainAuthType;
   /** Whether the domains was claimed by the organization through DNS verification. */
   claimed?: Maybe<Scalars["Boolean"]>;
@@ -6514,7 +7104,7 @@ export type OrganizationDomain = Node & {
   creator?: Maybe<User>;
   /** The unique identifier of the entity. */
   id: Scalars["ID"];
-  /** Domain name */
+  /** Domain name. */
   name: Scalars["String"];
   /**
    * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
@@ -6522,9 +7112,9 @@ export type OrganizationDomain = Node & {
    *     been updated after creation.
    */
   updatedAt: Scalars["DateTime"];
-  /** E-mail used to verify this domain */
+  /** E-mail used to verify this domain. */
   verificationEmail?: Maybe<Scalars["String"]>;
-  /** Is this domain verified */
+  /** Is this domain verified. */
   verified: Scalars["Boolean"];
 };
 
@@ -6588,7 +7178,7 @@ export type OrganizationExistsPayload = {
 /** An invitation to the organization that has been sent via email. */
 export type OrganizationInvite = Node & {
   __typename?: "OrganizationInvite";
-  /** The time at which the invite was accepted. Null, if the invite hasn't been accepted */
+  /** The time at which the invite was accepted. Null, if the invite hasn't been accepted. */
   acceptedAt?: Maybe<Scalars["DateTime"]>;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
   archivedAt?: Maybe<Scalars["DateTime"]>;
@@ -6596,7 +7186,7 @@ export type OrganizationInvite = Node & {
   createdAt: Scalars["DateTime"];
   /** The invitees email address. */
   email: Scalars["String"];
-  /** The time at which the invite will be expiring. Null, if the invite shouldn't expire */
+  /** The time at which the invite will be expiring. Null, if the invite shouldn't expire. */
   expiresAt?: Maybe<Scalars["DateTime"]>;
   /** The invite was sent to external address. */
   external: Scalars["Boolean"];
@@ -6634,7 +7224,7 @@ export type OrganizationInviteCreateInput = {
   id?: Maybe<Scalars["String"]>;
   /** The message to send to the invitee. */
   message?: Maybe<Scalars["String"]>;
-  /** [INTERNAL] Optional metadata about the invite */
+  /** [INTERNAL] Optional metadata about the invite. */
   metadata?: Maybe<Scalars["JSONObject"]>;
   /** What user role the invite should grant. */
   role?: Maybe<UserRoleType>;
@@ -6659,11 +7249,11 @@ export type OrganizationInviteFullDetailsPayload = {
   accepted: Scalars["Boolean"];
   /** When the invite was created. */
   createdAt: Scalars["DateTime"];
-  /** The email of the invitee */
+  /** The email of the invitee. */
   email: Scalars["String"];
   /** Whether the invite has expired. */
   expired: Scalars["Boolean"];
-  /** The name of the inviter */
+  /** The name of the inviter. */
   inviter: Scalars["String"];
   /** ID of the workspace the invite is for. */
   organizationId: Scalars["String"];
@@ -6673,7 +7263,7 @@ export type OrganizationInviteFullDetailsPayload = {
   organizationName: Scalars["String"];
   /** What user role the invite should grant. */
   role: UserRoleType;
-  /** The status of the invite */
+  /** The status of the invite. */
   status: OrganizationInviteStatus;
 };
 
@@ -6728,7 +7318,7 @@ export type OrganizationUpdateInput = {
   gitLinkbackMessagesEnabled?: Maybe<Scalars["Boolean"]>;
   /** Whether the Git integration linkback messages should be sent for public repositories. */
   gitPublicLinkbackMessagesEnabled?: Maybe<Scalars["Boolean"]>;
-  /** Linear Preview feature flags */
+  /** Linear Preview feature flags. */
   linearPreviewFlags?: Maybe<Scalars["JSONObject"]>;
   /** The logo of the organization. */
   logoUrl?: Maybe<Scalars["String"]>;
@@ -6860,6 +7450,8 @@ export type Project = Node & {
   completedScopeHistory: Array<Scalars["Float"]>;
   /** The project's content in markdown format. */
   content?: Maybe<Scalars["String"]>;
+  /** [Internal] The project's content as YJS state. */
+  contentState?: Maybe<Scalars["String"]>;
   /** The project was created based on this issue. */
   convertedFromIssue?: Maybe<Issue>;
   /** The time at which the entity was created. */
@@ -6944,6 +7536,7 @@ export type Project = Node & {
 export type ProjectDocumentsArgs = {
   after?: Maybe<Scalars["String"]>;
   before?: Maybe<Scalars["String"]>;
+  filter?: Maybe<DocumentFilter>;
   first?: Maybe<Scalars["Int"]>;
   includeArchived?: Maybe<Scalars["Boolean"]>;
   last?: Maybe<Scalars["Int"]>;
@@ -6987,6 +7580,7 @@ export type ProjectMembersArgs = {
 export type ProjectProjectMilestonesArgs = {
   after?: Maybe<Scalars["String"]>;
   before?: Maybe<Scalars["String"]>;
+  filter?: Maybe<ProjectMilestoneFilter>;
   first?: Maybe<Scalars["Int"]>;
   includeArchived?: Maybe<Scalars["Boolean"]>;
   last?: Maybe<Scalars["Int"]>;
@@ -7115,6 +7709,8 @@ export type ProjectCreateInput = {
   startDateResolution?: Maybe<DateResolutionType>;
   /** The state of the project. */
   state?: Maybe<Scalars["String"]>;
+  /** [INTERNAL] The ID of the project status. */
+  statusId?: Maybe<Scalars["String"]>;
   /** The planned target date of the project. */
   targetDate?: Maybe<Scalars["TimelessDate"]>;
   /** [INTERNAL] The resolution of the project's estimated completion date. */
@@ -7268,8 +7864,13 @@ export type ProjectMilestone = Node & {
   createdAt: Scalars["DateTime"];
   /** The project milestone's description in markdown format. */
   description?: Maybe<Scalars["String"]>;
-  /** [Internal] The project milestone's description as a Prosemirror document. */
+  /**
+   * [Internal] The project milestone's description as a Prosemirror document.
+   * @deprecated Use `descriptionState` instead.
+   */
   descriptionData?: Maybe<Scalars["JSON"]>;
+  /** [Internal] The project milestone's description as YJS state. */
+  descriptionState?: Maybe<Scalars["String"]>;
   /** The unique identifier of the entity. */
   id: Scalars["ID"];
   /** The name of the project milestone. */
@@ -7384,7 +7985,7 @@ export type ProjectMilestoneUpdateInput = {
   targetDate?: Maybe<Scalars["TimelessDate"]>;
 };
 
-/** A project related notification */
+/** A project related notification. */
 export type ProjectNotification = Entity &
   Node &
   Notification & {
@@ -7414,7 +8015,7 @@ export type ProjectNotification = Entity &
     readAt?: Maybe<Scalars["DateTime"]>;
     /** The time until a notification will be snoozed. After that it will appear in the inbox again. */
     snoozedUntilAt?: Maybe<Scalars["DateTime"]>;
-    /** Notification type */
+    /** Notification type. */
     type: Scalars["String"];
     /** The time at which a notification was unsnoozed.. */
     unsnoozedAt?: Maybe<Scalars["DateTime"]>;
@@ -7433,7 +8034,7 @@ export type ProjectNotificationSubscription = Entity &
   Node &
   NotificationSubscription & {
     __typename?: "ProjectNotificationSubscription";
-    /** Whether the subscription is active or not */
+    /** Whether the subscription is active or not. */
     active: Scalars["Boolean"];
     /** The time at which the entity was archived. Null if the entity has not been archived. */
     archivedAt?: Maybe<Scalars["DateTime"]>;
@@ -7508,6 +8109,8 @@ export type ProjectSearchResult = Node & {
   completedScopeHistory: Array<Scalars["Float"]>;
   /** The project's content in markdown format. */
   content?: Maybe<Scalars["String"]>;
+  /** [Internal] The project's content as YJS state. */
+  contentState?: Maybe<Scalars["String"]>;
   /** The project was created based on this issue. */
   convertedFromIssue?: Maybe<Issue>;
   /** The time at which the entity was created. */
@@ -7538,7 +8141,7 @@ export type ProjectSearchResult = Node & {
   links: ProjectLinkConnection;
   /** Users that are members of the project. */
   members: UserConnection;
-  /** Metadata related to search result */
+  /** Metadata related to search result. */
   metadata: Scalars["JSONObject"];
   /** The project's name. */
   name: Scalars["String"];
@@ -7593,6 +8196,7 @@ export type ProjectSearchResult = Node & {
 export type ProjectSearchResultDocumentsArgs = {
   after?: Maybe<Scalars["String"]>;
   before?: Maybe<Scalars["String"]>;
+  filter?: Maybe<DocumentFilter>;
   first?: Maybe<Scalars["Int"]>;
   includeArchived?: Maybe<Scalars["Boolean"]>;
   last?: Maybe<Scalars["Int"]>;
@@ -7632,6 +8236,7 @@ export type ProjectSearchResultMembersArgs = {
 export type ProjectSearchResultProjectMilestonesArgs = {
   after?: Maybe<Scalars["String"]>;
   before?: Maybe<Scalars["String"]>;
+  filter?: Maybe<ProjectMilestoneFilter>;
   first?: Maybe<Scalars["Int"]>;
   includeArchived?: Maybe<Scalars["Boolean"]>;
   last?: Maybe<Scalars["Int"]>;
@@ -7671,6 +8276,59 @@ export type ProjectSearchResultEdge = {
   node: ProjectSearchResult;
 };
 
+/** [ALPHA] A project status. */
+export type ProjectStatus = Node & {
+  __typename?: "ProjectStatus";
+  /** The time at which the entity was archived. Null if the entity has not been archived. */
+  archivedAt?: Maybe<Scalars["DateTime"]>;
+  /** The UI color of the status as a HEX string. */
+  color: Scalars["String"];
+  /** The time at which the entity was created. */
+  createdAt: Scalars["DateTime"];
+  /** Description of the status. */
+  description?: Maybe<Scalars["String"]>;
+  /** The unique identifier of the entity. */
+  id: Scalars["ID"];
+  /** Whether or not a project can be in this status indefinitely. */
+  indefinite: Scalars["Boolean"];
+  /** The name of the status. */
+  name: Scalars["String"];
+  /** The position of the status in the workspace's project flow. */
+  position: Scalars["Float"];
+  /** The type of the project status. */
+  type?: Maybe<ProjectStatusType>;
+  /**
+   * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+   *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+   *     been updated after creation.
+   */
+  updatedAt: Scalars["DateTime"];
+};
+
+export type ProjectStatusConnection = {
+  __typename?: "ProjectStatusConnection";
+  edges: Array<ProjectStatusEdge>;
+  nodes: Array<ProjectStatus>;
+  pageInfo: PageInfo;
+};
+
+export type ProjectStatusEdge = {
+  __typename?: "ProjectStatusEdge";
+  /** Used in `before` and `after` args */
+  cursor: Scalars["String"];
+  node: ProjectStatus;
+};
+
+/** A type of project status. */
+export enum ProjectStatusType {
+  Backlog = "backlog",
+  Canceled = "canceled",
+  Completed = "completed",
+  Paused = "paused",
+  Planned = "planned",
+  Started = "started",
+}
+
 /** Different tabs available inside a project. */
 export enum ProjectTab {
   Activity = "activity",
@@ -7685,10 +8343,12 @@ export type ProjectUpdate = Node & {
   archivedAt?: Maybe<Scalars["DateTime"]>;
   /** The update content in markdown format. */
   body: Scalars["String"];
+  /** [Internal] The content of the project update as a Prosemirror document. */
+  bodyData: Scalars["String"];
   /** The time at which the entity was created. */
   createdAt: Scalars["DateTime"];
   /** The diff between the current update and the previous one. */
-  diff?: Maybe<Scalars["JSON"]>;
+  diff?: Maybe<Scalars["JSONObject"]>;
   /** The diff between the current update and the previous one, formatted as markdown. */
   diffMarkdown?: Maybe<Scalars["String"]>;
   /** The time the project update was edited. */
@@ -7699,7 +8359,7 @@ export type ProjectUpdate = Node & {
   id: Scalars["ID"];
   /** [Internal] Serialized JSON representing current state of the project properties when posting the project update. */
   infoSnapshot?: Maybe<Scalars["JSONObject"]>;
-  /** [ALPHA] Whether project update diff should be hidden */
+  /** Whether project update diff should be hidden. */
   isDiffHidden: Scalars["Boolean"];
   /** The project that the update is associated with. */
   project: Project;
@@ -7731,7 +8391,7 @@ export type ProjectUpdateCreateInput = {
   health?: Maybe<ProjectUpdateHealthType>;
   /** The identifier. If none is provided, the backend will generate one. */
   id?: Maybe<Scalars["String"]>;
-  /** [ALPHA] Whether the diff between the current update and the previous one should be hidden. */
+  /** Whether the diff between the current update and the previous one should be hidden. */
   isDiffHidden?: Maybe<Scalars["Boolean"]>;
   /** The project to associate the project update with. */
   projectId: Scalars["String"];
@@ -7806,6 +8466,8 @@ export type ProjectUpdateInput = {
   startDateResolution?: Maybe<DateResolutionType>;
   /** The state of the project. */
   state?: Maybe<Scalars["String"]>;
+  /** [INTERNAL] The ID of the project status. */
+  statusId?: Maybe<Scalars["String"]>;
   /** The planned target date of the project. */
   targetDate?: Maybe<Scalars["TimelessDate"]>;
   /** [INTERNAL] The resolution of the project's estimated completion date. */
@@ -7903,7 +8565,7 @@ export type ProjectUpdateUpdateInput = {
   bodyData?: Maybe<Scalars["JSON"]>;
   /** The health of the project at the time of the update. */
   health?: Maybe<ProjectUpdateHealthType>;
-  /** [ALPHA] Whether the diff between the current update and the previous one should be hidden. */
+  /** Whether the diff between the current update and the previous one should be hidden. */
   isDiffHidden?: Maybe<Scalars["Boolean"]>;
 };
 
@@ -7948,7 +8610,7 @@ export type PushSubscriptionCreateInput = {
   data: Scalars["String"];
   /** The identifier in UUID v4 format. If none is provided, the backend will generate one. */
   id?: Maybe<Scalars["String"]>;
-  /** Whether this is a subscription payload for Google Cloud Messaging or Apple Push Notification service */
+  /** Whether this is a subscription payload for Google Cloud Messaging or Apple Push Notification service. */
   type?: Maybe<PushSubscriptionType>;
   /** The user identifier of the subscription. */
   userId?: Maybe<Scalars["String"]>;
@@ -7977,7 +8639,7 @@ export type PushSubscriptionTestPayload = {
   success: Scalars["Boolean"];
 };
 
-/** The different push subscription types */
+/** The different push subscription types. */
 export enum PushSubscriptionType {
   Apple = "apple",
   AppleDevelopment = "appleDevelopment",
@@ -7987,23 +8649,13 @@ export enum PushSubscriptionType {
 
 export type Query = {
   __typename?: "Query";
-  /**
-   * [DEPRECATED] [INTERNAL] One specific project milestone.
-   * @deprecated This mutation is deprecated, please use `projectMilestone` instead.
-   */
-  ProjectMilestone: ProjectMilestone;
-  /**
-   * [DEPRECATED] [INTERNAL] All milestones for the project.
-   * @deprecated This mutation is deprecated, please use `projectMilestones` instead.
-   */
-  ProjectMilestones: ProjectMilestoneConnection;
   /** All teams you the user can administrate. Administrable teams are teams whose settings the user can change, but to whose issues the user doesn't necessarily have access to. */
   administrableTeams: TeamConnection;
   /** All API keys for the user. */
   apiKeys: ApiKeyConnection;
   /** Get basic information for an application. */
   applicationInfo: Application;
-  /** [INTERNAL] Get basic information for a list of applications */
+  /** [INTERNAL] Get basic information for a list of applications. */
   applicationInfoByIds: Array<Application>;
   /** Get information for an application and whether a user has approved it for the given scopes. */
   applicationWithAuthorization: UserAuthorizedApplication;
@@ -8019,7 +8671,7 @@ export type Query = {
    * @deprecated Will be removed in near future, please use `attachmentsForURL` to get attachments and their issues instead.
    */
   attachmentIssue: Issue;
-  /** [Internal] Get a list of all unique attachment sources in the workspace */
+  /** [Internal] Get a list of all unique attachment sources in the workspace. */
   attachmentSources: AttachmentSourcesPayload;
   /**
    * All issue attachments.
@@ -8035,7 +8687,7 @@ export type Query = {
   auditEntryTypes: Array<AuditEntryType>;
   /** User's active sessions. */
   authenticationSessions: Array<AuthenticationSessionResponse>;
-  /** [INTERNAL] Get all authorized applications for a user */
+  /** [INTERNAL] Get all authorized applications for a user. */
   authorizedApplications: Array<AuthorizedApplication>;
   /** Fetch users belonging to this user account. */
   availableUsers: AuthResolverResponse;
@@ -8073,8 +8725,18 @@ export type Query = {
   favorite: Favorite;
   /** The user's favorites. */
   favorites: FavoriteConnection;
+  /** [Internal] One specific initiative. */
+  initiative: Initiative;
+  /** [INTERNAL] One specific initiativeToProject. */
+  initiativeToProject: InitiativeToProject;
+  /** [INTERNAL] returns a list of initiative to project entities. */
+  initiativeToProjects: InitiativeToProjectConnection;
+  /** [Internal] All initiatives in the workspace. */
+  initiatives: InitiativeConnection;
   /** One specific integration. */
   integration: Integration;
+  /** Checks if the integration has all required scopes. */
+  integrationHasScopes: IntegrationHasScopesPayload;
   /** One specific integrationTemplate. */
   integrationTemplate: IntegrationTemplate;
   /** Template and integration connections. */
@@ -8201,22 +8863,8 @@ export type Query = {
   workflowState: WorkflowState;
   /** All issue workflow states. */
   workflowStates: WorkflowStateConnection;
-  /** [INTERNAL] Get all authorized applications (with limited fields) for a workspace */
+  /** [INTERNAL] Get all authorized applications (with limited fields) for a workspace. */
   workspaceAuthorizedApplications: Array<WorkspaceAuthorizedApplication>;
-};
-
-export type QueryProjectMilestoneArgs = {
-  id: Scalars["String"];
-};
-
-export type QueryProjectMilestonesArgs = {
-  after?: Maybe<Scalars["String"]>;
-  before?: Maybe<Scalars["String"]>;
-  filter?: Maybe<ProjectMilestoneFilter>;
-  first?: Maybe<Scalars["Int"]>;
-  includeArchived?: Maybe<Scalars["Boolean"]>;
-  last?: Maybe<Scalars["Int"]>;
-  orderBy?: Maybe<PaginationOrderBy>;
 };
 
 export type QueryAdministrableTeamsArgs = {
@@ -8296,7 +8944,9 @@ export type QueryAuditEntriesArgs = {
 };
 
 export type QueryCommentArgs = {
-  id: Scalars["String"];
+  hash?: Maybe<Scalars["String"]>;
+  id?: Maybe<Scalars["String"]>;
+  issueId?: Maybe<Scalars["String"]>;
 };
 
 export type QueryCommentsArgs = {
@@ -8356,6 +9006,7 @@ export type QueryDocumentContentHistoryArgs = {
 export type QueryDocumentsArgs = {
   after?: Maybe<Scalars["String"]>;
   before?: Maybe<Scalars["String"]>;
+  filter?: Maybe<DocumentFilter>;
   first?: Maybe<Scalars["Int"]>;
   includeArchived?: Maybe<Scalars["Boolean"]>;
   last?: Maybe<Scalars["Int"]>;
@@ -8401,8 +9052,39 @@ export type QueryFavoritesArgs = {
   orderBy?: Maybe<PaginationOrderBy>;
 };
 
+export type QueryInitiativeArgs = {
+  id: Scalars["String"];
+};
+
+export type QueryInitiativeToProjectArgs = {
+  id: Scalars["String"];
+};
+
+export type QueryInitiativeToProjectsArgs = {
+  after?: Maybe<Scalars["String"]>;
+  before?: Maybe<Scalars["String"]>;
+  first?: Maybe<Scalars["Int"]>;
+  includeArchived?: Maybe<Scalars["Boolean"]>;
+  last?: Maybe<Scalars["Int"]>;
+  orderBy?: Maybe<PaginationOrderBy>;
+};
+
+export type QueryInitiativesArgs = {
+  after?: Maybe<Scalars["String"]>;
+  before?: Maybe<Scalars["String"]>;
+  first?: Maybe<Scalars["Int"]>;
+  includeArchived?: Maybe<Scalars["Boolean"]>;
+  last?: Maybe<Scalars["Int"]>;
+  orderBy?: Maybe<PaginationOrderBy>;
+};
+
 export type QueryIntegrationArgs = {
   id: Scalars["String"];
+};
+
+export type QueryIntegrationHasScopesArgs = {
+  integrationId: Scalars["String"];
+  scopes: Array<Scalars["String"]>;
 };
 
 export type QueryIntegrationTemplateArgs = {
@@ -8582,11 +9264,11 @@ export type QueryProjectLinksArgs = {
   orderBy?: Maybe<PaginationOrderBy>;
 };
 
-export type QueryProjectMilestoneArgs1 = {
+export type QueryProjectMilestoneArgs = {
   id: Scalars["String"];
 };
 
-export type QueryProjectMilestonesArgs1 = {
+export type QueryProjectMilestonesArgs = {
   after?: Maybe<Scalars["String"]>;
   before?: Maybe<Scalars["String"]>;
   filter?: Maybe<ProjectMilestoneFilter>;
@@ -8848,7 +9530,7 @@ export type ReactionCreateInput = {
   commentId?: Maybe<Scalars["String"]>;
   /** The emoji the user reacted with. */
   emoji?: Maybe<Scalars["String"]>;
-  /** The identifier in UUID v4 format. If none is provided, the backend will generate one */
+  /** The identifier in UUID v4 format. If none is provided, the backend will generate one. */
   id?: Maybe<Scalars["String"]>;
   /** The issue to associate the reaction with. */
   issueId?: Maybe<Scalars["String"]>;
@@ -8879,7 +9561,7 @@ export type RelationExistsComparator = {
   neq?: Maybe<Scalars["Boolean"]>;
 };
 
-/** Features release channel */
+/** Features release channel. */
 export enum ReleaseChannel {
   Beta = "beta",
   Internal = "internal",
@@ -8986,7 +9668,7 @@ export type RoadmapCreateInput = {
   id?: Maybe<Scalars["String"]>;
   /** The name of the roadmap. */
   name: Scalars["String"];
-  /** The owner of the roadmap */
+  /** The owner of the roadmap. */
   ownerId?: Maybe<Scalars["String"]>;
   /** The sort order of the roadmap within the organization. */
   sortOrder?: Maybe<Scalars["Float"]>;
@@ -9029,7 +9711,7 @@ export type RoadmapPayload = {
   success: Scalars["Boolean"];
 };
 
-/** Join table between projects and roadmaps */
+/** Join table between projects and roadmaps. */
 export type RoadmapToProject = Node & {
   __typename?: "RoadmapToProject";
   /** The time at which the entity was archived. Null if the entity has not been archived. */
@@ -9099,57 +9781,17 @@ export type RoadmapUpdateInput = {
   description?: Maybe<Scalars["String"]>;
   /** The name of the roadmap. */
   name?: Maybe<Scalars["String"]>;
-  /** The owner of the roadmap */
+  /** The owner of the roadmap. */
   ownerId?: Maybe<Scalars["String"]>;
   /** The sort order of the roadmap within the organization. */
   sortOrder?: Maybe<Scalars["Float"]>;
 };
 
-/** Which day count to use for SLA calculations */
+/** Which day count to use for SLA calculations. */
 export enum SlaDayCountType {
   All = "all",
   OnlyBusinessDays = "onlyBusinessDays",
 }
-
-export type SamlConfiguration = {
-  __typename?: "SamlConfiguration";
-  /** The issuer's custom entity ID. */
-  issuerEntityId?: Maybe<Scalars["String"]>;
-  /** Binding method for authentication call. Can be either `post` (default) or `redirect`. */
-  ssoBinding?: Maybe<Scalars["String"]>;
-  /** Sign in endpoint URL for the identity provider. */
-  ssoEndpoint?: Maybe<Scalars["String"]>;
-  /** The algorithm of the Signing Certificate. Can be one of `sha1`, `sha256` (default), or `sha512`. */
-  ssoSignAlgo?: Maybe<Scalars["String"]>;
-  /** X.509 Signing Certificate in string form. */
-  ssoSigningCert?: Maybe<Scalars["String"]>;
-};
-
-export type SamlConfigurationInput = {
-  /** The issuer's custom entity ID. */
-  issuerEntityId?: Maybe<Scalars["String"]>;
-  /** Binding method for authentication call. Can be either `post` (default) or `redirect`. */
-  ssoBinding?: Maybe<Scalars["String"]>;
-  /** Sign in endpoint URL for the identity provider. */
-  ssoEndpoint?: Maybe<Scalars["String"]>;
-  /** The algorithm of the Signing Certificate. Can be one of `sha1`, `sha256` (default), or `sha512`. */
-  ssoSignAlgo?: Maybe<Scalars["String"]>;
-  /** X.509 Signing Certificate in string form. */
-  ssoSigningCert?: Maybe<Scalars["String"]>;
-};
-
-/** The organization's SAML configuration */
-export type SamlConfigurationPayload = {
-  __typename?: "SamlConfigurationPayload";
-  /** The issuer's custom entity ID. */
-  issuerEntityId?: Maybe<Scalars["String"]>;
-  /** Binding method for authentication call. Can be either `post` (default) or `redirect`. */
-  ssoBinding?: Maybe<Scalars["String"]>;
-  /** Sign in endpoint URL for the identity provider. */
-  ssoEndpoint?: Maybe<Scalars["String"]>;
-  /** The algorithm of the Signing Certificate. Can be one of `sha1`, `sha256` (default), or `sha512`. */
-  ssoSignAlgo?: Maybe<Scalars["String"]>;
-};
 
 export enum SendStrategy {
   Desktop = "desktop",
@@ -9210,17 +9852,17 @@ export type SlackAsksSettingsInput = {
   slackChannelMapping?: Maybe<Array<SlackChannelNameMappingInput>>;
 };
 
-/** Tuple for mapping Slack channel IDs to names */
+/** Tuple for mapping Slack channel IDs to names. */
 export type SlackAsksTeamSettings = {
   __typename?: "SlackAsksTeamSettings";
-  /** Whether the default Asks template is enabled in the given channel for this team */
+  /** Whether the default Asks template is enabled in the given channel for this team. */
   hasDefaultAsk: Scalars["Boolean"];
   /** The Linear team ID. */
   id: Scalars["String"];
 };
 
 export type SlackAsksTeamSettingsInput = {
-  /** Whether the default Asks template is enabled in the given channel for this team */
+  /** Whether the default Asks template is enabled in the given channel for this team. */
   hasDefaultAsk: Scalars["Boolean"];
   /** The Linear team ID. */
   id: Scalars["String"];
@@ -9242,51 +9884,51 @@ export type SlackChannelConnectPayload = {
   success: Scalars["Boolean"];
 };
 
-/** Object for mapping Slack channel IDs to names and other settings */
+/** Object for mapping Slack channel IDs to names and other settings. */
 export type SlackChannelNameMapping = {
   __typename?: "SlackChannelNameMapping";
-  /** Whether or not @-mentioning the bot should automatically create an Ask with the message */
+  /** Whether or not @-mentioning the bot should automatically create an Ask with the message. */
   autoCreateOnBotMention?: Maybe<Scalars["Boolean"]>;
-  /** Whether or not using the :ticket: emoji in this channel should automatically create Asks */
+  /** Whether or not using the :ticket: emoji in this channel should automatically create Asks. */
   autoCreateOnEmoji?: Maybe<Scalars["Boolean"]>;
-  /** Whether or not top-level messages in this channel should automatically create Asks */
+  /** Whether or not top-level messages in this channel should automatically create Asks. */
   autoCreateOnMessage?: Maybe<Scalars["Boolean"]>;
   /** The optional template ID to use for Asks auto-created in this channel. If not set, auto-created Asks won't use any template. */
   autoCreateTemplateId?: Maybe<Scalars["String"]>;
-  /** Whether or not we the Linear Asks bot has been added to this Slack channel */
+  /** Whether or not we the Linear Asks bot has been added to this Slack channel. */
   botAdded?: Maybe<Scalars["Boolean"]>;
   /** The Slack channel ID. */
   id: Scalars["String"];
-  /** Whether or not the Slack channel is private */
+  /** Whether or not the Slack channel is private. */
   isPrivate?: Maybe<Scalars["Boolean"]>;
-  /** Whether or not the Slack channel is shared with an external org */
+  /** Whether or not the Slack channel is shared with an external org. */
   isShared?: Maybe<Scalars["Boolean"]>;
   /** The Slack channel name. */
   name: Scalars["String"];
-  /** Which teams are connected to the channel and settings for those teams */
+  /** Which teams are connected to the channel and settings for those teams. */
   teams: Array<SlackAsksTeamSettings>;
 };
 
 export type SlackChannelNameMappingInput = {
-  /** Whether or not @-mentioning the bot should automatically create an Ask with the message */
+  /** Whether or not @-mentioning the bot should automatically create an Ask with the message. */
   autoCreateOnBotMention?: Maybe<Scalars["Boolean"]>;
-  /** Whether or not using the :ticket: emoji in this channel should automatically create Asks */
+  /** Whether or not using the :ticket: emoji in this channel should automatically create Asks. */
   autoCreateOnEmoji?: Maybe<Scalars["Boolean"]>;
-  /** Whether or not top-level messages in this channel should automatically create Asks */
+  /** Whether or not top-level messages in this channel should automatically create Asks. */
   autoCreateOnMessage?: Maybe<Scalars["Boolean"]>;
   /** The optional template ID to use for Asks auto-created in this channel. If not set, auto-created Asks won't use any template. */
   autoCreateTemplateId?: Maybe<Scalars["String"]>;
-  /** Whether or not we the Linear Asks bot has been added to this Slack channel */
+  /** Whether or not we the Linear Asks bot has been added to this Slack channel. */
   botAdded?: Maybe<Scalars["Boolean"]>;
   /** The Slack channel ID. */
   id: Scalars["String"];
-  /** Whether or not the Slack channel is private */
+  /** Whether or not the Slack channel is private. */
   isPrivate?: Maybe<Scalars["Boolean"]>;
-  /** Whether or not the Slack channel is shared with an external org */
+  /** Whether or not the Slack channel is shared with an external org. */
   isShared?: Maybe<Scalars["Boolean"]>;
   /** The Slack channel name. */
   name: Scalars["String"];
-  /** Which teams are connected to the channel and settings for those teams */
+  /** Which teams are connected to the channel and settings for those teams. */
   teams: Array<SlackAsksTeamSettingsInput>;
 };
 
@@ -9450,8 +10092,6 @@ export type Team = Node & {
   autoClosePeriod?: Maybe<Scalars["Float"]>;
   /** The canceled workflow state which auto closed issues will be set to. Defaults to the first canceled state. */
   autoCloseStateId?: Maybe<Scalars["String"]>;
-  /** The automation states for the team. */
-  automationStates: GitAutomationStateConnection;
   /** The team's color. */
   color?: Maybe<Scalars["String"]>;
   /** The time at which the entity was created. */
@@ -9498,6 +10138,8 @@ export type Team = Node & {
   description?: Maybe<Scalars["String"]>;
   /** The workflow state into which issues are moved when a PR has been opened as draft. */
   draftWorkflowState?: Maybe<WorkflowState>;
+  /** The Git automation states for the team. */
+  gitAutomationStates: GitAutomationStateConnection;
   /** Whether to group recent issue history entries. */
   groupIssueHistory: Scalars["Boolean"];
   /** The icon of the team. */
@@ -9546,7 +10188,7 @@ export type Team = Node & {
   private: Scalars["Boolean"];
   /** Projects associated with the team. */
   projects: ProjectConnection;
-  /** Whether an issue needs to have a priority set before leaving triage */
+  /** Whether an issue needs to have a priority set before leaving triage. */
   requirePriorityToLeaveTriage: Scalars["Boolean"];
   /** The workflow state into which issues are moved when a review has been requested for the PR. */
   reviewWorkflowState?: Maybe<WorkflowState>;
@@ -9583,9 +10225,10 @@ export type Team = Node & {
 };
 
 /** An organizational unit that contains issues. */
-export type TeamAutomationStatesArgs = {
+export type TeamCyclesArgs = {
   after?: Maybe<Scalars["String"]>;
   before?: Maybe<Scalars["String"]>;
+  filter?: Maybe<CycleFilter>;
   first?: Maybe<Scalars["Int"]>;
   includeArchived?: Maybe<Scalars["Boolean"]>;
   last?: Maybe<Scalars["Int"]>;
@@ -9593,10 +10236,9 @@ export type TeamAutomationStatesArgs = {
 };
 
 /** An organizational unit that contains issues. */
-export type TeamCyclesArgs = {
+export type TeamGitAutomationStatesArgs = {
   after?: Maybe<Scalars["String"]>;
   before?: Maybe<Scalars["String"]>;
-  filter?: Maybe<CycleFilter>;
   first?: Maybe<Scalars["Int"]>;
   includeArchived?: Maybe<Scalars["Boolean"]>;
   last?: Maybe<Scalars["Int"]>;
@@ -9841,7 +10483,7 @@ export type TeamMembership = Node & {
   createdAt: Scalars["DateTime"];
   /** The unique identifier of the entity. */
   id: Scalars["ID"];
-  /** Whether the user is the owner of the team */
+  /** Whether the user is the owner of the team. */
   owner?: Maybe<Scalars["Boolean"]>;
   /** The order of the item in the users team list. */
   sortOrder: Scalars["Float"];
@@ -9906,7 +10548,7 @@ export type TeamNotificationSubscription = Entity &
   Node &
   NotificationSubscription & {
     __typename?: "TeamNotificationSubscription";
-    /** Whether the subscription is active or not */
+    /** Whether the subscription is active or not. */
     active: Scalars["Boolean"];
     /** The time at which the entity was archived. Null if the entity has not been archived. */
     archivedAt?: Maybe<Scalars["DateTime"]>;
@@ -9952,9 +10594,13 @@ export type TeamPayload = {
   team?: Maybe<Team>;
 };
 
-/** Tuple for mapping Linear teams to GitHub repos. */
+/** Mapping of Linear teams to GitHub repos. */
 export type TeamRepoMapping = {
   __typename?: "TeamRepoMapping";
+  /** Whether the sync for this mapping is bidirectional. */
+  bidirectional?: Maybe<Scalars["Boolean"]>;
+  /** Whether this mapping is the default one for issue creation. */
+  default?: Maybe<Scalars["Boolean"]>;
   /** The GitHub repo id. */
   gitHubRepoId: Scalars["Float"];
   /** The Linear team id to map to the given project. */
@@ -9962,6 +10608,10 @@ export type TeamRepoMapping = {
 };
 
 export type TeamRepoMappingInput = {
+  /** Whether the sync for this mapping is bidirectional. */
+  bidirectional?: Maybe<Scalars["Boolean"]>;
+  /** Whether this mapping is the default one for issue creation. */
+  default?: Maybe<Scalars["Boolean"]>;
   /** The GitHub repo id. */
   gitHubRepoId: Scalars["Float"];
   /** The Linear team id to map to the given project. */
@@ -9981,7 +10631,9 @@ export type TeamUpdateInput = {
   cycleCooldownTime?: Maybe<Scalars["Int"]>;
   /** The duration of each cycle in weeks. */
   cycleDuration?: Maybe<Scalars["Int"]>;
-  /** Whether the first cycle should start in the current or the next week. */
+  /** The date to begin cycles on. */
+  cycleEnabledStartDate?: Maybe<Scalars["DateTime"]>;
+  /** [DEPRECATED] Whether the first cycle should start in the current or the next week. */
   cycleEnabledStartWeek?: Maybe<Scalars["String"]>;
   /** Auto assign completed issues to current active cycle setting. */
   cycleIssueAutoAssignCompleted?: Maybe<Scalars["Boolean"]>;
@@ -10140,6 +10792,63 @@ export type TemplateUpdateInput = {
   templateData?: Maybe<Scalars["JSON"]>;
 };
 
+/** A time schedule. */
+export type TimeSchedule = Node & {
+  __typename?: "TimeSchedule";
+  /** The time at which the entity was archived. Null if the entity has not been archived. */
+  archivedAt?: Maybe<Scalars["DateTime"]>;
+  /** The time at which the entity was created. */
+  createdAt: Scalars["DateTime"];
+  /** The schedule entries. */
+  entries: Scalars["JSONObject"];
+  /** User presentable error message, if an error occurred while updating the schedule. */
+  error?: Maybe<Scalars["String"]>;
+  /** The identifier of the external schedule. */
+  externalId?: Maybe<Scalars["String"]>;
+  /** The URL to the external schedule. */
+  externalUrl?: Maybe<Scalars["String"]>;
+  /** The unique identifier of the entity. */
+  id: Scalars["ID"];
+  /** The identifier of the Linear integration populating the schedule. */
+  integration?: Maybe<Integration>;
+  /** The name of the schedule. */
+  name: Scalars["String"];
+  /** The organization of the schedule. */
+  organization: Organization;
+  /**
+   * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+   *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+   *     been updated after creation.
+   */
+  updatedAt: Scalars["DateTime"];
+};
+
+export type TimeScheduleConnection = {
+  __typename?: "TimeScheduleConnection";
+  edges: Array<TimeScheduleEdge>;
+  nodes: Array<TimeSchedule>;
+  pageInfo: PageInfo;
+};
+
+export type TimeScheduleEdge = {
+  __typename?: "TimeScheduleEdge";
+  /** Used in `before` and `after` args */
+  cursor: Scalars["String"];
+  node: TimeSchedule;
+};
+
+/** The time schedule entry. */
+export type TimeScheduleEntry = {
+  /** The end date of the schedule in ISO 8601 date-time format. */
+  endsAt: Scalars["DateTime"];
+  /** The start date of the schedule in ISO 8601 date-time format. */
+  startsAt: Scalars["DateTime"];
+  /** The email of the user on schedule. This is only used in case the user could not be mapped to a Linear user id. */
+  userEmail?: Maybe<Scalars["String"]>;
+  /** The Linear user id of the user on schedule. If the user cannot be mapped to a Linear user, use `userEmail` instead. */
+  userId?: Maybe<Scalars["String"]>;
+};
+
 /** Comparator for timeless dates. */
 export type TimelessDateComparator = {
   /** Equals constraint. */
@@ -10192,6 +10901,8 @@ export type TriageResponsibility = Node & {
   schedule?: Maybe<Scalars["JSONObject"]>;
   /** The team to which the triage responsibility belongs to. */
   team: Team;
+  /** The time schedule used for scheduling. */
+  timeSchedule: TimeSchedule;
   /**
    * The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
    *     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
@@ -10253,7 +10964,7 @@ export type TriageResponsibilityScheduleEntry = {
 /** Object representing Google Cloud upload policy, plus additional data. */
 export type UploadFile = {
   __typename?: "UploadFile";
-  /** The asset URL for the uploaded file. (assigned automatically) */
+  /** The asset URL for the uploaded file. (assigned automatically). */
   assetUrl: Scalars["String"];
   /** The content type. */
   contentType: Scalars["String"];
@@ -10263,7 +10974,7 @@ export type UploadFile = {
   metaData?: Maybe<Scalars["JSONObject"]>;
   /** The size of the uploaded file. */
   size: Scalars["Int"];
-  /** The signed URL the for the uploaded file. (assigned automatically) */
+  /** The signed URL the for the uploaded file. (assigned automatically). */
   uploadUrl: Scalars["String"];
 };
 
@@ -10398,6 +11109,8 @@ export type UserAccount = {
   __typename?: "UserAccount";
   /** The time at which the model was archived. */
   archivedAt?: Maybe<Scalars["DateTime"]>;
+  /** Whether not to send email auth links in the email auth emails. */
+  authTokenLinkDisabled: Scalars["Boolean"];
   /** The time at which the model was created. */
   createdAt: Scalars["DateTime"];
   /** The user's email address. */
@@ -10444,7 +11157,7 @@ export type UserAdminPayload = {
 /** Public information of the OAuth application, plus whether the application has been authorized for the given scopes. */
 export type UserAuthorizedApplication = {
   __typename?: "UserAuthorizedApplication";
-  /** Error associated with the application needing to be requested for approval in the workspace */
+  /** Error associated with the application needing to be requested for approval in the workspace. */
   approvalErrorCode?: Maybe<Scalars["String"]>;
   /** OAuth application's client ID. */
   clientId: Scalars["String"];
@@ -10593,7 +11306,7 @@ export enum UserFlagType {
   UpdatedSlackThreadSyncIntegration = "updatedSlackThreadSyncIntegration",
 }
 
-/** Operations that can be applied to UserFlagType */
+/** Operations that can be applied to UserFlagType. */
 export enum UserFlagUpdateOperation {
   Clear = "clear",
   Decr = "decr",
@@ -10606,7 +11319,7 @@ export type UserNotificationSubscription = Entity &
   Node &
   NotificationSubscription & {
     __typename?: "UserNotificationSubscription";
-    /** Whether the subscription is active or not */
+    /** Whether the subscription is active or not. */
     active: Scalars["Boolean"];
     /** The time at which the entity was archived. Null if the entity has not been archived. */
     archivedAt?: Maybe<Scalars["DateTime"]>;
@@ -10652,7 +11365,7 @@ export type UserPayload = {
   user?: Maybe<User>;
 };
 
-/** The different permission roles available to users on an organization */
+/** The different permission roles available to users on an organization. */
 export enum UserRoleType {
   Admin = "admin",
   Guest = "guest",
@@ -10780,6 +11493,8 @@ export type ViewPreferencesCreateInput = {
   cycleId?: Maybe<Scalars["String"]>;
   /** The identifier in UUID v4 format. If none is provided, the backend will generate one. */
   id?: Maybe<Scalars["String"]>;
+  /** [Internal] The initiative these view preferences are associated with. */
+  initiativeId?: Maybe<Scalars["String"]>;
   /** The default parameters for the insight on that view. */
   insights?: Maybe<Scalars["JSONObject"]>;
   /** The label these view preferences are associated with. */
@@ -10836,6 +11551,8 @@ export enum ViewType {
   CustomViews = "customViews",
   Cycle = "cycle",
   Inbox = "inbox",
+  Initiative = "initiative",
+  Initiatives = "initiatives",
   Label = "label",
   MyIssues = "myIssues",
   MyIssuesActivity = "myIssuesActivity",
@@ -10860,7 +11577,7 @@ export enum ViewType {
   UserProfileCreatedByUser = "userProfileCreatedByUser",
 }
 
-/** A webhook used to send HTTP notifications over data updates */
+/** A webhook used to send HTTP notifications over data updates. */
 export type Webhook = Node & {
   __typename?: "Webhook";
   /** Whether the Webhook is enabled for all public teams, including teams created after the webhook was created. */
@@ -10875,7 +11592,7 @@ export type Webhook = Node & {
   enabled: Scalars["Boolean"];
   /** The unique identifier of the entity. */
   id: Scalars["ID"];
-  /** Webhook label */
+  /** Webhook label. */
   label?: Maybe<Scalars["String"]>;
   /** The resource types this webhook is subscribed to. */
   resourceTypes: Array<Scalars["String"]>;
@@ -10889,7 +11606,7 @@ export type Webhook = Node & {
    *     been updated after creation.
    */
   updatedAt: Scalars["DateTime"];
-  /** Webhook URL */
+  /** Webhook URL. */
   url?: Maybe<Scalars["String"]>;
 };
 
@@ -11228,13 +11945,13 @@ export type WorkspaceAuthorizedApplication = {
   clientId: Scalars["String"];
   /** Image of the application. */
   imageUrl?: Maybe<Scalars["String"]>;
-  /** UserIds and membership dates of everyone who has authorized the application with the set of scopes */
+  /** UserIds and membership dates of everyone who has authorized the application with the set of scopes. */
   memberships: Array<AuthMembership>;
   /** Application name. */
   name: Scalars["String"];
   /** Scopes that are authorized for this application for a given user. */
   scope: Array<Scalars["String"]>;
-  /** Total number of members that authorized the application */
+  /** Total number of members that authorized the application. */
   totalMembers: Scalars["Float"];
   /** Whether or not webhooks are enabled for the application. */
   webhooksEnabled: Scalars["Boolean"];
@@ -11279,6 +11996,11 @@ export type ZendeskSettingsInput = {
   /** The URL of the connected Zendesk organization. */
   url: Scalars["String"];
 };
+
+export type GitAutomationTargetBranchFragment = { __typename: "GitAutomationTargetBranch" } & Pick<
+  GitAutomationTargetBranch,
+  "updatedAt" | "branchPattern" | "archivedAt" | "createdAt" | "id" | "isRegex"
+> & { team: { __typename?: "Team" } & Pick<Team, "id"> };
 
 type Entity_CustomViewNotificationSubscription_Fragment = { __typename: "CustomViewNotificationSubscription" } & Pick<
   CustomViewNotificationSubscription,
@@ -11343,11 +12065,21 @@ export type ActorBotFragment = { __typename: "ActorBot" } & Pick<
 
 export type CommentFragment = { __typename: "Comment" } & Pick<
   Comment,
-  "url" | "reactionData" | "body" | "updatedAt" | "archivedAt" | "createdAt" | "resolvedAt" | "editedAt" | "id"
+  | "url"
+  | "reactionData"
+  | "body"
+  | "updatedAt"
+  | "quotedText"
+  | "archivedAt"
+  | "createdAt"
+  | "resolvedAt"
+  | "editedAt"
+  | "id"
 > & {
     botActor?: Maybe<{ __typename?: "ActorBot" } & ActorBotFragment>;
     resolvingComment?: Maybe<{ __typename?: "Comment" } & Pick<Comment, "id">>;
     documentContent?: Maybe<{ __typename?: "DocumentContent" } & DocumentContentFragment>;
+    externalUser?: Maybe<{ __typename?: "ExternalUser" } & Pick<ExternalUser, "id">>;
     issue?: Maybe<{ __typename?: "Issue" } & Pick<Issue, "id">>;
     parent?: Maybe<{ __typename?: "Comment" } & Pick<Comment, "id">>;
     projectUpdate?: Maybe<{ __typename?: "ProjectUpdate" } & Pick<ProjectUpdate, "id">>;
@@ -11391,6 +12123,7 @@ export type CustomViewFragment = { __typename: "CustomView" } & Pick<
   | "color"
   | "description"
   | "filterData"
+  | "projectFilterData"
   | "filters"
   | "icon"
   | "updatedAt"
@@ -11403,6 +12136,7 @@ export type CustomViewFragment = { __typename: "CustomView" } & Pick<
 > & {
     team?: Maybe<{ __typename?: "Team" } & Pick<Team, "id">>;
     creator: { __typename?: "User" } & Pick<User, "id">;
+    updatedBy: { __typename?: "User" } & Pick<User, "id">;
     owner: { __typename?: "User" } & Pick<User, "id">;
   };
 
@@ -11436,17 +12170,7 @@ export type DocumentContentHistoryFragment = { __typename: "DocumentContentHisto
 
 export type DocumentFragment = { __typename: "Document" } & Pick<
   Document,
-  | "color"
-  | "title"
-  | "slugId"
-  | "contentData"
-  | "content"
-  | "icon"
-  | "updatedAt"
-  | "sortOrder"
-  | "archivedAt"
-  | "createdAt"
-  | "id"
+  "color" | "title" | "slugId" | "content" | "icon" | "updatedAt" | "sortOrder" | "archivedAt" | "createdAt" | "id"
 > & {
     lastAppliedTemplate?: Maybe<{ __typename?: "Template" } & Pick<Template, "id">>;
     project: { __typename?: "Project" } & Pick<Project, "id">;
@@ -11463,6 +12187,11 @@ export type CycleArchivePayloadFragment = { __typename: "CycleArchivePayload" } 
   CycleArchivePayload,
   "lastSyncId" | "success"
 > & { entity?: Maybe<{ __typename?: "Cycle" } & Pick<Cycle, "id">> };
+
+export type InitiativeArchivePayloadFragment = { __typename: "InitiativeArchivePayload" } & Pick<
+  InitiativeArchivePayload,
+  "lastSyncId" | "success"
+>;
 
 export type IssueArchivePayloadFragment = { __typename: "IssueArchivePayload" } & Pick<
   IssueArchivePayload,
@@ -11518,6 +12247,12 @@ type ArchivePayload_DeletePayload_Fragment = { __typename: "DeletePayload" } & P
 > &
   DeletePayloadFragment;
 
+type ArchivePayload_InitiativeArchivePayload_Fragment = { __typename: "InitiativeArchivePayload" } & Pick<
+  InitiativeArchivePayload,
+  "lastSyncId" | "success"
+> &
+  InitiativeArchivePayloadFragment;
+
 type ArchivePayload_IssueArchivePayload_Fragment = { __typename: "IssueArchivePayload" } & Pick<
   IssueArchivePayload,
   "lastSyncId" | "success"
@@ -11558,6 +12293,7 @@ export type ArchivePayloadFragment =
   | ArchivePayload_AttachmentArchivePayload_Fragment
   | ArchivePayload_CycleArchivePayload_Fragment
   | ArchivePayload_DeletePayload_Fragment
+  | ArchivePayload_InitiativeArchivePayload_Fragment
   | ArchivePayload_IssueArchivePayload_Fragment
   | ArchivePayload_NotificationArchivePayload_Fragment
   | ArchivePayload_ProjectArchivePayload_Fragment
@@ -11593,6 +12329,7 @@ type Notification_IssueNotification_Fragment = { __typename: "IssueNotification"
   "type" | "updatedAt" | "emailedAt" | "readAt" | "unsnoozedAt" | "archivedAt" | "createdAt" | "snoozedUntilAt" | "id"
 > & {
     botActor?: Maybe<{ __typename?: "ActorBot" } & ActorBotFragment>;
+    externalUserActor?: Maybe<{ __typename?: "ExternalUser" } & Pick<ExternalUser, "id">>;
     actor?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
     user: { __typename?: "User" } & Pick<User, "id">;
   } & IssueNotificationFragment;
@@ -11602,6 +12339,7 @@ type Notification_OauthClientApprovalNotification_Fragment = { __typename: "Oaut
   "type" | "updatedAt" | "emailedAt" | "readAt" | "unsnoozedAt" | "archivedAt" | "createdAt" | "snoozedUntilAt" | "id"
 > & {
     botActor?: Maybe<{ __typename?: "ActorBot" } & ActorBotFragment>;
+    externalUserActor?: Maybe<{ __typename?: "ExternalUser" } & Pick<ExternalUser, "id">>;
     actor?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
     user: { __typename?: "User" } & Pick<User, "id">;
   } & OauthClientApprovalNotificationFragment;
@@ -11611,6 +12349,7 @@ type Notification_ProjectNotification_Fragment = { __typename: "ProjectNotificat
   "type" | "updatedAt" | "emailedAt" | "readAt" | "unsnoozedAt" | "archivedAt" | "createdAt" | "snoozedUntilAt" | "id"
 > & {
     botActor?: Maybe<{ __typename?: "ActorBot" } & ActorBotFragment>;
+    externalUserActor?: Maybe<{ __typename?: "ExternalUser" } & Pick<ExternalUser, "id">>;
     actor?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
     user: { __typename?: "User" } & Pick<User, "id">;
   } & ProjectNotificationFragment;
@@ -11638,6 +12377,7 @@ export type ProjectNotificationFragment = { __typename: "ProjectNotification" } 
   "type" | "updatedAt" | "emailedAt" | "readAt" | "unsnoozedAt" | "archivedAt" | "createdAt" | "snoozedUntilAt" | "id"
 > & {
     botActor?: Maybe<{ __typename?: "ActorBot" } & ActorBotFragment>;
+    externalUserActor?: Maybe<{ __typename?: "ExternalUser" } & Pick<ExternalUser, "id">>;
     project: { __typename?: "Project" } & Pick<Project, "id">;
     projectUpdate?: Maybe<{ __typename?: "ProjectUpdate" } & Pick<ProjectUpdate, "id">>;
     actor?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
@@ -11812,6 +12552,7 @@ export type TriageResponsibilityFragment = { __typename: "TriageResponsibility" 
 > & {
     integration: { __typename?: "Integration" } & Pick<Integration, "id">;
     team: { __typename?: "Team" } & Pick<Team, "id">;
+    timeSchedule: { __typename?: "TimeSchedule" } & TimeScheduleFragment;
   };
 
 export type TemplateFragment = { __typename: "Template" } & Pick<
@@ -11823,22 +12564,37 @@ export type TemplateFragment = { __typename: "Template" } & Pick<
     lastUpdatedBy?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
   };
 
+export type TimeScheduleFragment = { __typename: "TimeSchedule" } & Pick<
+  TimeSchedule,
+  "externalUrl" | "externalId" | "updatedAt" | "name" | "entries" | "archivedAt" | "createdAt" | "id" | "error"
+> & { integration?: Maybe<{ __typename?: "Integration" } & Pick<Integration, "id">> };
+
 export type GitAutomationStateFragment = { __typename: "GitAutomationState" } & Pick<
   GitAutomationState,
-  "updatedAt" | "branchPattern" | "archivedAt" | "createdAt" | "id"
+  "updatedAt" | "archivedAt" | "createdAt" | "id" | "branchPattern"
 > & {
     state?: Maybe<{ __typename?: "WorkflowState" } & Pick<WorkflowState, "id">>;
+    targetBranch?: Maybe<{ __typename?: "GitAutomationTargetBranch" } & GitAutomationTargetBranchFragment>;
     team: { __typename?: "Team" } & Pick<Team, "id">;
   };
 
 export type ProjectUpdateFragment = { __typename: "ProjectUpdate" } & Pick<
   ProjectUpdate,
-  "url" | "diffMarkdown" | "diff" | "updatedAt" | "archivedAt" | "createdAt" | "editedAt" | "id" | "body"
+  | "url"
+  | "diffMarkdown"
+  | "diff"
+  | "updatedAt"
+  | "archivedAt"
+  | "createdAt"
+  | "editedAt"
+  | "id"
+  | "body"
+  | "isDiffHidden"
 > & { project: { __typename?: "Project" } & Pick<Project, "id">; user: { __typename?: "User" } & Pick<User, "id"> };
 
 export type UserAccountFragment = { __typename: "UserAccount" } & Pick<
   UserAccount,
-  "service" | "id" | "archivedAt" | "createdAt" | "updatedAt" | "email" | "name"
+  "service" | "id" | "archivedAt" | "createdAt" | "updatedAt" | "email" | "name" | "authTokenLinkDisabled"
 >;
 
 export type UserNotificationSubscriptionFragment = { __typename: "UserNotificationSubscription" } & Pick<
@@ -11856,7 +12612,7 @@ export type UserNotificationSubscriptionFragment = { __typename: "UserNotificati
 
 export type AuthUserFragment = { __typename: "AuthUser" } & Pick<
   AuthUser,
-  "avatarUrl" | "displayName" | "email" | "name" | "active" | "id"
+  "avatarUrl" | "displayName" | "email" | "name" | "userAccountId" | "active" | "id"
 > & { organization: { __typename?: "AuthOrganization" } & AuthOrganizationFragment };
 
 export type UserFragment = { __typename: "User" } & Pick<
@@ -11916,7 +12672,16 @@ export type ApiKeyFragment = { __typename: "ApiKey" } & Pick<
 export type EmailIntakeAddressFragment = { __typename: "EmailIntakeAddress" } & Pick<
   EmailIntakeAddress,
   "updatedAt" | "archivedAt" | "createdAt" | "id" | "address" | "enabled"
-> & { team: { __typename?: "Team" } & Pick<Team, "id">; creator?: Maybe<{ __typename?: "User" } & Pick<User, "id">> };
+> & {
+    team: { __typename?: "Team" } & Pick<Team, "id">;
+    template?: Maybe<{ __typename?: "Template" } & Pick<Template, "id">>;
+    creator?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
+  };
+
+export type ExternalUserFragment = { __typename: "ExternalUser" } & Pick<
+  ExternalUser,
+  "avatarUrl" | "displayName" | "email" | "name" | "updatedAt" | "lastSeen" | "archivedAt" | "createdAt" | "id"
+>;
 
 export type ProjectLinkFragment = { __typename: "ProjectLink" } & Pick<
   ProjectLink,
@@ -11945,6 +12710,11 @@ export type IntegrationFragment = { __typename: "Integration" } & Pick<
   "service" | "updatedAt" | "archivedAt" | "createdAt" | "id"
 > & { team?: Maybe<{ __typename?: "Team" } & Pick<Team, "id">>; creator: { __typename?: "User" } & Pick<User, "id"> };
 
+export type AuthOrganizationInviteFragment = { __typename: "AuthOrganizationInvite" } & Pick<
+  AuthOrganizationInvite,
+  "id"
+>;
+
 export type OrganizationInviteFragment = { __typename: "OrganizationInvite" } & Pick<
   OrganizationInvite,
   "metadata" | "external" | "email" | "updatedAt" | "archivedAt" | "createdAt" | "acceptedAt" | "expiresAt" | "id"
@@ -11968,6 +12738,7 @@ export type IssueNotificationFragment = { __typename: "IssueNotification" } & Pi
 > & {
     botActor?: Maybe<{ __typename?: "ActorBot" } & ActorBotFragment>;
     comment?: Maybe<{ __typename?: "Comment" } & Pick<Comment, "id">>;
+    externalUserActor?: Maybe<{ __typename?: "ExternalUser" } & Pick<ExternalUser, "id">>;
     issue: { __typename?: "Issue" } & Pick<Issue, "id">;
     subscriptions?: Maybe<
       Array<
@@ -12030,6 +12801,7 @@ export type IssueFragment = { __typename: "Issue" } & Pick<
 > & {
     botActor?: Maybe<{ __typename?: "ActorBot" } & ActorBotFragment>;
     cycle?: Maybe<{ __typename?: "Cycle" } & Pick<Cycle, "id">>;
+    externalUserCreator?: Maybe<{ __typename?: "ExternalUser" } & Pick<ExternalUser, "id">>;
     lastAppliedTemplate?: Maybe<{ __typename?: "Template" } & Pick<Template, "id">>;
     parent?: Maybe<{ __typename?: "Issue" } & Pick<Issue, "id">>;
     project?: Maybe<{ __typename?: "Project" } & Pick<Project, "id">>;
@@ -12048,6 +12820,7 @@ export type OauthClientApprovalNotificationFragment = { __typename: "OauthClient
 > & {
     oauthClientApproval: { __typename?: "OauthClientApproval" } & OauthClientApprovalFragment;
     botActor?: Maybe<{ __typename?: "ActorBot" } & ActorBotFragment>;
+    externalUserActor?: Maybe<{ __typename?: "ExternalUser" } & Pick<ExternalUser, "id">>;
     actor?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
     user: { __typename?: "User" } & Pick<User, "id">;
   };
@@ -12083,6 +12856,7 @@ export type AuthOrganizationFragment = { __typename: "AuthOrganization" } & Pick
   AuthOrganization,
   | "allowedAuthServices"
   | "previousUrlKeys"
+  | "serviceId"
   | "logoUrl"
   | "name"
   | "urlKey"
@@ -12186,6 +12960,11 @@ export type ArchiveResponseFragment = { __typename: "ArchiveResponse" } & Pick<
   "archive" | "totalCount" | "databaseVersion" | "includesDependencies"
 >;
 
+export type DataRecoveryFragment = { __typename: "DataRecovery" } & Pick<
+  DataRecovery,
+  "updatedAt" | "archivedAt" | "createdAt" | "id"
+>;
+
 export type TeamMembershipFragment = { __typename: "TeamMembership" } & Pick<
   TeamMembership,
   "updatedAt" | "sortOrder" | "archivedAt" | "createdAt" | "id" | "owner"
@@ -12250,6 +13029,7 @@ export type AttachmentFragment = { __typename: "Attachment" } & Pick<
 > & {
     creator?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
     issue: { __typename?: "Issue" } & Pick<Issue, "id">;
+    externalUserCreator?: Maybe<{ __typename?: "ExternalUser" } & Pick<ExternalUser, "id">>;
   };
 
 export type IssueRelationHistoryPayloadFragment = { __typename: "IssueRelationHistoryPayload" } & Pick<
@@ -12291,6 +13071,11 @@ export type IssueLabelFragment = { __typename: "IssueLabel" } & Pick<
     team?: Maybe<{ __typename?: "Team" } & Pick<Team, "id">>;
     creator?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
   };
+
+export type TeamRepoMappingFragment = { __typename: "TeamRepoMapping" } & Pick<
+  TeamRepoMapping,
+  "gitHubRepoId" | "linearTeamId" | "bidirectional" | "default"
+>;
 
 export type JiraProjectDataFragment = { __typename: "JiraProjectData" } & Pick<JiraProjectData, "id" | "key" | "name">;
 
@@ -12539,11 +13324,6 @@ export type IntegrationSettingsFragment = { __typename: "IntegrationSettings" } 
   zendesk?: Maybe<{ __typename?: "ZendeskSettings" } & ZendeskSettingsFragment>;
 };
 
-export type SamlConfigurationPayloadFragment = { __typename: "SamlConfigurationPayload" } & Pick<
-  SamlConfigurationPayload,
-  "ssoBinding" | "ssoEndpoint" | "ssoSignAlgo" | "issuerEntityId"
->;
-
 export type PaidSubscriptionFragment = { __typename: "PaidSubscription" } & Pick<
   PaidSubscription,
   | "collectionMethod"
@@ -12575,11 +13355,6 @@ export type UserSettingsFragment = { __typename: "UserSettings" } & Pick<
 export type JiraLinearMappingFragment = { __typename: "JiraLinearMapping" } & Pick<
   JiraLinearMapping,
   "jiraProjectId" | "linearTeamId" | "bidirectional" | "default"
->;
-
-export type TeamRepoMappingFragment = { __typename: "TeamRepoMapping" } & Pick<
-  TeamRepoMapping,
-  "gitHubRepoId" | "linearTeamId"
 >;
 
 export type SlackAsksTeamSettingsFragment = { __typename: "SlackAsksTeamSettings" } & Pick<
@@ -12700,15 +13475,6 @@ export type AuthApiKeyPayloadFragment = { __typename: "AuthApiKeyPayload" } & Pi
     authApiKey: { __typename?: "AuthApiKey" } & AuthApiKeyFragment;
   };
 
-export type AuthCreateOrJoinOrganizationResponseFragment = {
-  __typename: "AuthCreateOrJoinOrganizationResponse";
-} & Pick<AuthCreateOrJoinOrganizationResponse, "grantDomainAccess"> & {
-    authOrganization: { __typename?: "AuthOrganization" } & AuthOrganizationFragment;
-    authUser: { __typename?: "AuthUser" } & AuthUserFragment;
-    organization: { __typename?: "AuthOrganization" } & AuthOrganizationFragment;
-    user: { __typename?: "AuthUser" } & AuthUserFragment;
-  };
-
 export type AuthIntegrationFragment = { __typename: "AuthIntegration" } & Pick<AuthIntegration, "id">;
 
 export type AuthOauthClientFragment = { __typename: "AuthOauthClient" } & Pick<
@@ -12736,16 +13502,16 @@ export type AuthOauthClientWithTokensFragment = { __typename: "AuthOauthClientWi
 
 export type AuthOrganizationDomainFragment = { __typename: "AuthOrganizationDomain" } & Pick<
   AuthOrganizationDomain,
-  "id"
+  "id" | "claimed" | "name" | "organizationId" | "verified"
 >;
 
 export type AuthResolverResponseFragment = { __typename: "AuthResolverResponse" } & Pick<
   AuthResolverResponse,
-  "email" | "lastUsedOrganizationId" | "token" | "allowDomainAccess" | "id"
+  "token" | "email" | "lastUsedOrganizationId" | "allowDomainAccess" | "id"
 > & {
+    users: Array<{ __typename?: "AuthUser" } & AuthUserFragment>;
     lockedOrganizations?: Maybe<Array<{ __typename?: "AuthOrganization" } & AuthOrganizationFragment>>;
     availableOrganizations?: Maybe<Array<{ __typename?: "AuthOrganization" } & AuthOrganizationFragment>>;
-    users: Array<{ __typename?: "AuthUser" } & AuthUserFragment>;
   };
 
 export type AuthSuccessPayloadFragment = { __typename: "AuthSuccessPayload" } & Pick<AuthSuccessPayload, "success">;
@@ -12846,7 +13612,6 @@ export type DocumentSearchResultFragment = { __typename: "DocumentSearchResult" 
   | "color"
   | "title"
   | "slugId"
-  | "contentData"
   | "content"
   | "icon"
   | "updatedAt"
@@ -12866,6 +13631,11 @@ export type DocumentSearchResultConnectionFragment = { __typename: "DocumentSear
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
+export type EmailIntakeAddressPayloadFragment = { __typename: "EmailIntakeAddressPayload" } & Pick<
+  EmailIntakeAddressPayload,
+  "lastSyncId" | "success"
+> & { emailIntakeAddress: { __typename?: "EmailIntakeAddress" } & EmailIntakeAddressFragment };
+
 export type EmailUnsubscribePayloadFragment = { __typename: "EmailUnsubscribePayload" } & Pick<
   EmailUnsubscribePayload,
   "success"
@@ -12883,6 +13653,11 @@ export type EmojiConnectionFragment = { __typename: "EmojiConnection" } & {
 export type EmojiPayloadFragment = { __typename: "EmojiPayload" } & Pick<EmojiPayload, "lastSyncId" | "success"> & {
     emoji: { __typename?: "Emoji" } & Pick<Emoji, "id">;
   };
+
+export type ExternalUserConnectionFragment = { __typename: "ExternalUserConnection" } & {
+  nodes: Array<{ __typename?: "ExternalUser" } & ExternalUserFragment>;
+  pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
+};
 
 export type FavoriteConnectionFragment = { __typename: "FavoriteConnection" } & {
   nodes: Array<{ __typename?: "Favorite" } & FavoriteFragment>;
@@ -12909,6 +13684,11 @@ export type GitAutomationStatePayloadFragment = { __typename: "GitAutomationStat
   "lastSyncId" | "success"
 > & { gitAutomationState: { __typename?: "GitAutomationState" } & GitAutomationStateFragment };
 
+export type GitAutomationTargetBranchPayloadFragment = { __typename: "GitAutomationTargetBranchPayload" } & Pick<
+  GitAutomationTargetBranchPayload,
+  "lastSyncId" | "success"
+> & { targetBranch: { __typename?: "GitAutomationTargetBranch" } & GitAutomationTargetBranchFragment };
+
 export type GitHubCommitIntegrationPayloadFragment = { __typename: "GitHubCommitIntegrationPayload" } & Pick<
   GitHubCommitIntegrationPayload,
   "lastSyncId" | "webhookSecret" | "success"
@@ -12923,6 +13703,11 @@ export type IntegrationConnectionFragment = { __typename: "IntegrationConnection
   nodes: Array<{ __typename?: "Integration" } & IntegrationFragment>;
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
+
+export type IntegrationHasScopesPayloadFragment = { __typename: "IntegrationHasScopesPayload" } & Pick<
+  IntegrationHasScopesPayload,
+  "missingScopes" | "hasAllScopes"
+>;
 
 export type IntegrationPayloadFragment = { __typename: "IntegrationPayload" } & Pick<
   IntegrationPayload,
@@ -13062,6 +13847,7 @@ export type IssueSearchResultFragment = { __typename: "IssueSearchResult" } & Pi
 > & {
     botActor?: Maybe<{ __typename?: "ActorBot" } & ActorBotFragment>;
     cycle?: Maybe<{ __typename?: "Cycle" } & Pick<Cycle, "id">>;
+    externalUserCreator?: Maybe<{ __typename?: "ExternalUser" } & Pick<ExternalUser, "id">>;
     lastAppliedTemplate?: Maybe<{ __typename?: "Template" } & Pick<Template, "id">>;
     parent?: Maybe<{ __typename?: "Issue" } & Pick<Issue, "id">>;
     project?: Maybe<{ __typename?: "Project" } & Pick<Project, "id">>;
@@ -13105,6 +13891,8 @@ type Node_CycleNotificationSubscription_Fragment = { __typename: "CycleNotificat
   "id"
 >;
 
+type Node_DataRecovery_Fragment = { __typename: "DataRecovery" } & Pick<DataRecovery, "id">;
+
 type Node_Document_Fragment = { __typename: "Document" } & Pick<Document, "id">;
 
 type Node_DocumentContent_Fragment = { __typename: "DocumentContent" } & Pick<DocumentContent, "id">;
@@ -13122,9 +13910,20 @@ type Node_Emoji_Fragment = { __typename: "Emoji" } & Pick<Emoji, "id">;
 
 type Node_ExternalUser_Fragment = { __typename: "ExternalUser" } & Pick<ExternalUser, "id">;
 
+type Node_Facet_Fragment = { __typename: "Facet" } & Pick<Facet, "id">;
+
 type Node_Favorite_Fragment = { __typename: "Favorite" } & Pick<Favorite, "id">;
 
 type Node_GitAutomationState_Fragment = { __typename: "GitAutomationState" } & Pick<GitAutomationState, "id">;
+
+type Node_GitAutomationTargetBranch_Fragment = { __typename: "GitAutomationTargetBranch" } & Pick<
+  GitAutomationTargetBranch,
+  "id"
+>;
+
+type Node_Initiative_Fragment = { __typename: "Initiative" } & Pick<Initiative, "id">;
+
+type Node_InitiativeToProject_Fragment = { __typename: "InitiativeToProject" } & Pick<InitiativeToProject, "id">;
 
 type Node_Integration_Fragment = { __typename: "Integration" } & Pick<Integration, "id">;
 
@@ -13185,6 +13984,8 @@ type Node_ProjectNotificationSubscription_Fragment = { __typename: "ProjectNotif
 
 type Node_ProjectSearchResult_Fragment = { __typename: "ProjectSearchResult" } & Pick<ProjectSearchResult, "id">;
 
+type Node_ProjectStatus_Fragment = { __typename: "ProjectStatus" } & Pick<ProjectStatus, "id">;
+
 type Node_ProjectUpdate_Fragment = { __typename: "ProjectUpdate" } & Pick<ProjectUpdate, "id">;
 
 type Node_ProjectUpdateInteraction_Fragment = { __typename: "ProjectUpdateInteraction" } & Pick<
@@ -13210,6 +14011,8 @@ type Node_TeamNotificationSubscription_Fragment = { __typename: "TeamNotificatio
 >;
 
 type Node_Template_Fragment = { __typename: "Template" } & Pick<Template, "id">;
+
+type Node_TimeSchedule_Fragment = { __typename: "TimeSchedule" } & Pick<TimeSchedule, "id">;
 
 type Node_TriageResponsibility_Fragment = { __typename: "TriageResponsibility" } & Pick<TriageResponsibility, "id">;
 
@@ -13245,6 +14048,7 @@ export type NodeFragment =
   | Node_CustomViewNotificationSubscription_Fragment
   | Node_Cycle_Fragment
   | Node_CycleNotificationSubscription_Fragment
+  | Node_DataRecovery_Fragment
   | Node_Document_Fragment
   | Node_DocumentContent_Fragment
   | Node_DocumentContentHistory_Fragment
@@ -13252,8 +14056,12 @@ export type NodeFragment =
   | Node_EmailIntakeAddress_Fragment
   | Node_Emoji_Fragment
   | Node_ExternalUser_Fragment
+  | Node_Facet_Fragment
   | Node_Favorite_Fragment
   | Node_GitAutomationState_Fragment
+  | Node_GitAutomationTargetBranch_Fragment
+  | Node_Initiative_Fragment
+  | Node_InitiativeToProject_Fragment
   | Node_Integration_Fragment
   | Node_IntegrationTemplate_Fragment
   | Node_IntegrationsSettings_Fragment
@@ -13279,6 +14087,7 @@ export type NodeFragment =
   | Node_ProjectNotification_Fragment
   | Node_ProjectNotificationSubscription_Fragment
   | Node_ProjectSearchResult_Fragment
+  | Node_ProjectStatus_Fragment
   | Node_ProjectUpdate_Fragment
   | Node_ProjectUpdateInteraction_Fragment
   | Node_PushSubscription_Fragment
@@ -13289,6 +14098,7 @@ export type NodeFragment =
   | Node_TeamMembership_Fragment
   | Node_TeamNotificationSubscription_Fragment
   | Node_Template_Fragment
+  | Node_TimeSchedule_Fragment
   | Node_TriageResponsibility_Fragment
   | Node_User_Fragment
   | Node_UserNotificationSubscription_Fragment
@@ -13379,7 +14189,13 @@ export type OauthClientConnectionFragment = { __typename: "OauthClientConnection
   pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
 };
 
-export type OauthTokenFragment = { __typename: "OauthToken" } & Pick<OauthToken, "createdAt" | "id">;
+export type OauthTokenFragment = { __typename: "OauthToken" } & Pick<
+  OauthToken,
+  "userId" | "clientId" | "createdAt" | "id" | "revokedAt"
+> & {
+    user: { __typename?: "AuthUser" } & AuthUserFragment;
+    client: { __typename?: "AuthOauthClient" } & AuthOauthClientFragment;
+  };
 
 export type OrganizationCancelDeletePayloadFragment = { __typename: "OrganizationCancelDeletePayload" } & Pick<
   OrganizationCancelDeletePayload,
@@ -13614,11 +14430,6 @@ export type RoadmapToProjectPayloadFragment = { __typename: "RoadmapToProjectPay
   "lastSyncId" | "success"
 > & { roadmapToProject: { __typename?: "RoadmapToProject" } & Pick<RoadmapToProject, "id"> };
 
-export type SamlConfigurationFragment = { __typename: "SamlConfiguration" } & Pick<
-  SamlConfiguration,
-  "ssoBinding" | "ssoEndpoint" | "ssoSignAlgo" | "issuerEntityId" | "ssoSigningCert"
->;
-
 export type SlackChannelConnectPayloadFragment = { __typename: "SlackChannelConnectPayload" } & Pick<
   SlackChannelConnectPayload,
   "lastSyncId" | "nudgeToConnectMainSlackIntegration" | "nudgeToUpdateMainSlackIntegration" | "addBot" | "success"
@@ -13662,6 +14473,11 @@ export type TemplatePayloadFragment = { __typename: "TemplatePayload" } & Pick<
   TemplatePayload,
   "lastSyncId" | "success"
 > & { template: { __typename?: "Template" } & Pick<Template, "id"> };
+
+export type TimeScheduleConnectionFragment = { __typename: "TimeScheduleConnection" } & {
+  nodes: Array<{ __typename?: "TimeSchedule" } & TimeScheduleFragment>;
+  pageInfo: { __typename?: "PageInfo" } & PageInfoFragment;
+};
 
 export type TriageResponsibilityConnectionFragment = { __typename: "TriageResponsibilityConnection" } & {
   nodes: Array<{ __typename?: "TriageResponsibility" } & TriageResponsibilityFragment>;
@@ -14039,13 +14855,17 @@ export type AvailableUsersQuery = { __typename?: "Query" } & {
 };
 
 export type CommentQueryVariables = Exact<{
-  id: Scalars["String"];
+  hash?: Maybe<Scalars["String"]>;
+  id?: Maybe<Scalars["String"]>;
+  issueId?: Maybe<Scalars["String"]>;
 }>;
 
 export type CommentQuery = { __typename?: "Query" } & { comment: { __typename?: "Comment" } & CommentFragment };
 
 export type Comment_BotActorQueryVariables = Exact<{
-  id: Scalars["String"];
+  hash?: Maybe<Scalars["String"]>;
+  id?: Maybe<Scalars["String"]>;
+  issueId?: Maybe<Scalars["String"]>;
 }>;
 
 export type Comment_BotActorQuery = { __typename?: "Query" } & {
@@ -14053,7 +14873,9 @@ export type Comment_BotActorQuery = { __typename?: "Query" } & {
 };
 
 export type Comment_ChildrenQueryVariables = Exact<{
-  id: Scalars["String"];
+  hash?: Maybe<Scalars["String"]>;
+  id?: Maybe<Scalars["String"]>;
+  issueId?: Maybe<Scalars["String"]>;
   after?: Maybe<Scalars["String"]>;
   before?: Maybe<Scalars["String"]>;
   filter?: Maybe<CommentFilter>;
@@ -14068,7 +14890,9 @@ export type Comment_ChildrenQuery = { __typename?: "Query" } & {
 };
 
 export type Comment_DocumentContentQueryVariables = Exact<{
-  id: Scalars["String"];
+  hash?: Maybe<Scalars["String"]>;
+  id?: Maybe<Scalars["String"]>;
+  issueId?: Maybe<Scalars["String"]>;
 }>;
 
 export type Comment_DocumentContentQuery = { __typename?: "Query" } & {
@@ -14097,6 +14921,21 @@ export type CustomViewQueryVariables = Exact<{
 
 export type CustomViewQuery = { __typename?: "Query" } & {
   customView: { __typename?: "CustomView" } & CustomViewFragment;
+};
+
+export type CustomView_IssuesQueryVariables = Exact<{
+  id: Scalars["String"];
+  after?: Maybe<Scalars["String"]>;
+  before?: Maybe<Scalars["String"]>;
+  filter?: Maybe<IssueFilter>;
+  first?: Maybe<Scalars["Int"]>;
+  includeArchived?: Maybe<Scalars["Boolean"]>;
+  last?: Maybe<Scalars["Int"]>;
+  orderBy?: Maybe<PaginationOrderBy>;
+}>;
+
+export type CustomView_IssuesQuery = { __typename?: "Query" } & {
+  customView: { __typename?: "CustomView" } & { issues: { __typename?: "IssueConnection" } & IssueConnectionFragment };
 };
 
 export type CustomViewHasSubscribersQueryVariables = Exact<{
@@ -14191,6 +15030,7 @@ export type DocumentContentHistoryQuery = { __typename?: "Query" } & {
 export type DocumentsQueryVariables = Exact<{
   after?: Maybe<Scalars["String"]>;
   before?: Maybe<Scalars["String"]>;
+  filter?: Maybe<DocumentFilter>;
   first?: Maybe<Scalars["Int"]>;
   includeArchived?: Maybe<Scalars["Boolean"]>;
   last?: Maybe<Scalars["Int"]>;
@@ -14218,6 +15058,27 @@ export type EmojisQueryVariables = Exact<{
 
 export type EmojisQuery = { __typename?: "Query" } & {
   emojis: { __typename?: "EmojiConnection" } & EmojiConnectionFragment;
+};
+
+export type ExternalUserQueryVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type ExternalUserQuery = { __typename?: "Query" } & {
+  externalUser: { __typename?: "ExternalUser" } & ExternalUserFragment;
+};
+
+export type ExternalUsersQueryVariables = Exact<{
+  after?: Maybe<Scalars["String"]>;
+  before?: Maybe<Scalars["String"]>;
+  first?: Maybe<Scalars["Int"]>;
+  includeArchived?: Maybe<Scalars["Boolean"]>;
+  last?: Maybe<Scalars["Int"]>;
+  orderBy?: Maybe<PaginationOrderBy>;
+}>;
+
+export type ExternalUsersQuery = { __typename?: "Query" } & {
+  externalUsers: { __typename?: "ExternalUserConnection" } & ExternalUserConnectionFragment;
 };
 
 export type FavoriteQueryVariables = Exact<{
@@ -14261,6 +15122,15 @@ export type IntegrationQueryVariables = Exact<{
 
 export type IntegrationQuery = { __typename?: "Query" } & {
   integration: { __typename?: "Integration" } & IntegrationFragment;
+};
+
+export type IntegrationHasScopesQueryVariables = Exact<{
+  integrationId: Scalars["String"];
+  scopes: Array<Scalars["String"]> | Scalars["String"];
+}>;
+
+export type IntegrationHasScopesQuery = { __typename?: "Query" } & {
+  integrationHasScopes: { __typename?: "IntegrationHasScopesPayload" } & IntegrationHasScopesPayloadFragment;
 };
 
 export type IntegrationTemplateQueryVariables = Exact<{
@@ -14940,6 +15810,7 @@ export type Project_DocumentsQueryVariables = Exact<{
   id: Scalars["String"];
   after?: Maybe<Scalars["String"]>;
   before?: Maybe<Scalars["String"]>;
+  filter?: Maybe<DocumentFilter>;
   first?: Maybe<Scalars["Int"]>;
   includeArchived?: Maybe<Scalars["Boolean"]>;
   last?: Maybe<Scalars["Int"]>;
@@ -15003,6 +15874,7 @@ export type Project_ProjectMilestonesQueryVariables = Exact<{
   id: Scalars["String"];
   after?: Maybe<Scalars["String"]>;
   before?: Maybe<Scalars["String"]>;
+  filter?: Maybe<ProjectMilestoneFilter>;
   first?: Maybe<Scalars["Int"]>;
   includeArchived?: Maybe<Scalars["Boolean"]>;
   last?: Maybe<Scalars["Int"]>;
@@ -15345,22 +16217,6 @@ export type TeamQueryVariables = Exact<{
 
 export type TeamQuery = { __typename?: "Query" } & { team: { __typename?: "Team" } & TeamFragment };
 
-export type Team_AutomationStatesQueryVariables = Exact<{
-  id: Scalars["String"];
-  after?: Maybe<Scalars["String"]>;
-  before?: Maybe<Scalars["String"]>;
-  first?: Maybe<Scalars["Int"]>;
-  includeArchived?: Maybe<Scalars["Boolean"]>;
-  last?: Maybe<Scalars["Int"]>;
-  orderBy?: Maybe<PaginationOrderBy>;
-}>;
-
-export type Team_AutomationStatesQuery = { __typename?: "Query" } & {
-  team: { __typename?: "Team" } & {
-    automationStates: { __typename?: "GitAutomationStateConnection" } & GitAutomationStateConnectionFragment;
-  };
-};
-
 export type Team_CyclesQueryVariables = Exact<{
   id: Scalars["String"];
   after?: Maybe<Scalars["String"]>;
@@ -15374,6 +16230,22 @@ export type Team_CyclesQueryVariables = Exact<{
 
 export type Team_CyclesQuery = { __typename?: "Query" } & {
   team: { __typename?: "Team" } & { cycles: { __typename?: "CycleConnection" } & CycleConnectionFragment };
+};
+
+export type Team_GitAutomationStatesQueryVariables = Exact<{
+  id: Scalars["String"];
+  after?: Maybe<Scalars["String"]>;
+  before?: Maybe<Scalars["String"]>;
+  first?: Maybe<Scalars["Int"]>;
+  includeArchived?: Maybe<Scalars["Boolean"]>;
+  last?: Maybe<Scalars["Int"]>;
+  orderBy?: Maybe<PaginationOrderBy>;
+}>;
+
+export type Team_GitAutomationStatesQuery = { __typename?: "Query" } & {
+  team: { __typename?: "Team" } & {
+    gitAutomationStates: { __typename?: "GitAutomationStateConnection" } & GitAutomationStateConnectionFragment;
+  };
 };
 
 export type Team_IssuesQueryVariables = Exact<{
@@ -15815,6 +16687,7 @@ export type AttachmentLinkDiscordMutationVariables = Exact<{
   id?: Maybe<Scalars["String"]>;
   issueId: Scalars["String"];
   messageId: Scalars["String"];
+  title?: Maybe<Scalars["String"]>;
   url: Scalars["String"];
 }>;
 
@@ -15828,6 +16701,7 @@ export type AttachmentLinkFrontMutationVariables = Exact<{
   displayIconUrl?: Maybe<Scalars["String"]>;
   id?: Maybe<Scalars["String"]>;
   issueId: Scalars["String"];
+  title?: Maybe<Scalars["String"]>;
 }>;
 
 export type AttachmentLinkFrontMutation = { __typename?: "Mutation" } & {
@@ -15839,6 +16713,7 @@ export type AttachmentLinkGitHubIssueMutationVariables = Exact<{
   displayIconUrl?: Maybe<Scalars["String"]>;
   id?: Maybe<Scalars["String"]>;
   issueId: Scalars["String"];
+  title?: Maybe<Scalars["String"]>;
   url: Scalars["String"];
 }>;
 
@@ -15854,6 +16729,7 @@ export type AttachmentLinkGitHubPrMutationVariables = Exact<{
   number?: Maybe<Scalars["Float"]>;
   owner?: Maybe<Scalars["String"]>;
   repo?: Maybe<Scalars["String"]>;
+  title?: Maybe<Scalars["String"]>;
   url: Scalars["String"];
 }>;
 
@@ -15868,6 +16744,7 @@ export type AttachmentLinkGitLabMrMutationVariables = Exact<{
   issueId: Scalars["String"];
   number: Scalars["Float"];
   projectPathWithNamespace: Scalars["String"];
+  title?: Maybe<Scalars["String"]>;
   url: Scalars["String"];
 }>;
 
@@ -15881,6 +16758,7 @@ export type AttachmentLinkIntercomMutationVariables = Exact<{
   displayIconUrl?: Maybe<Scalars["String"]>;
   id?: Maybe<Scalars["String"]>;
   issueId: Scalars["String"];
+  title?: Maybe<Scalars["String"]>;
 }>;
 
 export type AttachmentLinkIntercomMutation = { __typename?: "Mutation" } & {
@@ -15931,6 +16809,7 @@ export type AttachmentLinkZendeskMutationVariables = Exact<{
   id?: Maybe<Scalars["String"]>;
   issueId: Scalars["String"];
   ticketId: Scalars["String"];
+  title?: Maybe<Scalars["String"]>;
 }>;
 
 export type AttachmentLinkZendeskMutation = { __typename?: "Mutation" } & {
@@ -16115,6 +16994,39 @@ export type UpdateDocumentMutation = { __typename?: "Mutation" } & {
   documentUpdate: { __typename?: "DocumentPayload" } & DocumentPayloadFragment;
 };
 
+export type CreateEmailIntakeAddressMutationVariables = Exact<{
+  input: EmailIntakeAddressCreateInput;
+}>;
+
+export type CreateEmailIntakeAddressMutation = { __typename?: "Mutation" } & {
+  emailIntakeAddressCreate: { __typename?: "EmailIntakeAddressPayload" } & EmailIntakeAddressPayloadFragment;
+};
+
+export type DeleteEmailIntakeAddressMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteEmailIntakeAddressMutation = { __typename?: "Mutation" } & {
+  emailIntakeAddressDelete: { __typename?: "DeletePayload" } & DeletePayloadFragment;
+};
+
+export type EmailIntakeAddressRotateMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type EmailIntakeAddressRotateMutation = { __typename?: "Mutation" } & {
+  emailIntakeAddressRotate: { __typename?: "EmailIntakeAddressPayload" } & EmailIntakeAddressPayloadFragment;
+};
+
+export type UpdateEmailIntakeAddressMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: EmailIntakeAddressUpdateInput;
+}>;
+
+export type UpdateEmailIntakeAddressMutation = { __typename?: "Mutation" } & {
+  emailIntakeAddressUpdate: { __typename?: "EmailIntakeAddressPayload" } & EmailIntakeAddressPayloadFragment;
+};
+
 export type EmailTokenUserAccountAuthMutationVariables = Exact<{
   input: TokenUserAccountAuthInput;
 }>;
@@ -16219,6 +17131,35 @@ export type UpdateGitAutomationStateMutation = { __typename?: "Mutation" } & {
   gitAutomationStateUpdate: { __typename?: "GitAutomationStatePayload" } & GitAutomationStatePayloadFragment;
 };
 
+export type CreateGitAutomationTargetBranchMutationVariables = Exact<{
+  input: GitAutomationTargetBranchCreateInput;
+}>;
+
+export type CreateGitAutomationTargetBranchMutation = { __typename?: "Mutation" } & {
+  gitAutomationTargetBranchCreate: {
+    __typename?: "GitAutomationTargetBranchPayload";
+  } & GitAutomationTargetBranchPayloadFragment;
+};
+
+export type DeleteGitAutomationTargetBranchMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type DeleteGitAutomationTargetBranchMutation = { __typename?: "Mutation" } & {
+  gitAutomationTargetBranchDelete: { __typename?: "DeletePayload" } & DeletePayloadFragment;
+};
+
+export type UpdateGitAutomationTargetBranchMutationVariables = Exact<{
+  id: Scalars["String"];
+  input: GitAutomationTargetBranchUpdateInput;
+}>;
+
+export type UpdateGitAutomationTargetBranchMutation = { __typename?: "Mutation" } & {
+  gitAutomationTargetBranchUpdate: {
+    __typename?: "GitAutomationTargetBranchPayload";
+  } & GitAutomationTargetBranchPayloadFragment;
+};
+
 export type GoogleUserAccountAuthMutationVariables = Exact<{
   input: GoogleUserAccountAuthInput;
 }>;
@@ -16244,6 +17185,14 @@ export type ImportFileUploadMutationVariables = Exact<{
 
 export type ImportFileUploadMutation = { __typename?: "Mutation" } & {
   importFileUpload: { __typename?: "UploadPayload" } & UploadPayloadFragment;
+};
+
+export type ArchiveIntegrationMutationVariables = Exact<{
+  id: Scalars["String"];
+}>;
+
+export type ArchiveIntegrationMutation = { __typename?: "Mutation" } & {
+  integrationArchive: { __typename?: "DeletePayload" } & DeletePayloadFragment;
 };
 
 export type IntegrationAsksConnectChannelMutationVariables = Exact<{
@@ -17849,6 +18798,24 @@ export const DeletePayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<DeletePayloadFragment, unknown>;
+export const InitiativeArchivePayloadFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "InitiativeArchivePayload" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "InitiativeArchivePayload" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<InitiativeArchivePayloadFragment, unknown>;
 export const IssueArchivePayloadFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -18005,6 +18972,14 @@ export const IssueNotificationFragmentDoc = {
           },
           {
             kind: "Field",
+            name: { kind: "Name", value: "externalUserActor" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+          {
+            kind: "Field",
             name: { kind: "Name", value: "issue" },
             selectionSet: {
               kind: "SelectionSet",
@@ -18110,6 +19085,14 @@ export const OauthClientApprovalNotificationFragmentDoc = {
               selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ActorBot" } }],
             },
           },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "externalUserActor" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           { kind: "Field", name: { kind: "Name", value: "emailedAt" } },
           { kind: "Field", name: { kind: "Name", value: "readAt" } },
@@ -18157,6 +19140,14 @@ export const ProjectNotificationFragmentDoc = {
             selectionSet: {
               kind: "SelectionSet",
               selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ActorBot" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "externalUserActor" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
             },
           },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
@@ -18222,6 +19213,14 @@ export const NotificationFragmentDoc = {
             selectionSet: {
               kind: "SelectionSet",
               selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ActorBot" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "externalUserActor" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
             },
           },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
@@ -18444,6 +19443,14 @@ export const ArchivePayloadFragmentDoc = {
             selectionSet: {
               kind: "SelectionSet",
               selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "DeletePayload" } }],
+            },
+          },
+          {
+            kind: "InlineFragment",
+            typeCondition: { kind: "NamedType", name: { kind: "Name", value: "InitiativeArchivePayload" } },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "InitiativeArchivePayload" } }],
             },
           },
           {
@@ -18751,6 +19758,7 @@ export const UserAccountFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           { kind: "Field", name: { kind: "Name", value: "email" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "authTokenLinkDisabled" } },
         ],
       },
     },
@@ -18834,44 +19842,23 @@ export const UserNotificationSubscriptionFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<UserNotificationSubscriptionFragment, unknown>;
-export const EmailIntakeAddressFragmentDoc = {
+export const AuthOrganizationInviteFragmentDoc = {
   kind: "Document",
   definitions: [
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "EmailIntakeAddress" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "EmailIntakeAddress" } },
+      name: { kind: "Name", value: "AuthOrganizationInvite" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "AuthOrganizationInvite" } },
       selectionSet: {
         kind: "SelectionSet",
         selections: [
           { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "team" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
-            },
-          },
-          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
-          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "creator" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
-            },
-          },
-          { kind: "Field", name: { kind: "Name", value: "address" } },
-          { kind: "Field", name: { kind: "Name", value: "enabled" } },
         ],
       },
     },
   ],
-} as unknown as DocumentNode<EmailIntakeAddressFragment, unknown>;
+} as unknown as DocumentNode<AuthOrganizationInviteFragment, unknown>;
 export const PaidSubscriptionFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -19032,6 +20019,26 @@ export const AuthenticationSessionResponseFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<AuthenticationSessionResponseFragment, unknown>;
+export const DataRecoveryFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "DataRecovery" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "DataRecovery" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DataRecoveryFragment, unknown>;
 export const OrganizationDomainFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -19219,6 +20226,8 @@ export const TeamRepoMappingFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "gitHubRepoId" } },
           { kind: "Field", name: { kind: "Name", value: "linearTeamId" } },
+          { kind: "Field", name: { kind: "Name", value: "bidirectional" } },
+          { kind: "Field", name: { kind: "Name", value: "default" } },
         ],
       },
     },
@@ -19807,26 +20816,6 @@ export const IntegrationSettingsFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<IntegrationSettingsFragment, unknown>;
-export const SamlConfigurationPayloadFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "SamlConfigurationPayload" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "SamlConfigurationPayload" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "ssoBinding" } },
-          { kind: "Field", name: { kind: "Name", value: "ssoEndpoint" } },
-          { kind: "Field", name: { kind: "Name", value: "ssoSignAlgo" } },
-          { kind: "Field", name: { kind: "Name", value: "issuerEntityId" } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<SamlConfigurationPayloadFragment, unknown>;
 export const UserSettingsFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -20059,6 +21048,14 @@ export const AttachmentFragmentDoc = {
             },
           },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "externalUserCreator" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
@@ -20268,111 +21265,6 @@ export const AuthApiKeyPayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<AuthApiKeyPayloadFragment, unknown>;
-export const AuthOrganizationFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "AuthOrganization" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "AuthOrganization" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "allowedAuthServices" } },
-          { kind: "Field", name: { kind: "Name", value: "previousUrlKeys" } },
-          { kind: "Field", name: { kind: "Name", value: "logoUrl" } },
-          { kind: "Field", name: { kind: "Name", value: "name" } },
-          { kind: "Field", name: { kind: "Name", value: "urlKey" } },
-          { kind: "Field", name: { kind: "Name", value: "deletionRequestedAt" } },
-          { kind: "Field", name: { kind: "Name", value: "id" } },
-          { kind: "Field", name: { kind: "Name", value: "samlEnabled" } },
-          { kind: "Field", name: { kind: "Name", value: "scimEnabled" } },
-          { kind: "Field", name: { kind: "Name", value: "userCount" } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<AuthOrganizationFragment, unknown>;
-export const AuthUserFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "AuthUser" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "AuthUser" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "avatarUrl" } },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "organization" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AuthOrganization" } }],
-            },
-          },
-          { kind: "Field", name: { kind: "Name", value: "displayName" } },
-          { kind: "Field", name: { kind: "Name", value: "email" } },
-          { kind: "Field", name: { kind: "Name", value: "name" } },
-          { kind: "Field", name: { kind: "Name", value: "active" } },
-          { kind: "Field", name: { kind: "Name", value: "id" } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<AuthUserFragment, unknown>;
-export const AuthCreateOrJoinOrganizationResponseFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "AuthCreateOrJoinOrganizationResponse" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "AuthCreateOrJoinOrganizationResponse" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "authOrganization" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AuthOrganization" } }],
-            },
-          },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "authUser" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AuthUser" } }],
-            },
-          },
-          { kind: "Field", name: { kind: "Name", value: "grantDomainAccess" } },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "organization" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AuthOrganization" } }],
-            },
-          },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "user" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AuthUser" } }],
-            },
-          },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<AuthCreateOrJoinOrganizationResponseFragment, unknown>;
 export const AuthIntegrationFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -20420,6 +21312,64 @@ export const AuthOauthClientFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<AuthOauthClientFragment, unknown>;
+export const AuthOrganizationFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "AuthOrganization" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "AuthOrganization" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "allowedAuthServices" } },
+          { kind: "Field", name: { kind: "Name", value: "previousUrlKeys" } },
+          { kind: "Field", name: { kind: "Name", value: "serviceId" } },
+          { kind: "Field", name: { kind: "Name", value: "logoUrl" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "urlKey" } },
+          { kind: "Field", name: { kind: "Name", value: "deletionRequestedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "samlEnabled" } },
+          { kind: "Field", name: { kind: "Name", value: "scimEnabled" } },
+          { kind: "Field", name: { kind: "Name", value: "userCount" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<AuthOrganizationFragment, unknown>;
+export const AuthUserFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "AuthUser" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "AuthUser" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "avatarUrl" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "organization" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AuthOrganization" } }],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "displayName" } },
+          { kind: "Field", name: { kind: "Name", value: "email" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "userAccountId" } },
+          { kind: "Field", name: { kind: "Name", value: "active" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<AuthUserFragment, unknown>;
 export const OauthTokenFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -20431,8 +21381,27 @@ export const OauthTokenFragmentDoc = {
         kind: "SelectionSet",
         selections: [
           { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "user" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AuthUser" } }],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "userId" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "client" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AuthOauthClient" } }],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "clientId" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "revokedAt" } },
         ],
       },
     },
@@ -20482,6 +21451,10 @@ export const AuthOrganizationDomainFragmentDoc = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "claimed" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "organizationId" } },
+          { kind: "Field", name: { kind: "Name", value: "verified" } },
         ],
       },
     },
@@ -20498,9 +21471,17 @@ export const AuthResolverResponseFragmentDoc = {
         kind: "SelectionSet",
         selections: [
           { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "token" } },
           { kind: "Field", name: { kind: "Name", value: "email" } },
           { kind: "Field", name: { kind: "Name", value: "lastUsedOrganizationId" } },
-          { kind: "Field", name: { kind: "Name", value: "token" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "users" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AuthUser" } }],
+            },
+          },
           {
             kind: "Field",
             name: { kind: "Name", value: "lockedOrganizations" },
@@ -20519,14 +21500,6 @@ export const AuthResolverResponseFragmentDoc = {
           },
           { kind: "Field", name: { kind: "Name", value: "allowDomainAccess" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "users" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "AuthUser" } }],
-            },
-          },
         ],
       },
     },
@@ -20610,6 +21583,14 @@ export const CommentFragmentDoc = {
           },
           {
             kind: "Field",
+            name: { kind: "Name", value: "externalUser" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+          {
+            kind: "Field",
             name: { kind: "Name", value: "issue" },
             selectionSet: {
               kind: "SelectionSet",
@@ -20633,6 +21614,7 @@ export const CommentFragmentDoc = {
               selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
             },
           },
+          { kind: "Field", name: { kind: "Name", value: "quotedText" } },
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
           { kind: "Field", name: { kind: "Name", value: "resolvedAt" } },
@@ -20862,6 +21844,7 @@ export const CustomViewFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "color" } },
           { kind: "Field", name: { kind: "Name", value: "description" } },
           { kind: "Field", name: { kind: "Name", value: "filterData" } },
+          { kind: "Field", name: { kind: "Name", value: "projectFilterData" } },
           { kind: "Field", name: { kind: "Name", value: "filters" } },
           { kind: "Field", name: { kind: "Name", value: "icon" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
@@ -20881,6 +21864,14 @@ export const CustomViewFragmentDoc = {
           {
             kind: "Field",
             name: { kind: "Name", value: "creator" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "updatedBy" },
             selectionSet: {
               kind: "SelectionSet",
               selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
@@ -21107,7 +22098,6 @@ export const DocumentFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "color" } },
           { kind: "Field", name: { kind: "Name", value: "title" } },
           { kind: "Field", name: { kind: "Name", value: "slugId" } },
-          { kind: "Field", name: { kind: "Name", value: "contentData" } },
           { kind: "Field", name: { kind: "Name", value: "content" } },
           { kind: "Field", name: { kind: "Name", value: "icon" } },
           {
@@ -21290,7 +22280,6 @@ export const DocumentSearchResultFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "color" } },
           { kind: "Field", name: { kind: "Name", value: "title" } },
           { kind: "Field", name: { kind: "Name", value: "slugId" } },
-          { kind: "Field", name: { kind: "Name", value: "contentData" } },
           { kind: "Field", name: { kind: "Name", value: "content" } },
           { kind: "Field", name: { kind: "Name", value: "icon" } },
           {
@@ -21408,6 +22397,78 @@ export const DocumentSearchResultConnectionFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<DocumentSearchResultConnectionFragment, unknown>;
+export const EmailIntakeAddressFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "EmailIntakeAddress" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "EmailIntakeAddress" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "team" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "template" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "creator" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "address" } },
+          { kind: "Field", name: { kind: "Name", value: "enabled" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<EmailIntakeAddressFragment, unknown>;
+export const EmailIntakeAddressPayloadFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "EmailIntakeAddressPayload" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "EmailIntakeAddressPayload" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "emailIntakeAddress" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "EmailIntakeAddress" } }],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<EmailIntakeAddressPayloadFragment, unknown>;
 export const EmailUnsubscribePayloadFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -21532,6 +22593,63 @@ export const EmojiPayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<EmojiPayloadFragment, unknown>;
+export const ExternalUserFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "ExternalUser" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "ExternalUser" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "avatarUrl" } },
+          { kind: "Field", name: { kind: "Name", value: "displayName" } },
+          { kind: "Field", name: { kind: "Name", value: "email" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "lastSeen" } },
+          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ExternalUserFragment, unknown>;
+export const ExternalUserConnectionFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "ExternalUserConnection" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "ExternalUserConnection" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "nodes" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ExternalUser" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "pageInfo" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "PageInfo" } }],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ExternalUserConnectionFragment, unknown>;
 export const FavoriteFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -21728,6 +22846,36 @@ export const FrontAttachmentPayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<FrontAttachmentPayloadFragment, unknown>;
+export const GitAutomationTargetBranchFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "GitAutomationTargetBranch" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "GitAutomationTargetBranch" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "branchPattern" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "team" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "isRegex" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<GitAutomationTargetBranchFragment, unknown>;
 export const GitAutomationStateFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -21748,7 +22896,14 @@ export const GitAutomationStateFragmentDoc = {
             },
           },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
-          { kind: "Field", name: { kind: "Name", value: "branchPattern" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "targetBranch" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "GitAutomationTargetBranch" } }],
+            },
+          },
           {
             kind: "Field",
             name: { kind: "Name", value: "team" },
@@ -21760,6 +22915,7 @@ export const GitAutomationStateFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "branchPattern" } },
         ],
       },
     },
@@ -21823,6 +22979,32 @@ export const GitAutomationStatePayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<GitAutomationStatePayloadFragment, unknown>;
+export const GitAutomationTargetBranchPayloadFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "GitAutomationTargetBranchPayload" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "GitAutomationTargetBranchPayload" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "targetBranch" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "GitAutomationTargetBranch" } }],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "lastSyncId" } },
+          { kind: "Field", name: { kind: "Name", value: "success" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<GitAutomationTargetBranchPayloadFragment, unknown>;
 export const GitHubCommitIntegrationPayloadFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -21938,6 +23120,24 @@ export const IntegrationConnectionFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<IntegrationConnectionFragment, unknown>;
+export const IntegrationHasScopesPayloadFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "IntegrationHasScopesPayload" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "IntegrationHasScopesPayload" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "missingScopes" } },
+          { kind: "Field", name: { kind: "Name", value: "hasAllScopes" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<IntegrationHasScopesPayloadFragment, unknown>;
 export const IntegrationPayloadFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -22217,6 +23417,14 @@ export const IssueFragmentDoc = {
           },
           { kind: "Field", name: { kind: "Name", value: "dueDate" } },
           { kind: "Field", name: { kind: "Name", value: "estimate" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "externalUserCreator" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
           { kind: "Field", name: { kind: "Name", value: "description" } },
           { kind: "Field", name: { kind: "Name", value: "title" } },
           { kind: "Field", name: { kind: "Name", value: "number" } },
@@ -23045,6 +24253,14 @@ export const IssueSearchResultFragmentDoc = {
           },
           { kind: "Field", name: { kind: "Name", value: "dueDate" } },
           { kind: "Field", name: { kind: "Name", value: "estimate" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "externalUserCreator" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
           { kind: "Field", name: { kind: "Name", value: "description" } },
           { kind: "Field", name: { kind: "Name", value: "title" } },
           { kind: "Field", name: { kind: "Name", value: "number" } },
@@ -24226,6 +25442,7 @@ export const ProjectUpdateFragmentDoc = {
               selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
             },
           },
+          { kind: "Field", name: { kind: "Name", value: "isDiffHidden" } },
         ],
       },
     },
@@ -24884,27 +26101,6 @@ export const RoadmapToProjectPayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<RoadmapToProjectPayloadFragment, unknown>;
-export const SamlConfigurationFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "SamlConfiguration" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "SamlConfiguration" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "ssoBinding" } },
-          { kind: "Field", name: { kind: "Name", value: "ssoEndpoint" } },
-          { kind: "Field", name: { kind: "Name", value: "ssoSignAlgo" } },
-          { kind: "Field", name: { kind: "Name", value: "issuerEntityId" } },
-          { kind: "Field", name: { kind: "Name", value: "ssoSigningCert" } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<SamlConfigurationFragment, unknown>;
 export const SlackChannelConnectPayloadFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -25389,6 +26585,71 @@ export const TemplatePayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<TemplatePayloadFragment, unknown>;
+export const TimeScheduleFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "TimeSchedule" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "TimeSchedule" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "externalUrl" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integration" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "externalId" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "entries" } },
+          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "error" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<TimeScheduleFragment, unknown>;
+export const TimeScheduleConnectionFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "TimeScheduleConnection" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "TimeScheduleConnection" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "nodes" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "TimeSchedule" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "pageInfo" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "PageInfo" } }],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<TimeScheduleConnectionFragment, unknown>;
 export const TriageResponsibilityFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -25421,6 +26682,14 @@ export const TriageResponsibilityFragmentDoc = {
           },
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "timeSchedule" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "TimeSchedule" } }],
+            },
+          },
           { kind: "Field", name: { kind: "Name", value: "id" } },
         ],
       },
@@ -27882,8 +29151,8 @@ export const AvailableUsersDocument = {
       },
     },
     ...AuthResolverResponseFragmentDoc.definitions,
-    ...AuthOrganizationFragmentDoc.definitions,
     ...AuthUserFragmentDoc.definitions,
+    ...AuthOrganizationFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<AvailableUsersQuery, AvailableUsersQueryVariables>;
 export const CommentDocument = {
@@ -27896,8 +29165,18 @@ export const CommentDocument = {
       variableDefinitions: [
         {
           kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "hash" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
           variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
         },
       ],
       selectionSet: {
@@ -27909,8 +29188,18 @@ export const CommentDocument = {
             arguments: [
               {
                 kind: "Argument",
+                name: { kind: "Name", value: "hash" },
+                value: { kind: "Variable", name: { kind: "Name", value: "hash" } },
+              },
+              {
+                kind: "Argument",
                 name: { kind: "Name", value: "id" },
                 value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "issueId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
               },
             ],
             selectionSet: {
@@ -27936,8 +29225,18 @@ export const Comment_BotActorDocument = {
       variableDefinitions: [
         {
           kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "hash" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
           variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
         },
       ],
       selectionSet: {
@@ -27949,8 +29248,18 @@ export const Comment_BotActorDocument = {
             arguments: [
               {
                 kind: "Argument",
+                name: { kind: "Name", value: "hash" },
+                value: { kind: "Variable", name: { kind: "Name", value: "hash" } },
+              },
+              {
+                kind: "Argument",
                 name: { kind: "Name", value: "id" },
                 value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "issueId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
               },
             ],
             selectionSet: {
@@ -27983,8 +29292,18 @@ export const Comment_ChildrenDocument = {
       variableDefinitions: [
         {
           kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "hash" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
           variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
         },
         {
           kind: "VariableDefinition",
@@ -28031,8 +29350,18 @@ export const Comment_ChildrenDocument = {
             arguments: [
               {
                 kind: "Argument",
+                name: { kind: "Name", value: "hash" },
+                value: { kind: "Variable", name: { kind: "Name", value: "hash" } },
+              },
+              {
+                kind: "Argument",
                 name: { kind: "Name", value: "id" },
                 value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "issueId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
               },
             ],
             selectionSet: {
@@ -28106,8 +29435,18 @@ export const Comment_DocumentContentDocument = {
       variableDefinitions: [
         {
           kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "hash" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
           variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
         },
       ],
       selectionSet: {
@@ -28119,8 +29458,18 @@ export const Comment_DocumentContentDocument = {
             arguments: [
               {
                 kind: "Argument",
+                name: { kind: "Name", value: "hash" },
+                value: { kind: "Variable", name: { kind: "Name", value: "hash" } },
+              },
+              {
+                kind: "Argument",
                 name: { kind: "Name", value: "id" },
                 value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "issueId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
               },
             ],
             selectionSet: {
@@ -28283,6 +29632,128 @@ export const CustomViewDocument = {
     ...CustomViewFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<CustomViewQuery, CustomViewQueryVariables>;
+export const CustomView_IssuesDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "customView_issues" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "before" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "filter" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "IssueFilter" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "includeArchived" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "last" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "orderBy" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "PaginationOrderBy" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "customView" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "issues" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "after" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "before" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "before" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "filter" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "filter" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "first" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "includeArchived" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "includeArchived" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "last" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "last" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "orderBy" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "orderBy" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueConnection" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    ...IssueConnectionFragmentDoc.definitions,
+    ...IssueFragmentDoc.definitions,
+    ...ActorBotFragmentDoc.definitions,
+    ...PageInfoFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CustomView_IssuesQuery, CustomView_IssuesQueryVariables>;
 export const CustomViewHasSubscribersDocument = {
   kind: "Document",
   definitions: [
@@ -28892,6 +30363,11 @@ export const DocumentsDocument = {
         },
         {
           kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "filter" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "DocumentFilter" } },
+        },
+        {
+          kind: "VariableDefinition",
           variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
           type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
         },
@@ -28927,6 +30403,11 @@ export const DocumentsDocument = {
                 kind: "Argument",
                 name: { kind: "Name", value: "before" },
                 value: { kind: "Variable", name: { kind: "Name", value: "before" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "filter" },
+                value: { kind: "Variable", name: { kind: "Name", value: "filter" } },
               },
               {
                 kind: "Argument",
@@ -29090,6 +30571,134 @@ export const EmojisDocument = {
     ...PageInfoFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<EmojisQuery, EmojisQueryVariables>;
+export const ExternalUserDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "externalUser" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "externalUser" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ExternalUser" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ExternalUserFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<ExternalUserQuery, ExternalUserQueryVariables>;
+export const ExternalUsersDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "externalUsers" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "before" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "includeArchived" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "last" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "orderBy" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "PaginationOrderBy" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "externalUsers" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "after" },
+                value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "before" },
+                value: { kind: "Variable", name: { kind: "Name", value: "before" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "first" },
+                value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "includeArchived" },
+                value: { kind: "Variable", name: { kind: "Name", value: "includeArchived" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "last" },
+                value: { kind: "Variable", name: { kind: "Name", value: "last" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "orderBy" },
+                value: { kind: "Variable", name: { kind: "Name", value: "orderBy" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ExternalUserConnection" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ExternalUserConnectionFragmentDoc.definitions,
+    ...ExternalUserFragmentDoc.definitions,
+    ...PageInfoFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<ExternalUsersQuery, ExternalUsersQueryVariables>;
 export const FavoriteDocument = {
   kind: "Document",
   definitions: [
@@ -29367,6 +30976,60 @@ export const IntegrationDocument = {
     ...IntegrationFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<IntegrationQuery, IntegrationQueryVariables>;
+export const IntegrationHasScopesDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "integrationHasScopes" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "scopes" } },
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "ListType",
+              type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationHasScopes" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "integrationId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "scopes" },
+                value: { kind: "Variable", name: { kind: "Name", value: "scopes" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IntegrationHasScopesPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...IntegrationHasScopesPayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<IntegrationHasScopesQuery, IntegrationHasScopesQueryVariables>;
 export const IntegrationTemplateDocument = {
   kind: "Document",
   definitions: [
@@ -33762,6 +35425,11 @@ export const Project_DocumentsDocument = {
         },
         {
           kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "filter" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "DocumentFilter" } },
+        },
+        {
+          kind: "VariableDefinition",
           variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
           type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
         },
@@ -33810,6 +35478,11 @@ export const Project_DocumentsDocument = {
                       kind: "Argument",
                       name: { kind: "Name", value: "before" },
                       value: { kind: "Variable", name: { kind: "Name", value: "before" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "filter" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "filter" } },
                     },
                     {
                       kind: "Argument",
@@ -34237,6 +35910,11 @@ export const Project_ProjectMilestonesDocument = {
         },
         {
           kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "filter" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ProjectMilestoneFilter" } },
+        },
+        {
+          kind: "VariableDefinition",
           variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
           type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
         },
@@ -34285,6 +35963,11 @@ export const Project_ProjectMilestonesDocument = {
                       kind: "Argument",
                       name: { kind: "Name", value: "before" },
                       value: { kind: "Variable", name: { kind: "Name", value: "before" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "filter" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "filter" } },
                     },
                     {
                       kind: "Argument",
@@ -36530,119 +38213,6 @@ export const TeamDocument = {
     ...TeamFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<TeamQuery, TeamQueryVariables>;
-export const Team_AutomationStatesDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "query",
-      name: { kind: "Name", value: "team_automationStates" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
-          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "before" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "includeArchived" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "last" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "orderBy" } },
-          type: { kind: "NamedType", name: { kind: "Name", value: "PaginationOrderBy" } },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "team" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "id" },
-                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [
-                {
-                  kind: "Field",
-                  name: { kind: "Name", value: "automationStates" },
-                  arguments: [
-                    {
-                      kind: "Argument",
-                      name: { kind: "Name", value: "after" },
-                      value: { kind: "Variable", name: { kind: "Name", value: "after" } },
-                    },
-                    {
-                      kind: "Argument",
-                      name: { kind: "Name", value: "before" },
-                      value: { kind: "Variable", name: { kind: "Name", value: "before" } },
-                    },
-                    {
-                      kind: "Argument",
-                      name: { kind: "Name", value: "first" },
-                      value: { kind: "Variable", name: { kind: "Name", value: "first" } },
-                    },
-                    {
-                      kind: "Argument",
-                      name: { kind: "Name", value: "includeArchived" },
-                      value: { kind: "Variable", name: { kind: "Name", value: "includeArchived" } },
-                    },
-                    {
-                      kind: "Argument",
-                      name: { kind: "Name", value: "last" },
-                      value: { kind: "Variable", name: { kind: "Name", value: "last" } },
-                    },
-                    {
-                      kind: "Argument",
-                      name: { kind: "Name", value: "orderBy" },
-                      value: { kind: "Variable", name: { kind: "Name", value: "orderBy" } },
-                    },
-                  ],
-                  selectionSet: {
-                    kind: "SelectionSet",
-                    selections: [
-                      { kind: "FragmentSpread", name: { kind: "Name", value: "GitAutomationStateConnection" } },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    ...GitAutomationStateConnectionFragmentDoc.definitions,
-    ...GitAutomationStateFragmentDoc.definitions,
-    ...PageInfoFragmentDoc.definitions,
-  ],
-} as unknown as DocumentNode<Team_AutomationStatesQuery, Team_AutomationStatesQueryVariables>;
 export const Team_CyclesDocument = {
   kind: "Document",
   definitions: [
@@ -36764,6 +38334,120 @@ export const Team_CyclesDocument = {
     ...PageInfoFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<Team_CyclesQuery, Team_CyclesQueryVariables>;
+export const Team_GitAutomationStatesDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "team_gitAutomationStates" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "before" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "includeArchived" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "last" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "orderBy" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "PaginationOrderBy" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "team" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "gitAutomationStates" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "after" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "before" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "before" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "first" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "includeArchived" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "includeArchived" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "last" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "last" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "orderBy" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "orderBy" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "FragmentSpread", name: { kind: "Name", value: "GitAutomationStateConnection" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    ...GitAutomationStateConnectionFragmentDoc.definitions,
+    ...GitAutomationStateFragmentDoc.definitions,
+    ...GitAutomationTargetBranchFragmentDoc.definitions,
+    ...PageInfoFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<Team_GitAutomationStatesQuery, Team_GitAutomationStatesQueryVariables>;
 export const Team_IssuesDocument = {
   kind: "Document",
   definitions: [
@@ -39807,6 +41491,11 @@ export const AttachmentLinkDiscordDocument = {
         },
         {
           kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "title" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
           variable: { kind: "Variable", name: { kind: "Name", value: "url" } },
           type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
         },
@@ -39847,6 +41536,11 @@ export const AttachmentLinkDiscordDocument = {
                 kind: "Argument",
                 name: { kind: "Name", value: "messageId" },
                 value: { kind: "Variable", name: { kind: "Name", value: "messageId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "title" },
+                value: { kind: "Variable", name: { kind: "Name", value: "title" } },
               },
               {
                 kind: "Argument",
@@ -39898,6 +41592,11 @@ export const AttachmentLinkFrontDocument = {
           variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
           type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
         },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "title" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
       ],
       selectionSet: {
         kind: "SelectionSet",
@@ -39930,6 +41629,11 @@ export const AttachmentLinkFrontDocument = {
                 kind: "Argument",
                 name: { kind: "Name", value: "issueId" },
                 value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "title" },
+                value: { kind: "Variable", name: { kind: "Name", value: "title" } },
               },
             ],
             selectionSet: {
@@ -39973,6 +41677,11 @@ export const AttachmentLinkGitHubIssueDocument = {
         },
         {
           kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "title" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
           variable: { kind: "Variable", name: { kind: "Name", value: "url" } },
           type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
         },
@@ -40003,6 +41712,11 @@ export const AttachmentLinkGitHubIssueDocument = {
                 kind: "Argument",
                 name: { kind: "Name", value: "issueId" },
                 value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "title" },
+                value: { kind: "Variable", name: { kind: "Name", value: "title" } },
               },
               {
                 kind: "Argument",
@@ -40066,6 +41780,11 @@ export const AttachmentLinkGitHubPrDocument = {
         },
         {
           kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "title" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
           variable: { kind: "Variable", name: { kind: "Name", value: "url" } },
           type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
         },
@@ -40111,6 +41830,11 @@ export const AttachmentLinkGitHubPrDocument = {
                 kind: "Argument",
                 name: { kind: "Name", value: "repo" },
                 value: { kind: "Variable", name: { kind: "Name", value: "repo" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "title" },
+                value: { kind: "Variable", name: { kind: "Name", value: "title" } },
               },
               {
                 kind: "Argument",
@@ -40169,6 +41893,11 @@ export const AttachmentLinkGitLabMrDocument = {
         },
         {
           kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "title" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
           variable: { kind: "Variable", name: { kind: "Name", value: "url" } },
           type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
         },
@@ -40209,6 +41938,11 @@ export const AttachmentLinkGitLabMrDocument = {
                 kind: "Argument",
                 name: { kind: "Name", value: "projectPathWithNamespace" },
                 value: { kind: "Variable", name: { kind: "Name", value: "projectPathWithNamespace" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "title" },
+                value: { kind: "Variable", name: { kind: "Name", value: "title" } },
               },
               {
                 kind: "Argument",
@@ -40260,6 +41994,11 @@ export const AttachmentLinkIntercomDocument = {
           variable: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
           type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
         },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "title" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
       ],
       selectionSet: {
         kind: "SelectionSet",
@@ -40292,6 +42031,11 @@ export const AttachmentLinkIntercomDocument = {
                 kind: "Argument",
                 name: { kind: "Name", value: "issueId" },
                 value: { kind: "Variable", name: { kind: "Name", value: "issueId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "title" },
+                value: { kind: "Variable", name: { kind: "Name", value: "title" } },
               },
             ],
             selectionSet: {
@@ -40592,6 +42336,11 @@ export const AttachmentLinkZendeskDocument = {
           variable: { kind: "Variable", name: { kind: "Name", value: "ticketId" } },
           type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
         },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "title" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
       ],
       selectionSet: {
         kind: "SelectionSet",
@@ -40624,6 +42373,11 @@ export const AttachmentLinkZendeskDocument = {
                 kind: "Argument",
                 name: { kind: "Name", value: "ticketId" },
                 value: { kind: "Variable", name: { kind: "Name", value: "ticketId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "title" },
+                value: { kind: "Variable", name: { kind: "Name", value: "title" } },
               },
             ],
             selectionSet: {
@@ -41555,6 +43309,177 @@ export const UpdateDocumentDocument = {
     ...DocumentPayloadFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<UpdateDocumentMutation, UpdateDocumentMutationVariables>;
+export const CreateEmailIntakeAddressDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createEmailIntakeAddress" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "EmailIntakeAddressCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "emailIntakeAddressCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "EmailIntakeAddressPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...EmailIntakeAddressPayloadFragmentDoc.definitions,
+    ...EmailIntakeAddressFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateEmailIntakeAddressMutation, CreateEmailIntakeAddressMutationVariables>;
+export const DeleteEmailIntakeAddressDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteEmailIntakeAddress" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "emailIntakeAddressDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "DeletePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...DeletePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteEmailIntakeAddressMutation, DeleteEmailIntakeAddressMutationVariables>;
+export const EmailIntakeAddressRotateDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "emailIntakeAddressRotate" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "emailIntakeAddressRotate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "EmailIntakeAddressPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...EmailIntakeAddressPayloadFragmentDoc.definitions,
+    ...EmailIntakeAddressFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<EmailIntakeAddressRotateMutation, EmailIntakeAddressRotateMutationVariables>;
+export const UpdateEmailIntakeAddressDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateEmailIntakeAddress" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "EmailIntakeAddressUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "emailIntakeAddressUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "EmailIntakeAddressPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...EmailIntakeAddressPayloadFragmentDoc.definitions,
+    ...EmailIntakeAddressFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateEmailIntakeAddressMutation, UpdateEmailIntakeAddressMutationVariables>;
 export const EmailTokenUserAccountAuthDocument = {
   kind: "Document",
   definitions: [
@@ -41594,8 +43519,8 @@ export const EmailTokenUserAccountAuthDocument = {
       },
     },
     ...AuthResolverResponseFragmentDoc.definitions,
-    ...AuthOrganizationFragmentDoc.definitions,
     ...AuthUserFragmentDoc.definitions,
+    ...AuthOrganizationFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<EmailTokenUserAccountAuthMutation, EmailTokenUserAccountAuthMutationVariables>;
 export const EmailUnsubscribeDocument = {
@@ -42008,6 +43933,7 @@ export const CreateGitAutomationStateDocument = {
     },
     ...GitAutomationStatePayloadFragmentDoc.definitions,
     ...GitAutomationStateFragmentDoc.definitions,
+    ...GitAutomationTargetBranchFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<CreateGitAutomationStateMutation, CreateGitAutomationStateMutationVariables>;
 export const DeleteGitAutomationStateDocument = {
@@ -42098,8 +44024,145 @@ export const UpdateGitAutomationStateDocument = {
     },
     ...GitAutomationStatePayloadFragmentDoc.definitions,
     ...GitAutomationStateFragmentDoc.definitions,
+    ...GitAutomationTargetBranchFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<UpdateGitAutomationStateMutation, UpdateGitAutomationStateMutationVariables>;
+export const CreateGitAutomationTargetBranchDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createGitAutomationTargetBranch" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "GitAutomationTargetBranchCreateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "gitAutomationTargetBranchCreate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "FragmentSpread", name: { kind: "Name", value: "GitAutomationTargetBranchPayload" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    ...GitAutomationTargetBranchPayloadFragmentDoc.definitions,
+    ...GitAutomationTargetBranchFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<CreateGitAutomationTargetBranchMutation, CreateGitAutomationTargetBranchMutationVariables>;
+export const DeleteGitAutomationTargetBranchDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteGitAutomationTargetBranch" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "gitAutomationTargetBranchDelete" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "DeletePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...DeletePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<DeleteGitAutomationTargetBranchMutation, DeleteGitAutomationTargetBranchMutationVariables>;
+export const UpdateGitAutomationTargetBranchDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateGitAutomationTargetBranch" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "GitAutomationTargetBranchUpdateInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "gitAutomationTargetBranchUpdate" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "FragmentSpread", name: { kind: "Name", value: "GitAutomationTargetBranchPayload" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    ...GitAutomationTargetBranchPayloadFragmentDoc.definitions,
+    ...GitAutomationTargetBranchFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<UpdateGitAutomationTargetBranchMutation, UpdateGitAutomationTargetBranchMutationVariables>;
 export const GoogleUserAccountAuthDocument = {
   kind: "Document",
   definitions: [
@@ -42139,8 +44202,8 @@ export const GoogleUserAccountAuthDocument = {
       },
     },
     ...AuthResolverResponseFragmentDoc.definitions,
-    ...AuthOrganizationFragmentDoc.definitions,
     ...AuthUserFragmentDoc.definitions,
+    ...AuthOrganizationFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<GoogleUserAccountAuthMutation, GoogleUserAccountAuthMutationVariables>;
 export const ImageUploadFromUrlDocument = {
@@ -42251,6 +44314,44 @@ export const ImportFileUploadDocument = {
     ...UploadFileHeaderFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<ImportFileUploadMutation, ImportFileUploadMutationVariables>;
+export const ArchiveIntegrationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "archiveIntegration" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NonNullType", type: { kind: "NamedType", name: { kind: "Name", value: "String" } } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrationArchive" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "DeletePayload" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...DeletePayloadFragmentDoc.definitions,
+  ],
+} as unknown as DocumentNode<ArchiveIntegrationMutation, ArchiveIntegrationMutationVariables>;
 export const IntegrationAsksConnectChannelDocument = {
   kind: "Document",
   definitions: [
@@ -47521,8 +49622,8 @@ export const SamlTokenUserAccountAuthDocument = {
       },
     },
     ...AuthResolverResponseFragmentDoc.definitions,
-    ...AuthOrganizationFragmentDoc.definitions,
     ...AuthUserFragmentDoc.definitions,
+    ...AuthOrganizationFragmentDoc.definitions,
   ],
 } as unknown as DocumentNode<SamlTokenUserAccountAuthMutation, SamlTokenUserAccountAuthMutationVariables>;
 export const CreateTeamDocument = {

--- a/packages/sdk/src/_tests/LinearSdk.test.ts
+++ b/packages/sdk/src/_tests/LinearSdk.test.ts
@@ -32,11 +32,11 @@ describe("LinearSdk", () => {
 
   it("parses JSON", async () => {
     const sdk = new LinearSdk(
-      resolveWithData({ projectUpdate: { id: "test", diff: JSON.stringify({ some: { nested: { data: 123 } } }) } })
+      resolveWithData({ template: { id: "test", templateData: JSON.stringify({ some: { nested: { data: 123 } } }) } })
     );
-    const response = await sdk.projectUpdate("test");
+    const response = await sdk.template("test");
 
-    expect((response?.diff?.some as any)?.nested?.data).toEqual(123);
+    expect((response?.templateData?.some as any)?.nested?.data).toEqual(123);
   });
 
   it("does not attempt to parse JSONObject", async () => {

--- a/packages/sdk/src/_tests/_generated.test.ts
+++ b/packages/sdk/src/_tests/_generated.test.ts
@@ -43,16 +43,6 @@ describe("generated", () => {
       }
     });
 
-    /** Test the team connection query for the GitAutomationState */
-    it("team.automationStates", async () => {
-      if (_team) {
-        const automationStates: L.GitAutomationStateConnection | undefined = await _team.automationStates();
-        expect(automationStates instanceof L.GitAutomationStateConnection);
-      } else {
-        console.warn("codegen-doc:print: No team found - cannot test _team.automationStates query");
-      }
-    });
-
     /** Test the team connection query for the Cycle */
     it("team.cycles", async () => {
       if (_team) {
@@ -60,6 +50,16 @@ describe("generated", () => {
         expect(cycles instanceof L.CycleConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.cycles query");
+      }
+    });
+
+    /** Test the team connection query for the GitAutomationState */
+    it("team.gitAutomationStates", async () => {
+      if (_team) {
+        const gitAutomationStates: L.GitAutomationStateConnection | undefined = await _team.gitAutomationStates();
+        expect(gitAutomationStates instanceof L.GitAutomationStateConnection);
+      } else {
+        console.warn("codegen-doc:print: No team found - cannot test _team.gitAutomationStates query");
       }
     });
 
@@ -451,6 +451,16 @@ describe("generated", () => {
       }
     });
 
+    /** Test the attachment.externalUserCreator query for L.ExternalUser */
+    it("attachment.externalUserCreator", async () => {
+      if (_attachment) {
+        const attachment_externalUserCreator: L.ExternalUser | undefined = await _attachment.externalUserCreator;
+        expect(attachment_externalUserCreator instanceof L.ExternalUser);
+      } else {
+        console.warn("codegen-doc:print: No Attachment found - cannot test attachment.externalUserCreator query");
+      }
+    });
+
     /** Test the attachment.issue query for L.Issue */
     it("attachment.issue", async () => {
       if (_attachment) {
@@ -493,6 +503,16 @@ describe("generated", () => {
         expect(attachment_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Attachment found - cannot test attachment.creator query");
+      }
+    });
+
+    /** Test the attachment.externalUserCreator query for L.ExternalUser */
+    it("attachment.externalUserCreator", async () => {
+      if (_attachment) {
+        const attachment_externalUserCreator: L.ExternalUser | undefined = await _attachment.externalUserCreator;
+        expect(attachment_externalUserCreator instanceof L.ExternalUser);
+      } else {
+        console.warn("codegen-doc:print: No Attachment found - cannot test attachment.externalUserCreator query");
       }
     });
 
@@ -559,7 +579,7 @@ describe("generated", () => {
     /** Test the root query for a single Comment */
     it("comment", async () => {
       if (_comment_id) {
-        const comment: L.Comment | undefined = await client.comment(_comment_id);
+        const comment: L.Comment | undefined = await client.comment({ id: _comment_id });
         _comment = comment;
         expect(comment instanceof L.Comment);
       } else {
@@ -594,6 +614,16 @@ describe("generated", () => {
         expect(documentContent instanceof L.DocumentContent);
       } else {
         console.warn("codegen-doc:print: No comment found - cannot test _comment.documentContent query");
+      }
+    });
+
+    /** Test the comment.externalUser query for L.ExternalUser */
+    it("comment.externalUser", async () => {
+      if (_comment) {
+        const comment_externalUser: L.ExternalUser | undefined = await _comment.externalUser;
+        expect(comment_externalUser instanceof L.ExternalUser);
+      } else {
+        console.warn("codegen-doc:print: No Comment found - cannot test comment.externalUser query");
       }
     });
 
@@ -692,6 +722,16 @@ describe("generated", () => {
       }
     });
 
+    /** Test the customView connection query for the Issue */
+    it("customView.issues", async () => {
+      if (_customView) {
+        const issues: L.IssueConnection | undefined = await _customView.issues();
+        expect(issues instanceof L.IssueConnection);
+      } else {
+        console.warn("codegen-doc:print: No customView found - cannot test _customView.issues query");
+      }
+    });
+
     /** Test the customView.creator query for L.User */
     it("customView.creator", async () => {
       if (_customView) {
@@ -729,6 +769,16 @@ describe("generated", () => {
         expect(customView_team instanceof L.Team);
       } else {
         console.warn("codegen-doc:print: No CustomView found - cannot test customView.team query");
+      }
+    });
+
+    /** Test the customView.updatedBy query for L.User */
+    it("customView.updatedBy", async () => {
+      if (_customView) {
+        const customView_updatedBy: L.User | undefined = await _customView.updatedBy;
+        expect(customView_updatedBy instanceof L.User);
+      } else {
+        console.warn("codegen-doc:print: No CustomView found - cannot test customView.updatedBy query");
       }
     });
   });
@@ -908,6 +958,41 @@ describe("generated", () => {
     });
   });
 
+  /** Test all ExternalUser queries */
+  describe("ExternalUsers", () => {
+    let _externalUser: L.ExternalUser | undefined;
+    let _externalUser_id: string | undefined;
+
+    /** Test the root connection query for the ExternalUser */
+    it("externalUsers", async () => {
+      const externalUsers: L.ExternalUserConnection | undefined = await client.externalUsers();
+      const externalUser = externalUsers?.nodes?.[0];
+      _externalUser_id = externalUser?.id;
+      expect(externalUsers instanceof L.ExternalUserConnection);
+    });
+
+    /** Test the root query for a single ExternalUser */
+    it("externalUser", async () => {
+      if (_externalUser_id) {
+        const externalUser: L.ExternalUser | undefined = await client.externalUser(_externalUser_id);
+        _externalUser = externalUser;
+        expect(externalUser instanceof L.ExternalUser);
+      } else {
+        console.warn("codegen-doc:print: No first ExternalUser found in connection - cannot test externalUser query");
+      }
+    });
+
+    /** Test the externalUser.organization query for L.Organization */
+    it("externalUser.organization", async () => {
+      if (_externalUser) {
+        const externalUser_organization: L.Organization | undefined = await _externalUser.organization;
+        expect(externalUser_organization instanceof L.Organization);
+      } else {
+        console.warn("codegen-doc:print: No ExternalUser found - cannot test externalUser.organization query");
+      }
+    });
+  });
+
   /** Test all Favorite queries */
   describe("Favorites", () => {
     let _favorite: L.Favorite | undefined;
@@ -1060,6 +1145,18 @@ describe("generated", () => {
       } else {
         console.warn("codegen-doc:print: No Favorite found - cannot test favorite.user query");
       }
+    });
+  });
+
+  /** Test IntegrationHasScopes query */
+  describe("IntegrationHasScopes", () => {
+    /** Test the root model query for IntegrationHasScopes */
+    it("integrationHasScopes", async () => {
+      const integrationHasScopes: L.IntegrationHasScopesPayload | undefined = await client.integrationHasScopes(
+        "mock-integrationId",
+        ["mock-scopes"]
+      );
+      expect(integrationHasScopes instanceof L.IntegrationHasScopesPayload);
     });
   });
 
@@ -1324,6 +1421,16 @@ describe("generated", () => {
       }
     });
 
+    /** Test the issue.externalUserCreator query for L.ExternalUser */
+    it("issue.externalUserCreator", async () => {
+      if (_issue) {
+        const issue_externalUserCreator: L.ExternalUser | undefined = await _issue.externalUserCreator;
+        expect(issue_externalUserCreator instanceof L.ExternalUser);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.externalUserCreator query");
+      }
+    });
+
     /** Test the issue.favorite query for L.Favorite */
     it("issue.favorite", async () => {
       if (_issue) {
@@ -1361,6 +1468,16 @@ describe("generated", () => {
         expect(issue_project instanceof L.Project);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.project query");
+      }
+    });
+
+    /** Test the issue.projectMilestone query for L.ProjectMilestone */
+    it("issue.projectMilestone", async () => {
+      if (_issue) {
+        const issue_projectMilestone: L.ProjectMilestone | undefined = await _issue.projectMilestone;
+        expect(issue_projectMilestone instanceof L.ProjectMilestone);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.projectMilestone query");
       }
     });
 
@@ -1710,6 +1827,16 @@ describe("generated", () => {
       }
     });
 
+    /** Test the issue.externalUserCreator query for L.ExternalUser */
+    it("issue.externalUserCreator", async () => {
+      if (_issue) {
+        const issue_externalUserCreator: L.ExternalUser | undefined = await _issue.externalUserCreator;
+        expect(issue_externalUserCreator instanceof L.ExternalUser);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.externalUserCreator query");
+      }
+    });
+
     /** Test the issue.favorite query for L.Favorite */
     it("issue.favorite", async () => {
       if (_issue) {
@@ -1747,6 +1874,16 @@ describe("generated", () => {
         expect(issue_project instanceof L.Project);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.project query");
+      }
+    });
+
+    /** Test the issue.projectMilestone query for L.ProjectMilestone */
+    it("issue.projectMilestone", async () => {
+      if (_issue) {
+        const issue_projectMilestone: L.ProjectMilestone | undefined = await _issue.projectMilestone;
+        expect(issue_projectMilestone instanceof L.ProjectMilestone);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.projectMilestone query");
       }
     });
 
@@ -2045,6 +2182,16 @@ describe("generated", () => {
       }
     });
 
+    /** Test the issue.externalUserCreator query for L.ExternalUser */
+    it("issue.externalUserCreator", async () => {
+      if (_issue) {
+        const issue_externalUserCreator: L.ExternalUser | undefined = await _issue.externalUserCreator;
+        expect(issue_externalUserCreator instanceof L.ExternalUser);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.externalUserCreator query");
+      }
+    });
+
     /** Test the issue.favorite query for L.Favorite */
     it("issue.favorite", async () => {
       if (_issue) {
@@ -2082,6 +2229,16 @@ describe("generated", () => {
         expect(issue_project instanceof L.Project);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.project query");
+      }
+    });
+
+    /** Test the issue.projectMilestone query for L.ProjectMilestone */
+    it("issue.projectMilestone", async () => {
+      if (_issue) {
+        const issue_projectMilestone: L.ProjectMilestone | undefined = await _issue.projectMilestone;
+        expect(issue_projectMilestone instanceof L.ProjectMilestone);
+      } else {
+        console.warn("codegen-doc:print: No Issue found - cannot test issue.projectMilestone query");
       }
     });
 
@@ -2286,6 +2443,16 @@ describe("generated", () => {
         expect(notification_actor instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Notification found - cannot test notification.actor query");
+      }
+    });
+
+    /** Test the notification.externalUserActor query for L.ExternalUser */
+    it("notification.externalUserActor", async () => {
+      if (_notification) {
+        const notification_externalUserActor: L.ExternalUser | undefined = await _notification.externalUserActor;
+        expect(notification_externalUserActor instanceof L.ExternalUser);
+      } else {
+        console.warn("codegen-doc:print: No Notification found - cannot test notification.externalUserActor query");
       }
     });
 
@@ -3015,16 +3182,6 @@ describe("generated", () => {
       }
     });
 
-    /** Test the team connection query for the GitAutomationState */
-    it("team.automationStates", async () => {
-      if (_team) {
-        const automationStates: L.GitAutomationStateConnection | undefined = await _team.automationStates();
-        expect(automationStates instanceof L.GitAutomationStateConnection);
-      } else {
-        console.warn("codegen-doc:print: No team found - cannot test _team.automationStates query");
-      }
-    });
-
     /** Test the team connection query for the Cycle */
     it("team.cycles", async () => {
       if (_team) {
@@ -3032,6 +3189,16 @@ describe("generated", () => {
         expect(cycles instanceof L.CycleConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.cycles query");
+      }
+    });
+
+    /** Test the team connection query for the GitAutomationState */
+    it("team.gitAutomationStates", async () => {
+      if (_team) {
+        const gitAutomationStates: L.GitAutomationStateConnection | undefined = await _team.gitAutomationStates();
+        expect(gitAutomationStates instanceof L.GitAutomationStateConnection);
+      } else {
+        console.warn("codegen-doc:print: No team found - cannot test _team.gitAutomationStates query");
       }
     });
 

--- a/packages/sdk/src/schema.graphql
+++ b/packages/sdk/src/schema.graphql
@@ -11,7 +11,7 @@ type ActorBot {
   A url pointing to the avatar representing this bot.
   """
   avatarUrl: String
-  id: ID!
+  id: ID
   """
   The display name of the bot.
   """
@@ -466,7 +466,7 @@ type AttachmentPayload {
 
 type AttachmentSourcesPayload {
   """
-  A unique list of all source types used in this workspace
+  A unique list of all source types used in this workspace.
   """
   sources: JSONObject!
 }
@@ -618,6 +618,10 @@ input AuthApiKeyCreateInput {
   The API key value.
   """
   key: String!
+  """
+  The label for the API key.
+  """
+  label: String!
 }
 
 type AuthApiKeyPayload {
@@ -629,14 +633,6 @@ type AuthApiKeyPayload {
   Whether the operation was successful.
   """
   success: Boolean!
-}
-
-type AuthCreateOrJoinOrganizationResponse {
-  authOrganization: AuthOrganization!
-  authUser: AuthUser!
-  grantDomainAccess: Boolean
-  organization: AuthOrganization!
-  user: AuthUser!
 }
 
 type AuthIntegration {
@@ -824,6 +820,10 @@ type AuthOrganization {
   """
   previousUrlKeys: [String!]!
   """
+  The feature release channel the organization belongs to.
+  """
+  releaseChannel: ReleaseChannel!
+  """
   Whether SAML authentication is enabled for organization.
   """
   samlEnabled: Boolean!
@@ -836,6 +836,10 @@ type AuthOrganization {
   """
   scimEnabled: Boolean!
   """
+  The email domain or URL key for the organization.
+  """
+  serviceId: String!
+  """
   The organization's unique URL key.
   """
   urlKey: String!
@@ -843,6 +847,21 @@ type AuthOrganization {
 }
 
 type AuthOrganizationDomain {
+  authType: OrganizationDomainAuthType!
+  claimed: Boolean
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  name: String!
+  organizationId: String!
+  verified: Boolean!
+}
+
+"""
+An invitation to the organization that has been sent via email.
+"""
+type AuthOrganizationInvite {
   """
   The unique identifier of the entity.
   """
@@ -855,13 +874,13 @@ type AuthResolverResponse {
   """
   allowDomainAccess: Boolean
   """
-  Organizations this account has access to, but is not yet a member.
+  List of organizations allowing this user account to join automatically.
   """
   availableOrganizations: [AuthOrganization!]
   """
   Email for the authenticated account.
   """
-  email: String
+  email: String!
   """
   User account ID.
   """
@@ -871,15 +890,15 @@ type AuthResolverResponse {
   """
   lastUsedOrganizationId: String
   """
-  List of organizations this user account is part of but are currently locked because of the current auth service.
+  List of organization available to this user account but locked due to the current auth method.
   """
   lockedOrganizations: [AuthOrganization!]
   """
-  JWT token for authentication of the account.
+  Application token.
   """
-  token: String
+  token: String @deprecated(reason: "Deprecated and not used anymore. Never populated.")
   """
-  Users belonging to this account.
+  List of active users that belong to the user account.
   """
   users: [AuthUser!]!
 }
@@ -920,6 +939,10 @@ type AuthUser {
   Organization the user belongs to.
   """
   organization: AuthOrganization!
+  """
+  User account id the user belongs to.
+  """
+  userAccountId: String!
 }
 
 """
@@ -990,7 +1013,7 @@ type AuthenticationSession {
 }
 
 """
-Authentication session information
+Authentication session information.
 """
 type AuthenticationSessionResponse {
   """
@@ -1151,7 +1174,7 @@ type Comment implements Node {
   """
   bodyData: String!
   """
-  The bot that created the comment
+  The bot that created the comment.
   """
   botActor: ActorBot
   """
@@ -1220,7 +1243,11 @@ type Comment implements Node {
   """
   projectUpdate: ProjectUpdate
   """
-  Emoji reaction summary, grouped by emoji type
+  The text that this comment references. Only defined for inline comments.
+  """
+  quotedText: String
+  """
+  Emoji reaction summary, grouped by emoji type.
   """
   reactionData: JSONObject!
   """
@@ -1361,9 +1388,13 @@ input CommentCreateInput {
   """
   parentId: String
   """
-  The prject update to associate the comment with.
+  The project update to associate the comment with.
   """
   projectUpdateId: String
+  """
+  The text that this comment references. Only defined for inline comments.
+  """
+  quotedText: String
 }
 
 type CommentEdge {
@@ -1444,6 +1475,10 @@ input CommentUpdateInput {
   The comment content as a Prosemirror document.
   """
   bodyData: JSON
+  """
+  The text that this comment references. Only defined for inline comments.
+  """
+  quotedText: String
   """
   [INTERNAL] The child comment that resolves this thread.
   """
@@ -1559,7 +1594,7 @@ type ContactPayload {
 }
 
 """
-[INTERNAL] Input for sending a message to the Linear Sales team
+[INTERNAL] Input for sending a message to the Linear Sales team.
 """
 input ContactSalesCreateInput {
   """
@@ -1678,6 +1713,39 @@ type CustomView implements Node {
   """
   id: ID!
   """
+  Issues associated with the custom view.
+  """
+  issues(
+    """
+    A cursor to be used with first for forward pagination
+    """
+    after: String
+    """
+    A cursor to be used with last for backward pagination.
+    """
+    before: String
+    """
+    Filter returned issues.
+    """
+    filter: IssueFilter
+    """
+    The number of items to forward paginate (used with after). Defaults to 50.
+    """
+    first: Int
+    """
+    Should archived resources be included (default: false)
+    """
+    includeArchived: Boolean
+    """
+    The number of items to backward paginate (used with before). Defaults to 50.
+    """
+    last: Int
+    """
+    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+    """
+    orderBy: PaginationOrderBy
+  ): IssueConnection!
+  """
   The model name of the custom view.
   """
   modelName: String!
@@ -1694,7 +1762,7 @@ type CustomView implements Node {
   """
   owner: User!
   """
-  [ALPHA] The filter applied to projects in the custom view.
+  The filter applied to projects in the custom view.
   """
   projectFilterData: JSONObject
   """
@@ -1712,7 +1780,7 @@ type CustomView implements Node {
   """
   updatedAt: DateTime!
   """
-  [ALPHA] The user who last updated the custom view.
+  The user who last updated the custom view.
   """
   updatedBy: User!
 }
@@ -1757,9 +1825,13 @@ input CustomViewCreateInput {
   """
   ownerId: String
   """
-  [ALPHA] The project filter applied to issues in the custom view.
+  The project filter applied to issues in the custom view.
   """
   projectFilterData: JSONObject
+  """
+  [Internal] The id of the project associated with the custom view.
+  """
+  projectId: String
   """
   Whether the custom view is shared with everyone in the organization.
   """
@@ -1790,7 +1862,7 @@ A custom view notification subscription.
 """
 type CustomViewNotificationSubscription implements Entity & Node & NotificationSubscription {
   """
-  Whether the subscription is active or not
+  Whether the subscription is active or not.
   """
   active: Boolean!
   """
@@ -1913,9 +1985,13 @@ input CustomViewUpdateInput {
   """
   ownerId: String
   """
-  [ALPHA] The project filter applied to issues in the custom view.
+  The project filter applied to issues in the custom view.
   """
   projectFilterData: JSONObject
+  """
+  [Internal] The id of the project associated with the custom view.
+  """
+  projectId: String
   """
   Whether the custom view is shared with everyone in the organization.
   """
@@ -2214,7 +2290,7 @@ A cycle notification subscription.
 """
 type CycleNotificationSubscription implements Entity & Node & NotificationSubscription {
   """
-  Whether the subscription is active or not
+  Whether the subscription is active or not.
   """
   active: Boolean!
   """
@@ -2292,13 +2368,16 @@ type CyclePayload {
   success: Boolean!
 }
 
+"""
+[DEPRECATED] Input for shifting all cycles by a certain number of days. Mutation is now deprecated.
+"""
 input CycleShiftAllInput {
   """
-  The number of days to shift the cycles by.
+  [DEPRECATED] The number of days to shift the cycles by.
   """
   daysToShift: Float!
   """
-  The cycle id at which to start the shift.
+  [DEPRECATED] The cycle id at which to start the shift.
   """
   id: String!
 }
@@ -2324,6 +2403,30 @@ input CycleUpdateInput {
   The start date of the cycle.
   """
   startsAt: DateTime
+}
+
+"""
+Data recovery.
+"""
+type DataRecovery implements Node {
+  """
+  The time at which the entity was archived. Null if the entity has not been archived.
+  """
+  archivedAt: DateTime
+  """
+  The time at which the entity was created.
+  """
+  createdAt: DateTime!
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  """
+  The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+      for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+      been updated after creation.
+  """
+  updatedAt: DateTime!
 }
 
 """
@@ -2434,9 +2537,13 @@ type Document implements Node {
   """
   content: String
   """
-  The documents content as a Prosemirror document.
+  [Internal] The documents content as a Prosemirror document.
   """
   contentData: JSON @deprecated(reason: "Use content instead.")
+  """
+  [Internal] The documents content as YJS state.
+  """
+  contentState: String
   """
   The time at which the entity was created.
   """
@@ -2485,6 +2592,60 @@ type Document implements Node {
   updatedBy: User!
 }
 
+"""
+Document filtering options.
+"""
+input DocumentCollectionFilter {
+  """
+  Compound filters, all of which need to be matched by the document.
+  """
+  and: [DocumentCollectionFilter!]
+  """
+  Comparator for the created at date.
+  """
+  createdAt: DateComparator
+  """
+  Filters that the document's creator must satisfy.
+  """
+  creator: UserFilter
+  """
+  Filters that needs to be matched by all documents.
+  """
+  every: DocumentFilter
+  """
+  Comparator for the identifier.
+  """
+  id: IDComparator
+  """
+  Comparator for the collection length.
+  """
+  length: NumberComparator
+  """
+  Compound filters, one of which need to be matched by the document.
+  """
+  or: [DocumentCollectionFilter!]
+  """
+  Filters that the document's project must satisfy.
+  """
+  project: ProjectFilter
+  """
+  Comparator for the document slug ID.
+  """
+  slugId: StringComparator
+  """
+  Filters that needs to be matched by some documents.
+  """
+  some: DocumentFilter
+  """
+  Comparator for the document title.
+  """
+  title: StringComparator
+  """
+  Comparator for the updated at date.
+  """
+  updatedAt: DateComparator
+}
+
 type DocumentConnection {
   edges: [DocumentEdge!]!
   nodes: [Document!]!
@@ -2506,7 +2667,7 @@ type DocumentContent implements Node {
   """
   [Internal] The document content as a Prosemirror document.
   """
-  contentData: JSONObject
+  contentData: JSONObject @deprecated(reason: "Use `contentState` instead")
   """
   The document content state as a base64 encoded string.
   """
@@ -2536,7 +2697,7 @@ type DocumentContent implements Node {
   """
   projectMilestone: ProjectMilestone
   """
-  The time at which the document content was restored from a previous version
+  The time at which the document content was restored from a previous version.
   """
   restoredAt: DateTime
   """
@@ -2556,9 +2717,17 @@ input DocumentContentFilter {
   """
   createdAt: DateComparator
   """
+  Filters that the document content document must satisfy.
+  """
+  document: DocumentFilter
+  """
   Comparator for the identifier.
   """
   id: IDComparator
+  """
+  Filters that the document content project must satisfy.
+  """
+  project: ProjectFilter
   """
   Comparator for the updated at date.
   """
@@ -2566,7 +2735,7 @@ input DocumentContentFilter {
 }
 
 """
-A document content history for a document
+A document content history for a document.
 """
 type DocumentContentHistory implements Node {
   """
@@ -2582,7 +2751,7 @@ type DocumentContentHistory implements Node {
   """
   contentData: JSONObject
   """
-  The timestamp associated with the DocumentContent when it was originally saved
+  The timestamp associated with the DocumentContent when it was originally saved.
   """
   contentDataSnapshotAt: DateTime!
   """
@@ -2686,6 +2855,48 @@ type DocumentEdge {
   node: Document!
 }
 
+"""
+Document filtering options.
+"""
+input DocumentFilter {
+  """
+  Compound filters, all of which need to be matched by the document.
+  """
+  and: [DocumentFilter!]
+  """
+  Comparator for the created at date.
+  """
+  createdAt: DateComparator
+  """
+  Filters that the document's creator must satisfy.
+  """
+  creator: UserFilter
+  """
+  Comparator for the identifier.
+  """
+  id: IDComparator
+  """
+  Compound filters, one of which need to be matched by the document.
+  """
+  or: [DocumentFilter!]
+  """
+  Filters that the document's project must satisfy.
+  """
+  project: ProjectFilter
+  """
+  Comparator for the document slug ID.
+  """
+  slugId: StringComparator
+  """
+  Comparator for the document title.
+  """
+  title: StringComparator
+  """
+  Comparator for the updated at date.
+  """
+  updatedAt: DateComparator
+}
+
 type DocumentPayload {
   """
   The document that was created or updated.
@@ -2729,9 +2940,13 @@ type DocumentSearchResult implements Node {
   """
   content: String
   """
-  The documents content as a Prosemirror document.
+  [Internal] The documents content as a Prosemirror document.
   """
   contentData: JSON @deprecated(reason: "Use content instead.")
+  """
+  [Internal] The documents content as YJS state.
+  """
+  contentState: String
   """
   The time at which the entity was created.
   """
@@ -2753,7 +2968,7 @@ type DocumentSearchResult implements Node {
   """
   lastAppliedTemplate: Template
   """
-  Metadata related to search result
+  Metadata related to search result.
   """
   metadata: JSONObject!
   """
@@ -2834,7 +3049,7 @@ input DocumentUpdateInput {
 }
 
 """
-An email address that can be used for submitting issues
+An email address that can be used for submitting issues.
 """
 type EmailIntakeAddress implements Node {
   """
@@ -2862,15 +3077,56 @@ type EmailIntakeAddress implements Node {
   """
   id: ID!
   """
+  The organization that the email address is associated with.
+  """
+  organization: Organization!
+  """
   The team that the email address is associated with.
   """
   team: Team!
+  """
+  The template that the email address is associated with.
+  """
+  template: Template
   """
   The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
       for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
       been updated after creation.
   """
   updatedAt: DateTime!
+}
+
+input EmailIntakeAddressCreateInput {
+  """
+  The identifier in UUID v4 format. If none is provided, the backend will generate one.
+  """
+  id: String
+  """
+  The identifier or key of the team this email address will intake issues for.
+  """
+  teamId: String!
+}
+
+type EmailIntakeAddressPayload {
+  """
+  The email address that was created or updated.
+  """
+  emailIntakeAddress: EmailIntakeAddress!
+  """
+  The identifier of the last sync operation.
+  """
+  lastSyncId: Float!
+  """
+  Whether the operation was successful.
+  """
+  success: Boolean!
+}
+
+input EmailIntakeAddressUpdateInput {
+  """
+  Whether the email address is currently enabled. If set to false, the email address will be disabled and no longer accept incoming emails.
+  """
+  enabled: Boolean!
 }
 
 input EmailSubscribeInput {
@@ -3106,7 +3362,7 @@ input EstimateComparator {
 }
 
 """
-[ALPHA] An external authenticated (e.g., through Slack) user which doesn't have a Linear account, but can create and update entities in Linear from the external system that authenticated them.
+An external authenticated (e.g., through Slack) user which doesn't have a Linear account, but can create and update entities in Linear from the external system that authenticated them.
 """
 type ExternalUser implements Node {
   """
@@ -3165,6 +3421,48 @@ type ExternalUserEdge {
   """
   cursor: String!
   node: ExternalUser!
+}
+
+"""
+[ALPHA] A facet. Facets are joins between entities. A facet can tie a custom view to a project, or a a project to a roadmap for example.
+"""
+type Facet implements Node {
+  """
+  The time at which the entity was archived. Null if the entity has not been archived.
+  """
+  archivedAt: DateTime
+  """
+  The time at which the entity was created.
+  """
+  createdAt: DateTime!
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  """
+  The sort order of the facet.
+  """
+  sortOrder: Float!
+  """
+  The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+      for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+      been updated after creation.
+  """
+  updatedAt: DateTime!
+}
+
+type FacetConnection {
+  edges: [FacetEdge!]!
+  nodes: [Facet!]!
+  pageInfo: PageInfo!
+}
+
+type FacetEdge {
+  """
+  Used in `before` and `after` args
+  """
+  cursor: String!
+  node: Facet!
 }
 
 """
@@ -3315,6 +3613,10 @@ input FavoriteCreateInput {
   The identifier. If none is provided, the backend will generate one.
   """
   id: String
+  """
+  [INTERNAL] The identifier of the initiative to favorite.
+  """
+  initiativeId: String
   """
   The identifier of the issue to favorite.
   """
@@ -3468,9 +3770,9 @@ type GitAutomationState implements Node {
   """
   archivedAt: DateTime
   """
-  The target branch, if null, the automation will be triggered on any branch.
+  [DEPRECATED] The target branch, if null, the automation will be triggered on any branch.
   """
-  branchPattern: String!
+  branchPattern: String @deprecated(reason: "Use targetBranch instead.")
   """
   The time at which the entity was created.
   """
@@ -3487,6 +3789,10 @@ type GitAutomationState implements Node {
   The associated workflow state.
   """
   state: WorkflowState
+  """
+  The target branch associated to this automation state.
+  """
+  targetBranch: GitAutomationTargetBranch
   """
   The team to which this automation state belongs.
   """
@@ -3507,7 +3813,7 @@ type GitAutomationStateConnection {
 
 input GitAutomationStateCreateInput {
   """
-  The target branch pattern. If null, all branches are targeted.
+  [DEPRECATED] The target branch pattern. If null, all branches are targeted.
   """
   branchPattern: String
   """
@@ -3522,6 +3828,10 @@ input GitAutomationStateCreateInput {
   The associated workflow state. If null, will override default behaviour and take no action.
   """
   stateId: String
+  """
+  The associated target branch. If null, all branches are targeted.
+  """
+  targetBranchId: String
   """
   The team associated with the automation state.
   """
@@ -3553,7 +3863,7 @@ type GitAutomationStatePayload {
 
 input GitAutomationStateUpdateInput {
   """
-  The target branch pattern. If null, all branches are targeted.
+  [DEPRECATED] The target branch pattern. If null, all branches are targeted.
   """
   branchPattern: String
   """
@@ -3564,6 +3874,10 @@ input GitAutomationStateUpdateInput {
   The associated workflow state.
   """
   stateId: String
+  """
+  The associated target branch. If null, all branches are targeted.
+  """
+  targetBranchId: String
 }
 
 """
@@ -3575,6 +3889,116 @@ enum GitAutomationStates {
   mergeable
   review
   start
+}
+
+"""
+A Git target branch for which there are automations (GitAutomationState).
+"""
+type GitAutomationTargetBranch implements Node {
+  """
+  The time at which the entity was archived. Null if the entity has not been archived.
+  """
+  archivedAt: DateTime
+  """
+  Automation states associated with the target branch.
+  """
+  automationStates(
+    """
+    A cursor to be used with first for forward pagination
+    """
+    after: String
+    """
+    A cursor to be used with last for backward pagination.
+    """
+    before: String
+    """
+    The number of items to forward paginate (used with after). Defaults to 50.
+    """
+    first: Int
+    """
+    Should archived resources be included (default: false)
+    """
+    includeArchived: Boolean
+    """
+    The number of items to backward paginate (used with before). Defaults to 50.
+    """
+    last: Int
+    """
+    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+    """
+    orderBy: PaginationOrderBy
+  ): GitAutomationStateConnection!
+  """
+  The target branch pattern.
+  """
+  branchPattern: String!
+  """
+  The time at which the entity was created.
+  """
+  createdAt: DateTime!
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  """
+  Whether the branch pattern is a regular expression.
+  """
+  isRegex: Boolean!
+  """
+  The team to which this Git target branch automation belongs.
+  """
+  team: Team!
+  """
+  The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+      for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+      been updated after creation.
+  """
+  updatedAt: DateTime!
+}
+
+input GitAutomationTargetBranchCreateInput {
+  """
+  The target branch pattern.
+  """
+  branchPattern: String!
+  """
+  The identifier in UUID v4 format. If none is provided, the backend will generate one.
+  """
+  id: String
+  """
+  Whether the branch pattern is a regular expression.
+  """
+  isRegex: Boolean = false
+  """
+  The team associated with the Git target branch automation.
+  """
+  teamId: String!
+}
+
+type GitAutomationTargetBranchPayload {
+  """
+  The identifier of the last sync operation.
+  """
+  lastSyncId: Float!
+  """
+  Whether the operation was successful.
+  """
+  success: Boolean!
+  """
+  The Git target branch automation that was created or updated.
+  """
+  targetBranch: GitAutomationTargetBranch!
+}
+
+input GitAutomationTargetBranchUpdateInput {
+  """
+  The target branch pattern.
+  """
+  branchPattern: String
+  """
+  Whether the branch pattern is a regular expression.
+  """
+  isRegex: Boolean
 }
 
 type GitHubCommitIntegrationPayload {
@@ -3601,14 +4025,14 @@ Metadata and settings for a GitHub Personal integration.
 """
 type GitHubPersonalSettings {
   """
-  The GitHub user's name
+  The GitHub user's name.
   """
   login: String!
 }
 
 input GitHubPersonalSettingsInput {
   """
-  The GitHub user's name
+  The GitHub user's name.
   """
   login: String!
 }
@@ -3643,38 +4067,38 @@ Metadata and settings for a GitHub integration.
 """
 type GitHubSettings {
   """
-  The avatar URL for the GitHub organization
+  The avatar URL for the GitHub organization.
   """
   orgAvatarUrl: String!
   """
-  The GitHub organization's name
+  The GitHub organization's name.
   """
   orgLogin: String!
   """
-  The names of the repositories connected for the GitHub integration
+  The names of the repositories connected for the GitHub integration.
   """
   repositories: [GitHubRepo!]
   """
-  Mapping of team to repository for syncing
+  Mapping of team to repository for syncing.
   """
   repositoriesMapping: [TeamRepoMapping!]
 }
 
 input GitHubSettingsInput {
   """
-  The avatar URL for the GitHub organization
+  The avatar URL for the GitHub organization.
   """
   orgAvatarUrl: String!
   """
-  The GitHub organization's name
+  The GitHub organization's name.
   """
   orgLogin: String!
   """
-  The names of the repositories connected for the GitHub integration
+  The names of the repositories connected for the GitHub integration.
   """
   repositories: [GitHubRepoInput!]
   """
-  Mapping of team to repository for syncing
+  Mapping of team to repository for syncing.
   """
   repositoriesMapping: [TeamRepoMappingInput!]
 }
@@ -3684,30 +4108,30 @@ Metadata and settings for a GitLab integration.
 """
 type GitLabSettings {
   """
-  The ISO timestamp the GitLab access token expires
+  The ISO timestamp the GitLab access token expires.
   """
   expiresAt: String
   """
-  Whether the token is limited to a read-only scope
+  Whether the token is limited to a read-only scope.
   """
   readonly: Boolean
   """
-  The self-hosted URL of the GitLab instance
+  The self-hosted URL of the GitLab instance.
   """
   url: String
 }
 
 input GitLabSettingsInput {
   """
-  The ISO timestamp the GitLab access token expires
+  The ISO timestamp the GitLab access token expires.
   """
   expiresAt: String
   """
-  Whether the token is limited to a read-only scope
+  Whether the token is limited to a read-only scope.
   """
   readonly: Boolean
   """
-  The self-hosted URL of the GitLab instance
+  The self-hosted URL of the GitLab instance.
   """
   url: String
 }
@@ -3789,7 +4213,7 @@ input GoogleUserAccountAuthInput {
   """
   code: String!
   """
-  An optional invite link for an organization.
+  An optional invite link for an organization used to populate available organizations.
   """
   inviteLink: String
   """
@@ -3848,6 +4272,313 @@ type ImageUploadFromUrlPayload {
 }
 
 """
+[INTERNAL] An initiative to group projects.
+"""
+type Initiative implements Node {
+  """
+  The time at which the entity was archived. Null if the entity has not been archived.
+  """
+  archivedAt: DateTime
+  """
+  The initiative's color.
+  """
+  color: String
+  """
+  The time at which the entity was created.
+  """
+  createdAt: DateTime!
+  """
+  The user who created the initiative.
+  """
+  creator: User!
+  """
+  The description of the initiative.
+  """
+  description: String
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  """
+  The name of the initiative.
+  """
+  name: String!
+  """
+  The organization of the initiative.
+  """
+  organization: Organization!
+  """
+  The user who owns the initiative.
+  """
+  owner: User!
+  """
+  Projects associated with the initiative.
+  """
+  projects(
+    """
+    A cursor to be used with first for forward pagination
+    """
+    after: String
+    """
+    A cursor to be used with last for backward pagination.
+    """
+    before: String
+    """
+    [Internal] Filter returned projects.
+    """
+    filter: ProjectFilter
+    """
+    The number of items to forward paginate (used with after). Defaults to 50.
+    """
+    first: Int
+    """
+    Should archived resources be included (default: false)
+    """
+    includeArchived: Boolean
+    """
+    The number of items to backward paginate (used with before). Defaults to 50.
+    """
+    last: Int
+    """
+    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+    """
+    orderBy: PaginationOrderBy
+  ): ProjectConnection!
+  """
+  The initiative's unique URL slug.
+  """
+  slugId: String!
+  """
+  The sort order of the initiative within the organization.
+  """
+  sortOrder: Float!
+  """
+  The estimated completion date of the initiative.
+  """
+  targetDate: TimelessDate
+  """
+  [INTERNAL] The resolution of the initiative's estimated completion date.
+  """
+  targetDateResolution: DateResolutionType
+  """
+  The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+      for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+      been updated after creation.
+  """
+  updatedAt: DateTime!
+}
+
+"""
+A generic payload return from entity archive mutations.
+"""
+type InitiativeArchivePayload implements ArchivePayload {
+  """
+  The archived/unarchived entity. Null if entity was deleted.
+  """
+  entity: Initiative
+  """
+  The identifier of the last sync operation.
+  """
+  lastSyncId: Float!
+  """
+  Whether the operation was successful.
+  """
+  success: Boolean!
+}
+
+type InitiativeConnection {
+  edges: [InitiativeEdge!]!
+  nodes: [Initiative!]!
+  pageInfo: PageInfo!
+}
+
+"""
+[Internal] The properties of the initiative to create.
+"""
+input InitiativeCreateInput {
+  """
+  The initiative's color.
+  """
+  color: String
+  """
+  The description of the initiative.
+  """
+  description: String
+  """
+  The identifier in UUID v4 format. If none is provided, the backend will generate one.
+  """
+  id: String
+  """
+  The name of the initiative.
+  """
+  name: String!
+  """
+  The owner of the initiative.
+  """
+  ownerId: String
+  """
+  The sort order of the initiative within the organization.
+  """
+  sortOrder: Float
+}
+
+type InitiativeEdge {
+  """
+  Used in `before` and `after` args
+  """
+  cursor: String!
+  node: Initiative!
+}
+
+"""
+[Internal] The payload returned by the initiative mutations.
+"""
+type InitiativePayload {
+  """
+  The initiative that was created or updated.
+  """
+  initiative: Initiative!
+  """
+  The identifier of the last sync operation.
+  """
+  lastSyncId: Float!
+  """
+  Whether the operation was successful.
+  """
+  success: Boolean!
+}
+
+"""
+[INTERNAL] Join table between projects and initiatives.
+"""
+type InitiativeToProject implements Node {
+  """
+  The time at which the entity was archived. Null if the entity has not been archived.
+  """
+  archivedAt: DateTime
+  """
+  The time at which the entity was created.
+  """
+  createdAt: DateTime!
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  """
+  The initiative that the project is associated with.
+  """
+  initiative: Initiative!
+  """
+  The project that the initiative is associated with.
+  """
+  project: Project!
+  """
+  The sort order of the project within the initiative.
+  """
+  sortOrder: String!
+  """
+  The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+      for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+      been updated after creation.
+  """
+  updatedAt: DateTime!
+}
+
+type InitiativeToProjectConnection {
+  edges: [InitiativeToProjectEdge!]!
+  nodes: [InitiativeToProject!]!
+  pageInfo: PageInfo!
+}
+
+"""
+[INTERNAL] The properties of the initiativeToProject to create.
+"""
+input InitiativeToProjectCreateInput {
+  """
+  The identifier in UUID v4 format. If none is provided, the backend will generate one.
+  """
+  id: String
+  """
+  The identifier of the initiative.
+  """
+  initiativeId: String!
+  """
+  The identifier of the project.
+  """
+  projectId: String!
+  """
+  The sort order for the project within its organization.
+  """
+  sortOrder: Float
+}
+
+type InitiativeToProjectEdge {
+  """
+  Used in `before` and `after` args
+  """
+  cursor: String!
+  node: InitiativeToProject!
+}
+
+"""
+[INTERNAL] The result of a initiativeToProject mutation.
+"""
+type InitiativeToProjectPayload {
+  """
+  The initiativeToProject that was created or updated.
+  """
+  initiativeToProject: InitiativeToProject!
+  """
+  The identifier of the last sync operation.
+  """
+  lastSyncId: Float!
+  """
+  Whether the operation was successful.
+  """
+  success: Boolean!
+}
+
+"""
+[INTERNAL] The properties of the initiativeToProject to update.
+"""
+input InitiativeToProjectUpdateInput {
+  """
+  The sort order for the project within its organization.
+  """
+  sortOrder: Float
+}
+
+"""
+[Internal] The properties of the initiative to update.
+"""
+input InitiativeUpdateInput {
+  """
+  The initiative's color.
+  """
+  color: String
+  """
+  The description of the initiative.
+  """
+  description: String
+  """
+  The name of the initiative.
+  """
+  name: String
+  """
+  The owner of the initiative.
+  """
+  ownerId: String
+  """
+  The sort order of the initiative within the organization.
+  """
+  sortOrder: Float
+  """
+  The estimated completion date of the initiative.
+  """
+  targetDate: TimelessDate
+}
+
+"""
 An integration with an external service.
 """
 type Integration implements Node {
@@ -3899,6 +4630,17 @@ type IntegrationEdge {
   """
   cursor: String!
   node: Integration!
+}
+
+type IntegrationHasScopesPayload {
+  """
+  Whether the integration has the required scopes.
+  """
+  hasAllScopes: Boolean!
+  """
+  The missing scopes.
+  """
+  missingScopes: [String!]
 }
 
 type IntegrationPayload {
@@ -3967,7 +4709,7 @@ enum IntegrationService {
 }
 
 """
-The integration resource's settings
+The integration resource's settings.
 """
 type IntegrationSettings {
   front: FrontSettings
@@ -4010,7 +4752,7 @@ input IntegrationSettingsInput {
 }
 
 """
-Join table between templates and integrations
+Join table between templates and integrations.
 """
 type IntegrationTemplate implements Node {
   """
@@ -4126,11 +4868,11 @@ type IntegrationsSettings implements Node {
   """
   slackIssueNewComment: Boolean
   """
-  Whether to send a Slack message when an SLA is breached
+  Whether to send a Slack message when an SLA is breached.
   """
   slackIssueSlaBreached: Boolean
   """
-  Whether to send a Slack message when an SLA is at high risk
+  Whether to send a Slack message when an SLA is at high risk.
   """
   slackIssueSlaHighRisk: Boolean
   """
@@ -4197,7 +4939,7 @@ input IntegrationsSettingsCreateInput {
   """
   slackIssueSlaBreached: Boolean
   """
-  Whether to send a Slack message when an SLA is at high risk
+  Whether to send a Slack message when an SLA is at high risk.
   """
   slackIssueSlaHighRisk: Boolean
   """
@@ -4267,7 +5009,7 @@ input IntegrationsSettingsUpdateInput {
   """
   slackIssueSlaBreached: Boolean
   """
-  Whether to send a Slack message when an SLA is at high risk
+  Whether to send a Slack message when an SLA is at high risk.
   """
   slackIssueSlaHighRisk: Boolean
   """
@@ -4505,6 +5247,10 @@ type Issue implements Node {
   """
   descriptionData: JSON @deprecated(reason: "Use description instead.")
   """
+  [Internal] The issue's description content as YJS state.
+  """
+  descriptionState: String
+  """
   The date at which the issue is due.
   """
   dueDate: TimelessDate
@@ -4513,7 +5259,7 @@ type Issue implements Node {
   """
   estimate: Float
   """
-  [ALPHA] The external user who created the issue.
+  The external user who created the issue.
   """
   externalUserCreator: ExternalUser
   """
@@ -5064,7 +5810,7 @@ input IssueCreateInput {
   """
   parentId: String
   """
-  Whether the passed sort order should be preserved
+  Whether the passed sort order should be preserved.
   """
   preserveSortOrderOnCreate: Boolean
   """
@@ -5436,7 +6182,7 @@ type IssueHistory implements Node {
   """
   autoClosed: Boolean
   """
-  The bot that performed the action
+  The bot that performed the action.
   """
   botActor: ActorBot
   """
@@ -5464,7 +6210,7 @@ type IssueHistory implements Node {
   """
   fromCycleId: String
   """
-  What the due date was changed from
+  What the due date was changed from.
   """
   fromDueDate: TimelessDate
   """
@@ -5557,7 +6303,7 @@ type IssueHistory implements Node {
   """
   toCycleId: String
   """
-  What the due date was changed to
+  What the due date was changed to.
   """
   toDueDate: TimelessDate
   """
@@ -5635,7 +6381,7 @@ type IssueHistoryEdge {
 }
 
 """
-An import job for data from an external service
+An import job for data from an external service.
 """
 type IssueImport implements Node {
   """
@@ -5659,7 +6405,7 @@ type IssueImport implements Node {
   """
   error: String
   """
-  Error code and metadata, if one has occurred during the import
+  Error code and metadata, if one has occurred during the import.
   """
   errorMetadata: JSONObject
   """
@@ -5683,7 +6429,7 @@ type IssueImport implements Node {
   """
   status: String!
   """
-  New team's name in cases when teamId not set
+  New team's name in cases when teamId not set.
   """
   teamName: String
   """
@@ -5717,19 +6463,19 @@ type IssueImportDeletePayload {
 }
 
 """
-Issue import mapping input
+Issue import mapping input.
 """
 input IssueImportMappingInput {
   """
-  The mapping configuration for epics
+  The mapping configuration for epics.
   """
   epics: JSONObject
   """
-  The mapping configuration for users
+  The mapping configuration for users.
   """
   users: JSONObject
   """
-  The mapping configuration for workflow states
+  The mapping configuration for workflow states.
   """
   workflowStates: JSONObject
 }
@@ -6047,7 +6793,7 @@ input IssueLabelUpdateInput {
 }
 
 """
-An issue related notification
+An issue related notification.
 """
 type IssueNotification implements Entity & Node & Notification {
   """
@@ -6104,11 +6850,11 @@ type IssueNotification implements Entity & Node & Notification {
   """
   subscriptions: [NotificationSubscription!]
   """
-  The team related to the notification.
+  The team related to the issue notification.
   """
   team: Team!
   """
-  Notification type
+  Notification type.
   """
   type: String!
   """
@@ -6223,7 +6969,7 @@ type IssueRelationEdge {
 }
 
 """
-Issue relation history's payload
+Issue relation history's payload.
 """
 type IssueRelationHistoryPayload {
   """
@@ -6450,6 +7196,10 @@ type IssueSearchResult implements Node {
   """
   descriptionData: JSON @deprecated(reason: "Use description instead.")
   """
+  [Internal] The issue's description content as YJS state.
+  """
+  descriptionState: String
+  """
   The date at which the issue is due.
   """
   dueDate: TimelessDate
@@ -6458,7 +7208,7 @@ type IssueSearchResult implements Node {
   """
   estimate: Float
   """
-  [ALPHA] The external user who created the issue.
+  The external user who created the issue.
   """
   externalUserCreator: ExternalUser
   """
@@ -6577,7 +7327,7 @@ type IssueSearchResult implements Node {
   """
   lastAppliedTemplate: Template
   """
-  Metadata related to search result
+  Metadata related to search result.
   """
   metadata: JSONObject!
   """
@@ -7006,11 +7756,15 @@ input JiraSettingsInput {
 
 input JiraUpdateInput {
   """
-  The id of the integration to update
+  The id of the integration to update.
   """
   id: String!
   """
-  Whether to refresh Jira Projects for the integration
+  Whether to refresh Jira metadata for the integration.
+  """
+  updateMetadata: Boolean
+  """
+  Whether to refresh Jira Projects for the integration.
   """
   updateProjects: Boolean
 }
@@ -7031,7 +7785,7 @@ A label notification subscription.
 """
 type LabelNotificationSubscription implements Entity & Node & NotificationSubscription {
   """
-  Whether the subscription is active or not
+  Whether the subscription is active or not.
   """
   active: Boolean!
   """
@@ -7103,7 +7857,7 @@ type LogoutResponse {
 
 type Mutation {
   """
-  Creates an integration api key for Airbyte to connect with Linear
+  Creates an integration api key for Airbyte to connect with Linear.
   """
   airbyteIntegrationConnect(
     """
@@ -7173,7 +7927,7 @@ type Mutation {
     """
     displayIconUrl: String
     """
-    Optional attachment ID that may be provided through the API
+    Optional attachment ID that may be provided through the API.
     """
     id: String
     """
@@ -7184,6 +7938,10 @@ type Mutation {
     The Discord message ID for the message to link.
     """
     messageId: String!
+    """
+    The title to use for the attachment.
+    """
+    title: String
     """
     The Discord message URL for the message to link.
     """
@@ -7206,13 +7964,17 @@ type Mutation {
     """
     displayIconUrl: String
     """
-    Optional attachment ID that may be provided through the API
+    Optional attachment ID that may be provided through the API.
     """
     id: String
     """
     The issue for which to link the Front conversation.
     """
     issueId: String!
+    """
+    The title to use for the attachment.
+    """
+    title: String
   ): FrontAttachmentPayload!
   """
   Link a GitHub issue to a Linear issue.
@@ -7227,13 +7989,17 @@ type Mutation {
     """
     displayIconUrl: String
     """
-    Optional attachment ID that may be provided through the API
+    Optional attachment ID that may be provided through the API.
     """
     id: String
     """
     The Linear issue for which to link the GitHub issue.
     """
     issueId: String!
+    """
+    The title to use for the attachment.
+    """
+    title: String
     """
     The URL of the GitHub issue to link.
     """
@@ -7252,7 +8018,7 @@ type Mutation {
     """
     displayIconUrl: String
     """
-    Optional attachment ID that may be provided through the API
+    Optional attachment ID that may be provided through the API.
     """
     id: String
     """
@@ -7272,6 +8038,10 @@ type Mutation {
     """
     repo: String
     """
+    The title to use for the attachment.
+    """
+    title: String
+    """
     The URL of the GitHub pull request to link.
     """
     url: String!
@@ -7289,7 +8059,7 @@ type Mutation {
     """
     displayIconUrl: String
     """
-    Optional attachment ID that may be provided through the API
+    Optional attachment ID that may be provided through the API.
     """
     id: String
     """
@@ -7301,9 +8071,13 @@ type Mutation {
     """
     number: Float!
     """
-    The path name to the project including any (sub)groups. E.g. linear/main/client
+    The path name to the project including any (sub)groups. E.g. linear/main/client.
     """
     projectPathWithNamespace: String!
+    """
+    The title to use for the attachment.
+    """
+    title: String
     """
     The URL of the GitLab merge request to link.
     """
@@ -7326,13 +8100,17 @@ type Mutation {
     """
     displayIconUrl: String
     """
-    Optional attachment ID that may be provided through the API
+    Optional attachment ID that may be provided through the API.
     """
     id: String
     """
     The issue for which to link the Intercom conversation.
     """
     issueId: String!
+    """
+    The title to use for the attachment.
+    """
+    title: String
   ): AttachmentPayload!
   """
   Link an existing Jira issue to an issue.
@@ -7364,7 +8142,7 @@ type Mutation {
     """
     displayIconUrl: String
     """
-    Optional attachment ID that may be provided through the API
+    Optional attachment ID that may be provided through the API.
     """
     id: String
     """
@@ -7376,7 +8154,7 @@ type Mutation {
     """
     latest: String!
     """
-    Optional title that may be provided through the API
+    The title to use for the attachment.
     """
     title: String
     """
@@ -7430,7 +8208,7 @@ type Mutation {
     """
     displayIconUrl: String
     """
-    Optional attachment ID that may be provided through the API
+    Optional attachment ID that may be provided through the API.
     """
     id: String
     """
@@ -7441,6 +8219,10 @@ type Mutation {
     The Zendesk ticket ID to link.
     """
     ticketId: String!
+    """
+    The title to use for the attachment.
+    """
+    title: String
   ): AttachmentPayload!
   """
   Unsyncs an existing synced Slack attachment.
@@ -7612,7 +8394,7 @@ type Mutation {
     input: CycleCreateInput!
   ): CyclePayload!
   """
-  Shifts all cycles starts by a certain number of weeks.
+  [DEPRECATED] Shifts all cycles starts by a certain number of weeks.
   """
   cycleShiftAll(
     """
@@ -7664,6 +8446,46 @@ type Mutation {
     """
     input: DocumentUpdateInput!
   ): DocumentPayload!
+  """
+  Creates a new email intake address.
+  """
+  emailIntakeAddressCreate(
+    """
+    The email intake address object to create.
+    """
+    input: EmailIntakeAddressCreateInput!
+  ): EmailIntakeAddressPayload!
+  """
+  Deletes an email intake address object.
+  """
+  emailIntakeAddressDelete(
+    """
+    The identifier of the email intake address to delete.
+    """
+    id: String!
+  ): DeletePayload!
+  """
+  Rotates an existing email intake address.
+  """
+  emailIntakeAddressRotate(
+    """
+    The identifier of the email intake address.
+    """
+    id: String!
+  ): EmailIntakeAddressPayload!
+  """
+  Updates an existing email intake address.
+  """
+  emailIntakeAddressUpdate(
+    """
+    The identifier of the email intake address.
+    """
+    id: String!
+    """
+    The properties of the email intake address to update.
+    """
+    input: EmailIntakeAddressUpdateInput!
+  ): EmailIntakeAddressPayload!
   """
   [INTERNAL] Subscribes the email to the newsletter.
   """
@@ -7806,6 +8628,37 @@ type Mutation {
     input: GitAutomationStateUpdateInput!
   ): GitAutomationStatePayload!
   """
+  Creates a Git target branch automation.
+  """
+  gitAutomationTargetBranchCreate(
+    """
+    The Git target branch automation to create.
+    """
+    input: GitAutomationTargetBranchCreateInput!
+  ): GitAutomationTargetBranchPayload!
+  """
+  Archives a Git target branch automation.
+  """
+  gitAutomationTargetBranchDelete(
+    """
+    The identifier of the Git target branch automation to archive.
+    """
+    id: String!
+  ): DeletePayload!
+  """
+  Updates an existing Git target branch automation.
+  """
+  gitAutomationTargetBranchUpdate(
+    """
+    The identifier of the Git target branch automation to update.
+    """
+    id: String!
+    """
+    The updates.
+    """
+    input: GitAutomationTargetBranchUpdateInput!
+  ): GitAutomationTargetBranchPayload!
+  """
   Authenticate user account through Google OAuth. This is the 2nd step of OAuth flow.
   """
   googleUserAccountAuth(
@@ -7844,6 +8697,95 @@ type Mutation {
     """
     size: Int!
   ): UploadPayload!
+  """
+  [Internal] Archives a initiative.
+  """
+  initiativeArchive(
+    """
+    The identifier of the initiative to archive.
+    """
+    id: String!
+  ): InitiativeArchivePayload!
+  """
+  [Internal] Creates a new initiative.
+  """
+  initiativeCreate(
+    """
+    The properties of the initiative to create.
+    """
+    input: InitiativeCreateInput!
+  ): InitiativePayload!
+  """
+  [Internal] Deletes a initiative.
+  """
+  initiativeDelete(
+    """
+    The identifier of the initiative to delete.
+    """
+    id: String!
+  ): DeletePayload!
+  """
+  [INTERNAL] Creates a new initiativeToProject join.
+  """
+  initiativeToProjectCreate(
+    """
+    The properties of the initiativeToProject to create.
+    """
+    input: InitiativeToProjectCreateInput!
+  ): InitiativeToProjectPayload!
+  """
+  [INTERNAL] Deletes a initiativeToProject.
+  """
+  initiativeToProjectDelete(
+    """
+    The identifier of the initiativeToProject to delete.
+    """
+    id: String!
+  ): DeletePayload!
+  """
+  [INTERNAL] Updates a initiativeToProject.
+  """
+  initiativeToProjectUpdate(
+    """
+    The identifier of the initiativeToProject to update.
+    """
+    id: String!
+    """
+    The properties of the initiativeToProject to update.
+    """
+    input: InitiativeToProjectUpdateInput!
+  ): InitiativeToProjectPayload!
+  """
+  [Internal] Unarchives a initiative.
+  """
+  initiativeUnarchive(
+    """
+    The identifier of the initiative to unarchive.
+    """
+    id: String!
+  ): InitiativeArchivePayload!
+  """
+  [Internal] Updates a initiative.
+  """
+  initiativeUpdate(
+    """
+    The identifier of the initiative to update.
+    """
+    id: String!
+    """
+    The properties of the initiative to update.
+    """
+    input: InitiativeUpdateInput!
+  ): InitiativePayload!
+  """
+  Archives an integration.
+  """
+  integrationArchive(
+    """
+    The identifier of the integration to archive.
+    """
+    id: String!
+  ): DeletePayload!
   """
   Connect a Slack channel to Asks.
   """
@@ -7936,7 +8878,7 @@ type Mutation {
     """
     accessToken: String!
     """
-    The URL of the GitLab installation
+    The URL of the GitLab installation.
     """
     gitlabUrl: String!
   ): IntegrationPayload!
@@ -8003,11 +8945,11 @@ type Mutation {
     code: String
   ): IntegrationPayload!
   """
-  [INTERNAL] Updates a Jira Integration
+  [INTERNAL] Updates a Jira Integration.
   """
   integrationJiraUpdate(
     """
-    Jira integration update input
+    Jira integration update input.
     """
     input: JiraUpdateInput!
   ): IntegrationPayload!
@@ -8089,7 +9031,7 @@ type Mutation {
     shouldUseV2Auth: Boolean
   ): IntegrationPayload!
   """
-  Integrates the organization with the Slack Asks app
+  Integrates the organization with the Slack Asks app.
   """
   integrationSlackAsks(
     """
@@ -8278,7 +9220,7 @@ type Mutation {
     """
     id: String!
     """
-    Whether to trash the issue
+    Whether to trash the issue.
     """
     trash: Boolean
   ): IssueArchivePayload!
@@ -8975,7 +9917,7 @@ type Mutation {
     """
     id: String!
     """
-    Whether to trash the project
+    Whether to trash the project.
     """
     trash: Boolean
   ): ProjectArchivePayload! @deprecated(reason: "Deprecated in favor of projectDelete.")
@@ -9437,7 +10379,7 @@ type Mutation {
   """
   userExternalUserDisconnect(
     """
-    The external service to disconnect
+    The external service to disconnect.
     """
     service: String!
   ): UserPayload!
@@ -9450,7 +10392,7 @@ type Mutation {
     """
     flag: UserFlagType!
     """
-    Flag operation to perform
+    Flag operation to perform.
     """
     operation: UserFlagUpdateOperation!
   ): UserSettingsFlagPayload!
@@ -9678,7 +10620,7 @@ interface Notification implements Entity & Node {
   """
   snoozedUntilAt: DateTime
   """
-  Notification type
+  Notification type.
   """
   type: String!
   """
@@ -9786,7 +10728,7 @@ Notification subscriptions for models.
 """
 interface NotificationSubscription implements Entity & Node {
   """
-  Whether the subscription is active or not
+  Whether the subscription is active or not.
   """
   active: Boolean!
   """
@@ -10101,9 +11043,63 @@ input NullableDocumentContentFilter {
   """
   createdAt: DateComparator
   """
+  Filters that the document content document must satisfy.
+  """
+  document: DocumentFilter
+  """
   Comparator for the identifier.
   """
   id: IDComparator
+  """
+  Filters that the document content project must satisfy.
+  """
+  project: ProjectFilter
+  """
+  Comparator for the updated at date.
+  """
+  updatedAt: DateComparator
+}
+
+"""
+Document filtering options.
+"""
+input NullableDocumentFilter {
+  """
+  Compound filters, all of which need to be matched by the document.
+  """
+  and: [NullableDocumentFilter!]
+  """
+  Comparator for the created at date.
+  """
+  createdAt: DateComparator
+  """
+  Filters that the document's creator must satisfy.
+  """
+  creator: UserFilter
+  """
+  Comparator for the identifier.
+  """
+  id: IDComparator
+  """
+  Filter based on the existence of the relation.
+  """
+  null: Boolean
+  """
+  Compound filters, one of which need to be matched by the document.
+  """
+  or: [NullableDocumentFilter!]
+  """
+  Filters that the document's project must satisfy.
+  """
+  project: ProjectFilter
+  """
+  Comparator for the document slug ID.
+  """
+  slugId: StringComparator
+  """
+  Comparator for the document title.
+  """
+  title: StringComparator
   """
   Comparator for the updated at date.
   """
@@ -10748,7 +11744,7 @@ input NumberComparator {
 }
 
 """
-The different requests statuses possible for an OAuth client approval request
+The different requests statuses possible for an OAuth client approval request.
 """
 enum OAuthClientApprovalStatus {
   approved
@@ -10831,7 +11827,7 @@ type OauthClient implements Node {
   """
   webhookSecret: String
   """
-  Webhook URL
+  Webhook URL.
   """
   webhookUrl: String
 }
@@ -10889,7 +11885,7 @@ type OauthClientApproval implements Node {
 }
 
 """
-An oauth client approval related notification
+An oauth client approval related notification.
 """
 type OauthClientApprovalNotification implements Entity & Node & Notification {
   """
@@ -10934,7 +11930,7 @@ type OauthClientApprovalNotification implements Entity & Node & Notification {
   """
   snoozedUntilAt: DateTime
   """
-  Notification type
+  Notification type.
   """
   type: String!
   """
@@ -10968,8 +11964,22 @@ type OauthClientEdge {
 }
 
 type OauthToken {
+  """
+  OAuth2 client for which the access token belongs to.
+  """
+  client: AuthOauthClient!
+  clientId: String!
   createdAt: DateTime!
-  id: ID!
+  id: Float!
+  revokedAt: DateTime
+  """
+  Auth user who authorized the OAuth application.
+  """
+  user: AuthUser!
+  """
+  Id of the user who authorized the OAuth application.
+  """
+  userId: String!
 }
 
 input OnboardingCustomerSurvey {
@@ -10982,11 +11992,11 @@ An organization. Organizations are root-level objects that contain user accounts
 """
 type Organization implements Node {
   """
-  Whether member users are allowed to send invites
+  Whether member users are allowed to send invites.
   """
   allowMembersToInvite: Boolean
   """
-  Allowed authentication providers, empty array means all are allowed
+  Allowed authentication providers, empty array means all are allowed.
   """
   allowedAuthServices: [String!]!
   """
@@ -11128,7 +12138,7 @@ type Organization implements Node {
   """
   samlEnabled: Boolean!
   """
-  [INTERNAL] SAML settings
+  [INTERNAL] SAML settings.
   """
   samlSettings: JSONObject
   """
@@ -11136,7 +12146,7 @@ type Organization implements Node {
   """
   scimEnabled: Boolean!
   """
-  Which day count to use for SLA calculations
+  Which day count to use for SLA calculations.
   """
   slaDayCount: SLADayCountType!
   """
@@ -11260,7 +12270,7 @@ type Organization implements Node {
 
 type OrganizationAcceptedOrExpiredInviteDetailsPayload {
   """
-  The status of the invite
+  The status of the invite.
   """
   status: OrganizationInviteStatus!
 }
@@ -11288,7 +12298,7 @@ type OrganizationDomain implements Node {
   """
   archivedAt: DateTime
   """
-  What type of auth is the domain used for
+  What type of auth is the domain used for.
   """
   authType: OrganizationDomainAuthType!
   """
@@ -11308,7 +12318,7 @@ type OrganizationDomain implements Node {
   """
   id: ID!
   """
-  Domain name
+  Domain name.
   """
   name: String!
   """
@@ -11318,11 +12328,11 @@ type OrganizationDomain implements Node {
   """
   updatedAt: DateTime!
   """
-  E-mail used to verify this domain
+  E-mail used to verify this domain.
   """
   verificationEmail: String
   """
-  Is this domain verified
+  Is this domain verified.
   """
   verified: Boolean!
 }
@@ -11419,7 +12429,7 @@ An invitation to the organization that has been sent via email.
 """
 type OrganizationInvite implements Node {
   """
-  The time at which the invite was accepted. Null, if the invite hasn't been accepted
+  The time at which the invite was accepted. Null, if the invite hasn't been accepted.
   """
   acceptedAt: DateTime
   """
@@ -11435,7 +12445,7 @@ type OrganizationInvite implements Node {
   """
   email: String!
   """
-  The time at which the invite will be expiring. Null, if the invite shouldn't expire
+  The time at which the invite will be expiring. Null, if the invite shouldn't expire.
   """
   expiresAt: DateTime
   """
@@ -11494,7 +12504,7 @@ input OrganizationInviteCreateInput {
   """
   message: String
   """
-  [INTERNAL] Optional metadata about the invite
+  [INTERNAL] Optional metadata about the invite.
   """
   metadata: JSONObject
   """
@@ -11529,7 +12539,7 @@ type OrganizationInviteFullDetailsPayload {
   """
   createdAt: DateTime!
   """
-  The email of the invitee
+  The email of the invitee.
   """
   email: String!
   """
@@ -11537,7 +12547,7 @@ type OrganizationInviteFullDetailsPayload {
   """
   expired: Boolean!
   """
-  The name of the inviter
+  The name of the inviter.
   """
   inviter: String!
   """
@@ -11557,7 +12567,7 @@ type OrganizationInviteFullDetailsPayload {
   """
   role: UserRoleType!
   """
-  The status of the invite
+  The status of the invite.
   """
   status: OrganizationInviteStatus!
 }
@@ -11641,7 +12651,7 @@ input OrganizationUpdateInput {
   """
   gitPublicLinkbackMessagesEnabled: Boolean
   """
-  Linear Preview feature flags
+  Linear Preview feature flags.
   """
   linearPreviewFlags: JSONObject
   """
@@ -11868,6 +12878,10 @@ type Project implements Node {
   """
   content: String
   """
+  [Internal] The project's content as YJS state.
+  """
+  contentState: String
+  """
   The project was created based on this issue.
   """
   convertedFromIssue: Issue
@@ -11895,6 +12909,10 @@ type Project implements Node {
     A cursor to be used with last for backward pagination.
     """
     before: String
+    """
+    Filter returned documents.
+    """
+    filter: DocumentFilter
     """
     The number of items to forward paginate (used with after). Defaults to 50.
     """
@@ -12059,6 +13077,10 @@ type Project implements Node {
     A cursor to be used with last for backward pagination.
     """
     before: String
+    """
+    Filter returned milestones.
+    """
+    filter: ProjectMilestoneFilter
     """
     The number of items to forward paginate (used with after). Defaults to 50.
     """
@@ -12398,6 +13420,10 @@ input ProjectCreateInput {
   """
   state: String
   """
+  [INTERNAL] The ID of the project status.
+  """
+  statusId: String
+  """
   The planned target date of the project.
   """
   targetDate: TimelessDate
@@ -12654,7 +13680,11 @@ type ProjectMilestone implements Node {
   """
   [Internal] The project milestone's description as a Prosemirror document.
   """
-  descriptionData: JSON
+  descriptionData: JSON @deprecated(reason: "Use `descriptionState` instead.")
+  """
+  [Internal] The project milestone's description as YJS state.
+  """
+  descriptionState: String
   """
   The unique identifier of the entity.
   """
@@ -12847,7 +13877,7 @@ input ProjectMilestoneUpdateInput {
 }
 
 """
-A project related notification
+A project related notification.
 """
 type ProjectNotification implements Entity & Node & Notification {
   """
@@ -12896,7 +13926,7 @@ type ProjectNotification implements Entity & Node & Notification {
   """
   snoozedUntilAt: DateTime
   """
-  Notification type
+  Notification type.
   """
   type: String!
   """
@@ -12920,7 +13950,7 @@ A project notification subscription.
 """
 type ProjectNotificationSubscription implements Entity & Node & NotificationSubscription {
   """
-  Whether the subscription is active or not
+  Whether the subscription is active or not.
   """
   active: Boolean!
   """
@@ -13046,6 +14076,10 @@ type ProjectSearchResult implements Node {
   """
   content: String
   """
+  [Internal] The project's content as YJS state.
+  """
+  contentState: String
+  """
   The project was created based on this issue.
   """
   convertedFromIssue: Issue
@@ -13073,6 +14107,10 @@ type ProjectSearchResult implements Node {
     A cursor to be used with last for backward pagination.
     """
     before: String
+    """
+    Filter returned documents.
+    """
+    filter: DocumentFilter
     """
     The number of items to forward paginate (used with after). Defaults to 50.
     """
@@ -13218,7 +14256,7 @@ type ProjectSearchResult implements Node {
     orderBy: PaginationOrderBy
   ): UserConnection!
   """
-  Metadata related to search result
+  Metadata related to search result.
   """
   metadata: JSONObject!
   """
@@ -13241,6 +14279,10 @@ type ProjectSearchResult implements Node {
     A cursor to be used with last for backward pagination.
     """
     before: String
+    """
+    Filter returned milestones.
+    """
+    filter: ProjectMilestoneFilter
     """
     The number of items to forward paginate (used with after). Defaults to 50.
     """
@@ -13407,6 +14449,80 @@ type ProjectSearchResultEdge {
 }
 
 """
+[ALPHA] A project status.
+"""
+type ProjectStatus implements Node {
+  """
+  The time at which the entity was archived. Null if the entity has not been archived.
+  """
+  archivedAt: DateTime
+  """
+  The UI color of the status as a HEX string.
+  """
+  color: String!
+  """
+  The time at which the entity was created.
+  """
+  createdAt: DateTime!
+  """
+  Description of the status.
+  """
+  description: String
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  """
+  Whether or not a project can be in this status indefinitely.
+  """
+  indefinite: Boolean!
+  """
+  The name of the status.
+  """
+  name: String!
+  """
+  The position of the status in the workspace's project flow.
+  """
+  position: Float!
+  """
+  The type of the project status.
+  """
+  type: ProjectStatusType
+  """
+  The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+      for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+      been updated after creation.
+  """
+  updatedAt: DateTime!
+}
+
+type ProjectStatusConnection {
+  edges: [ProjectStatusEdge!]!
+  nodes: [ProjectStatus!]!
+  pageInfo: PageInfo!
+}
+
+type ProjectStatusEdge {
+  """
+  Used in `before` and `after` args
+  """
+  cursor: String!
+  node: ProjectStatus!
+}
+
+"""
+A type of project status.
+"""
+enum ProjectStatusType {
+  backlog
+  canceled
+  completed
+  paused
+  planned
+  started
+}
+
+"""
 Different tabs available inside a project.
 """
 enum ProjectTab {
@@ -13428,13 +14544,17 @@ type ProjectUpdate implements Node {
   """
   body: String!
   """
+  [Internal] The content of the project update as a Prosemirror document.
+  """
+  bodyData: String!
+  """
   The time at which the entity was created.
   """
   createdAt: DateTime!
   """
   The diff between the current update and the previous one.
   """
-  diff: JSON
+  diff: JSONObject
   """
   The diff between the current update and the previous one, formatted as markdown.
   """
@@ -13456,7 +14576,7 @@ type ProjectUpdate implements Node {
   """
   infoSnapshot: JSONObject
   """
-  [ALPHA] Whether project update diff should be hidden
+  Whether project update diff should be hidden.
   """
   isDiffHidden: Boolean!
   """
@@ -13503,7 +14623,7 @@ input ProjectUpdateCreateInput {
   """
   id: String
   """
-  [ALPHA] Whether the diff between the current update and the previous one should be hidden.
+  Whether the diff between the current update and the previous one should be hidden.
   """
   isDiffHidden: Boolean
   """
@@ -13636,6 +14756,10 @@ input ProjectUpdateInput {
   The state of the project.
   """
   state: String
+  """
+  [INTERNAL] The ID of the project status.
+  """
+  statusId: String
   """
   The planned target date of the project.
   """
@@ -13780,7 +14904,7 @@ input ProjectUpdateUpdateInput {
   """
   health: ProjectUpdateHealthType
   """
-  [ALPHA] Whether the diff between the current update and the previous one should be hidden.
+  Whether the diff between the current update and the previous one should be hidden.
   """
   isDiffHidden: Boolean
 }
@@ -13844,7 +14968,7 @@ input PushSubscriptionCreateInput {
   """
   id: String
   """
-  Whether this is a subscription payload for Google Cloud Messaging or Apple Push Notification service
+  Whether this is a subscription payload for Google Cloud Messaging or Apple Push Notification service.
   """
   type: PushSubscriptionType = web
   """
@@ -13884,7 +15008,7 @@ type PushSubscriptionTestPayload {
 }
 
 """
-The different push subscription types
+The different push subscription types.
 """
 enum PushSubscriptionType {
   apple
@@ -13894,45 +15018,6 @@ enum PushSubscriptionType {
 }
 
 type Query {
-  """
-  [DEPRECATED] [INTERNAL] One specific project milestone.
-  """
-  ProjectMilestone(id: String!): ProjectMilestone!
-    @deprecated(reason: "This mutation is deprecated, please use `projectMilestone` instead.")
-  """
-  [DEPRECATED] [INTERNAL] All milestones for the project.
-  """
-  ProjectMilestones(
-    """
-    A cursor to be used with first for forward pagination
-    """
-    after: String
-    """
-    A cursor to be used with last for backward pagination.
-    """
-    before: String
-    """
-    Filter returned project milestones.
-    """
-    filter: ProjectMilestoneFilter
-    """
-    The number of items to forward paginate (used with after). Defaults to 50.
-    """
-    first: Int
-    """
-    Should archived resources be included (default: false)
-    """
-    includeArchived: Boolean
-    """
-    The number of items to backward paginate (used with before). Defaults to 50.
-    """
-    last: Int
-    """
-    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
-    """
-    orderBy: PaginationOrderBy
-  ): ProjectMilestoneConnection!
-    @deprecated(reason: "This mutation is deprecated, please use `projectMilestones` instead.")
   """
   All teams you the user can administrate. Administrable teams are teams whose settings the user can change, but to whose issues the user doesn't necessarily have access to.
   """
@@ -14005,7 +15090,7 @@ type Query {
     clientId: String!
   ): Application!
   """
-  [INTERNAL] Get basic information for a list of applications
+  [INTERNAL] Get basic information for a list of applications.
   """
   applicationInfoByIds(
     """
@@ -14030,7 +15115,7 @@ type Query {
     """
     redirectUri: String
     """
-    Scopes being requested by the application
+    Scopes being requested by the application.
     """
     scope: [String!]!
   ): UserAuthorizedApplication!
@@ -14056,11 +15141,11 @@ type Query {
       reason: "Will be removed in near future, please use `attachmentsForURL` to get attachments and their issues instead."
     )
   """
-  [Internal] Get a list of all unique attachment sources in the workspace
+  [Internal] Get a list of all unique attachment sources in the workspace.
   """
   attachmentSources(
     """
-    (optional) if provided will only return attachment sources for the given team
+    (optional) if provided will only return attachment sources for the given team.
     """
     teamId: String
   ): AttachmentSourcesPayload!
@@ -14174,7 +15259,7 @@ type Query {
   """
   authenticationSessions: [AuthenticationSessionResponse!]!
   """
-  [INTERNAL] Get all authorized applications for a user
+  [INTERNAL] Get all authorized applications for a user.
   """
   authorizedApplications: [AuthorizedApplication!]!
   """
@@ -14186,9 +15271,17 @@ type Query {
   """
   comment(
     """
+    The hash of the comment to retrieve, must be combined with an issueId.
+    """
+    hash: String
+    """
     The identifier of the comment to retrieve.
     """
-    id: String!
+    id: String
+    """
+    The issue for which to find the comment.
+    """
+    issueId: String
   ): Comment!
   """
   All comments.
@@ -14327,6 +15420,10 @@ type Query {
     """
     before: String
     """
+    Filter returned documents.
+    """
+    filter: DocumentFilter
+    """
     The number of items to forward paginate (used with after). Defaults to 50.
     """
     first: Int
@@ -14348,7 +15445,7 @@ type Query {
   """
   emoji(
     """
-    The identifier of the emoji to retrieve.
+    The identifier or the name of the emoji to retrieve.
     """
     id: String!
   ): Emoji!
@@ -14453,9 +15550,88 @@ type Query {
     orderBy: PaginationOrderBy
   ): FavoriteConnection!
   """
+  [Internal] One specific initiative.
+  """
+  initiative(id: String!): Initiative!
+  """
+  [INTERNAL] One specific initiativeToProject.
+  """
+  initiativeToProject(id: String!): InitiativeToProject!
+  """
+  [INTERNAL] returns a list of initiative to project entities.
+  """
+  initiativeToProjects(
+    """
+    A cursor to be used with first for forward pagination
+    """
+    after: String
+    """
+    A cursor to be used with last for backward pagination.
+    """
+    before: String
+    """
+    The number of items to forward paginate (used with after). Defaults to 50.
+    """
+    first: Int
+    """
+    Should archived resources be included (default: false)
+    """
+    includeArchived: Boolean
+    """
+    The number of items to backward paginate (used with before). Defaults to 50.
+    """
+    last: Int
+    """
+    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+    """
+    orderBy: PaginationOrderBy
+  ): InitiativeToProjectConnection!
+  """
+  [Internal] All initiatives in the workspace.
+  """
+  initiatives(
+    """
+    A cursor to be used with first for forward pagination
+    """
+    after: String
+    """
+    A cursor to be used with last for backward pagination.
+    """
+    before: String
+    """
+    The number of items to forward paginate (used with after). Defaults to 50.
+    """
+    first: Int
+    """
+    Should archived resources be included (default: false)
+    """
+    includeArchived: Boolean
+    """
+    The number of items to backward paginate (used with before). Defaults to 50.
+    """
+    last: Int
+    """
+    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+    """
+    orderBy: PaginationOrderBy
+  ): InitiativeConnection!
+  """
   One specific integration.
   """
   integration(id: String!): Integration!
+  """
+  Checks if the integration has all required scopes.
+  """
+  integrationHasScopes(
+    """
+    The integration ID.
+    """
+    integrationId: String!
+    """
+    Required scopes.
+    """
+    scopes: [String!]!
+  ): IntegrationHasScopesPayload!
   """
   One specific integrationTemplate.
   """
@@ -14568,11 +15744,11 @@ type Query {
   """
   issueImportCheckCSV(
     """
-    CSV storage url
+    CSV storage url.
     """
     csvUrl: String!
     """
-    The service the CSV containing data from
+    The service the CSV containing data from.
     """
     service: String!
   ): IssueImportCheckPayload!
@@ -15153,7 +16329,7 @@ type Query {
     """
     includeArchived: Boolean
     """
-    Should associated comments be searched (default: true)
+    Should associated comments be searched (default: true).
     """
     includeComments: Boolean
     """
@@ -15165,7 +16341,7 @@ type Query {
     """
     orderBy: PaginationOrderBy
     """
-    UUID of a team to use as a boost
+    UUID of a team to use as a boost.
     """
     teamId: String
     """
@@ -15198,7 +16374,7 @@ type Query {
     """
     includeArchived: Boolean
     """
-    Should associated comments be searched (default: true)
+    Should associated comments be searched (default: true).
     """
     includeComments: Boolean
     """
@@ -15210,7 +16386,7 @@ type Query {
     """
     orderBy: PaginationOrderBy
     """
-    UUID of a team to use as a boost
+    UUID of a team to use as a boost.
     """
     teamId: String
     """
@@ -15239,7 +16415,7 @@ type Query {
     """
     includeArchived: Boolean
     """
-    Should associated comments be searched (default: true)
+    Should associated comments be searched (default: true).
     """
     includeComments: Boolean
     """
@@ -15251,7 +16427,7 @@ type Query {
     """
     orderBy: PaginationOrderBy
     """
-    UUID of a team to use as a boost
+    UUID of a team to use as a boost.
     """
     teamId: String
     """
@@ -15360,7 +16536,7 @@ type Query {
   """
   templatesForIntegration(
     """
-    The type of integration for which to return associated templates
+    The type of integration for which to return associated templates.
     """
     integrationType: String!
   ): [Template!]!
@@ -15494,7 +16670,7 @@ type Query {
     orderBy: PaginationOrderBy
   ): WorkflowStateConnection!
   """
-  [INTERNAL] Get all authorized applications (with limited fields) for a workspace
+  [INTERNAL] Get all authorized applications (with limited fields) for a workspace.
   """
   workspaceAuthorizedApplications: [WorkspaceAuthorizedApplication!]!
 }
@@ -15601,7 +16777,7 @@ input ReactionCreateInput {
   """
   emoji: String
   """
-  The identifier in UUID v4 format. If none is provided, the backend will generate one
+  The identifier in UUID v4 format. If none is provided, the backend will generate one.
   """
   id: String
   """
@@ -15646,7 +16822,7 @@ input RelationExistsComparator {
 }
 
 """
-Features release channel
+Features release channel.
 """
 enum ReleaseChannel {
   beta
@@ -15836,7 +17012,7 @@ input RoadmapCreateInput {
   """
   name: String!
   """
-  The owner of the roadmap
+  The owner of the roadmap.
   """
   ownerId: String
   """
@@ -15907,7 +17083,7 @@ type RoadmapPayload {
 }
 
 """
-Join table between projects and roadmaps
+Join table between projects and roadmaps.
 """
 type RoadmapToProject implements Node {
   """
@@ -16011,7 +17187,7 @@ input RoadmapUpdateInput {
   """
   name: String
   """
-  The owner of the roadmap
+  The owner of the roadmap.
   """
   ownerId: String
   """
@@ -16021,79 +17197,11 @@ input RoadmapUpdateInput {
 }
 
 """
-Which day count to use for SLA calculations
+Which day count to use for SLA calculations.
 """
 enum SLADayCountType {
   all
   onlyBusinessDays
-}
-
-type SamlConfiguration {
-  """
-  The issuer's custom entity ID.
-  """
-  issuerEntityId: String
-  """
-  Binding method for authentication call. Can be either `post` (default) or `redirect`.
-  """
-  ssoBinding: String
-  """
-  Sign in endpoint URL for the identity provider.
-  """
-  ssoEndpoint: String
-  """
-  The algorithm of the Signing Certificate. Can be one of `sha1`, `sha256` (default), or `sha512`.
-  """
-  ssoSignAlgo: String
-  """
-  X.509 Signing Certificate in string form.
-  """
-  ssoSigningCert: String
-}
-
-input SamlConfigurationInput {
-  """
-  The issuer's custom entity ID.
-  """
-  issuerEntityId: String
-  """
-  Binding method for authentication call. Can be either `post` (default) or `redirect`.
-  """
-  ssoBinding: String
-  """
-  Sign in endpoint URL for the identity provider.
-  """
-  ssoEndpoint: String
-  """
-  The algorithm of the Signing Certificate. Can be one of `sha1`, `sha256` (default), or `sha512`.
-  """
-  ssoSignAlgo: String
-  """
-  X.509 Signing Certificate in string form.
-  """
-  ssoSigningCert: String
-}
-
-"""
-The organization's SAML configuration
-"""
-type SamlConfigurationPayload {
-  """
-  The issuer's custom entity ID.
-  """
-  issuerEntityId: String
-  """
-  Binding method for authentication call. Can be either `post` (default) or `redirect`.
-  """
-  ssoBinding: String
-  """
-  Sign in endpoint URL for the identity provider.
-  """
-  ssoEndpoint: String
-  """
-  The algorithm of the Signing Certificate. Can be one of `sha1`, `sha256` (default), or `sha512`.
-  """
-  ssoSignAlgo: String
 }
 
 enum SendStrategy {
@@ -16182,11 +17290,11 @@ input SlackAsksSettingsInput {
 }
 
 """
-Tuple for mapping Slack channel IDs to names
+Tuple for mapping Slack channel IDs to names.
 """
 type SlackAsksTeamSettings {
   """
-  Whether the default Asks template is enabled in the given channel for this team
+  Whether the default Asks template is enabled in the given channel for this team.
   """
   hasDefaultAsk: Boolean!
   """
@@ -16197,7 +17305,7 @@ type SlackAsksTeamSettings {
 
 input SlackAsksTeamSettingsInput {
   """
-  Whether the default Asks template is enabled in the given channel for this team
+  Whether the default Asks template is enabled in the given channel for this team.
   """
   hasDefaultAsk: Boolean!
   """
@@ -16234,19 +17342,19 @@ type SlackChannelConnectPayload {
 }
 
 """
-Object for mapping Slack channel IDs to names and other settings
+Object for mapping Slack channel IDs to names and other settings.
 """
 type SlackChannelNameMapping {
   """
-  Whether or not @-mentioning the bot should automatically create an Ask with the message
+  Whether or not @-mentioning the bot should automatically create an Ask with the message.
   """
   autoCreateOnBotMention: Boolean
   """
-  Whether or not using the :ticket: emoji in this channel should automatically create Asks
+  Whether or not using the :ticket: emoji in this channel should automatically create Asks.
   """
   autoCreateOnEmoji: Boolean
   """
-  Whether or not top-level messages in this channel should automatically create Asks
+  Whether or not top-level messages in this channel should automatically create Asks.
   """
   autoCreateOnMessage: Boolean
   """
@@ -16254,7 +17362,7 @@ type SlackChannelNameMapping {
   """
   autoCreateTemplateId: String
   """
-  Whether or not we the Linear Asks bot has been added to this Slack channel
+  Whether or not we the Linear Asks bot has been added to this Slack channel.
   """
   botAdded: Boolean
   """
@@ -16262,11 +17370,11 @@ type SlackChannelNameMapping {
   """
   id: String!
   """
-  Whether or not the Slack channel is private
+  Whether or not the Slack channel is private.
   """
   isPrivate: Boolean
   """
-  Whether or not the Slack channel is shared with an external org
+  Whether or not the Slack channel is shared with an external org.
   """
   isShared: Boolean
   """
@@ -16274,22 +17382,22 @@ type SlackChannelNameMapping {
   """
   name: String!
   """
-  Which teams are connected to the channel and settings for those teams
+  Which teams are connected to the channel and settings for those teams.
   """
   teams: [SlackAsksTeamSettings!]!
 }
 
 input SlackChannelNameMappingInput {
   """
-  Whether or not @-mentioning the bot should automatically create an Ask with the message
+  Whether or not @-mentioning the bot should automatically create an Ask with the message.
   """
   autoCreateOnBotMention: Boolean
   """
-  Whether or not using the :ticket: emoji in this channel should automatically create Asks
+  Whether or not using the :ticket: emoji in this channel should automatically create Asks.
   """
   autoCreateOnEmoji: Boolean
   """
-  Whether or not top-level messages in this channel should automatically create Asks
+  Whether or not top-level messages in this channel should automatically create Asks.
   """
   autoCreateOnMessage: Boolean
   """
@@ -16297,7 +17405,7 @@ input SlackChannelNameMappingInput {
   """
   autoCreateTemplateId: String
   """
-  Whether or not we the Linear Asks bot has been added to this Slack channel
+  Whether or not we the Linear Asks bot has been added to this Slack channel.
   """
   botAdded: Boolean
   """
@@ -16305,11 +17413,11 @@ input SlackChannelNameMappingInput {
   """
   id: String!
   """
-  Whether or not the Slack channel is private
+  Whether or not the Slack channel is private.
   """
   isPrivate: Boolean
   """
-  Whether or not the Slack channel is shared with an external org
+  Whether or not the Slack channel is shared with an external org.
   """
   isShared: Boolean
   """
@@ -16317,7 +17425,7 @@ input SlackChannelNameMappingInput {
   """
   name: String!
   """
-  Which teams are connected to the channel and settings for those teams
+  Which teams are connected to the channel and settings for those teams.
   """
   teams: [SlackAsksTeamSettingsInput!]!
 }
@@ -16594,35 +17702,6 @@ type Team implements Node {
   """
   autoCloseStateId: String
   """
-  The automation states for the team.
-  """
-  automationStates(
-    """
-    A cursor to be used with first for forward pagination
-    """
-    after: String
-    """
-    A cursor to be used with last for backward pagination.
-    """
-    before: String
-    """
-    The number of items to forward paginate (used with after). Defaults to 50.
-    """
-    first: Int
-    """
-    Should archived resources be included (default: false)
-    """
-    includeArchived: Boolean
-    """
-    The number of items to backward paginate (used with before). Defaults to 50.
-    """
-    last: Int
-    """
-    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
-    """
-    orderBy: PaginationOrderBy
-  ): GitAutomationStateConnection!
-  """
   The team's color.
   """
   color: String
@@ -16731,6 +17810,35 @@ type Team implements Node {
   The workflow state into which issues are moved when a PR has been opened as draft.
   """
   draftWorkflowState: WorkflowState
+  """
+  The Git automation states for the team.
+  """
+  gitAutomationStates(
+    """
+    A cursor to be used with first for forward pagination
+    """
+    after: String
+    """
+    A cursor to be used with last for backward pagination.
+    """
+    before: String
+    """
+    The number of items to forward paginate (used with after). Defaults to 50.
+    """
+    first: Int
+    """
+    Should archived resources be included (default: false)
+    """
+    includeArchived: Boolean
+    """
+    The number of items to backward paginate (used with before). Defaults to 50.
+    """
+    last: Int
+    """
+    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+    """
+    orderBy: PaginationOrderBy
+  ): GitAutomationStateConnection!
   """
   Whether to group recent issue history entries.
   """
@@ -16978,7 +18086,7 @@ type Team implements Node {
     orderBy: PaginationOrderBy
   ): ProjectConnection!
   """
-  Whether an issue needs to have a priority set before leaving triage
+  Whether an issue needs to have a priority set before leaving triage.
   """
   requirePriorityToLeaveTriage: Boolean!
   """
@@ -17388,7 +18496,7 @@ type TeamMembership implements Node {
   """
   id: ID!
   """
-  Whether the user is the owner of the team
+  Whether the user is the owner of the team.
   """
   owner: Boolean
   """
@@ -17479,7 +18587,7 @@ A team notification subscription.
 """
 type TeamNotificationSubscription implements Entity & Node & NotificationSubscription {
   """
-  Whether the subscription is active or not
+  Whether the subscription is active or not.
   """
   active: Boolean!
   """
@@ -17558,9 +18666,17 @@ type TeamPayload {
 }
 
 """
-Tuple for mapping Linear teams to GitHub repos.
+Mapping of Linear teams to GitHub repos.
 """
 type TeamRepoMapping {
+  """
+  Whether the sync for this mapping is bidirectional.
+  """
+  bidirectional: Boolean
+  """
+  Whether this mapping is the default one for issue creation.
+  """
+  default: Boolean
   """
   The GitHub repo id.
   """
@@ -17572,6 +18688,14 @@ type TeamRepoMapping {
 }
 
 input TeamRepoMappingInput {
+  """
+  Whether the sync for this mapping is bidirectional.
+  """
+  bidirectional: Boolean
+  """
+  Whether this mapping is the default one for issue creation.
+  """
+  default: Boolean
   """
   The GitHub repo id.
   """
@@ -17608,7 +18732,11 @@ input TeamUpdateInput {
   """
   cycleDuration: Int
   """
-  Whether the first cycle should start in the current or the next week.
+  The date to begin cycles on.
+  """
+  cycleEnabledStartDate: DateTime
+  """
+  [DEPRECATED] Whether the first cycle should start in the current or the next week.
   """
   cycleEnabledStartWeek: String
   """
@@ -17889,6 +19017,94 @@ input TemplateUpdateInput {
 }
 
 """
+A time schedule.
+"""
+type TimeSchedule implements Node {
+  """
+  The time at which the entity was archived. Null if the entity has not been archived.
+  """
+  archivedAt: DateTime
+  """
+  The time at which the entity was created.
+  """
+  createdAt: DateTime!
+  """
+  The schedule entries.
+  """
+  entries: JSONObject!
+  """
+  User presentable error message, if an error occurred while updating the schedule.
+  """
+  error: String
+  """
+  The identifier of the external schedule.
+  """
+  externalId: String
+  """
+  The URL to the external schedule.
+  """
+  externalUrl: String
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  """
+  The identifier of the Linear integration populating the schedule.
+  """
+  integration: Integration
+  """
+  The name of the schedule.
+  """
+  name: String!
+  """
+  The organization of the schedule.
+  """
+  organization: Organization!
+  """
+  The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
+      for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
+      been updated after creation.
+  """
+  updatedAt: DateTime!
+}
+
+type TimeScheduleConnection {
+  edges: [TimeScheduleEdge!]!
+  nodes: [TimeSchedule!]!
+  pageInfo: PageInfo!
+}
+
+type TimeScheduleEdge {
+  """
+  Used in `before` and `after` args
+  """
+  cursor: String!
+  node: TimeSchedule!
+}
+
+"""
+The time schedule entry.
+"""
+input TimeScheduleEntry {
+  """
+  The end date of the schedule in ISO 8601 date-time format.
+  """
+  endsAt: DateTime!
+  """
+  The start date of the schedule in ISO 8601 date-time format.
+  """
+  startsAt: DateTime!
+  """
+  The email of the user on schedule. This is only used in case the user could not be mapped to a Linear user id.
+  """
+  userEmail: String
+  """
+  The Linear user id of the user on schedule. If the user cannot be mapped to a Linear user, use `userEmail` instead.
+  """
+  userId: String
+}
+
+"""
 Represents a date in ISO 8601 format. Accepts shortcuts like `2021` to represent midnight Fri Jan 01 2021. Also accepts ISO 8601 durations strings which are added to the current date to create the represented date (e.g '-P2W1D' represents the date that was two weeks and 1 day ago)
 """
 scalar TimelessDate
@@ -17991,6 +19207,10 @@ type TriageResponsibility implements Node {
   """
   team: Team!
   """
+  The time schedule used for scheduling.
+  """
+  timeSchedule: TimeSchedule!
+  """
   The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
       for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
       been updated after creation.
@@ -18084,7 +19304,7 @@ Object representing Google Cloud upload policy, plus additional data.
 """
 type UploadFile {
   """
-  The asset URL for the uploaded file. (assigned automatically)
+  The asset URL for the uploaded file. (assigned automatically).
   """
   assetUrl: String!
   """
@@ -18102,7 +19322,7 @@ type UploadFile {
   """
   size: Int!
   """
-  The signed URL the for the uploaded file. (assigned automatically)
+  The signed URL the for the uploaded file. (assigned automatically).
   """
   uploadUrl: String!
 }
@@ -18374,6 +19594,10 @@ type UserAccount {
   """
   archivedAt: DateTime
   """
+  Whether not to send email auth links in the email auth emails.
+  """
+  authTokenLinkDisabled: Boolean!
+  """
   The time at which the model was created.
   """
   createdAt: DateTime!
@@ -18453,7 +19677,7 @@ Public information of the OAuth application, plus whether the application has be
 """
 type UserAuthorizedApplication {
   """
-  Error associated with the application needing to be requested for approval in the workspace
+  Error associated with the application needing to be requested for approval in the workspace.
   """
   approvalErrorCode: String
   """
@@ -18684,7 +19908,7 @@ enum UserFlagType {
 }
 
 """
-Operations that can be applied to UserFlagType
+Operations that can be applied to UserFlagType.
 """
 enum UserFlagUpdateOperation {
   clear
@@ -18698,7 +19922,7 @@ A user notification subscription.
 """
 type UserNotificationSubscription implements Entity & Node & NotificationSubscription {
   """
-  Whether the subscription is active or not
+  Whether the subscription is active or not.
   """
   active: Boolean!
   """
@@ -18777,7 +20001,7 @@ type UserPayload {
 }
 
 """
-The different permission roles available to users on an organization
+The different permission roles available to users on an organization.
 """
 enum UserRoleType {
   admin
@@ -18986,6 +20210,10 @@ input ViewPreferencesCreateInput {
   """
   id: String
   """
+  [Internal] The initiative these view preferences are associated with.
+  """
+  initiativeId: String
+  """
   The default parameters for the insight on that view.
   """
   insights: JSONObject
@@ -19072,6 +20300,8 @@ enum ViewType {
   customViews
   cycle
   inbox
+  initiative
+  initiatives
   label
   myIssues
   myIssuesActivity
@@ -19097,7 +20327,7 @@ enum ViewType {
 }
 
 """
-A webhook used to send HTTP notifications over data updates
+A webhook used to send HTTP notifications over data updates.
 """
 type Webhook implements Node {
   """
@@ -19125,7 +20355,7 @@ type Webhook implements Node {
   """
   id: ID!
   """
-  Webhook label
+  Webhook label.
   """
   label: String
   """
@@ -19147,7 +20377,7 @@ type Webhook implements Node {
   """
   updatedAt: DateTime!
   """
-  Webhook URL
+  Webhook URL.
   """
   url: String
 }
@@ -19689,7 +20919,7 @@ type WorkspaceAuthorizedApplication {
   """
   imageUrl: String
   """
-  UserIds and membership dates of everyone who has authorized the application with the set of scopes
+  UserIds and membership dates of everyone who has authorized the application with the set of scopes.
   """
   memberships: [AuthMembership!]!
   """
@@ -19701,7 +20931,7 @@ type WorkspaceAuthorizedApplication {
   """
   scope: [String!]!
   """
-  Total number of members that authorized the application
+  Total number of members that authorized the application.
   """
   totalMembers: Float!
   """

--- a/packages/sdk/src/schema.json
+++ b/packages/sdk/src/schema.json
@@ -18,13 +18,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -333,8 +329,8 @@
             "deprecationReason": null
           },
           {
-            "name": "key",
-            "description": "The API key value.",
+            "name": "label",
+            "description": "The label for the API key.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -349,8 +345,8 @@
             "deprecationReason": null
           },
           {
-            "name": "label",
-            "description": "The label for the API key.",
+            "name": "key",
+            "description": "The API key value.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -661,6 +657,11 @@
           {
             "kind": "OBJECT",
             "name": "DeletePayload",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "InitiativeArchivePayload",
             "ofType": null
           },
           {
@@ -1804,7 +1805,7 @@
         "fields": [
           {
             "name": "sources",
-            "description": "A unique list of all source types used in this workspace",
+            "description": "A unique list of all source types used in this workspace.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2366,6 +2367,22 @@
             "deprecationReason": null
           },
           {
+            "name": "label",
+            "description": "The label for the API key.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "key",
             "description": "The API key value.",
             "type": {
@@ -2419,93 +2436,6 @@
                 "name": "AuthApiKey",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "AuthCreateOrJoinOrganizationResponse",
-        "description": null,
-        "fields": [
-          {
-            "name": "organization",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "AuthOrganization",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "user",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "AuthUser",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "authOrganization",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "AuthOrganization",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "authUser",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "AuthUser",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "grantDomainAccess",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3220,6 +3150,22 @@
             "deprecationReason": null
           },
           {
+            "name": "releaseChannel",
+            "description": "The feature release channel the organization belongs to.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ReleaseChannel",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "samlEnabled",
             "description": "Whether SAML authentication is enabled for organization.",
             "args": [],
@@ -3288,6 +3234,22 @@
             "deprecationReason": null
           },
           {
+            "name": "serviceId",
+            "description": "The email domain or URL key for the organization.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "userCount",
             "description": null,
             "args": [],
@@ -3313,6 +3275,109 @@
         "kind": "OBJECT",
         "name": "AuthOrganizationDomain",
         "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "verified",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "claimed",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "authType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "OrganizationDomainAuthType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AuthOrganizationInvite",
+        "description": "An invitation to the organization that has been sent via email.",
         "fields": [
           {
             "name": "id",
@@ -3358,25 +3423,17 @@
             "deprecationReason": null
           },
           {
-            "name": "token",
-            "description": "JWT token for authentication of the account.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "email",
             "description": "Email for the authenticated account.",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3395,7 +3452,7 @@
           },
           {
             "name": "users",
-            "description": "Users belonging to this account.",
+            "description": "List of active users that belong to the user account.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3419,7 +3476,7 @@
           },
           {
             "name": "availableOrganizations",
-            "description": "Organizations this account has access to, but is not yet a member.",
+            "description": "List of organizations allowing this user account to join automatically.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -3439,7 +3496,7 @@
           },
           {
             "name": "lockedOrganizations",
-            "description": "List of organizations this user account is part of but are currently locked because of the current auth service.",
+            "description": "List of organization available to this user account but locked due to the current auth method.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -3468,6 +3525,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "token",
+            "description": "Application token.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Deprecated and not used anymore. Never populated."
           }
         ],
         "inputFields": null,
@@ -3593,6 +3662,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userAccountId",
+            "description": "User account id the user belongs to.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -3859,7 +3944,7 @@
       {
         "kind": "OBJECT",
         "name": "AuthenticationSessionResponse",
-        "description": "Authentication session information",
+        "description": "Authentication session information.",
         "fields": [
           {
             "name": "id",
@@ -4601,8 +4686,20 @@
             "deprecationReason": null
           },
           {
+            "name": "quotedText",
+            "description": "The text that this comment references. Only defined for inline comments.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "reactionData",
-            "description": "Emoji reaction summary, grouped by emoji type",
+            "description": "Emoji reaction summary, grouped by emoji type.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4735,7 +4832,7 @@
           },
           {
             "name": "botActor",
-            "description": "The bot that created the comment",
+            "description": "The bot that created the comment.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -5081,7 +5178,7 @@
           },
           {
             "name": "projectUpdateId",
-            "description": "The prject update to associate the comment with.",
+            "description": "The project update to associate the comment with.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -5169,6 +5266,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "quotedText",
+            "description": "The text that this comment references. Only defined for inline comments.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null,
@@ -5474,6 +5583,18 @@
           {
             "name": "resolvingCommentId",
             "description": "[INTERNAL] The child comment that resolves this thread.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "quotedText",
+            "description": "The text that this comment references. Only defined for inline comments.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -5920,7 +6041,7 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ContactSalesCreateInput",
-        "description": "[INTERNAL] Input for sending a message to the Linear Sales team",
+        "description": "[INTERNAL] Input for sending a message to the Linear Sales team.",
         "fields": null,
         "inputFields": [
           {
@@ -6388,7 +6509,7 @@
           },
           {
             "name": "updatedBy",
-            "description": "[ALPHA] The user who last updated the custom view.",
+            "description": "The user who last updated the custom view.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6436,7 +6557,7 @@
           },
           {
             "name": "projectFilterData",
-            "description": "[ALPHA] The filter applied to projects in the custom view.",
+            "description": "The filter applied to projects in the custom view.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -6472,6 +6593,107 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issues",
+            "description": "Issues associated with the custom view.",
+            "args": [
+              {
+                "name": "filter",
+                "description": "Filter returned issues.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "IssueFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": "A cursor to be used with last for backward pagination.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "after",
+                "description": "A cursor to be used with first for forward pagination",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": "The number of items to forward paginate (used with after). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "The number of items to backward paginate (used with before). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "includeArchived",
+                "description": "Should archived resources be included (default: false)",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "By which field should the pagination order by. Available options are createdAt (default) and updatedAt.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "PaginationOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IssueConnection",
                 "ofType": null
               }
             },
@@ -6648,6 +6870,18 @@
             "deprecationReason": null
           },
           {
+            "name": "projectId",
+            "description": "[Internal] The id of the project associated with the custom view.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ownerId",
             "description": "The owner of the custom view.",
             "type": {
@@ -6685,7 +6919,7 @@
           },
           {
             "name": "projectFilterData",
-            "description": "[ALPHA] The project filter applied to issues in the custom view.",
+            "description": "The project filter applied to issues in the custom view.",
             "type": {
               "kind": "SCALAR",
               "name": "JSONObject",
@@ -6965,7 +7199,7 @@
           },
           {
             "name": "active",
-            "description": "Whether the subscription is active or not",
+            "description": "Whether the subscription is active or not.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7198,6 +7432,18 @@
             "deprecationReason": null
           },
           {
+            "name": "projectId",
+            "description": "[Internal] The id of the project associated with the custom view.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ownerId",
             "description": "The owner of the custom view.",
             "type": {
@@ -7235,7 +7481,7 @@
           },
           {
             "name": "projectFilterData",
-            "description": "[ALPHA] The project filter applied to issues in the custom view.",
+            "description": "The project filter applied to issues in the custom view.",
             "type": {
               "kind": "SCALAR",
               "name": "JSONObject",
@@ -8489,7 +8735,7 @@
           },
           {
             "name": "active",
-            "description": "Whether the subscription is active or not",
+            "description": "Whether the subscription is active or not.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -8607,12 +8853,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "CycleShiftAllInput",
-        "description": null,
+        "description": "[DEPRECATED] Input for shifting all cycles by a certain number of days. Mutation is now deprecated.",
         "fields": null,
         "inputFields": [
           {
             "name": "id",
-            "description": "The cycle id at which to start the shift.",
+            "description": "[DEPRECATED] The cycle id at which to start the shift.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8628,7 +8874,7 @@
           },
           {
             "name": "daysToShift",
-            "description": "The number of days to shift the cycles by.",
+            "description": "[DEPRECATED] The number of days to shift the cycles by.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8715,6 +8961,83 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DataRecovery",
+        "description": "Data recovery.",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time at which the entity was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those\n    for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't\n    been updated after creation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archivedAt",
+            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -9241,8 +9564,20 @@
             "deprecationReason": null
           },
           {
+            "name": "contentState",
+            "description": "[Internal] The documents content as YJS state.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "contentData",
-            "description": "The documents content as a Prosemirror document.",
+            "description": "[Internal] The documents content as a Prosemirror document.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -9261,6 +9596,177 @@
             "ofType": null
           }
         ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "DocumentCollectionFilter",
+        "description": "Document filtering options.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": "Comparator for the identifier.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IDComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "Comparator for the created at date.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DateComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "Comparator for the updated at date.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DateComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": "Comparator for the document title.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slugId",
+            "description": "Comparator for the document slug ID.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "creator",
+            "description": "Filters that the document's creator must satisfy.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "UserFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project",
+            "description": "Filters that the document's project must satisfy.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ProjectFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "and",
+            "description": "Compound filters, all of which need to be matched by the document.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "DocumentCollectionFilter",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "or",
+            "description": "Compound filters, one of which need to be matched by the document.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "DocumentCollectionFilter",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "some",
+            "description": "Filters that needs to be matched by some documents.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DocumentFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "every",
+            "description": "Filters that needs to be matched by all documents.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DocumentFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "length",
+            "description": "Comparator for the collection length.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "NumberComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -9425,8 +9931,8 @@
               "name": "JSONObject",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use `contentState` instead"
           },
           {
             "name": "contentState",
@@ -9490,7 +9996,7 @@
           },
           {
             "name": "restoredAt",
-            "description": "The time at which the document content was restored from a previous version",
+            "description": "The time at which the document content was restored from a previous version.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -9553,6 +10059,30 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "project",
+            "description": "Filters that the document content project must satisfy.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ProjectFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "document",
+            "description": "Filters that the document content document must satisfy.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DocumentFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -9562,7 +10092,7 @@
       {
         "kind": "OBJECT",
         "name": "DocumentContentHistory",
-        "description": "A document content history for a document",
+        "description": "A document content history for a document.",
         "fields": [
           {
             "name": "id",
@@ -9678,7 +10208,7 @@
           },
           {
             "name": "contentDataSnapshotAt",
-            "description": "The timestamp associated with the DocumentContent when it was originally saved ",
+            "description": "The timestamp associated with the DocumentContent when it was originally saved.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -10013,6 +10543,141 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "DocumentFilter",
+        "description": "Document filtering options.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": "Comparator for the identifier.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IDComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "Comparator for the created at date.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DateComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "Comparator for the updated at date.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DateComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": "Comparator for the document title.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slugId",
+            "description": "Comparator for the document slug ID.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "creator",
+            "description": "Filters that the document's creator must satisfy.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "UserFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project",
+            "description": "Filters that the document's project must satisfy.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ProjectFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "and",
+            "description": "Compound filters, all of which need to be matched by the document.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "DocumentFilter",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "or",
+            "description": "Compound filters, one of which need to be matched by the document.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "DocumentFilter",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -10392,8 +11057,20 @@
             "deprecationReason": null
           },
           {
+            "name": "contentState",
+            "description": "[Internal] The documents content as YJS state.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "contentData",
-            "description": "The documents content as a Prosemirror document.",
+            "description": "[Internal] The documents content as a Prosemirror document.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -10405,7 +11082,7 @@
           },
           {
             "name": "metadata",
-            "description": "Metadata related to search result",
+            "description": "Metadata related to search result.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -10659,7 +11336,7 @@
       {
         "kind": "OBJECT",
         "name": "EmailIntakeAddress",
-        "description": "An email address that can be used for submitting issues",
+        "description": "An email address that can be used for submitting issues.",
         "fields": [
           {
             "name": "id",
@@ -10754,6 +11431,18 @@
             "deprecationReason": null
           },
           {
+            "name": "template",
+            "description": "The template that the email address is associated with.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Template",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "team",
             "description": "The team that the email address is associated with.",
             "args": [],
@@ -10763,6 +11452,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "Team",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organization",
+            "description": "The organization that the email address is associated with.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Organization",
                 "ofType": null
               }
             },
@@ -10790,6 +11495,131 @@
             "ofType": null
           }
         ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "EmailIntakeAddressCreateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": "The identifier in UUID v4 format. If none is provided, the backend will generate one.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "teamId",
+            "description": "The identifier or key of the team this email address will intake issues for.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EmailIntakeAddressPayload",
+        "description": null,
+        "fields": [
+          {
+            "name": "lastSyncId",
+            "description": "The identifier of the last sync operation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "emailIntakeAddress",
+            "description": "The email address that was created or updated.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EmailIntakeAddress",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "success",
+            "description": "Whether the operation was successful.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "EmailIntakeAddressUpdateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "enabled",
+            "description": "Whether the email address is currently enabled. If set to false, the email address will be disabled and no longer accept incoming emails.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -11741,7 +12571,7 @@
       {
         "kind": "OBJECT",
         "name": "ExternalUser",
-        "description": "[ALPHA] An external authenticated (e.g., through Slack) user which doesn't have a Linear account, but can create and update entities in Linear from the external system that authenticated them.",
+        "description": "An external authenticated (e.g., through Slack) user which doesn't have a Linear account, but can create and update entities in Linear from the external system that authenticated them.",
         "fields": [
           {
             "name": "id",
@@ -11989,6 +12819,217 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "ExternalUser",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cursor",
+            "description": "Used in `before` and `after` args",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Facet",
+        "description": "[ALPHA] A facet. Facets are joins between entities. A facet can tie a custom view to a project, or a a project to a roadmap for example.",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time at which the entity was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those\n    for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't\n    been updated after creation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archivedAt",
+            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sortOrder",
+            "description": "The sort order of the facet.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "FacetConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "FacetEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Facet",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "FacetEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Facet",
                 "ofType": null
               }
             },
@@ -12637,6 +13678,18 @@
             "deprecationReason": null
           },
           {
+            "name": "initiativeId",
+            "description": "[INTERNAL] The identifier of the initiative to favorite.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "labelId",
             "description": "The identifier of the label to favorite.",
             "type": {
@@ -13105,17 +14158,13 @@
             "deprecationReason": null
           },
           {
-            "name": "branchPattern",
-            "description": "The target branch, if null, the automation will be triggered on any branch.",
+            "name": "targetBranch",
+            "description": "The target branch associated to this automation state.",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "OBJECT",
+              "name": "GitAutomationTargetBranch",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -13135,6 +14184,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "branchPattern",
+            "description": "[DEPRECATED] The target branch, if null, the automation will be triggered on any branch.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use targetBranch instead."
           }
         ],
         "inputFields": null,
@@ -13271,7 +14332,19 @@
           },
           {
             "name": "branchPattern",
-            "description": "The target branch pattern. If null, all branches are targeted.",
+            "description": "[DEPRECATED] The target branch pattern. If null, all branches are targeted.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "targetBranchId",
+            "description": "The associated target branch. If null, all branches are targeted.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13424,7 +14497,19 @@
           },
           {
             "name": "branchPattern",
-            "description": "The target branch pattern. If null, all branches are targeted.",
+            "description": "[DEPRECATED] The target branch pattern. If null, all branches are targeted.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "targetBranchId",
+            "description": "The associated target branch. If null, all branches are targeted.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13490,6 +14575,381 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GitAutomationTargetBranch",
+        "description": "A Git target branch for which there are automations (GitAutomationState).",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time at which the entity was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those\n    for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't\n    been updated after creation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archivedAt",
+            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team",
+            "description": "The team to which this Git target branch automation belongs.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Team",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "branchPattern",
+            "description": "The target branch pattern.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isRegex",
+            "description": "Whether the branch pattern is a regular expression.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "automationStates",
+            "description": "Automation states associated with the target branch.",
+            "args": [
+              {
+                "name": "before",
+                "description": "A cursor to be used with last for backward pagination.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "after",
+                "description": "A cursor to be used with first for forward pagination",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": "The number of items to forward paginate (used with after). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "The number of items to backward paginate (used with before). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "includeArchived",
+                "description": "Should archived resources be included (default: false)",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "By which field should the pagination order by. Available options are createdAt (default) and updatedAt.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "PaginationOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitAutomationStateConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "GitAutomationTargetBranchCreateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": "The identifier in UUID v4 format. If none is provided, the backend will generate one.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "teamId",
+            "description": "The team associated with the Git target branch automation.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "branchPattern",
+            "description": "The target branch pattern.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isRegex",
+            "description": "Whether the branch pattern is a regular expression.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": "false",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GitAutomationTargetBranchPayload",
+        "description": null,
+        "fields": [
+          {
+            "name": "lastSyncId",
+            "description": "The identifier of the last sync operation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "targetBranch",
+            "description": "The Git target branch automation that was created or updated.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitAutomationTargetBranch",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "success",
+            "description": "Whether the operation was successful.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "GitAutomationTargetBranchUpdateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "branchPattern",
+            "description": "The target branch pattern.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isRegex",
+            "description": "Whether the branch pattern is a regular expression.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -13570,7 +15030,7 @@
         "fields": [
           {
             "name": "login",
-            "description": "The GitHub user's name",
+            "description": "The GitHub user's name.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -13598,7 +15058,7 @@
         "inputFields": [
           {
             "name": "login",
-            "description": "The GitHub user's name",
+            "description": "The GitHub user's name.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13710,7 +15170,7 @@
         "fields": [
           {
             "name": "orgAvatarUrl",
-            "description": "The avatar URL for the GitHub organization",
+            "description": "The avatar URL for the GitHub organization.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -13726,7 +15186,7 @@
           },
           {
             "name": "orgLogin",
-            "description": "The GitHub organization's name",
+            "description": "The GitHub organization's name.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -13742,7 +15202,7 @@
           },
           {
             "name": "repositories",
-            "description": "The names of the repositories connected for the GitHub integration",
+            "description": "The names of the repositories connected for the GitHub integration.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -13762,7 +15222,7 @@
           },
           {
             "name": "repositoriesMapping",
-            "description": "Mapping of team to repository for syncing",
+            "description": "Mapping of team to repository for syncing.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -13794,7 +15254,7 @@
         "inputFields": [
           {
             "name": "orgAvatarUrl",
-            "description": "The avatar URL for the GitHub organization",
+            "description": "The avatar URL for the GitHub organization.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13810,7 +15270,7 @@
           },
           {
             "name": "orgLogin",
-            "description": "The GitHub organization's name",
+            "description": "The GitHub organization's name.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13826,7 +15286,7 @@
           },
           {
             "name": "repositories",
-            "description": "The names of the repositories connected for the GitHub integration",
+            "description": "The names of the repositories connected for the GitHub integration.",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -13846,7 +15306,7 @@
           },
           {
             "name": "repositoriesMapping",
-            "description": "Mapping of team to repository for syncing",
+            "description": "Mapping of team to repository for syncing.",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -13876,7 +15336,7 @@
         "fields": [
           {
             "name": "url",
-            "description": "The self-hosted URL of the GitLab instance",
+            "description": "The self-hosted URL of the GitLab instance.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -13888,7 +15348,7 @@
           },
           {
             "name": "readonly",
-            "description": "Whether the token is limited to a read-only scope",
+            "description": "Whether the token is limited to a read-only scope.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -13900,7 +15360,7 @@
           },
           {
             "name": "expiresAt",
-            "description": "The ISO timestamp the GitLab access token expires",
+            "description": "The ISO timestamp the GitLab access token expires.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -13924,7 +15384,7 @@
         "inputFields": [
           {
             "name": "url",
-            "description": "The self-hosted URL of the GitLab instance",
+            "description": "The self-hosted URL of the GitLab instance.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13936,7 +15396,7 @@
           },
           {
             "name": "readonly",
-            "description": "Whether the token is limited to a read-only scope",
+            "description": "Whether the token is limited to a read-only scope.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -13948,7 +15408,7 @@
           },
           {
             "name": "expiresAt",
-            "description": "The ISO timestamp the GitLab access token expires",
+            "description": "The ISO timestamp the GitLab access token expires.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14378,7 +15838,7 @@
           },
           {
             "name": "inviteLink",
-            "description": "An optional invite link for an organization.",
+            "description": "An optional invite link for an organization used to populate available organizations.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14520,6 +15980,1128 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Initiative",
+        "description": "[INTERNAL] An initiative to group projects.",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time at which the entity was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those\n    for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't\n    been updated after creation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archivedAt",
+            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "The name of the initiative.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "The description of the initiative.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organization",
+            "description": "The organization of the initiative.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Organization",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "creator",
+            "description": "The user who created the initiative.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner",
+            "description": "The user who owns the initiative.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slugId",
+            "description": "The initiative's unique URL slug.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sortOrder",
+            "description": "The sort order of the initiative within the organization.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "color",
+            "description": "The initiative's color.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "targetDate",
+            "description": "The estimated completion date of the initiative.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "TimelessDate",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "targetDateResolution",
+            "description": "[INTERNAL] The resolution of the initiative's estimated completion date.",
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "DateResolutionType",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projects",
+            "description": "Projects associated with the initiative.",
+            "args": [
+              {
+                "name": "filter",
+                "description": "[Internal] Filter returned projects.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ProjectFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": "A cursor to be used with last for backward pagination.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "after",
+                "description": "A cursor to be used with first for forward pagination",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": "The number of items to forward paginate (used with after). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "The number of items to backward paginate (used with before). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "includeArchived",
+                "description": "Should archived resources be included (default: false)",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "By which field should the pagination order by. Available options are createdAt (default) and updatedAt.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "PaginationOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProjectConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "InitiativeArchivePayload",
+        "description": "A generic payload return from entity archive mutations.",
+        "fields": [
+          {
+            "name": "lastSyncId",
+            "description": "The identifier of the last sync operation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "success",
+            "description": "Whether the operation was successful.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "entity",
+            "description": "The archived/unarchived entity. Null if entity was deleted.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Initiative",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "ArchivePayload",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "InitiativeConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "InitiativeEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Initiative",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "InitiativeCreateInput",
+        "description": "[Internal] The properties of the initiative to create.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": "The identifier in UUID v4 format. If none is provided, the backend will generate one.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "The name of the initiative.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "The description of the initiative.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ownerId",
+            "description": "The owner of the initiative.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sortOrder",
+            "description": "The sort order of the initiative within the organization.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "color",
+            "description": "The initiative's color.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "InitiativeEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Initiative",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cursor",
+            "description": "Used in `before` and `after` args",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "InitiativePayload",
+        "description": "[Internal] The payload returned by the initiative mutations.",
+        "fields": [
+          {
+            "name": "lastSyncId",
+            "description": "The identifier of the last sync operation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiative",
+            "description": "The initiative that was created or updated.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Initiative",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "success",
+            "description": "Whether the operation was successful.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "InitiativeToProject",
+        "description": "[INTERNAL] Join table between projects and initiatives.",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time at which the entity was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those\n    for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't\n    been updated after creation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archivedAt",
+            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project",
+            "description": "The project that the initiative is associated with.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Project",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiative",
+            "description": "The initiative that the project is associated with.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Initiative",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sortOrder",
+            "description": "The sort order of the project within the initiative.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "InitiativeToProjectConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "InitiativeToProjectEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "InitiativeToProject",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "InitiativeToProjectCreateInput",
+        "description": "[INTERNAL] The properties of the initiativeToProject to create.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": "The identifier in UUID v4 format. If none is provided, the backend will generate one.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectId",
+            "description": "The identifier of the project.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiativeId",
+            "description": "The identifier of the initiative.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sortOrder",
+            "description": "The sort order for the project within its organization.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "InitiativeToProjectEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "InitiativeToProject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cursor",
+            "description": "Used in `before` and `after` args",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "InitiativeToProjectPayload",
+        "description": "[INTERNAL] The result of a initiativeToProject mutation.",
+        "fields": [
+          {
+            "name": "lastSyncId",
+            "description": "The identifier of the last sync operation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiativeToProject",
+            "description": "The initiativeToProject that was created or updated.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "InitiativeToProject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "success",
+            "description": "Whether the operation was successful.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "InitiativeToProjectUpdateInput",
+        "description": "[INTERNAL] The properties of the initiativeToProject to update.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "sortOrder",
+            "description": "The sort order for the project within its organization.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "InitiativeUpdateInput",
+        "description": "[Internal] The properties of the initiative to update.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "name",
+            "description": "The name of the initiative.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "The description of the initiative.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ownerId",
+            "description": "The owner of the initiative.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sortOrder",
+            "description": "The sort order of the initiative within the organization.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "color",
+            "description": "The initiative's color.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "targetDate",
+            "description": "The estimated completion date of the initiative.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "TimelessDate",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -14767,6 +17349,53 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "IntegrationHasScopesPayload",
+        "description": null,
+        "fields": [
+          {
+            "name": "hasAllScopes",
+            "description": "Whether the integration has the required scopes.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "missingScopes",
+            "description": "The missing scopes.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               }
             },
             "isDeprecated": false,
@@ -15069,7 +17698,7 @@
       {
         "kind": "OBJECT",
         "name": "IntegrationSettings",
-        "description": "The integration resource's settings",
+        "description": "The integration resource's settings.",
         "fields": [
           {
             "name": "slack",
@@ -15499,7 +18128,7 @@
       {
         "kind": "OBJECT",
         "name": "IntegrationTemplate",
-        "description": "Join table between templates and integrations",
+        "description": "Join table between templates and integrations.",
         "fields": [
           {
             "name": "id",
@@ -16024,7 +18653,7 @@
           },
           {
             "name": "slackIssueSlaHighRisk",
-            "description": "Whether to send a Slack message when an SLA is at high risk",
+            "description": "Whether to send a Slack message when an SLA is at high risk.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -16036,7 +18665,7 @@
           },
           {
             "name": "slackIssueSlaBreached",
-            "description": "Whether to send a Slack message when an SLA is breached",
+            "description": "Whether to send a Slack message when an SLA is breached.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -16261,7 +18890,7 @@
           },
           {
             "name": "slackIssueSlaHighRisk",
-            "description": "Whether to send a Slack message when an SLA is at high risk",
+            "description": "Whether to send a Slack message when an SLA is at high risk.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -16530,7 +19159,7 @@
           },
           {
             "name": "slackIssueSlaHighRisk",
-            "description": "Whether to send a Slack message when an SLA is at high risk",
+            "description": "Whether to send a Slack message when an SLA is at high risk.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -17126,7 +19755,7 @@
           },
           {
             "name": "externalUserCreator",
-            "description": "[ALPHA] The external user who created the issue.",
+            "description": "The external user who created the issue.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -18123,6 +20752,18 @@
             },
             "isDeprecated": true,
             "deprecationReason": "Use description instead."
+          },
+          {
+            "name": "descriptionState",
+            "description": "[Internal] The issue's description content as YJS state.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -19186,7 +21827,7 @@
           },
           {
             "name": "preserveSortOrderOnCreate",
-            "description": "Whether the passed sort order should be preserved",
+            "description": "Whether the passed sort order should be preserved.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -20778,7 +23419,7 @@
           },
           {
             "name": "fromDueDate",
-            "description": "What the due date was changed from",
+            "description": "What the due date was changed from.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -20790,7 +23431,7 @@
           },
           {
             "name": "toDueDate",
-            "description": "What the due date was changed to",
+            "description": "What the due date was changed to.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -20814,7 +23455,7 @@
           },
           {
             "name": "botActor",
-            "description": "The bot that performed the action",
+            "description": "The bot that performed the action.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -20997,7 +23638,7 @@
       {
         "kind": "OBJECT",
         "name": "IssueImport",
-        "description": "An import job for data from an external service",
+        "description": "An import job for data from an external service.",
         "fields": [
           {
             "name": "id",
@@ -21061,7 +23702,7 @@
           },
           {
             "name": "teamName",
-            "description": "New team's name in cases when teamId not set",
+            "description": "New team's name in cases when teamId not set.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -21169,7 +23810,7 @@
           },
           {
             "name": "errorMetadata",
-            "description": "Error code and metadata, if one has occurred during the import",
+            "description": "Error code and metadata, if one has occurred during the import.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -21276,12 +23917,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "IssueImportMappingInput",
-        "description": "Issue import mapping input",
+        "description": "Issue import mapping input.",
         "fields": null,
         "inputFields": [
           {
             "name": "users",
-            "description": "The mapping configuration for users",
+            "description": "The mapping configuration for users.",
             "type": {
               "kind": "SCALAR",
               "name": "JSONObject",
@@ -21293,7 +23934,7 @@
           },
           {
             "name": "workflowStates",
-            "description": "The mapping configuration for workflow states",
+            "description": "The mapping configuration for workflow states.",
             "type": {
               "kind": "SCALAR",
               "name": "JSONObject",
@@ -21305,7 +23946,7 @@
           },
           {
             "name": "epics",
-            "description": "The mapping configuration for epics",
+            "description": "The mapping configuration for epics.",
             "type": {
               "kind": "SCALAR",
               "name": "JSONObject",
@@ -22425,7 +25066,7 @@
       {
         "kind": "OBJECT",
         "name": "IssueNotification",
-        "description": "An issue related notification",
+        "description": "An issue related notification.",
         "fields": [
           {
             "name": "id",
@@ -22489,7 +25130,7 @@
           },
           {
             "name": "type",
-            "description": "Notification type",
+            "description": "Notification type.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22645,7 +25286,7 @@
           },
           {
             "name": "team",
-            "description": "The team related to the notification.",
+            "description": "The team related to the issue notification.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23116,7 +25757,7 @@
       {
         "kind": "OBJECT",
         "name": "IssueRelationHistoryPayload",
-        "description": "Issue relation history's payload",
+        "description": "Issue relation history's payload.",
         "fields": [
           {
             "name": "identifier",
@@ -23825,7 +26466,7 @@
           },
           {
             "name": "externalUserCreator",
-            "description": "[ALPHA] The external user who created the issue.",
+            "description": "The external user who created the issue.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -24824,8 +27465,20 @@
             "deprecationReason": "Use description instead."
           },
           {
+            "name": "descriptionState",
+            "description": "[Internal] The issue's description content as YJS state.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "metadata",
-            "description": "Metadata related to search result",
+            "description": "Metadata related to search result.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25823,7 +28476,7 @@
         "inputFields": [
           {
             "name": "id",
-            "description": "The id of the integration to update",
+            "description": "The id of the integration to update.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -25839,7 +28492,19 @@
           },
           {
             "name": "updateProjects",
-            "description": "Whether to refresh Jira Projects for the integration",
+            "description": "Whether to refresh Jira Projects for the integration.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateMetadata",
+            "description": "Whether to refresh Jira metadata for the integration.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -26076,7 +28741,7 @@
           },
           {
             "name": "active",
-            "description": "Whether the subscription is active or not",
+            "description": "Whether the subscription is active or not.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26378,6 +29043,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "title",
+                "description": "The title to use for the attachment.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "url",
                 "description": "The url to link.",
                 "type": {
@@ -26404,18 +29081,6 @@
                     "name": "String",
                     "ofType": null
                   }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "title",
-                "description": "The title to use for the attachment.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -26475,6 +29140,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "title",
+                "description": "The title to use for the attachment.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "issueId",
                 "description": "The issue for which to link the GitLab merge request.",
                 "type": {
@@ -26492,7 +29169,7 @@
               },
               {
                 "name": "id",
-                "description": "Optional attachment ID that may be provided through the API",
+                "description": "Optional attachment ID that may be provided through the API.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -26520,7 +29197,7 @@
               },
               {
                 "name": "projectPathWithNamespace",
-                "description": "The path name to the project including any (sub)groups. E.g. linear/main/client",
+                "description": "The path name to the project including any (sub)groups. E.g. linear/main/client.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -26592,6 +29269,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "title",
+                "description": "The title to use for the attachment.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "issueId",
                 "description": "The Linear issue for which to link the GitHub issue.",
                 "type": {
@@ -26609,7 +29298,7 @@
               },
               {
                 "name": "id",
-                "description": "Optional attachment ID that may be provided through the API",
+                "description": "Optional attachment ID that may be provided through the API.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -26677,6 +29366,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "title",
+                "description": "The title to use for the attachment.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "issueId",
                 "description": "The issue for which to link the GitHub pull request.",
                 "type": {
@@ -26694,7 +29395,7 @@
               },
               {
                 "name": "id",
-                "description": "Optional attachment ID that may be provided through the API",
+                "description": "Optional attachment ID that may be provided through the API.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -26798,6 +29499,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "title",
+                "description": "The title to use for the attachment.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "ticketId",
                 "description": "The Zendesk ticket ID to link.",
                 "type": {
@@ -26831,7 +29544,7 @@
               },
               {
                 "name": "id",
-                "description": "Optional attachment ID that may be provided through the API",
+                "description": "Optional attachment ID that may be provided through the API.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -26883,6 +29596,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "title",
+                "description": "The title to use for the attachment.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "issueId",
                 "description": "The issue for which to link the Discord message.",
                 "type": {
@@ -26900,7 +29625,7 @@
               },
               {
                 "name": "id",
-                "description": "Optional attachment ID that may be provided through the API",
+                "description": "Optional attachment ID that may be provided through the API.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -27000,6 +29725,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "title",
+                "description": "The title to use for the attachment.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "channel",
                 "description": "The Slack channel ID for the message to link.",
                 "type": {
@@ -27076,20 +29813,8 @@
                 "deprecationReason": null
               },
               {
-                "name": "title",
-                "description": "Optional title that may be provided through the API",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
                 "name": "id",
-                "description": "Optional attachment ID that may be provided through the API",
+                "description": "Optional attachment ID that may be provided through the API.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -27141,6 +29866,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "title",
+                "description": "The title to use for the attachment.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "conversationId",
                 "description": "The Front conversation ID to link.",
                 "type": {
@@ -27174,7 +29911,7 @@
               },
               {
                 "name": "id",
-                "description": "Optional attachment ID that may be provided through the API",
+                "description": "Optional attachment ID that may be provided through the API.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -27226,6 +29963,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "title",
+                "description": "The title to use for the attachment.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "conversationId",
                 "description": "The Intercom conversation ID to link.",
                 "type": {
@@ -27243,7 +29992,7 @@
               },
               {
                 "name": "id",
-                "description": "Optional attachment ID that may be provided through the API",
+                "description": "Optional attachment ID that may be provided through the API.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -28212,7 +30961,7 @@
           },
           {
             "name": "cycleShiftAll",
-            "description": "Shifts all cycles starts by a certain number of weeks.",
+            "description": "[DEPRECATED] Shifts all cycles starts by a certain number of weeks.",
             "args": [
               {
                 "name": "input",
@@ -28359,6 +31108,154 @@
             "deprecationReason": null
           },
           {
+            "name": "emailIntakeAddressCreate",
+            "description": "Creates a new email intake address.",
+            "args": [
+              {
+                "name": "input",
+                "description": "The email intake address object to create.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "EmailIntakeAddressCreateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EmailIntakeAddressPayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "emailIntakeAddressRotate",
+            "description": "Rotates an existing email intake address.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The identifier of the email intake address.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EmailIntakeAddressPayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "emailIntakeAddressUpdate",
+            "description": "Updates an existing email intake address.",
+            "args": [
+              {
+                "name": "input",
+                "description": "The properties of the email intake address to update.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "EmailIntakeAddressUpdateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "id",
+                "description": "The identifier of the email intake address.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EmailIntakeAddressPayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "emailIntakeAddressDelete",
+            "description": "Deletes an email intake address object.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The identifier of the email intake address to delete.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeletePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "emailSubscribe",
             "description": "[INTERNAL] Subscribes the email to the newsletter.",
             "args": [
@@ -28464,6 +31361,302 @@
               {
                 "name": "id",
                 "description": "The identifier of the emoji to delete.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeletePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiativeCreate",
+            "description": "[Internal] Creates a new initiative.",
+            "args": [
+              {
+                "name": "input",
+                "description": "The properties of the initiative to create.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InitiativeCreateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "InitiativePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiativeUpdate",
+            "description": "[Internal] Updates a initiative.",
+            "args": [
+              {
+                "name": "input",
+                "description": "The properties of the initiative to update.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InitiativeUpdateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "id",
+                "description": "The identifier of the initiative to update.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "InitiativePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiativeArchive",
+            "description": "[Internal] Archives a initiative.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The identifier of the initiative to archive.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "InitiativeArchivePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiativeUnarchive",
+            "description": "[Internal] Unarchives a initiative.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The identifier of the initiative to unarchive.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "InitiativeArchivePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiativeDelete",
+            "description": "[Internal] Deletes a initiative.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The identifier of the initiative to delete.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeletePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiativeToProjectCreate",
+            "description": "[INTERNAL] Creates a new initiativeToProject join.",
+            "args": [
+              {
+                "name": "input",
+                "description": "The properties of the initiativeToProject to create.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InitiativeToProjectCreateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "InitiativeToProjectPayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiativeToProjectUpdate",
+            "description": "[INTERNAL] Updates a initiativeToProject.",
+            "args": [
+              {
+                "name": "input",
+                "description": "The properties of the initiativeToProject to update.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InitiativeToProjectUpdateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "id",
+                "description": "The identifier of the initiativeToProject to update.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "InitiativeToProjectPayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiativeToProjectDelete",
+            "description": "[INTERNAL] Deletes a initiativeToProject.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The identifier of the initiativeToProject to delete.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -28920,6 +32113,121 @@
             "deprecationReason": null
           },
           {
+            "name": "gitAutomationTargetBranchCreate",
+            "description": "Creates a Git target branch automation.",
+            "args": [
+              {
+                "name": "input",
+                "description": "The Git target branch automation to create.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "GitAutomationTargetBranchCreateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitAutomationTargetBranchPayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "gitAutomationTargetBranchUpdate",
+            "description": "Updates an existing Git target branch automation.",
+            "args": [
+              {
+                "name": "input",
+                "description": "The updates.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "GitAutomationTargetBranchUpdateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "id",
+                "description": "The identifier of the Git target branch automation to update.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitAutomationTargetBranchPayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "gitAutomationTargetBranchDelete",
+            "description": "Archives a Git target branch automation.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The identifier of the Git target branch automation to archive.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeletePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "integrationRequest",
             "description": "Requests a currently unavailable integration.",
             "args": [
@@ -29056,7 +32364,7 @@
             "args": [
               {
                 "name": "gitlabUrl",
-                "description": "The URL of the GitLab installation",
+                "description": "The URL of the GitLab installation.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -29101,7 +32409,7 @@
           },
           {
             "name": "airbyteIntegrationConnect",
-            "description": "Creates an integration api key for Airbyte to connect with Linear",
+            "description": "Creates an integration api key for Airbyte to connect with Linear.",
             "args": [
               {
                 "name": "input",
@@ -29200,11 +32508,11 @@
           },
           {
             "name": "integrationJiraUpdate",
-            "description": "[INTERNAL] Updates a Jira Integration",
+            "description": "[INTERNAL] Updates a Jira Integration.",
             "args": [
               {
                 "name": "input",
-                "description": "Jira integration update input",
+                "description": "Jira integration update input.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -29641,7 +32949,7 @@
           },
           {
             "name": "integrationSlackAsks",
-            "description": "Integrates the organization with the Slack Asks app",
+            "description": "Integrates the organization with the Slack Asks app.",
             "args": [
               {
                 "name": "redirectUri",
@@ -30402,6 +33710,39 @@
             "deprecationReason": null
           },
           {
+            "name": "integrationArchive",
+            "description": "Archives an integration.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The identifier of the integration to archive.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeletePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "integrationsSettingsCreate",
             "description": "Creates new settings for one or more integrations.",
             "args": [
@@ -30554,8 +33895,8 @@
             "description": "Kicks off a GitHub import job.",
             "args": [
               {
-                "name": "id",
-                "description": "ID of issue import. If not provided it will be generated.",
+                "name": "organizationId",
+                "description": "ID of the organization into which to import data.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30566,11 +33907,11 @@
                 "deprecationReason": null
               },
               {
-                "name": "includeClosedIssues",
-                "description": "Whether or not we should collect the data for closed issues.",
+                "name": "teamId",
+                "description": "ID of the team into which to import data.",
                 "type": {
                   "kind": "SCALAR",
-                  "name": "Boolean",
+                  "name": "String",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -30578,11 +33919,11 @@
                 "deprecationReason": null
               },
               {
-                "name": "instantProcess",
-                "description": "Whether to instantly process the import with the default configuration mapping.",
+                "name": "teamName",
+                "description": "Name of new team. When teamId is not set.",
                 "type": {
                   "kind": "SCALAR",
-                  "name": "Boolean",
+                  "name": "String",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -30590,20 +33931,8 @@
                 "deprecationReason": null
               },
               {
-                "name": "githubShouldImportOrgProjects",
-                "description": "Whether or not we should import GitHub organization level projects.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "githubRepoOwner",
-                "description": "GitHub owner (user or org) for the repository from which we will import data.",
+                "name": "githubToken",
+                "description": "GitHub token to fetch information from the GitHub API.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -30634,8 +33963,8 @@
                 "deprecationReason": null
               },
               {
-                "name": "githubToken",
-                "description": "GitHub token to fetch information from the GitHub API.",
+                "name": "githubRepoOwner",
+                "description": "GitHub owner (user or org) for the repository from which we will import data.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -30650,11 +33979,11 @@
                 "deprecationReason": null
               },
               {
-                "name": "teamName",
-                "description": "Name of new team. When teamId is not set.",
+                "name": "githubShouldImportOrgProjects",
+                "description": "Whether or not we should import GitHub organization level projects.",
                 "type": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Boolean",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -30662,11 +33991,11 @@
                 "deprecationReason": null
               },
               {
-                "name": "teamId",
-                "description": "ID of the team into which to import data.",
+                "name": "instantProcess",
+                "description": "Whether to instantly process the import with the default configuration mapping.",
                 "type": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Boolean",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -30674,8 +34003,20 @@
                 "deprecationReason": null
               },
               {
-                "name": "organizationId",
-                "description": "ID of the organization into which to import data.",
+                "name": "includeClosedIssues",
+                "description": "Whether or not we should collect the data for closed issues.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "id",
+                "description": "ID of issue import. If not provided it will be generated.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30703,8 +34044,8 @@
             "description": "Kicks off a Jira import job.",
             "args": [
               {
-                "name": "id",
-                "description": "ID of issue import. If not provided it will be generated.",
+                "name": "organizationId",
+                "description": "ID of the organization into which to import data.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30715,11 +34056,11 @@
                 "deprecationReason": null
               },
               {
-                "name": "includeClosedIssues",
-                "description": "Whether or not we should collect the data for closed issues.",
+                "name": "teamId",
+                "description": "ID of the team into which to import data. Empty to create new team.",
                 "type": {
                   "kind": "SCALAR",
-                  "name": "Boolean",
+                  "name": "String",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -30727,11 +34068,11 @@
                 "deprecationReason": null
               },
               {
-                "name": "instantProcess",
-                "description": "Whether to instantly process the import with the default configuration mapping.",
+                "name": "teamName",
+                "description": "Name of new team. When teamId is not set.",
                 "type": {
                   "kind": "SCALAR",
-                  "name": "Boolean",
+                  "name": "String",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -30739,24 +34080,8 @@
                 "deprecationReason": null
               },
               {
-                "name": "jiraHostname",
-                "description": "Jira installation or cloud hostname.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "jiraEmail",
-                "description": "Jira user account email.",
+                "name": "jiraToken",
+                "description": "Jira personal access token to access Jira REST API.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -30787,8 +34112,8 @@
                 "deprecationReason": null
               },
               {
-                "name": "jiraToken",
-                "description": "Jira personal access token to access Jira REST API.",
+                "name": "jiraEmail",
+                "description": "Jira user account email.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -30803,11 +34128,27 @@
                 "deprecationReason": null
               },
               {
-                "name": "teamName",
-                "description": "Name of new team. When teamId is not set.",
+                "name": "jiraHostname",
+                "description": "Jira installation or cloud hostname.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "instantProcess",
+                "description": "Whether to instantly process the import with the default configuration mapping.",
                 "type": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Boolean",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -30815,11 +34156,11 @@
                 "deprecationReason": null
               },
               {
-                "name": "teamId",
-                "description": "ID of the team into which to import data. Empty to create new team.",
+                "name": "includeClosedIssues",
+                "description": "Whether or not we should collect the data for closed issues.",
                 "type": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Boolean",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -30827,8 +34168,8 @@
                 "deprecationReason": null
               },
               {
-                "name": "organizationId",
-                "description": "ID of the organization into which to import data.",
+                "name": "id",
+                "description": "ID of issue import. If not provided it will be generated.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30961,76 +34302,8 @@
             "description": "Kicks off a Shortcut (formerly Clubhouse) import job.",
             "args": [
               {
-                "name": "id",
-                "description": "ID of issue import. If not provided it will be generated.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "includeClosedIssues",
-                "description": "Whether or not we should collect the data for closed issues.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "instantProcess",
-                "description": "Whether to instantly process the import with the default configuration mapping.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "clubhouseGroupName",
-                "description": "Shortcut (formerly Clubhouse) group name to choose which issues we should import.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "clubhouseToken",
-                "description": "Shortcut (formerly Clubhouse) token to fetch information from the Clubhouse API.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "teamName",
-                "description": "Name of new team. When teamId is not set.",
+                "name": "organizationId",
+                "description": "ID of the organization into which to import data.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31053,8 +34326,76 @@
                 "deprecationReason": null
               },
               {
-                "name": "organizationId",
-                "description": "ID of the organization into which to import data.",
+                "name": "teamName",
+                "description": "Name of new team. When teamId is not set.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "clubhouseToken",
+                "description": "Shortcut (formerly Clubhouse) token to fetch information from the Clubhouse API.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "clubhouseGroupName",
+                "description": "Shortcut (formerly Clubhouse) group name to choose which issues we should import.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "instantProcess",
+                "description": "Whether to instantly process the import with the default configuration mapping.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "includeClosedIssues",
+                "description": "Whether or not we should collect the data for closed issues.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "id",
+                "description": "ID of issue import. If not provided it will be generated.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31082,76 +34423,8 @@
             "description": "Kicks off an Asana import job.",
             "args": [
               {
-                "name": "id",
-                "description": "ID of issue import. If not provided it will be generated.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "includeClosedIssues",
-                "description": "Whether or not we should collect the data for closed issues.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "instantProcess",
-                "description": "Whether to instantly process the import with the default configuration mapping.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "asanaTeamName",
-                "description": "Asana team name to choose which issues we should import.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "asanaToken",
-                "description": "Asana token to fetch information from the Asana API.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "teamName",
-                "description": "Name of new team. When teamId is not set.",
+                "name": "organizationId",
+                "description": "ID of the organization into which to import data.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31174,8 +34447,76 @@
                 "deprecationReason": null
               },
               {
-                "name": "organizationId",
-                "description": "ID of the organization into which to import data.",
+                "name": "teamName",
+                "description": "Name of new team. When teamId is not set.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "asanaToken",
+                "description": "Asana token to fetch information from the Asana API.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "asanaTeamName",
+                "description": "Asana team name to choose which issues we should import.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "instantProcess",
+                "description": "Whether to instantly process the import with the default configuration mapping.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "includeClosedIssues",
+                "description": "Whether or not we should collect the data for closed issues.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "id",
+                "description": "ID of issue import. If not provided it will be generated.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31716,7 +35057,7 @@
             "args": [
               {
                 "name": "trash",
-                "description": "Whether to trash the issue",
+                "description": "Whether to trash the issue.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
@@ -33319,7 +36660,7 @@
             "args": [
               {
                 "name": "trash",
-                "description": "Whether to trash the project",
+                "description": "Whether to trash the project.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
@@ -34642,7 +37983,7 @@
             "args": [
               {
                 "name": "service",
-                "description": "The external service to disconnect",
+                "description": "The external service to disconnect.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -34992,7 +38333,7 @@
             "args": [
               {
                 "name": "operation",
-                "description": "Flag operation to perform",
+                "description": "Flag operation to perform.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -35459,6 +38800,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "DataRecovery",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "Document",
             "ofType": null
           },
@@ -35494,12 +38840,32 @@
           },
           {
             "kind": "OBJECT",
+            "name": "Facet",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "Favorite",
             "ofType": null
           },
           {
             "kind": "OBJECT",
             "name": "GitAutomationState",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "GitAutomationTargetBranch",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "Initiative",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "InitiativeToProject",
             "ofType": null
           },
           {
@@ -35629,6 +38995,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "ProjectStatus",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "ProjectUpdate",
             "ofType": null
           },
@@ -35675,6 +39046,11 @@
           {
             "kind": "OBJECT",
             "name": "Template",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "TimeSchedule",
             "ofType": null
           },
           {
@@ -35791,7 +39167,7 @@
           },
           {
             "name": "type",
-            "description": "Notification type",
+            "description": "Notification type.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36481,7 +39857,7 @@
           },
           {
             "name": "active",
-            "description": "Whether the subscription is active or not",
+            "description": "Whether the subscription is active or not.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37462,6 +40838,177 @@
               "kind": "INPUT_OBJECT",
               "name": "DateComparator",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project",
+            "description": "Filters that the document content project must satisfy.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ProjectFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "document",
+            "description": "Filters that the document content document must satisfy.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DocumentFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "NullableDocumentFilter",
+        "description": "Document filtering options.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": "Comparator for the identifier.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IDComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "Comparator for the created at date.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DateComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "Comparator for the updated at date.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DateComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": "Comparator for the document title.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slugId",
+            "description": "Comparator for the document slug ID.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringComparator",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "creator",
+            "description": "Filters that the document's creator must satisfy.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "UserFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project",
+            "description": "Filters that the document's project must satisfy.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ProjectFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "null",
+            "description": "Filter based on the existence of the relation.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "and",
+            "description": "Compound filters, all of which need to be matched by the document.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "NullableDocumentFilter",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "or",
+            "description": "Compound filters, one of which need to be matched by the document.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "NullableDocumentFilter",
+                  "ofType": null
+                }
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -39485,7 +43032,7 @@
       {
         "kind": "ENUM",
         "name": "OAuthClientApprovalStatus",
-        "description": "The different requests statuses possible for an OAuth client approval request",
+        "description": "The different requests statuses possible for an OAuth client approval request.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -39778,7 +43325,7 @@
           },
           {
             "name": "webhookUrl",
-            "description": "Webhook URL",
+            "description": "Webhook URL.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -40000,7 +43547,7 @@
       {
         "kind": "OBJECT",
         "name": "OauthClientApprovalNotification",
-        "description": "An oauth client approval related notification",
+        "description": "An oauth client approval related notification.",
         "fields": [
           {
             "name": "id",
@@ -40064,7 +43611,7 @@
           },
           {
             "name": "type",
-            "description": "Notification type",
+            "description": "Notification type.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -40348,9 +43895,21 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "ID",
+                "name": "Float",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "revokedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -40365,6 +43924,70 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "client",
+            "description": "OAuth2 client for which the access token belongs to.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AuthOauthClient",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "clientId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user",
+            "description": "Auth user who authorized the OAuth application.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AuthUser",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": "Id of the user who authorized the OAuth application.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -40679,7 +44302,7 @@
           },
           {
             "name": "samlSettings",
-            "description": "[INTERNAL] SAML settings",
+            "description": "[INTERNAL] SAML settings.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -40707,7 +44330,7 @@
           },
           {
             "name": "allowedAuthServices",
-            "description": "Allowed authentication providers, empty array means all are allowed",
+            "description": "Allowed authentication providers, empty array means all are allowed.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -40779,7 +44402,7 @@
           },
           {
             "name": "allowMembersToInvite",
-            "description": "Whether member users are allowed to send invites",
+            "description": "Whether member users are allowed to send invites.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -40807,7 +44430,7 @@
           },
           {
             "name": "slaDayCount",
-            "description": "Which day count to use for SLA calculations",
+            "description": "Which day count to use for SLA calculations.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -41365,7 +44988,7 @@
         "fields": [
           {
             "name": "status",
-            "description": "The status of the invite",
+            "description": "The status of the invite.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -41506,7 +45129,7 @@
           },
           {
             "name": "name",
-            "description": "Domain name",
+            "description": "Domain name.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -41522,7 +45145,7 @@
           },
           {
             "name": "verified",
-            "description": "Is this domain verified",
+            "description": "Is this domain verified.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -41538,7 +45161,7 @@
           },
           {
             "name": "verificationEmail",
-            "description": "E-mail used to verify this domain",
+            "description": "E-mail used to verify this domain.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -41562,7 +45185,7 @@
           },
           {
             "name": "authType",
-            "description": "What type of auth is the domain used for",
+            "description": "What type of auth is the domain used for.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -42000,7 +45623,7 @@
           },
           {
             "name": "acceptedAt",
-            "description": "The time at which the invite was accepted. Null, if the invite hasn't been accepted",
+            "description": "The time at which the invite was accepted. Null, if the invite hasn't been accepted.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -42012,7 +45635,7 @@
           },
           {
             "name": "expiresAt",
-            "description": "The time at which the invite will be expiring. Null, if the invite shouldn't expire",
+            "description": "The time at which the invite will be expiring. Null, if the invite shouldn't expire.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -42249,7 +45872,7 @@
           },
           {
             "name": "metadata",
-            "description": "[INTERNAL] Optional metadata about the invite",
+            "description": "[INTERNAL] Optional metadata about the invite.",
             "type": {
               "kind": "SCALAR",
               "name": "JSONObject",
@@ -42335,7 +45958,7 @@
         "fields": [
           {
             "name": "status",
-            "description": "The status of the invite",
+            "description": "The status of the invite.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -42351,7 +45974,7 @@
           },
           {
             "name": "inviter",
-            "description": "The name of the inviter",
+            "description": "The name of the inviter.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -42367,7 +45990,7 @@
           },
           {
             "name": "email",
-            "description": "The email of the invitee",
+            "description": "The email of the invitee.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -42864,7 +46487,7 @@
           },
           {
             "name": "linearPreviewFlags",
-            "description": "Linear Preview feature flags",
+            "description": "Linear Preview feature flags.",
             "type": {
               "kind": "SCALAR",
               "name": "JSONObject",
@@ -43564,22 +47187,6 @@
             "deprecationReason": null
           },
           {
-            "name": "state",
-            "description": "The type of the state.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "creator",
             "description": "The user who created the project.",
             "args": [],
@@ -44255,6 +47862,18 @@
             "description": "Documents associated with the project.",
             "args": [
               {
+                "name": "filter",
+                "description": "Filter returned documents.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "DocumentFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "before",
                 "description": "A cursor to be used with last for backward pagination.",
                 "type": {
@@ -44343,6 +47962,18 @@
             "name": "projectMilestones",
             "description": "Milestones associated with the project.",
             "args": [
+              {
+                "name": "filter",
+                "description": "Filter returned milestones.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ProjectMilestoneFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
               {
                 "name": "before",
                 "description": "A cursor to be used with last for backward pagination.",
@@ -44670,6 +48301,34 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contentState",
+            "description": "[Internal] The project's content as YJS state.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "state",
+            "description": "The type of the state.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -45222,6 +48881,18 @@
           {
             "name": "state",
             "description": "The state of the project.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "statusId",
+            "description": "[INTERNAL] The ID of the project status.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -46367,6 +50038,18 @@
               "name": "JSON",
               "ofType": null
             },
+            "isDeprecated": true,
+            "deprecationReason": "Use `descriptionState` instead."
+          },
+          {
+            "name": "descriptionState",
+            "description": "[Internal] The project milestone's description as YJS state.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -46994,7 +50677,7 @@
       {
         "kind": "OBJECT",
         "name": "ProjectNotification",
-        "description": "A project related notification",
+        "description": "A project related notification.",
         "fields": [
           {
             "name": "id",
@@ -47058,7 +50741,7 @@
           },
           {
             "name": "type",
-            "description": "Notification type",
+            "description": "Notification type.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -47405,7 +51088,7 @@
           },
           {
             "name": "active",
-            "description": "Whether the subscription is active or not",
+            "description": "Whether the subscription is active or not.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -47755,22 +51438,6 @@
           {
             "name": "color",
             "description": "The project's color.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "state",
-            "description": "The type of the state.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -48460,6 +52127,18 @@
             "description": "Documents associated with the project.",
             "args": [
               {
+                "name": "filter",
+                "description": "Filter returned documents.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "DocumentFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "before",
                 "description": "A cursor to be used with last for backward pagination.",
                 "type": {
@@ -48548,6 +52227,18 @@
             "name": "projectMilestones",
             "description": "Milestones associated with the project.",
             "args": [
+              {
+                "name": "filter",
+                "description": "Filter returned milestones.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ProjectMilestoneFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
               {
                 "name": "before",
                 "description": "A cursor to be used with last for backward pagination.",
@@ -48880,8 +52571,36 @@
             "deprecationReason": null
           },
           {
+            "name": "contentState",
+            "description": "[Internal] The project's content as YJS state.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "state",
+            "description": "The type of the state.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "metadata",
-            "description": "Metadata related to search result",
+            "description": "Metadata related to search result.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -49023,6 +52742,336 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProjectStatus",
+        "description": "[ALPHA] A project status.",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time at which the entity was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those\n    for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't\n    been updated after creation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archivedAt",
+            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "The name of the status.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "color",
+            "description": "The UI color of the status as a HEX string.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "Description of the status.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "position",
+            "description": "The position of the status in the workspace's project flow.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "The type of the project status.",
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "ProjectStatusType",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "indefinite",
+            "description": "Whether or not a project can be in this status indefinitely.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProjectStatusConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProjectStatusEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProjectStatus",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProjectStatusEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProjectStatus",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cursor",
+            "description": "Used in `before` and `after` args",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ProjectStatusType",
+        "description": "A type of project status.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "backlog",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "planned",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "started",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "paused",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "completed",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canceled",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -49209,7 +53258,7 @@
           },
           {
             "name": "isDiffHidden",
-            "description": "[ALPHA] Whether project update diff should be hidden",
+            "description": "Whether project update diff should be hidden.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -49217,6 +53266,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bodyData",
+            "description": "[Internal] The content of the project update as a Prosemirror document.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -49245,7 +53310,7 @@
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "JSON",
+              "name": "JSONObject",
               "ofType": null
             },
             "isDeprecated": false,
@@ -49422,7 +53487,7 @@
           },
           {
             "name": "isDiffHidden",
-            "description": "[ALPHA] Whether the diff between the current update and the previous one should be hidden.",
+            "description": "Whether the diff between the current update and the previous one should be hidden.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -49629,6 +53694,18 @@
           {
             "name": "state",
             "description": "The state of the project.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "statusId",
+            "description": "[INTERNAL] The ID of the project status.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -50437,7 +54514,7 @@
           },
           {
             "name": "isDiffHidden",
-            "description": "[ALPHA] Whether the diff between the current update and the previous one should be hidden.",
+            "description": "Whether the diff between the current update and the previous one should be hidden.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -50727,7 +54804,7 @@
           },
           {
             "name": "type",
-            "description": "Whether this is a subscription payload for Google Cloud Messaging or Apple Push Notification service",
+            "description": "Whether this is a subscription payload for Google Cloud Messaging or Apple Push Notification service.",
             "type": {
               "kind": "ENUM",
               "name": "PushSubscriptionType",
@@ -50874,7 +54951,7 @@
       {
         "kind": "ENUM",
         "name": "PushSubscriptionType",
-        "description": "The different push subscription types",
+        "description": "The different push subscription types.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -51035,7 +55112,7 @@
           },
           {
             "name": "applicationInfoByIds",
-            "description": "[INTERNAL] Get basic information for a list of applications",
+            "description": "[INTERNAL] Get basic information for a list of applications.",
             "args": [
               {
                 "name": "ids",
@@ -51112,7 +55189,7 @@
               },
               {
                 "name": "scope",
-                "description": "Scopes being requested by the application",
+                "description": "Scopes being requested by the application.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -51165,7 +55242,7 @@
           },
           {
             "name": "authorizedApplications",
-            "description": "[INTERNAL] Get all authorized applications for a user",
+            "description": "[INTERNAL] Get all authorized applications for a user.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -51189,7 +55266,7 @@
           },
           {
             "name": "workspaceAuthorizedApplications",
-            "description": "[INTERNAL] Get all authorized applications (with limited fields) for a workspace",
+            "description": "[INTERNAL] Get all authorized applications (with limited fields) for a workspace.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -51485,11 +55562,11 @@
           },
           {
             "name": "attachmentSources",
-            "description": "[Internal] Get a list of all unique attachment sources in the workspace",
+            "description": "[Internal] Get a list of all unique attachment sources in the workspace.",
             "args": [
               {
                 "name": "teamId",
-                "description": "(optional) if provided will only return attachment sources for the given team",
+                "description": "(optional) if provided will only return attachment sources for the given team.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -51831,13 +55908,33 @@
                 "name": "id",
                 "description": "The identifier of the comment to retrieve.",
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "issueId",
+                "description": "The issue for which to find the comment.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "hash",
+                "description": "The hash of the comment to retrieve, must be combined with an issueId.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -52228,6 +56325,18 @@
             "description": "All documents in the workspace.",
             "args": [
               {
+                "name": "filter",
+                "description": "Filter returned documents.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "DocumentFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "before",
                 "description": "A cursor to be used with last for backward pagination.",
                 "type": {
@@ -52440,7 +56549,7 @@
             "args": [
               {
                 "name": "id",
-                "description": "The identifier of the emoji to retrieve.",
+                "description": "The identifier or the name of the emoji to retrieve.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -52583,6 +56692,250 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "ExternalUser",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiatives",
+            "description": "[Internal] All initiatives in the workspace.",
+            "args": [
+              {
+                "name": "before",
+                "description": "A cursor to be used with last for backward pagination.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "after",
+                "description": "A cursor to be used with first for forward pagination",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": "The number of items to forward paginate (used with after). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "The number of items to backward paginate (used with before). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "includeArchived",
+                "description": "Should archived resources be included (default: false)",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "By which field should the pagination order by. Available options are createdAt (default) and updatedAt.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "PaginationOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "InitiativeConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiative",
+            "description": "[Internal] One specific initiative.",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Initiative",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiativeToProjects",
+            "description": "[INTERNAL] returns a list of initiative to project entities.",
+            "args": [
+              {
+                "name": "before",
+                "description": "A cursor to be used with last for backward pagination.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "after",
+                "description": "A cursor to be used with first for forward pagination",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": "The number of items to forward paginate (used with after). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "The number of items to backward paginate (used with before). Defaults to 50.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "includeArchived",
+                "description": "Should archived resources be included (default: false)",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "By which field should the pagination order by. Available options are createdAt (default) and updatedAt.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "PaginationOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "InitiativeToProjectConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiativeToProject",
+            "description": "[INTERNAL] One specific initiativeToProject.",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "InitiativeToProject",
                 "ofType": null
               }
             },
@@ -52827,6 +57180,63 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "Integration",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "integrationHasScopes",
+            "description": "Checks if the integration has all required scopes.",
+            "args": [
+              {
+                "name": "scopes",
+                "description": "Required scopes.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "integrationId",
+                "description": "The integration ID.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IntegrationHasScopesPayload",
                 "ofType": null
               }
             },
@@ -53128,7 +57538,7 @@
             "args": [
               {
                 "name": "csvUrl",
-                "description": "CSV storage url",
+                "description": "CSV storage url.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -53144,7 +57554,7 @@
               },
               {
                 "name": "service",
-                "description": "The service the CSV containing data from",
+                "description": "The service the CSV containing data from.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -54627,140 +59037,6 @@
             "deprecationReason": null
           },
           {
-            "name": "ProjectMilestones",
-            "description": "[DEPRECATED] [INTERNAL] All milestones for the project.",
-            "args": [
-              {
-                "name": "filter",
-                "description": "Filter returned project milestones.",
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "ProjectMilestoneFilter",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "before",
-                "description": "A cursor to be used with last for backward pagination.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "after",
-                "description": "A cursor to be used with first for forward pagination",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "first",
-                "description": "The number of items to forward paginate (used with after). Defaults to 50.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "last",
-                "description": "The number of items to backward paginate (used with before). Defaults to 50.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "includeArchived",
-                "description": "Should archived resources be included (default: false)",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "orderBy",
-                "description": "By which field should the pagination order by. Available options are createdAt (default) and updatedAt.",
-                "type": {
-                  "kind": "ENUM",
-                  "name": "PaginationOrderBy",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ProjectMilestoneConnection",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "This mutation is deprecated, please use `projectMilestones` instead."
-          },
-          {
-            "name": "ProjectMilestone",
-            "description": "[DEPRECATED] [INTERNAL] One specific project milestone.",
-            "args": [
-              {
-                "name": "id",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ProjectMilestone",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "This mutation is deprecated, please use `projectMilestone` instead."
-          },
-          {
             "name": "projects",
             "description": "All projects.",
             "args": [
@@ -55477,7 +59753,7 @@
               },
               {
                 "name": "includeComments",
-                "description": "Should associated comments be searched (default: true)",
+                "description": "Should associated comments be searched (default: true).",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
@@ -55489,7 +59765,7 @@
               },
               {
                 "name": "teamId",
-                "description": "UUID of a team to use as a boost",
+                "description": "UUID of a team to use as a boost.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -55606,7 +59882,7 @@
               },
               {
                 "name": "includeComments",
-                "description": "Should associated comments be searched (default: true)",
+                "description": "Should associated comments be searched (default: true).",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
@@ -55618,7 +59894,7 @@
               },
               {
                 "name": "teamId",
-                "description": "UUID of a team to use as a boost",
+                "description": "UUID of a team to use as a boost.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -55747,7 +60023,7 @@
               },
               {
                 "name": "includeComments",
-                "description": "Should associated comments be searched (default: true)",
+                "description": "Should associated comments be searched (default: true).",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
@@ -55759,7 +60035,7 @@
               },
               {
                 "name": "teamId",
-                "description": "UUID of a team to use as a boost",
+                "description": "UUID of a team to use as a boost.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -56202,7 +60478,7 @@
             "args": [
               {
                 "name": "integrationType",
-                "description": "The type of integration for which to return associated templates",
+                "description": "The type of integration for which to return associated templates.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -57071,7 +61347,7 @@
         "inputFields": [
           {
             "name": "id",
-            "description": "The identifier in UUID v4 format. If none is provided, the backend will generate one",
+            "description": "The identifier in UUID v4 format. If none is provided, the backend will generate one.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -57274,7 +61550,7 @@
       {
         "kind": "ENUM",
         "name": "ReleaseChannel",
-        "description": "Features release channel",
+        "description": "Features release channel.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -57947,7 +62223,7 @@
           },
           {
             "name": "ownerId",
-            "description": "The owner of the roadmap",
+            "description": "The owner of the roadmap.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -58214,7 +62490,7 @@
       {
         "kind": "OBJECT",
         "name": "RoadmapToProject",
-        "description": "Join table between projects and roadmaps",
+        "description": "Join table between projects and roadmaps.",
         "fields": [
           {
             "name": "id",
@@ -58635,7 +62911,7 @@
           },
           {
             "name": "ownerId",
-            "description": "The owner of the roadmap",
+            "description": "The owner of the roadmap.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -58677,7 +62953,7 @@
       {
         "kind": "ENUM",
         "name": "SLADayCountType",
-        "description": "Which day count to use for SLA calculations",
+        "description": "Which day count to use for SLA calculations.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -58695,207 +62971,6 @@
             "deprecationReason": null
           }
         ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "SamlConfiguration",
-        "description": null,
-        "fields": [
-          {
-            "name": "ssoEndpoint",
-            "description": "Sign in endpoint URL for the identity provider.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ssoBinding",
-            "description": "Binding method for authentication call. Can be either `post` (default) or `redirect`.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ssoSignAlgo",
-            "description": "The algorithm of the Signing Certificate. Can be one of `sha1`, `sha256` (default), or `sha512`.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "issuerEntityId",
-            "description": "The issuer's custom entity ID.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ssoSigningCert",
-            "description": "X.509 Signing Certificate in string form.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "SamlConfigurationInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "ssoSigningCert",
-            "description": "X.509 Signing Certificate in string form.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ssoEndpoint",
-            "description": "Sign in endpoint URL for the identity provider.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ssoBinding",
-            "description": "Binding method for authentication call. Can be either `post` (default) or `redirect`.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ssoSignAlgo",
-            "description": "The algorithm of the Signing Certificate. Can be one of `sha1`, `sha256` (default), or `sha512`.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "issuerEntityId",
-            "description": "The issuer's custom entity ID.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "SamlConfigurationPayload",
-        "description": "The organization's SAML configuration",
-        "fields": [
-          {
-            "name": "ssoEndpoint",
-            "description": "Sign in endpoint URL for the identity provider.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ssoBinding",
-            "description": "Binding method for authentication call. Can be either `post` (default) or `redirect`.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ssoSignAlgo",
-            "description": "The algorithm of the Signing Certificate. Can be one of `sha1`, `sha256` (default), or `sha512`.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "issuerEntityId",
-            "description": "The issuer's custom entity ID.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -59224,7 +63299,7 @@
       {
         "kind": "OBJECT",
         "name": "SlackAsksTeamSettings",
-        "description": "Tuple for mapping Slack channel IDs to names",
+        "description": "Tuple for mapping Slack channel IDs to names.",
         "fields": [
           {
             "name": "id",
@@ -59244,7 +63319,7 @@
           },
           {
             "name": "hasDefaultAsk",
-            "description": "Whether the default Asks template is enabled in the given channel for this team",
+            "description": "Whether the default Asks template is enabled in the given channel for this team.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -59288,7 +63363,7 @@
           },
           {
             "name": "hasDefaultAsk",
-            "description": "Whether the default Asks template is enabled in the given channel for this team",
+            "description": "Whether the default Asks template is enabled in the given channel for this team.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -59405,7 +63480,7 @@
       {
         "kind": "OBJECT",
         "name": "SlackChannelNameMapping",
-        "description": "Object for mapping Slack channel IDs to names and other settings",
+        "description": "Object for mapping Slack channel IDs to names and other settings.",
         "fields": [
           {
             "name": "id",
@@ -59441,7 +63516,7 @@
           },
           {
             "name": "isPrivate",
-            "description": "Whether or not the Slack channel is private",
+            "description": "Whether or not the Slack channel is private.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -59453,7 +63528,7 @@
           },
           {
             "name": "isShared",
-            "description": "Whether or not the Slack channel is shared with an external org",
+            "description": "Whether or not the Slack channel is shared with an external org.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -59465,7 +63540,7 @@
           },
           {
             "name": "botAdded",
-            "description": "Whether or not we the Linear Asks bot has been added to this Slack channel",
+            "description": "Whether or not we the Linear Asks bot has been added to this Slack channel.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -59477,7 +63552,7 @@
           },
           {
             "name": "teams",
-            "description": "Which teams are connected to the channel and settings for those teams",
+            "description": "Which teams are connected to the channel and settings for those teams.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -59501,7 +63576,7 @@
           },
           {
             "name": "autoCreateOnMessage",
-            "description": "Whether or not top-level messages in this channel should automatically create Asks",
+            "description": "Whether or not top-level messages in this channel should automatically create Asks.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -59513,7 +63588,7 @@
           },
           {
             "name": "autoCreateOnEmoji",
-            "description": "Whether or not using the :ticket: emoji in this channel should automatically create Asks",
+            "description": "Whether or not using the :ticket: emoji in this channel should automatically create Asks.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -59525,7 +63600,7 @@
           },
           {
             "name": "autoCreateOnBotMention",
-            "description": "Whether or not @-mentioning the bot should automatically create an Ask with the message",
+            "description": "Whether or not @-mentioning the bot should automatically create an Ask with the message.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -59593,7 +63668,7 @@
           },
           {
             "name": "isPrivate",
-            "description": "Whether or not the Slack channel is private",
+            "description": "Whether or not the Slack channel is private.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -59605,7 +63680,7 @@
           },
           {
             "name": "isShared",
-            "description": "Whether or not the Slack channel is shared with an external org",
+            "description": "Whether or not the Slack channel is shared with an external org.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -59617,7 +63692,7 @@
           },
           {
             "name": "botAdded",
-            "description": "Whether or not we the Linear Asks bot has been added to this Slack channel",
+            "description": "Whether or not we the Linear Asks bot has been added to this Slack channel.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -59629,7 +63704,7 @@
           },
           {
             "name": "teams",
-            "description": "Which teams are connected to the channel and settings for those teams",
+            "description": "Which teams are connected to the channel and settings for those teams.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -59653,7 +63728,7 @@
           },
           {
             "name": "autoCreateOnMessage",
-            "description": "Whether or not top-level messages in this channel should automatically create Asks",
+            "description": "Whether or not top-level messages in this channel should automatically create Asks.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -59665,7 +63740,7 @@
           },
           {
             "name": "autoCreateOnEmoji",
-            "description": "Whether or not using the :ticket: emoji in this channel should automatically create Asks",
+            "description": "Whether or not using the :ticket: emoji in this channel should automatically create Asks.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -59677,7 +63752,7 @@
           },
           {
             "name": "autoCreateOnBotMention",
-            "description": "Whether or not @-mentioning the bot should automatically create an Ask with the message",
+            "description": "Whether or not @-mentioning the bot should automatically create an Ask with the message.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -61044,7 +65119,7 @@
           },
           {
             "name": "requirePriorityToLeaveTriage",
-            "description": "Whether an issue needs to have a priority set before leaving triage",
+            "description": "Whether an issue needs to have a priority set before leaving triage.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -62010,8 +66085,8 @@
             "deprecationReason": null
           },
           {
-            "name": "automationStates",
-            "description": "The automation states for the team.",
+            "name": "gitAutomationStates",
+            "description": "The Git automation states for the team.",
             "args": [
               {
                 "name": "before",
@@ -63360,7 +67435,7 @@
           },
           {
             "name": "owner",
-            "description": "Whether the user is the owner of the team",
+            "description": "Whether the user is the owner of the team.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -63868,7 +67943,7 @@
           },
           {
             "name": "active",
-            "description": "Whether the subscription is active or not",
+            "description": "Whether the subscription is active or not.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -63986,7 +68061,7 @@
       {
         "kind": "OBJECT",
         "name": "TeamRepoMapping",
-        "description": "Tuple for mapping Linear teams to GitHub repos.",
+        "description": "Mapping of Linear teams to GitHub repos.",
         "fields": [
           {
             "name": "linearTeamId",
@@ -64016,6 +68091,30 @@
                 "name": "Float",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bidirectional",
+            "description": "Whether the sync for this mapping is bidirectional.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "default",
+            "description": "Whether this mapping is the default one for issue creation.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -64059,6 +68158,30 @@
                 "name": "Float",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bidirectional",
+            "description": "Whether the sync for this mapping is bidirectional.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "default",
+            "description": "Whether this mapping is the default one for issue creation.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -64221,10 +68344,22 @@
           },
           {
             "name": "cycleEnabledStartWeek",
-            "description": "Whether the first cycle should start in the current or the next week.",
+            "description": "[DEPRECATED] Whether the first cycle should start in the current or the next week.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cycleEnabledStartDate",
+            "description": "The date to begin cycles on.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
               "ofType": null
             },
             "defaultValue": null,
@@ -65113,6 +69248,364 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "TimeSchedule",
+        "description": "A time schedule.",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time at which the entity was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those\n    for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't\n    been updated after creation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archivedAt",
+            "description": "The time at which the entity was archived. Null if the entity has not been archived.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organization",
+            "description": "The organization of the schedule.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Organization",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "The name of the schedule.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "entries",
+            "description": "The schedule entries.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSONObject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "error",
+            "description": "User presentable error message, if an error occurred while updating the schedule.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "integration",
+            "description": "The identifier of the Linear integration populating the schedule.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Integration",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "externalId",
+            "description": "The identifier of the external schedule.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "externalUrl",
+            "description": "The URL to the external schedule.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "TimeScheduleConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "TimeScheduleEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "TimeSchedule",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "TimeScheduleEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "TimeSchedule",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cursor",
+            "description": "Used in `before` and `after` args",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "TimeScheduleEntry",
+        "description": "The time schedule entry.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "startsAt",
+            "description": "The start date of the schedule in ISO 8601 date-time format.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endsAt",
+            "description": "The end date of the schedule in ISO 8601 date-time format.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": "The Linear user id of the user on schedule. If the user cannot be mapped to a Linear user, use `userEmail` instead.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userEmail",
+            "description": "The email of the user on schedule. This is only used in case the user could not be mapped to a Linear user id.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "SCALAR",
         "name": "TimelessDate",
         "description": "Represents a date in ISO 8601 format. Accepts shortcuts like `2021` to represent midnight Fri Jan 01 2021. Also accepts ISO 8601 durations strings which are added to the current date to create the represented date (e.g '-P2W1D' represents the date that was two weeks and 1 day ago) ",
@@ -65467,6 +69960,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "Integration",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timeSchedule",
+            "description": "The time schedule used for scheduling.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "TimeSchedule",
                 "ofType": null
               }
             },
@@ -65860,7 +70369,7 @@
           },
           {
             "name": "uploadUrl",
-            "description": "The signed URL the for the uploaded file. (assigned automatically)",
+            "description": "The signed URL the for the uploaded file. (assigned automatically).",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -65876,7 +70385,7 @@
           },
           {
             "name": "assetUrl",
-            "description": "The asset URL for the uploaded file. (assigned automatically)",
+            "description": "The asset URL for the uploaded file. (assigned automatically).",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -66891,6 +71400,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "authTokenLinkDisabled",
+            "description": "Whether not to send email auth links in the email auth emails.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -67223,7 +71748,7 @@
           },
           {
             "name": "approvalErrorCode",
-            "description": "Error associated with the application needing to be requested for approval in the workspace",
+            "description": "Error associated with the application needing to be requested for approval in the workspace.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -68012,7 +72537,7 @@
       {
         "kind": "ENUM",
         "name": "UserFlagUpdateOperation",
-        "description": "Operations that can be applied to UserFlagType",
+        "description": "Operations that can be applied to UserFlagType.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -68227,7 +72752,7 @@
           },
           {
             "name": "active",
-            "description": "Whether the subscription is active or not",
+            "description": "Whether the subscription is active or not.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -68345,7 +72870,7 @@
       {
         "kind": "ENUM",
         "name": "UserRoleType",
-        "description": "The different permission roles available to users on an organization",
+        "description": "The different permission roles available to users on an organization.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -69143,6 +73668,18 @@
             "deprecationReason": null
           },
           {
+            "name": "initiativeId",
+            "description": "[Internal] The initiative these view preferences are associated with.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "labelId",
             "description": "The label these view preferences are associated with.",
             "type": {
@@ -69471,6 +74008,18 @@
             "deprecationReason": null
           },
           {
+            "name": "initiative",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiatives",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "projects",
             "description": null,
             "isDeprecated": false,
@@ -69524,7 +74073,7 @@
       {
         "kind": "OBJECT",
         "name": "Webhook",
-        "description": "A webhook used to send HTTP notifications over data updates",
+        "description": "A webhook used to send HTTP notifications over data updates.",
         "fields": [
           {
             "name": "id",
@@ -69588,7 +74137,7 @@
           },
           {
             "name": "label",
-            "description": "Webhook label",
+            "description": "Webhook label.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -69600,7 +74149,7 @@
           },
           {
             "name": "url",
-            "description": "Webhook URL",
+            "description": "Webhook URL.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -71943,7 +76492,7 @@
           },
           {
             "name": "totalMembers",
-            "description": "Total number of members that authorized the application",
+            "description": "Total number of members that authorized the application.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -71959,7 +76508,7 @@
           },
           {
             "name": "memberships",
-            "description": "UserIds and membership dates of everyone who has authorized the application with the set of scopes",
+            "description": "UserIds and membership dates of everyone who has authorized the application with the set of scopes.",
             "args": [],
             "type": {
               "kind": "NON_NULL",


### PR DESCRIPTION
We introduced a breaking change on Jan 5th when we allowed to query comments by hash ID and issueId. This schema change introduced a new arg type:
```
@Args() { id, issueId, hash }: CommentFindArgs
```
`CommentFindArgs` where all arguments are optional. There are validators at the API level to ensure validity of the passed arguments, but these do not have an impact on the schema.

This change means we now have a root query for an Entity that has 0 required arguments. This was a rather deep assumption in the SDK. The change broke some operation generation as well as test generation. 

The way tests for entities are working is as follows:
 - We query all comments with `client.comments()` and keep the first one
 - We then try to manually fetch this single comment by ID
 - We keep this comment and then call model queries on this instance: `await _comment.children()` or `await _comment.externalUser` for example

Because the `comment` query now accepts `id?, hash?, issueId?`, the SDK cannot assume what argument to use to call the query.

This PR adds support for these kind of root queries by assuming that if:
 - we're dealing with a root query
 - all it's arguments are optional
 - but it has one argument named `id`
 - then we can use this `id` argument in place of a required argument. 