### PR TITLE
feat: use issue.createdAt when creating issues

### DIFF
--- a/.changeset/witty-rockets-teach.md
+++ b/.changeset/witty-rockets-teach.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": minor
+---
+
+feat: use issue.createdAt when creating issues

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -320,6 +320,7 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
       labelIds,
       stateId,
       assigneeId,
+      createdAt: issue.createdAt,
       dueDate: formattedDueDate,
     });
   }


### PR DESCRIPTION
Use `issue.createdAt` to create issue with the appropriate creation date rather than the import date.

The description shows as updated now as the API created a new `DocumentContent` for this new `Issue`:

![CleanShot 2024-03-07 at 12 47 26@2x](https://github.com/linear/linear/assets/2076017/66fa786b-19fc-494f-9da5-fedb1d55f8de)

That's something we can look at addressing on the backend.