### PR TITLE
fix: specify CSV delimiter

### DIFF
--- a/.changeset/dull-hats-pump.md
+++ b/.changeset/dull-hats-pump.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": patch
+---
+
+fix: specify CSV delimiter

--- a/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
+++ b/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
@@ -46,7 +46,9 @@ export class LinearCsvImporter implements Importer {
   }
 
   public import = async (): Promise<ImportResult> => {
-    const data = (await csv().fromFile(this.filePath)) as LinearIssueType[];
+    const data = (await csv({
+      delimiter: ";"
+    }).fromFile(this.filePath)) as LinearIssueType[];
 
     const importData: ImportResult = {
       issues: [],


### PR DESCRIPTION
The Linear CSV importer in the CLI importer relies on `csvtojson` to parse the CSV file. It's trying to infer the delimiter from the file but can somehow fail sometimes, throwing of the rest of the import.

As we know that Linear CSVs use `;` as a delimiter, we can hardcode it here.