### PR TITLE
fix: properly paginate teams and users in CLI importer

### DIFF
--- a/.changeset/young-pianos-prove.md
+++ b/.changeset/young-pianos-prove.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": patch
+---
+
+fix: properly paginate teams and users in CLI importer


### PR DESCRIPTION
This PR makes use of the newly introduced pagination helper in the SDK to properly paginate teams and users in CLI importer.

We will most likely need to rethink UX at some point if we need to support larger teams, as the current selection mode is a bit tedious if you have more than 25 teams