### PR TITLE
fix: map assignees by email before name

### DIFF
--- a/.changeset/lucky-knives-sort.md
+++ b/.changeset/lucky-knives-sort.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": minor
+---
+
+fix: map assignees by email before name

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -239,11 +239,16 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
     }
   }
 
-  const existingUserMap = {} as { [name: string]: string };
+  const existingUserMapByName = {} as { [name: string]: string };
+  const existingUserMapByEmail = {} as { [email: string]: string };
   for (const user of allUsers) {
     const userName = user.name?.toLowerCase();
-    if (userName && user.id && !existingUserMap[userName]) {
-      existingUserMap[userName] = user.id;
+    if (userName && user.id && !existingUserMapByName[userName]) {
+      existingUserMapByName[userName] = user.id;
+    }
+
+    if (user.id && !existingUserMapByEmail[user.email]) {
+      existingUserMapByEmail[user.email] = user.id;
     }
   }
 
@@ -284,8 +289,9 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
       }
     }
 
-    const existingAssigneeId: string | undefined = !!issue.assigneeId
-      ? existingUserMap[issue.assigneeId.toLowerCase()]
+    const issueAssigneeId = issue.assigneeId?.toLowerCase();
+    const existingAssigneeId: string | undefined = !!issueAssigneeId
+      ? existingUserMapByEmail[issueAssigneeId] ?? existingUserMapByName[issueAssigneeId]
       : undefined;
 
     let assigneeId: string | undefined;

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -243,11 +243,11 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
   const existingUserMapByEmail = {} as { [email: string]: string };
   for (const user of allUsers) {
     const userName = user.name?.toLowerCase();
-    if (userName && user.id && !existingUserMapByName[userName]) {
+    if (userName && !existingUserMapByName[userName]) {
       existingUserMapByName[userName] = user.id;
     }
 
-    if (user.id && !existingUserMapByEmail[user.email]) {
+    if (!existingUserMapByEmail[user.email]) {
       existingUserMapByEmail[user.email] = user.id;
     }
   }


### PR DESCRIPTION
Depending on the import service, the issue's `assigneeId` can either be a user name or an email.

This PR changes the logic to pick `existingAssigneeId` from a match by email first, and then fall back on name match if there's no email match. 