### PR TITLE
Move pagination helper into Request class

### DIFF
--- a/.changeset/eighty-bees-tap.md
+++ b/.changeset/eighty-bees-tap.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": minor
+---
+
+fix: move pagination helper into `Request` class

--- a/packages/codegen-sdk/src/print-request.ts
+++ b/packages/codegen-sdk/src/print-request.ts
@@ -63,8 +63,29 @@ export function printRequest(): string {
 
         public constructor(${args.printInput}) {
           this._${Sdk.REQUEST_NAME} = ${Sdk.REQUEST_NAME}
-        }
-      }`,
+        }`,
+        "\n",
+        printPaginate(),
+      `}`,
     "\n",
   ]);
+}
+
+/**
+ * Print the pagination helper
+ */
+function printPaginate(): string {
+  return printLines([
+    printComment([`Helper to paginate over all pages of a given connection query.`, `@param fn The query to paginate`, `@param args The arguments to pass to the query`]),
+    printLines([`public async paginate<T extends ${Sdk.NODE_TYPE}, U>(fn: (variables: U) => ${Sdk.FETCH_TYPE}<${Sdk.CONNECTION_CLASS}<T>>, args: U): Promise<T[]> {
+      const boundFn = fn.bind(this)
+      let connection: ${Sdk.CONNECTION_CLASS}<T> =  (await boundFn(args));
+      const nodes = connection.${Sdk.NODE_NAME};
+      while(connection.${Sdk.PAGEINFO_NAME}.hasNextPage) {
+        connection = (await boundFn({...args, after: connection.${Sdk.PAGEINFO_NAME}.endCursor}));
+        nodes.push(...connection.${Sdk.NODE_NAME});
+      }
+      return nodes;
+    }`])
+  ])
 }

--- a/packages/sdk/src/_generated_sdk.ts
+++ b/packages/sdk/src/_generated_sdk.ts
@@ -18,6 +18,22 @@ export class Request {
   public constructor(request: LinearRequest) {
     this._request = request;
   }
+
+  /**
+   * Helper to paginate over all pages of a given connection query.
+   * @param fn The query to paginate
+   * @param args The arguments to pass to the query
+   */
+  public async paginate<T extends Node, U>(fn: (variables: U) => LinearFetch<Connection<T>>, args: U): Promise<T[]> {
+    const boundFn = fn.bind(this);
+    let connection: Connection<T> = await boundFn(args);
+    const nodes = connection.nodes;
+    while (connection.pageInfo.hasNextPage) {
+      connection = await boundFn({ ...args, after: connection.pageInfo.endCursor });
+      nodes.push(...connection.nodes);
+    }
+    return nodes;
+  }
 }
 
 /** Fetch return type wrapped in a promise */

--- a/packages/sdk/src/_tests/LinearClient.test.ts
+++ b/packages/sdk/src/_tests/LinearClient.test.ts
@@ -74,7 +74,7 @@ describe("LinearClient", () => {
 
     let requestCount = 0;
 
-    const {requests } = ctx.res(() =>  {
+    const { requests } = ctx.res(() =>  {
       if(requestCount === 0){
         requestCount++;
         return {

--- a/packages/sdk/src/_tests/LinearClient.test.ts
+++ b/packages/sdk/src/_tests/LinearClient.test.ts
@@ -74,7 +74,7 @@ describe("LinearClient", () => {
 
     let requestCount = 0;
 
-    ctx.res(() =>  {
+    const {requests } = ctx.res(() =>  {
       if(requestCount === 0){
         requestCount++;
         return {
@@ -108,7 +108,8 @@ describe("LinearClient", () => {
       }
       });
 
-    const allTeamLabels = await client.paginate(team.labels, {includeArchived: true});
+    const allTeamLabels = await team.paginate(team.labels, {includeArchived: true});
     expect(allTeamLabels.length).toEqual(2)
+    expect(requests.at(-1)?.body.variables?.["id"]).toEqual("teamId");
   });
 });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -3,7 +3,7 @@ import { parseLinearError } from "./error";
 import { LinearGraphQLClient } from "./graphql-client";
 import { LinearClientOptions, LinearClientParsedOptions } from "./types";
 import { serializeUserAgent } from "./utils";
-import { Connection, LinearFetch, LinearSdk } from "./_generated_sdk";
+import { Connection, LinearFetch, LinearSdk, Request } from "./_generated_sdk";
 import { Node } from "./_generated_documents";
 
 /**
@@ -69,21 +69,5 @@ export class LinearClient extends LinearSdk {
 
     this.options = parsedOptions;
     this.client = graphQLClient;
-  }
-
-  /**
-   * Helper to paginate over all pages of a given connection query.
-   * @param fn The query to paginate
-   * @param args The arguments to pass to the query
-   */
-  public async paginate<T extends Node, U>(fn: (variables: U) => LinearFetch<Connection<T>>, args: U): Promise<T[]> {
-    const boundFn = fn.bind(this);
-    let connection: Connection<T> =  (await boundFn(args));
-    const nodes = connection.nodes;
-    while(connection.pageInfo.hasNextPage) {
-      connection = (await boundFn({...args, after: connection.pageInfo.endCursor}));
-      nodes.push(...connection.nodes);
-    }
-    return nodes;
   }
 }

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -3,8 +3,7 @@ import { parseLinearError } from "./error";
 import { LinearGraphQLClient } from "./graphql-client";
 import { LinearClientOptions, LinearClientParsedOptions } from "./types";
 import { serializeUserAgent } from "./utils";
-import { Connection, LinearFetch, LinearSdk, Request } from "./_generated_sdk";
-import { Node } from "./_generated_documents";
+import { LinearSdk } from "./_generated_sdk";
 
 /**
  * Validate and return default LinearGraphQLClient options


### PR DESCRIPTION
Follow-up on #486

In order for non-root queries to be properly bound during pagination calls, we need to move `paginate` into a parent class of `LinearClient`: `Request`. Otherwise, the `id` parameter is not bound and the query fails as `id` is always required.

As `Request` is a generated (printed) class, the pagination helper needs to be a generated function as well. A unit test is added to catch the missing ID parameter on the query.
 
Towards LIN-18253