### PR TITLE
Revert "fix: specify CSV delimiter (#459)"

### DIFF
--- a/.changeset/lovely-taxis-tease.md
+++ b/.changeset/lovely-taxis-tease.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": patch
+---
+
+fix: revert CSV delimiter change

--- a/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
+++ b/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
@@ -46,9 +46,7 @@ export class LinearCsvImporter implements Importer {
   }
 
   public import = async (): Promise<ImportResult> => {
-    const data = (await csv({
-      delimiter: ";"
-    }).fromFile(this.filePath)) as LinearIssueType[];
+    const data = (await csv().fromFile(this.filePath)) as LinearIssueType[];
 
     const importData: ImportResult = {
       issues: [],


### PR DESCRIPTION
This reverts commit 6e6639e where we tried to hardcode CSV delimiter value to overcome an issue with issue descriptions containing commas. Will revisit once we have identified the inconsistencies in the CSV file that led to this change.