### PR TITLE
feat: add pagination helper

### DIFF
--- a/.changeset/spicy-brooms-repair.md
+++ b/.changeset/spicy-brooms-repair.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": minor
+---
+
+feat: add pagination helper

--- a/packages/sdk/src/_tests/LinearClient.test.ts
+++ b/packages/sdk/src/_tests/LinearClient.test.ts
@@ -12,7 +12,7 @@ describe("LinearClient", () => {
           viewer: { id: "viewerId" },
           team: {
             id: "teamId",
-            labels: { nodes: [{ id: "labelId" }], pageInfo: { hasNextPage: false, hasPreviousPage: false } },
+            labels: { nodes: [{ id: "labelId" }], pageInfo: { hasNextPage: true, hasPreviousPage: false, endCursor: "endCursorId" } },
             states: { nodes: [{ id: "stateId" }], pageInfo: { hasNextPage: false, hasPreviousPage: false } },
           },
         },
@@ -65,5 +65,24 @@ describe("LinearClient", () => {
       expect(error.message).toEqual(expect.stringContaining("GraphQL Error (Code: 401) - Unauthorized"));
       expect(error.type).toEqual(LinearErrorType.AuthenticationError);
     }
+  });
+
+  it("supports pagination", async () => {
+    const client = new LinearClient({ apiKey: MOCK_API_KEY, apiUrl: ctx.url });
+    const team = await client.team("someTeamId");
+
+    ctx.customSpecs['endCursorId'] = {
+      body: {
+        data: {
+          team: {
+            id: "teamId",
+            labels: { nodes: [{ id: "labelId" }], pageInfo: { hasNextPage: false, hasPreviousPage: false } },
+          },
+        },
+      },
+    }
+
+    const allTeamLabels = await client.paginate(team.labels, {includeArchived: true});
+    expect(allTeamLabels.length).toEqual(2)
   });
 });


### PR DESCRIPTION
This PR adds a pagination helper to easily iterate over all pages of a `Connection` with the SDK.

The CLI importer lacks pagination on Users and Teams and will be fixed with this helper to properly iterate over these connections once released. 

In order to provide a unit test, which also acts as an usage example, it is required to modify the test server to allow to return different results for different queries (we need to return `hasNextPage: false` at some point for the test to complete). Approach for this is very simple for now: tests can supply a different response Mock, identified by a unique element from the query body.