### PR TITLE
fix: do not use .children call to check if label is a group

### DIFF
--- a/.changeset/few-timers-guess.md
+++ b/.changeset/few-timers-guess.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": patch
+---
+
+fix: do not use .children call to check if label is a group

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -194,8 +194,7 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
 
   for (const label of existingLabels) {
     const labelName = label.name?.toLowerCase();
-    const children = await label.children();
-    if (children?.nodes?.length > 0) {
+    if (label.isGroup) {
       if (labelName && label.id && !existingLabelGroupsMap[labelName]) {
         existingLabelGroupsMap[labelName] = label.id;
       }


### PR DESCRIPTION
Use of `.children()` on each label slows down import considerably when the workspace has many labels.