### PR TITLE
feat: add support for enums

### DIFF
--- a/.changeset/selfish-eagles-cough.md
+++ b/.changeset/selfish-eagles-cough.md
@@ -1,0 +1,7 @@
+---
+"@linear/codegen-doc": minor
+"@linear/codegen-sdk": minor
+"@linear/sdk": minor
+---
+
+feat: add support for enums

--- a/packages/codegen-doc/src/context-visitor.ts
+++ b/packages/codegen-doc/src/context-visitor.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_SCALARS } from "@graphql-codegen/visitor-plugin-common";
 import autoBind from "auto-bind";
 import {
+  EnumTypeDefinitionNode,
   FieldDefinitionNode,
   GraphQLSchema,
   InterfaceTypeDefinitionNode,
@@ -21,6 +22,7 @@ export class ContextVisitor<Config extends PluginConfig> {
   private _queries: FieldDefinitionNode[] = [];
   private _mutations: FieldDefinitionNode[] = [];
   private _interfaceImplementations: { [interfaceName: string]: ObjectTypeDefinitionNode[] } = {};
+  private _enums: EnumTypeDefinitionNode[] = [];
 
   /** Initialize the visitor */
   public constructor(schema: GraphQLSchema, config: Config) {
@@ -56,6 +58,7 @@ export class ContextVisitor<Config extends PluginConfig> {
             ),
           ])
       ),
+      enums: this._enums,
     };
   }
 
@@ -90,6 +93,14 @@ export class ContextVisitor<Config extends PluginConfig> {
     /** Record all interface types */
     enter: (node: InterfaceTypeDefinitionNode): InterfaceTypeDefinitionNode => {
       this._interfaces = [...this._interfaces, node];
+      return node;
+    },
+  };
+
+  public EnumTypeDefinition = {
+    /** Record all enums types */
+    enter: (node: EnumTypeDefinitionNode): EnumTypeDefinitionNode => {
+      this._enums = [...this._enums, node];
       return node;
     },
   };

--- a/packages/codegen-doc/src/field.ts
+++ b/packages/codegen-doc/src/field.ts
@@ -1,5 +1,5 @@
-import { FieldDefinitionNode } from "graphql";
-import { PluginContext } from "./types";
+import { EnumTypeDefinitionNode, FieldDefinitionNode } from "graphql";
+import { Named, PluginContext } from "./types";
 import { reduceTypeName } from "./utils";
 import { findObject, isValidObject } from "./object";
 
@@ -8,6 +8,20 @@ import { findObject, isValidObject } from "./object";
  */
 export function isScalarField(context: PluginContext, field: FieldDefinitionNode): boolean {
   return Object.keys(context.scalars).includes(reduceTypeName(field.type));
+}
+
+/**
+ * Get the enum type matching the name arg
+ */
+export function findEnum(
+  context: PluginContext,
+  field?: FieldDefinitionNode | Named<FieldDefinitionNode>
+): EnumTypeDefinitionNode | undefined {
+  if (field) {
+    const type = reduceTypeName(field.type);
+    return context.enums.find(operation => operation.name.value === type);
+  }
+  return undefined;
 }
 
 /**

--- a/packages/codegen-doc/src/fragment-visitor.ts
+++ b/packages/codegen-doc/src/fragment-visitor.ts
@@ -11,7 +11,7 @@ import {
   ObjectTypeDefinitionNode,
 } from "graphql";
 import { getRequiredArgs } from "./args";
-import { isValidField } from "./field";
+import { findEnum, isValidField } from "./field";
 import { isValidFragment } from "./fragment";
 import { findInterface, findObject, isConnection } from "./object";
 import { printGraphqlComment, printGraphqlDebug, printGraphqlDescription, printLines } from "./print";
@@ -121,8 +121,8 @@ export class FragmentVisitor {
         const node = _node as unknown as Named<FieldDefinitionNode>;
         const description = node.description?.value ? printGraphqlComment([node.description?.value]) : undefined;
 
-        /** Print field name if it is a scalar */
-        if (Object.values(this._context.scalars).includes(type)) {
+        /** Print field name if it is a scalar or an enum */
+        if (Object.values(this._context.scalars).includes(type) || findEnum(this._context, node)) {
           return printLines([description, printGraphqlDebug(_node), node.name]);
         }
 

--- a/packages/codegen-doc/src/types.ts
+++ b/packages/codegen-doc/src/types.ts
@@ -5,6 +5,7 @@ import {
   GraphQLSchema,
   InterfaceTypeDefinitionNode,
   ObjectTypeDefinitionNode,
+  EnumTypeDefinitionNode
 } from "graphql";
 
 /**
@@ -112,6 +113,8 @@ export interface PluginContext<C extends PluginConfig = PluginConfig> {
   operationMap: Record<OperationType, string>;
   /** All implementations of an interface */
   interfaceImplementations: { [interfaceName: string]: ObjectTypeDefinitionNode[] };
+  /** All enums */
+  enums: readonly EnumTypeDefinitionNode[];
   /** The plugin config */
   config: C;
 }

--- a/packages/codegen-sdk/src/model-visitor.ts
+++ b/packages/codegen-sdk/src/model-visitor.ts
@@ -1,4 +1,5 @@
 import {
+  findEnum,
   findObject,
   findQuery,
   getObjectName,
@@ -27,7 +28,7 @@ import {
 import { Sdk } from "./constants";
 import { printNamespaced } from "./print";
 import {
-  SdkConnectionField,
+  SdkConnectionField, SdkEnumField,
   SdkInterfaceField,
   SdkListField,
   SdkModel,
@@ -190,6 +191,18 @@ export class ModelVisitor {
             };
           }
         }
+
+        /** Identify enum fields */
+        const enumField = findEnum(this._context, node);
+        if(enumField) {
+          return {
+            __typename: SdkModelFieldType.enum,
+            node,
+            name,
+            type,
+            nonNull,
+          };
+        }
       }
 
       /** Ignore the field */
@@ -220,6 +233,7 @@ function leaveObjectOrInterface(_node: ObjectTypeDefinitionNode | InterfaceTypeD
           []) as SdkScalarListField[],
         connection: (fields?.filter(field => field.__typename === SdkModelFieldType.connection) ??
           []) as SdkConnectionField[],
+        enum: (fields?.filter(field => field.__typename === SdkModelFieldType.enum) ?? []) as SdkEnumField[],
       },
     };
   } else {

--- a/packages/codegen-sdk/src/print-model.ts
+++ b/packages/codegen-sdk/src/print-model.ts
@@ -110,6 +110,12 @@ function printModel(context: SdkPluginContext, model: SdkModel): string {
                 : printTernary(printSet(`this.${field.name}`, `${Sdk.DATA_NAME}.${field.name}`), operationCall);
             })
           ),
+          printDebug("fields.enum"),
+          printLines(
+            model.fields.enum.map(field =>
+              printSet(`this.${field.name}`, `${Sdk.DATA_NAME}.${field.name}${field.nonNull ? "" : " ?? undefined"}`)
+            )
+          ),
           printDebug("fields.query"),
           printLines(
             model.fields.query.map(field =>
@@ -121,7 +127,7 @@ function printModel(context: SdkPluginContext, model: SdkModel): string {
                   )
                 : undefined
             )
-          ),
+          )
         ])}
       }
 
@@ -148,6 +154,12 @@ function printModel(context: SdkPluginContext, model: SdkModel): string {
         printLines(
           model.fields.object.map((field /** Ignore objects returned by an operation */) =>
             printModelField(field, `public ${field.name}${field.nonNull ? "" : "?"}: ${field.object.name.value}`)
+          )
+        ),
+        printDebug("fields.enum"),
+        printLines(
+          model.fields.enum.map(field =>
+            printModelField(field, `public ${field.name}${field.nonNull ? "" : "?"}: ${field.type}`)
           )
         ),
       ])}

--- a/packages/codegen-sdk/src/types.ts
+++ b/packages/codegen-sdk/src/types.ts
@@ -129,6 +129,7 @@ export enum SdkModelFieldType {
   list = "SdkListField ",
   scalarList = "SdkScalarListField",
   connection = "SdkConnectionField",
+  enum = "SdkEnumField"
 }
 
 /**
@@ -203,6 +204,14 @@ export interface SdkListField extends Omit<SdkScalarField, "__typename"> {
 }
 
 /**
+ * A field with enum type
+ */
+export interface SdkEnumField extends Omit<SdkScalarField, "__typename"> {
+  __typename: SdkModelFieldType.enum;
+}
+
+
+/**
  * One of the model field types
  */
 export type SdkModelField =
@@ -212,7 +221,8 @@ export type SdkModelField =
   | SdkInterfaceField
   | SdkListField
   | SdkScalarListField
-  | SdkConnectionField;
+  | SdkConnectionField
+  | SdkEnumField;
 
 /**
  * The processed sdk model node
@@ -242,5 +252,6 @@ export interface SdkModel {
     list: SdkListField[];
     scalarList: SdkScalarListField[];
     connection: SdkConnectionField[];
+    enum: SdkEnumField[];
   };
 }

--- a/packages/sdk/naming-override/index.js
+++ b/packages/sdk/naming-override/index.js
@@ -5,6 +5,9 @@ const changeCaseAll = require("change-case-all");
 // counter.
 const duplicateQueries = ["ProjectMilestone", "ProjectMilestones"];
 
+// We have some non pascal cased types that we need to keep as is.
+const incorrectCase = ["SLADayCountType"];
+
 // Object containing counters of how many times we've seen each DuplicateQueryNameArgs type.
 const deduplicate = Object.fromEntries(duplicateQueries.map(query => [`Query${query}Args`, 0]));
 
@@ -14,6 +17,9 @@ exports.case = (type) => {
       type = type + deduplicate[type];
     }
     deduplicate[type] += 1
+  }
+  if(incorrectCase.includes(type)) {
+    return type;
   }
   return changeCaseAll.pascalCase(type)
 }

--- a/packages/sdk/src/_generated_documents.graphql
+++ b/packages/sdk/src/_generated_documents.graphql
@@ -202,6 +202,10 @@ fragment CustomViewNotificationSubscription on CustomViewNotificationSubscriptio
   createdAt
   # The type of subscription.
   notificationSubscriptionTypes
+  # The type of user view to which the notification subscription context is associated with.
+  userContextViewType
+  # The type of view to which the notification subscription context is associated with.
+  contextViewType
   # The unique identifier of the entity.
   id
   # The user that subscribed to receive notifications.
@@ -298,6 +302,10 @@ fragment CycleNotificationSubscription on CycleNotificationSubscription {
   createdAt
   # The type of subscription.
   notificationSubscriptionTypes
+  # The type of user view to which the notification subscription context is associated with.
+  userContextViewType
+  # The type of view to which the notification subscription context is associated with.
+  contextViewType
   # The unique identifier of the entity.
   id
   # The user that subscribed to receive notifications.
@@ -623,6 +631,10 @@ fragment LabelNotificationSubscription on LabelNotificationSubscription {
   createdAt
   # The type of subscription.
   notificationSubscriptionTypes
+  # The type of user view to which the notification subscription context is associated with.
+  userContextViewType
+  # The type of view to which the notification subscription context is associated with.
+  contextViewType
   # The unique identifier of the entity.
   id
   # The user that subscribed to receive notifications.
@@ -751,6 +763,10 @@ fragment ProjectNotificationSubscription on ProjectNotificationSubscription {
   createdAt
   # The type of subscription.
   notificationSubscriptionTypes
+  # The type of user view to which the notification subscription context is associated with.
+  userContextViewType
+  # The type of view to which the notification subscription context is associated with.
+  contextViewType
   # The unique identifier of the entity.
   id
   # The user that subscribed to receive notifications.
@@ -1263,6 +1279,10 @@ fragment TeamNotificationSubscription on TeamNotificationSubscription {
   createdAt
   # The type of subscription.
   notificationSubscriptionTypes
+  # The type of user view to which the notification subscription context is associated with.
+  userContextViewType
+  # The type of view to which the notification subscription context is associated with.
+  contextViewType
   # The unique identifier of the entity.
   id
   # The user that subscribed to receive notifications.
@@ -1284,6 +1304,8 @@ fragment TriageResponsibility on TriageResponsibility {
   manualSelection {
     ...TriageResponsibilityManualSelection
   }
+  # The action to take when an issue is added to triage.
+  action
   # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
   #     been updated after creation.
@@ -1379,6 +1401,8 @@ fragment GitAutomationState on GitAutomationState {
   state {
     id
   }
+  # The event that triggers the automation.
+  event
   # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
   #     been updated after creation.
@@ -1410,6 +1434,8 @@ fragment ProjectUpdate on ProjectUpdate {
   diffMarkdown
   # The diff between the current update and the previous one.
   diff
+  # The health of the project at the time of the update.
+  health
   # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
   #     for which updates should not produce an update to updatedAt (see skipUpdatedAtKeys). This is the same as the creation time if the entity hasn't
   #     been updated after creation.
@@ -1490,6 +1516,10 @@ fragment UserNotificationSubscription on UserNotificationSubscription {
   createdAt
   # The type of subscription.
   notificationSubscriptionTypes
+  # The type of user view to which the notification subscription context is associated with.
+  userContextViewType
+  # The type of view to which the notification subscription context is associated with.
+  contextViewType
   # The unique identifier of the entity.
   id
   # The user subscribed to.
@@ -1841,6 +1871,8 @@ fragment OrganizationInvite on OrganizationInvite {
   expiresAt
   # The unique identifier of the entity.
   id
+  # The user role that the invitee will receive upon accepting the invite.
+  role
   # The user who created the invitation.
   inviter {
     id
@@ -1918,6 +1950,8 @@ fragment Issue on Issue {
   trashed
   # Id of the labels associated with this issue.
   labelIds
+  # Integration type that created this issue, if applicable.
+  integrationSourceType
   # Issue URL.
   url
   # Issue's human readable identifier (e.g. ENG-123).
@@ -2093,6 +2127,12 @@ fragment Organization on Organization {
   previousUrlKeys
   # Rolling 30-day total upload volume for the organization, in megabytes.
   periodUploadVolume
+  # The day at which to prompt for project updates.
+  projectUpdateRemindersDay
+  # The feature release channel the organization belongs to.
+  releaseChannel
+  # The frequency at which to prompt for project updates.
+  projectUpdatesReminderFrequency
   # The hour at which to prompt for project updates.
   projectUpdateRemindersHour
   # The last time at which the entity was meaningfully updated, i.e. for all changes of syncable properties except those
@@ -2133,6 +2173,8 @@ fragment Organization on Organization {
   gitPublicLinkbackMessagesEnabled
   # Whether the organization is using a roadmap.
   roadmapEnabled
+  # Which day count to use for SLA calculations.
+  slaDayCount
 }
 
 # An organization. Organizations are root-level objects that contain users and teams.
@@ -2144,6 +2186,8 @@ fragment AuthOrganization on AuthOrganization {
   previousUrlKeys
   # The email domain or URL key for the organization.
   serviceId
+  # The feature release channel the organization belongs to.
+  releaseChannel
   # The organization's logo URL.
   logoUrl
   # The organization's name.
@@ -2371,6 +2415,8 @@ fragment AuthenticationSessionResponse on AuthenticationSessionResponse {
   operatingSystem
   # Session's user-agent.
   userAgent
+  # Type of application used to authenticate.
+  type
   # Used web browser.
   browserType
   # When was the session last seen
@@ -2441,6 +2487,8 @@ fragment OrganizationDomain on OrganizationDomain {
   creator {
     id
   }
+  # What type of auth is the domain used for.
+  authType
   # Whether the domains was claimed by the organization through DNS verification.
   claimed
 }
@@ -2776,6 +2824,10 @@ fragment NotificationSubscription on NotificationSubscription {
   archivedAt
   # The time at which the entity was created.
   createdAt
+  # The type of user view to which the notification subscription context is associated with.
+  userContextViewType
+  # The type of view to which the notification subscription context is associated with.
+  contextViewType
   # The unique identifier of the entity.
   id
   # The user that subscribed to receive notifications.
@@ -2990,6 +3042,8 @@ fragment OauthClientApproval on OauthClientApproval {
   denyReason
   # The scopes the app has requested.
   scopes
+  # The status for the OAuth client approval request.
+  status
   # The time at which the entity was archived. Null if the entity has not been archived.
   archivedAt
   # The time at which the entity was created.
@@ -3048,6 +3102,8 @@ fragment SlackAsksSettings on SlackAsksSettings {
   slackChannelMapping {
     ...SlackChannelNameMapping
   }
+  # The user role type that is allowed to manage Asks settings.
+  canAdministrate
   # Whether to show unfurl previews in Slack
   shouldUnfurl
 }
@@ -3057,6 +3113,7 @@ fragment SlackPostSettings on SlackPostSettings {
   __typename
   channel
   channelId
+  channelType
   configurationUrl
 }
 
@@ -3283,6 +3340,8 @@ fragment AuthenticationSession on AuthenticationSession {
   operatingSystem
   # Session's user-agent.
   userAgent
+  # Type of application used to authenticate.
+  type
   # Used web browser.
   browserType
   # When was the session last seen
@@ -3345,6 +3404,8 @@ fragment Favorite on Favorite {
   parent {
     id
   }
+  # The targeted tab of the project.
+  projectTab
   # The team of the favorited predefined view.
   predefinedViewTeam {
     id
@@ -3586,6 +3647,7 @@ fragment AuthOrganizationDomain on AuthOrganizationDomain {
   __typename
   # The unique identifier of the entity.
   id
+  authType
   claimed
   name
   organizationId
@@ -4248,6 +4310,8 @@ fragment IssueSearchResult on IssueSearchResult {
   trashed
   # Id of the labels associated with this issue.
   labelIds
+  # Integration type that created this issue, if applicable.
+  integrationSourceType
   # Issue URL.
   url
   # Issue's human readable identifier (e.g. ENG-123).
@@ -4470,6 +4534,12 @@ fragment OauthToken on OauthToken {
   revokedAt
 }
 
+fragment OrganizationAcceptedOrExpiredInviteDetailsPayload on OrganizationAcceptedOrExpiredInviteDetailsPayload {
+  __typename
+  # The status of the invite.
+  status
+}
+
 fragment OrganizationCancelDeletePayload on OrganizationCancelDeletePayload {
   __typename
   # Whether the operation was successful.
@@ -4512,8 +4582,12 @@ fragment OrganizationInviteFullDetailsPayload on OrganizationInviteFullDetailsPa
   email
   # The name of the inviter.
   inviter
+  # The status of the invite.
+  status
   # URL of the workspace logo the invite is for.
   organizationLogoUrl
+  # What user role the invite should grant.
+  role
   # When the invite was created.
   createdAt
   # Whether the invite has already been accepted.
@@ -5317,6 +5391,8 @@ fragment WorkflowDefinition on WorkflowDefinition {
   groupName
   # The name of the workflow.
   name
+  # The object type (e.g. Issue) that triggers this workflow.
+  triggerType
   # The sort order of the workflow definition within its siblings.
   sortOrder
   # The team associated with the workflow. If not set, the workflow is associated with the entire organization.
@@ -5327,6 +5403,14 @@ fragment WorkflowDefinition on WorkflowDefinition {
   archivedAt
   # The time at which the entity was created.
   createdAt
+  # The type of the event that triggers off the workflow.
+  trigger
+  # The type of the workflow.
+  type
+  # The type of user view to which this workflow's context is associated with.
+  userContextViewType
+  # The type of view to which this workflow's context is associated with.
+  contextViewType
   # The unique identifier of the entity.
   id
   # The user who created the workflow.

--- a/packages/sdk/src/_generated_documents.ts
+++ b/packages/sdk/src/_generated_documents.ts
@@ -7229,7 +7229,7 @@ export type Organization = Node & {
   /** Whether SCIM provisioning is enabled for organization. */
   scimEnabled: Scalars["Boolean"];
   /** Which day count to use for SLA calculations. */
-  slaDayCount: SlaDayCountType;
+  slaDayCount: SLADayCountType;
   /** The organization's subscription to a paid plan. */
   subscription?: Maybe<PaidSubscription>;
   /** Teams associated with the organization. */
@@ -7597,7 +7597,7 @@ export type OrganizationUpdateInput = {
   /** Whether the organization is using roadmap. */
   roadmapEnabled?: Maybe<Scalars["Boolean"]>;
   /** Which day count to use for SLA calculation. */
-  slaDayCount?: Maybe<SlaDayCountType>;
+  slaDayCount?: Maybe<SLADayCountType>;
   /** Internal. Whether SLAs have been enabled for the organization. */
   slaEnabled?: Maybe<Scalars["Boolean"]>;
   /** The URL key of the organization. */
@@ -10168,7 +10168,7 @@ export type RoadmapUpdateInput = {
 };
 
 /** Which day count to use for SLA calculations. */
-export enum SlaDayCountType {
+export enum SLADayCountType {
   All = "all",
   OnlyBusinessDays = "onlyBusinessDays",
 }
@@ -12687,7 +12687,14 @@ export type EmojiFragment = { __typename: "Emoji" } & Pick<
 
 export type CustomViewNotificationSubscriptionFragment = { __typename: "CustomViewNotificationSubscription" } & Pick<
   CustomViewNotificationSubscription,
-  "updatedAt" | "archivedAt" | "createdAt" | "notificationSubscriptionTypes" | "id" | "active"
+  | "updatedAt"
+  | "archivedAt"
+  | "createdAt"
+  | "notificationSubscriptionTypes"
+  | "userContextViewType"
+  | "contextViewType"
+  | "id"
+  | "active"
 > & {
     cycle?: Maybe<{ __typename?: "Cycle" } & Pick<Cycle, "id">>;
     label?: Maybe<{ __typename?: "IssueLabel" } & Pick<IssueLabel, "id">>;
@@ -12722,7 +12729,14 @@ export type CustomViewFragment = { __typename: "CustomView" } & Pick<
 
 export type CycleNotificationSubscriptionFragment = { __typename: "CycleNotificationSubscription" } & Pick<
   CycleNotificationSubscription,
-  "updatedAt" | "archivedAt" | "createdAt" | "notificationSubscriptionTypes" | "id" | "active"
+  | "updatedAt"
+  | "archivedAt"
+  | "createdAt"
+  | "notificationSubscriptionTypes"
+  | "userContextViewType"
+  | "contextViewType"
+  | "id"
+  | "active"
 > & {
     customView?: Maybe<{ __typename?: "CustomView" } & Pick<CustomView, "id">>;
     label?: Maybe<{ __typename?: "IssueLabel" } & Pick<IssueLabel, "id">>;
@@ -12898,7 +12912,14 @@ export type DeletePayloadFragment = { __typename: "DeletePayload" } & Pick<
 
 export type LabelNotificationSubscriptionFragment = { __typename: "LabelNotificationSubscription" } & Pick<
   LabelNotificationSubscription,
-  "updatedAt" | "archivedAt" | "createdAt" | "notificationSubscriptionTypes" | "id" | "active"
+  | "updatedAt"
+  | "archivedAt"
+  | "createdAt"
+  | "notificationSubscriptionTypes"
+  | "userContextViewType"
+  | "contextViewType"
+  | "id"
+  | "active"
 > & {
     customView?: Maybe<{ __typename?: "CustomView" } & Pick<CustomView, "id">>;
     cycle?: Maybe<{ __typename?: "Cycle" } & Pick<Cycle, "id">>;
@@ -12951,7 +12972,14 @@ export type NotificationFragment =
 
 export type ProjectNotificationSubscriptionFragment = { __typename: "ProjectNotificationSubscription" } & Pick<
   ProjectNotificationSubscription,
-  "updatedAt" | "archivedAt" | "createdAt" | "notificationSubscriptionTypes" | "id" | "active"
+  | "updatedAt"
+  | "archivedAt"
+  | "createdAt"
+  | "notificationSubscriptionTypes"
+  | "userContextViewType"
+  | "contextViewType"
+  | "id"
+  | "active"
 > & {
     customView?: Maybe<{ __typename?: "CustomView" } & Pick<CustomView, "id">>;
     cycle?: Maybe<{ __typename?: "Cycle" } & Pick<Cycle, "id">>;
@@ -13126,7 +13154,14 @@ export type WorkflowStateFragment = { __typename: "WorkflowState" } & Pick<
 
 export type TeamNotificationSubscriptionFragment = { __typename: "TeamNotificationSubscription" } & Pick<
   TeamNotificationSubscription,
-  "updatedAt" | "archivedAt" | "createdAt" | "notificationSubscriptionTypes" | "id" | "active"
+  | "updatedAt"
+  | "archivedAt"
+  | "createdAt"
+  | "notificationSubscriptionTypes"
+  | "userContextViewType"
+  | "contextViewType"
+  | "id"
+  | "active"
 > & {
     customView?: Maybe<{ __typename?: "CustomView" } & Pick<CustomView, "id">>;
     cycle?: Maybe<{ __typename?: "Cycle" } & Pick<Cycle, "id">>;
@@ -13139,7 +13174,7 @@ export type TeamNotificationSubscriptionFragment = { __typename: "TeamNotificati
 
 export type TriageResponsibilityFragment = { __typename: "TriageResponsibility" } & Pick<
   TriageResponsibility,
-  "updatedAt" | "archivedAt" | "createdAt" | "id"
+  "action" | "updatedAt" | "archivedAt" | "createdAt" | "id"
 > & {
     manualSelection?: Maybe<
       { __typename?: "TriageResponsibilityManualSelection" } & TriageResponsibilityManualSelectionFragment
@@ -13168,7 +13203,7 @@ export type TimeScheduleFragment = { __typename: "TimeSchedule" } & Pick<
 
 export type GitAutomationStateFragment = { __typename: "GitAutomationState" } & Pick<
   GitAutomationState,
-  "updatedAt" | "archivedAt" | "createdAt" | "id" | "branchPattern"
+  "event" | "updatedAt" | "archivedAt" | "createdAt" | "id" | "branchPattern"
 > & {
     state?: Maybe<{ __typename?: "WorkflowState" } & Pick<WorkflowState, "id">>;
     targetBranch?: Maybe<{ __typename?: "GitAutomationTargetBranch" } & GitAutomationTargetBranchFragment>;
@@ -13180,6 +13215,7 @@ export type ProjectUpdateFragment = { __typename: "ProjectUpdate" } & Pick<
   | "url"
   | "diffMarkdown"
   | "diff"
+  | "health"
   | "updatedAt"
   | "archivedAt"
   | "createdAt"
@@ -13196,7 +13232,14 @@ export type UserAccountFragment = { __typename: "UserAccount" } & Pick<
 
 export type UserNotificationSubscriptionFragment = { __typename: "UserNotificationSubscription" } & Pick<
   UserNotificationSubscription,
-  "updatedAt" | "archivedAt" | "createdAt" | "notificationSubscriptionTypes" | "id" | "active"
+  | "updatedAt"
+  | "archivedAt"
+  | "createdAt"
+  | "notificationSubscriptionTypes"
+  | "userContextViewType"
+  | "contextViewType"
+  | "id"
+  | "active"
 > & {
     customView?: Maybe<{ __typename?: "CustomView" } & Pick<CustomView, "id">>;
     cycle?: Maybe<{ __typename?: "Cycle" } & Pick<Cycle, "id">>;
@@ -13322,7 +13365,16 @@ export type AuthOrganizationInviteFragment = { __typename: "AuthOrganizationInvi
 
 export type OrganizationInviteFragment = { __typename: "OrganizationInvite" } & Pick<
   OrganizationInvite,
-  "metadata" | "external" | "email" | "updatedAt" | "archivedAt" | "createdAt" | "acceptedAt" | "expiresAt" | "id"
+  | "metadata"
+  | "external"
+  | "email"
+  | "updatedAt"
+  | "archivedAt"
+  | "createdAt"
+  | "acceptedAt"
+  | "expiresAt"
+  | "id"
+  | "role"
 > & {
     inviter: { __typename?: "User" } & Pick<User, "id">;
     invitee?: Maybe<{ __typename?: "User" } & Pick<User, "id">>;
@@ -13376,6 +13428,7 @@ export type IssueFragment = { __typename: "Issue" } & Pick<
   Issue,
   | "trashed"
   | "labelIds"
+  | "integrationSourceType"
   | "url"
   | "identifier"
   | "priorityLabel"
@@ -13439,6 +13492,9 @@ export type OrganizationFragment = { __typename: "Organization" } & Pick<
   | "createdIssueCount"
   | "previousUrlKeys"
   | "periodUploadVolume"
+  | "projectUpdateRemindersDay"
+  | "releaseChannel"
+  | "projectUpdatesReminderFrequency"
   | "projectUpdateRemindersHour"
   | "updatedAt"
   | "fiscalYearStartMonth"
@@ -13456,6 +13512,7 @@ export type OrganizationFragment = { __typename: "Organization" } & Pick<
   | "gitLinkbackMessagesEnabled"
   | "gitPublicLinkbackMessagesEnabled"
   | "roadmapEnabled"
+  | "slaDayCount"
 > & { subscription?: Maybe<{ __typename?: "PaidSubscription" } & PaidSubscriptionFragment> };
 
 export type AuthOrganizationFragment = { __typename: "AuthOrganization" } & Pick<
@@ -13463,6 +13520,7 @@ export type AuthOrganizationFragment = { __typename: "AuthOrganization" } & Pick
   | "allowedAuthServices"
   | "previousUrlKeys"
   | "serviceId"
+  | "releaseChannel"
   | "logoUrl"
   | "name"
   | "urlKey"
@@ -13558,6 +13616,7 @@ export type AuthenticationSessionResponseFragment = { __typename: "Authenticatio
   | "name"
   | "operatingSystem"
   | "userAgent"
+  | "type"
   | "browserType"
   | "lastActiveAt"
   | "id"
@@ -13575,7 +13634,7 @@ export type TeamMembershipFragment = { __typename: "TeamMembership" } & Pick<
 
 export type OrganizationDomainFragment = { __typename: "OrganizationDomain" } & Pick<
   OrganizationDomain,
-  "name" | "verificationEmail" | "verified" | "updatedAt" | "archivedAt" | "createdAt" | "id" | "claimed"
+  "name" | "verificationEmail" | "verified" | "updatedAt" | "archivedAt" | "createdAt" | "id" | "authType" | "claimed"
 > & { creator?: Maybe<{ __typename?: "User" } & Pick<User, "id">> };
 
 export type FrontSettingsFragment = { __typename: "FrontSettings" } & Pick<
@@ -13702,7 +13761,10 @@ export type GitLabSettingsFragment = { __typename: "GitLabSettings" } & Pick<
 
 type NotificationSubscription_CustomViewNotificationSubscription_Fragment = {
   __typename: "CustomViewNotificationSubscription";
-} & Pick<CustomViewNotificationSubscription, "updatedAt" | "archivedAt" | "createdAt" | "id" | "active"> & {
+} & Pick<
+  CustomViewNotificationSubscription,
+  "updatedAt" | "archivedAt" | "createdAt" | "userContextViewType" | "contextViewType" | "id" | "active"
+> & {
     customView: { __typename?: "CustomView" } & Pick<CustomView, "id">;
     cycle?: Maybe<{ __typename?: "Cycle" } & Pick<Cycle, "id">>;
     label?: Maybe<{ __typename?: "IssueLabel" } & Pick<IssueLabel, "id">>;
@@ -13714,7 +13776,10 @@ type NotificationSubscription_CustomViewNotificationSubscription_Fragment = {
 
 type NotificationSubscription_CycleNotificationSubscription_Fragment = {
   __typename: "CycleNotificationSubscription";
-} & Pick<CycleNotificationSubscription, "updatedAt" | "archivedAt" | "createdAt" | "id" | "active"> & {
+} & Pick<
+  CycleNotificationSubscription,
+  "updatedAt" | "archivedAt" | "createdAt" | "userContextViewType" | "contextViewType" | "id" | "active"
+> & {
     customView?: Maybe<{ __typename?: "CustomView" } & Pick<CustomView, "id">>;
     cycle: { __typename?: "Cycle" } & Pick<Cycle, "id">;
     label?: Maybe<{ __typename?: "IssueLabel" } & Pick<IssueLabel, "id">>;
@@ -13726,7 +13791,10 @@ type NotificationSubscription_CycleNotificationSubscription_Fragment = {
 
 type NotificationSubscription_LabelNotificationSubscription_Fragment = {
   __typename: "LabelNotificationSubscription";
-} & Pick<LabelNotificationSubscription, "updatedAt" | "archivedAt" | "createdAt" | "id" | "active"> & {
+} & Pick<
+  LabelNotificationSubscription,
+  "updatedAt" | "archivedAt" | "createdAt" | "userContextViewType" | "contextViewType" | "id" | "active"
+> & {
     customView?: Maybe<{ __typename?: "CustomView" } & Pick<CustomView, "id">>;
     cycle?: Maybe<{ __typename?: "Cycle" } & Pick<Cycle, "id">>;
     label: { __typename?: "IssueLabel" } & Pick<IssueLabel, "id">;
@@ -13738,7 +13806,10 @@ type NotificationSubscription_LabelNotificationSubscription_Fragment = {
 
 type NotificationSubscription_ProjectNotificationSubscription_Fragment = {
   __typename: "ProjectNotificationSubscription";
-} & Pick<ProjectNotificationSubscription, "updatedAt" | "archivedAt" | "createdAt" | "id" | "active"> & {
+} & Pick<
+  ProjectNotificationSubscription,
+  "updatedAt" | "archivedAt" | "createdAt" | "userContextViewType" | "contextViewType" | "id" | "active"
+> & {
     customView?: Maybe<{ __typename?: "CustomView" } & Pick<CustomView, "id">>;
     cycle?: Maybe<{ __typename?: "Cycle" } & Pick<Cycle, "id">>;
     label?: Maybe<{ __typename?: "IssueLabel" } & Pick<IssueLabel, "id">>;
@@ -13750,7 +13821,10 @@ type NotificationSubscription_ProjectNotificationSubscription_Fragment = {
 
 type NotificationSubscription_TeamNotificationSubscription_Fragment = {
   __typename: "TeamNotificationSubscription";
-} & Pick<TeamNotificationSubscription, "updatedAt" | "archivedAt" | "createdAt" | "id" | "active"> & {
+} & Pick<
+  TeamNotificationSubscription,
+  "updatedAt" | "archivedAt" | "createdAt" | "userContextViewType" | "contextViewType" | "id" | "active"
+> & {
     customView?: Maybe<{ __typename?: "CustomView" } & Pick<CustomView, "id">>;
     cycle?: Maybe<{ __typename?: "Cycle" } & Pick<Cycle, "id">>;
     label?: Maybe<{ __typename?: "IssueLabel" } & Pick<IssueLabel, "id">>;
@@ -13762,7 +13836,10 @@ type NotificationSubscription_TeamNotificationSubscription_Fragment = {
 
 type NotificationSubscription_UserNotificationSubscription_Fragment = {
   __typename: "UserNotificationSubscription";
-} & Pick<UserNotificationSubscription, "updatedAt" | "archivedAt" | "createdAt" | "id" | "active"> & {
+} & Pick<
+  UserNotificationSubscription,
+  "updatedAt" | "archivedAt" | "createdAt" | "userContextViewType" | "contextViewType" | "id" | "active"
+> & {
     customView?: Maybe<{ __typename?: "CustomView" } & Pick<CustomView, "id">>;
     cycle?: Maybe<{ __typename?: "Cycle" } & Pick<Cycle, "id">>;
     label?: Maybe<{ __typename?: "IssueLabel" } & Pick<IssueLabel, "id">>;
@@ -13867,6 +13944,7 @@ export type OauthClientApprovalFragment = { __typename: "OauthClientApproval" } 
   | "requestReason"
   | "denyReason"
   | "scopes"
+  | "status"
   | "archivedAt"
   | "createdAt"
   | "id"
@@ -13887,14 +13965,14 @@ export type SharedSlackSettingsFragment = { __typename: "SharedSlackSettings" } 
 
 export type SlackAsksSettingsFragment = { __typename: "SlackAsksSettings" } & Pick<
   SlackAsksSettings,
-  "enterpriseName" | "teamId" | "teamName" | "shouldUnfurl"
+  "enterpriseName" | "teamId" | "teamName" | "canAdministrate" | "shouldUnfurl"
 > & {
     slackChannelMapping?: Maybe<Array<{ __typename?: "SlackChannelNameMapping" } & SlackChannelNameMappingFragment>>;
   };
 
 export type SlackPostSettingsFragment = { __typename: "SlackPostSettings" } & Pick<
   SlackPostSettings,
-  "channel" | "channelId" | "configurationUrl"
+  "channel" | "channelId" | "channelType" | "configurationUrl"
 >;
 
 export type IntegrationsSettingsFragment = { __typename: "IntegrationsSettings" } & Pick<
@@ -13996,6 +14074,7 @@ export type AuthenticationSessionFragment = { __typename: "AuthenticationSession
   | "name"
   | "operatingSystem"
   | "userAgent"
+  | "type"
   | "browserType"
   | "lastActiveAt"
   | "id"
@@ -14003,7 +14082,15 @@ export type AuthenticationSessionFragment = { __typename: "AuthenticationSession
 
 export type FavoriteFragment = { __typename: "Favorite" } & Pick<
   Favorite,
-  "updatedAt" | "folderName" | "sortOrder" | "archivedAt" | "createdAt" | "predefinedViewType" | "type" | "id"
+  | "updatedAt"
+  | "folderName"
+  | "sortOrder"
+  | "projectTab"
+  | "archivedAt"
+  | "createdAt"
+  | "predefinedViewType"
+  | "type"
+  | "id"
 > & {
     customView?: Maybe<{ __typename?: "CustomView" } & Pick<CustomView, "id">>;
     cycle?: Maybe<{ __typename?: "Cycle" } & Pick<Cycle, "id">>;
@@ -14122,7 +14209,7 @@ export type AuthOauthClientWithTokensFragment = { __typename: "AuthOauthClientWi
 
 export type AuthOrganizationDomainFragment = { __typename: "AuthOrganizationDomain" } & Pick<
   AuthOrganizationDomain,
-  "id" | "claimed" | "name" | "organizationId" | "verified"
+  "id" | "authType" | "claimed" | "name" | "organizationId" | "verified"
 >;
 
 export type AuthResolverResponseFragment = { __typename: "AuthResolverResponse" } & Pick<
@@ -14437,6 +14524,7 @@ export type IssueSearchResultFragment = { __typename: "IssueSearchResult" } & Pi
   IssueSearchResult,
   | "trashed"
   | "labelIds"
+  | "integrationSourceType"
   | "url"
   | "identifier"
   | "priorityLabel"
@@ -14816,6 +14904,10 @@ export type OauthTokenFragment = { __typename: "OauthToken" } & Pick<
     client: { __typename?: "AuthOauthClient" } & AuthOauthClientFragment;
   };
 
+export type OrganizationAcceptedOrExpiredInviteDetailsPayloadFragment = {
+  __typename: "OrganizationAcceptedOrExpiredInviteDetailsPayload";
+} & Pick<OrganizationAcceptedOrExpiredInviteDetailsPayload, "status">;
+
 export type OrganizationCancelDeletePayloadFragment = { __typename: "OrganizationCancelDeletePayload" } & Pick<
   OrganizationCancelDeletePayload,
   "success"
@@ -14845,7 +14937,9 @@ export type OrganizationInviteFullDetailsPayloadFragment = {
   | "organizationName"
   | "email"
   | "inviter"
+  | "status"
   | "organizationLogoUrl"
+  | "role"
   | "createdAt"
   | "accepted"
   | "expired"
@@ -15218,9 +15312,14 @@ export type WorkflowDefinitionFragment = { __typename: "WorkflowDefinition" } & 
   | "updatedAt"
   | "groupName"
   | "name"
+  | "triggerType"
   | "sortOrder"
   | "archivedAt"
   | "createdAt"
+  | "trigger"
+  | "type"
+  | "userContextViewType"
+  | "contextViewType"
   | "id"
   | "enabled"
 > & {
@@ -19219,6 +19318,8 @@ export const CustomViewNotificationSubscriptionFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
           { kind: "Field", name: { kind: "Name", value: "notificationSubscriptionTypes" } },
+          { kind: "Field", name: { kind: "Name", value: "userContextViewType" } },
+          { kind: "Field", name: { kind: "Name", value: "contextViewType" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
           {
             kind: "Field",
@@ -19297,6 +19398,8 @@ export const CycleNotificationSubscriptionFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
           { kind: "Field", name: { kind: "Name", value: "notificationSubscriptionTypes" } },
+          { kind: "Field", name: { kind: "Name", value: "userContextViewType" } },
+          { kind: "Field", name: { kind: "Name", value: "contextViewType" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
           {
             kind: "Field",
@@ -19596,6 +19699,8 @@ export const NotificationSubscriptionFragmentDoc = {
           },
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "userContextViewType" } },
+          { kind: "Field", name: { kind: "Name", value: "contextViewType" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
           {
             kind: "Field",
@@ -19726,6 +19831,7 @@ export const OauthClientApprovalFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "requestReason" } },
           { kind: "Field", name: { kind: "Name", value: "denyReason" } },
           { kind: "Field", name: { kind: "Name", value: "scopes" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
@@ -20239,6 +20345,8 @@ export const LabelNotificationSubscriptionFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
           { kind: "Field", name: { kind: "Name", value: "notificationSubscriptionTypes" } },
+          { kind: "Field", name: { kind: "Name", value: "userContextViewType" } },
+          { kind: "Field", name: { kind: "Name", value: "contextViewType" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
           {
             kind: "Field",
@@ -20317,6 +20425,8 @@ export const ProjectNotificationSubscriptionFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
           { kind: "Field", name: { kind: "Name", value: "notificationSubscriptionTypes" } },
+          { kind: "Field", name: { kind: "Name", value: "userContextViewType" } },
+          { kind: "Field", name: { kind: "Name", value: "contextViewType" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
           {
             kind: "Field",
@@ -20395,6 +20505,8 @@ export const TeamNotificationSubscriptionFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
           { kind: "Field", name: { kind: "Name", value: "notificationSubscriptionTypes" } },
+          { kind: "Field", name: { kind: "Name", value: "userContextViewType" } },
+          { kind: "Field", name: { kind: "Name", value: "contextViewType" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
           {
             kind: "Field",
@@ -20497,6 +20609,8 @@ export const UserNotificationSubscriptionFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
           { kind: "Field", name: { kind: "Name", value: "notificationSubscriptionTypes" } },
+          { kind: "Field", name: { kind: "Name", value: "userContextViewType" } },
+          { kind: "Field", name: { kind: "Name", value: "contextViewType" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
           {
             kind: "Field",
@@ -20534,6 +20648,7 @@ export const AuthOrganizationFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "allowedAuthServices" } },
           { kind: "Field", name: { kind: "Name", value: "previousUrlKeys" } },
           { kind: "Field", name: { kind: "Name", value: "serviceId" } },
+          { kind: "Field", name: { kind: "Name", value: "releaseChannel" } },
           { kind: "Field", name: { kind: "Name", value: "logoUrl" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "urlKey" } },
@@ -20685,6 +20800,9 @@ export const OrganizationFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "createdIssueCount" } },
           { kind: "Field", name: { kind: "Name", value: "previousUrlKeys" } },
           { kind: "Field", name: { kind: "Name", value: "periodUploadVolume" } },
+          { kind: "Field", name: { kind: "Name", value: "projectUpdateRemindersDay" } },
+          { kind: "Field", name: { kind: "Name", value: "releaseChannel" } },
+          { kind: "Field", name: { kind: "Name", value: "projectUpdatesReminderFrequency" } },
           { kind: "Field", name: { kind: "Name", value: "projectUpdateRemindersHour" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           { kind: "Field", name: { kind: "Name", value: "fiscalYearStartMonth" } },
@@ -20710,6 +20828,7 @@ export const OrganizationFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "gitLinkbackMessagesEnabled" } },
           { kind: "Field", name: { kind: "Name", value: "gitPublicLinkbackMessagesEnabled" } },
           { kind: "Field", name: { kind: "Name", value: "roadmapEnabled" } },
+          { kind: "Field", name: { kind: "Name", value: "slaDayCount" } },
         ],
       },
     },
@@ -20784,6 +20903,7 @@ export const AuthenticationSessionResponseFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "operatingSystem" } },
           { kind: "Field", name: { kind: "Name", value: "userAgent" } },
+          { kind: "Field", name: { kind: "Name", value: "type" } },
           { kind: "Field", name: { kind: "Name", value: "browserType" } },
           { kind: "Field", name: { kind: "Name", value: "lastActiveAt" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
@@ -20818,6 +20938,7 @@ export const OrganizationDomainFragmentDoc = {
               selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
             },
           },
+          { kind: "Field", name: { kind: "Name", value: "authType" } },
           { kind: "Field", name: { kind: "Name", value: "claimed" } },
         ],
       },
@@ -21386,6 +21507,7 @@ export const SlackAsksSettingsFragmentDoc = {
               selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "SlackChannelNameMapping" } }],
             },
           },
+          { kind: "Field", name: { kind: "Name", value: "canAdministrate" } },
           { kind: "Field", name: { kind: "Name", value: "shouldUnfurl" } },
         ],
       },
@@ -21405,6 +21527,7 @@ export const SlackPostSettingsFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "channel" } },
           { kind: "Field", name: { kind: "Name", value: "channelId" } },
+          { kind: "Field", name: { kind: "Name", value: "channelType" } },
           { kind: "Field", name: { kind: "Name", value: "configurationUrl" } },
         ],
       },
@@ -21655,6 +21778,7 @@ export const AuthenticationSessionFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "operatingSystem" } },
           { kind: "Field", name: { kind: "Name", value: "userAgent" } },
+          { kind: "Field", name: { kind: "Name", value: "type" } },
           { kind: "Field", name: { kind: "Name", value: "browserType" } },
           { kind: "Field", name: { kind: "Name", value: "lastActiveAt" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
@@ -22177,6 +22301,7 @@ export const AuthOrganizationDomainFragmentDoc = {
         selections: [
           { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "authType" } },
           { kind: "Field", name: { kind: "Name", value: "claimed" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
           { kind: "Field", name: { kind: "Name", value: "organizationId" } },
@@ -23480,6 +23605,7 @@ export const FavoriteFragmentDoc = {
               selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
             },
           },
+          { kind: "Field", name: { kind: "Name", value: "projectTab" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "predefinedViewTeam" },
@@ -23623,6 +23749,7 @@ export const GitAutomationStateFragmentDoc = {
               selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
             },
           },
+          { kind: "Field", name: { kind: "Name", value: "event" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           {
             kind: "Field",
@@ -24121,6 +24248,7 @@ export const IssueFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "trashed" } },
           { kind: "Field", name: { kind: "Name", value: "labelIds" } },
+          { kind: "Field", name: { kind: "Name", value: "integrationSourceType" } },
           { kind: "Field", name: { kind: "Name", value: "url" } },
           { kind: "Field", name: { kind: "Name", value: "identifier" } },
           { kind: "Field", name: { kind: "Name", value: "priorityLabel" } },
@@ -24964,6 +25092,7 @@ export const IssueSearchResultFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "__typename" } },
           { kind: "Field", name: { kind: "Name", value: "trashed" } },
           { kind: "Field", name: { kind: "Name", value: "labelIds" } },
+          { kind: "Field", name: { kind: "Name", value: "integrationSourceType" } },
           { kind: "Field", name: { kind: "Name", value: "url" } },
           { kind: "Field", name: { kind: "Name", value: "identifier" } },
           { kind: "Field", name: { kind: "Name", value: "priorityLabel" } },
@@ -25430,6 +25559,26 @@ export const OauthClientConnectionFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<OauthClientConnectionFragment, unknown>;
+export const OrganizationAcceptedOrExpiredInviteDetailsPayloadFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "OrganizationAcceptedOrExpiredInviteDetailsPayload" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "OrganizationAcceptedOrExpiredInviteDetailsPayload" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<OrganizationAcceptedOrExpiredInviteDetailsPayloadFragment, unknown>;
 export const OrganizationCancelDeletePayloadFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -25502,6 +25651,7 @@ export const OrganizationInviteFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "acceptedAt" } },
           { kind: "Field", name: { kind: "Name", value: "expiresAt" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "role" } },
           {
             kind: "Field",
             name: { kind: "Name", value: "inviter" },
@@ -25571,7 +25721,9 @@ export const OrganizationInviteFullDetailsPayloadFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "organizationName" } },
           { kind: "Field", name: { kind: "Name", value: "email" } },
           { kind: "Field", name: { kind: "Name", value: "inviter" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
           { kind: "Field", name: { kind: "Name", value: "organizationLogoUrl" } },
+          { kind: "Field", name: { kind: "Name", value: "role" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
           { kind: "Field", name: { kind: "Name", value: "accepted" } },
           { kind: "Field", name: { kind: "Name", value: "expired" } },
@@ -26221,6 +26373,7 @@ export const ProjectUpdateFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "url" } },
           { kind: "Field", name: { kind: "Name", value: "diffMarkdown" } },
           { kind: "Field", name: { kind: "Name", value: "diff" } },
+          { kind: "Field", name: { kind: "Name", value: "health" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           {
             kind: "Field",
@@ -27566,6 +27719,7 @@ export const TriageResponsibilityFragmentDoc = {
               ],
             },
           },
+          { kind: "Field", name: { kind: "Name", value: "action" } },
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           {
             kind: "Field",
@@ -28180,6 +28334,7 @@ export const WorkflowDefinitionFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
           { kind: "Field", name: { kind: "Name", value: "groupName" } },
           { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "triggerType" } },
           { kind: "Field", name: { kind: "Name", value: "sortOrder" } },
           {
             kind: "Field",
@@ -28191,6 +28346,10 @@ export const WorkflowDefinitionFragmentDoc = {
           },
           { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "trigger" } },
+          { kind: "Field", name: { kind: "Name", value: "type" } },
+          { kind: "Field", name: { kind: "Name", value: "userContextViewType" } },
+          { kind: "Field", name: { kind: "Name", value: "contextViewType" } },
           { kind: "Field", name: { kind: "Name", value: "id" } },
           {
             kind: "Field",

--- a/packages/sdk/src/_generated_sdk.ts
+++ b/packages/sdk/src/_generated_sdk.ts
@@ -893,6 +893,7 @@ export class AuthOrganization extends Request {
     this.serviceId = data.serviceId;
     this.urlKey = data.urlKey;
     this.userCount = data.userCount;
+    this.releaseChannel = data.releaseChannel;
   }
 
   /** Allowed authentication providers, empty array means all are allowed */
@@ -918,6 +919,8 @@ export class AuthOrganization extends Request {
   /** The organization's unique URL key. */
   public urlKey: string;
   public userCount: number;
+  /** The feature release channel the organization belongs to. */
+  public releaseChannel: L.ReleaseChannel;
 }
 /**
  * AuthOrganizationDomain model
@@ -933,6 +936,7 @@ export class AuthOrganizationDomain extends Request {
     this.name = data.name;
     this.organizationId = data.organizationId;
     this.verified = data.verified;
+    this.authType = data.authType;
   }
 
   public claimed?: boolean;
@@ -941,6 +945,7 @@ export class AuthOrganizationDomain extends Request {
   public name: string;
   public organizationId: string;
   public verified: boolean;
+  public authType: L.OrganizationDomainAuthType;
 }
 /**
  * An invitation to the organization that has been sent via email.
@@ -1074,6 +1079,7 @@ export class AuthenticationSession extends Request {
     this.operatingSystem = data.operatingSystem ?? undefined;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
     this.userAgent = data.userAgent ?? undefined;
+    this.type = data.type;
   }
 
   /** Used web browser. */
@@ -1105,6 +1111,8 @@ export class AuthenticationSession extends Request {
   public updatedAt: Date;
   /** Session's user-agent. */
   public userAgent?: string;
+  /** Type of application used to authenticate. */
+  public type: L.AuthenticationSessionType;
 }
 /**
  * Authentication session information.
@@ -1131,6 +1139,7 @@ export class AuthenticationSessionResponse extends Request {
     this.operatingSystem = data.operatingSystem ?? undefined;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
     this.userAgent = data.userAgent ?? undefined;
+    this.type = data.type;
   }
 
   /** Used web browser. */
@@ -1164,6 +1173,8 @@ export class AuthenticationSessionResponse extends Request {
   public updatedAt: Date;
   /** Session's user-agent. */
   public userAgent?: string;
+  /** Type of application used to authenticate. */
+  public type: L.AuthenticationSessionType;
 }
 /**
  * AuthorizedApplicationBase model
@@ -1631,6 +1642,8 @@ export class CustomViewNotificationSubscription extends Request {
     this.id = data.id;
     this.notificationSubscriptionTypes = data.notificationSubscriptionTypes;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
+    this.contextViewType = data.contextViewType ?? undefined;
+    this.userContextViewType = data.userContextViewType ?? undefined;
     this._customView = data.customView;
     this._cycle = data.cycle ?? undefined;
     this._label = data.label ?? undefined;
@@ -1656,6 +1669,10 @@ export class CustomViewNotificationSubscription extends Request {
    *     been updated after creation.
    */
   public updatedAt: Date;
+  /** The type of view to which the notification subscription context is associated with. */
+  public contextViewType?: L.ContextViewType;
+  /** The type of user view to which the notification subscription context is associated with. */
+  public userContextViewType?: L.UserContextViewType;
   /** The custom view subscribed to. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return new CustomViewQuery(this._request).fetch(this._customView.id);
@@ -1894,6 +1911,8 @@ export class CycleNotificationSubscription extends Request {
     this.id = data.id;
     this.notificationSubscriptionTypes = data.notificationSubscriptionTypes;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
+    this.contextViewType = data.contextViewType ?? undefined;
+    this.userContextViewType = data.userContextViewType ?? undefined;
     this._customView = data.customView ?? undefined;
     this._cycle = data.cycle;
     this._label = data.label ?? undefined;
@@ -1919,6 +1938,10 @@ export class CycleNotificationSubscription extends Request {
    *     been updated after creation.
    */
   public updatedAt: Date;
+  /** The type of view to which the notification subscription context is associated with. */
+  public contextViewType?: L.ContextViewType;
+  /** The type of user view to which the notification subscription context is associated with. */
+  public userContextViewType?: L.UserContextViewType;
   /** The contextual custom view associated with the notification subscription. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return this._customView?.id ? new CustomViewQuery(this._request).fetch(this._customView?.id) : undefined;
@@ -2747,6 +2770,7 @@ export class Favorite extends Request {
     this.sortOrder = data.sortOrder;
     this.type = data.type;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
+    this.projectTab = data.projectTab ?? undefined;
     this._customView = data.customView ?? undefined;
     this._cycle = data.cycle ?? undefined;
     this._document = data.document ?? undefined;
@@ -2781,6 +2805,8 @@ export class Favorite extends Request {
    *     been updated after creation.
    */
   public updatedAt: Date;
+  /** The targeted tab of the project. */
+  public projectTab?: L.ProjectTab;
   /** The favorited custom view. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return this._customView?.id ? new CustomViewQuery(this._request).fetch(this._customView?.id) : undefined;
@@ -2955,6 +2981,7 @@ export class GitAutomationState extends Request {
     this.id = data.id;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
     this.targetBranch = data.targetBranch ? new GitAutomationTargetBranch(request, data.targetBranch) : undefined;
+    this.event = data.event;
     this._state = data.state ?? undefined;
     this._team = data.team;
   }
@@ -2975,6 +3002,8 @@ export class GitAutomationState extends Request {
   public updatedAt: Date;
   /** The target branch associated to this automation state. */
   public targetBranch?: GitAutomationTargetBranch;
+  /** The event that triggers the automation. */
+  public event: L.GitAutomationStates;
   /** The associated workflow state. */
   public get state(): LinearFetch<WorkflowState> | undefined {
     return this._state?.id ? new WorkflowStateQuery(this._request).fetch(this._state?.id) : undefined;
@@ -3832,6 +3861,7 @@ export class Issue extends Request {
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
     this.url = data.url;
     this.botActor = data.botActor ? new ActorBot(request, data.botActor) : undefined;
+    this.integrationSourceType = data.integrationSourceType ?? undefined;
     this._assignee = data.assignee ?? undefined;
     this._creator = data.creator ?? undefined;
     this._cycle = data.cycle ?? undefined;
@@ -3911,6 +3941,8 @@ export class Issue extends Request {
   public url: string;
   /** The bot that created the issue, if applicable. */
   public botActor?: ActorBot;
+  /** Integration type that created this issue, if applicable. */
+  public integrationSourceType?: L.IntegrationService;
   /** The user to whom the issue is assigned to. */
   public get assignee(): LinearFetch<User> | undefined {
     return this._assignee?.id ? new UserQuery(this._request).fetch(this._assignee?.id) : undefined;
@@ -4942,6 +4974,7 @@ export class IssueSearchResult extends Request {
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
     this.url = data.url;
     this.botActor = data.botActor ? new ActorBot(request, data.botActor) : undefined;
+    this.integrationSourceType = data.integrationSourceType ?? undefined;
     this._assignee = data.assignee ?? undefined;
     this._creator = data.creator ?? undefined;
     this._cycle = data.cycle ?? undefined;
@@ -5023,6 +5056,8 @@ export class IssueSearchResult extends Request {
   public url: string;
   /** The bot that created the issue, if applicable. */
   public botActor?: ActorBot;
+  /** Integration type that created this issue, if applicable. */
+  public integrationSourceType?: L.IntegrationService;
   /** The user to whom the issue is assigned to. */
   public get assignee(): LinearFetch<User> | undefined {
     return this._assignee?.id ? new UserQuery(this._request).fetch(this._assignee?.id) : undefined;
@@ -5209,6 +5244,8 @@ export class LabelNotificationSubscription extends Request {
     this.id = data.id;
     this.notificationSubscriptionTypes = data.notificationSubscriptionTypes;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
+    this.contextViewType = data.contextViewType ?? undefined;
+    this.userContextViewType = data.userContextViewType ?? undefined;
     this._customView = data.customView ?? undefined;
     this._cycle = data.cycle ?? undefined;
     this._label = data.label;
@@ -5234,6 +5271,10 @@ export class LabelNotificationSubscription extends Request {
    *     been updated after creation.
    */
   public updatedAt: Date;
+  /** The type of view to which the notification subscription context is associated with. */
+  public contextViewType?: L.ContextViewType;
+  /** The type of user view to which the notification subscription context is associated with. */
+  public userContextViewType?: L.UserContextViewType;
   /** The contextual custom view associated with the notification subscription. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return this._customView?.id ? new CustomViewQuery(this._request).fetch(this._customView?.id) : undefined;
@@ -5495,6 +5536,8 @@ export class NotificationSubscription extends Request {
     this.createdAt = parseDate(data.createdAt) ?? new Date();
     this.id = data.id;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
+    this.contextViewType = data.contextViewType ?? undefined;
+    this.userContextViewType = data.userContextViewType ?? undefined;
     this._customView = data.customView ?? undefined;
     this._cycle = data.cycle ?? undefined;
     this._label = data.label ?? undefined;
@@ -5518,6 +5561,10 @@ export class NotificationSubscription extends Request {
    *     been updated after creation.
    */
   public updatedAt: Date;
+  /** The type of view to which the notification subscription context is associated with. */
+  public contextViewType?: L.ContextViewType;
+  /** The type of user view to which the notification subscription context is associated with. */
+  public userContextViewType?: L.UserContextViewType;
   /** The contextual custom view associated with the notification subscription. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return this._customView?.id ? new CustomViewQuery(this._request).fetch(this._customView?.id) : undefined;
@@ -5753,6 +5800,7 @@ export class OauthClientApproval extends Request {
     this.responderId = data.responderId ?? undefined;
     this.scopes = data.scopes;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
+    this.status = data.status;
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
@@ -5779,6 +5827,8 @@ export class OauthClientApproval extends Request {
    *     been updated after creation.
    */
   public updatedAt: Date;
+  /** The status for the OAuth client approval request. */
+  public status: L.OAuthClientApprovalStatus;
 }
 /**
  * An oauth client approval related notification.
@@ -5951,6 +6001,10 @@ export class Organization extends Request {
     this.urlKey = data.urlKey;
     this.userCount = data.userCount;
     this.subscription = data.subscription ? new PaidSubscription(request, data.subscription) : undefined;
+    this.projectUpdateRemindersDay = data.projectUpdateRemindersDay;
+    this.projectUpdatesReminderFrequency = data.projectUpdatesReminderFrequency;
+    this.releaseChannel = data.releaseChannel;
+    this.slaDayCount = data.slaDayCount;
   }
 
   /** Whether member users are allowed to send invites. */
@@ -6005,6 +6059,14 @@ export class Organization extends Request {
   public userCount: number;
   /** The organization's subscription to a paid plan. */
   public subscription?: PaidSubscription;
+  /** The day at which to prompt for project updates. */
+  public projectUpdateRemindersDay: L.Day;
+  /** The frequency at which to prompt for project updates. */
+  public projectUpdatesReminderFrequency: L.ProjectUpdateReminderFrequency;
+  /** The feature release channel the organization belongs to. */
+  public releaseChannel: L.ReleaseChannel;
+  /** Which day count to use for SLA calculations. */
+  public slaDayCount: L.SLADayCountType;
 
   /** Integrations associated with the organization. */
   public integrations(variables?: L.Organization_IntegrationsQueryVariables) {
@@ -6034,6 +6096,21 @@ export class Organization extends Request {
   public update(input: L.OrganizationUpdateInput) {
     return new UpdateOrganizationMutation(this._request).fetch(input);
   }
+}
+/**
+ * OrganizationAcceptedOrExpiredInviteDetailsPayload model
+ *
+ * @param request - function to call the graphql client
+ * @param data - L.OrganizationAcceptedOrExpiredInviteDetailsPayloadFragment response data
+ */
+export class OrganizationAcceptedOrExpiredInviteDetailsPayload extends Request {
+  public constructor(request: LinearRequest, data: L.OrganizationAcceptedOrExpiredInviteDetailsPayloadFragment) {
+    super(request);
+    this.status = data.status;
+  }
+
+  /** The status of the invite. */
+  public status: L.OrganizationInviteStatus;
 }
 /**
  * OrganizationCancelDeletePayload model
@@ -6084,6 +6161,7 @@ export class OrganizationDomain extends Request {
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
     this.verificationEmail = data.verificationEmail ?? undefined;
     this.verified = data.verified;
+    this.authType = data.authType;
     this._creator = data.creator ?? undefined;
   }
 
@@ -6107,6 +6185,8 @@ export class OrganizationDomain extends Request {
   public verificationEmail?: string;
   /** Is this domain verified. */
   public verified: boolean;
+  /** What type of auth is the domain used for. */
+  public authType: L.OrganizationDomainAuthType;
   /** The user who added the domain. */
   public get creator(): LinearFetch<User> | undefined {
     return this._creator?.id ? new UserQuery(this._request).fetch(this._creator?.id) : undefined;
@@ -6156,6 +6236,7 @@ export class OrganizationInvite extends Request {
     this.id = data.id;
     this.metadata = data.metadata;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
+    this.role = data.role;
     this._invitee = data.invitee ?? undefined;
     this._inviter = data.inviter;
   }
@@ -6182,6 +6263,8 @@ export class OrganizationInvite extends Request {
    *     been updated after creation.
    */
   public updatedAt: Date;
+  /** The user role that the invitee will receive upon accepting the invite. */
+  public role: L.UserRoleType;
   /** The user who has accepted the invite. Null, if the invite hasn't been accepted. */
   public get invitee(): LinearFetch<User> | undefined {
     return this._invitee?.id ? new UserQuery(this._request).fetch(this._invitee?.id) : undefined;
@@ -6247,6 +6330,8 @@ export class OrganizationInviteFullDetailsPayload extends Request {
     this.organizationId = data.organizationId;
     this.organizationLogoUrl = data.organizationLogoUrl ?? undefined;
     this.organizationName = data.organizationName;
+    this.role = data.role;
+    this.status = data.status;
   }
 
   /** Whether the invite has already been accepted. */
@@ -6267,6 +6352,10 @@ export class OrganizationInviteFullDetailsPayload extends Request {
   public organizationLogoUrl?: string;
   /** Name of the workspace the invite is for. */
   public organizationName: string;
+  /** What user role the invite should grant. */
+  public role: L.UserRoleType;
+  /** The status of the invite. */
+  public status: L.OrganizationInviteStatus;
 }
 /**
  * OrganizationInviteLinkDetailsPayload model
@@ -7062,6 +7151,8 @@ export class ProjectNotificationSubscription extends Request {
     this.id = data.id;
     this.notificationSubscriptionTypes = data.notificationSubscriptionTypes;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
+    this.contextViewType = data.contextViewType ?? undefined;
+    this.userContextViewType = data.userContextViewType ?? undefined;
     this._customView = data.customView ?? undefined;
     this._cycle = data.cycle ?? undefined;
     this._label = data.label ?? undefined;
@@ -7087,6 +7178,10 @@ export class ProjectNotificationSubscription extends Request {
    *     been updated after creation.
    */
   public updatedAt: Date;
+  /** The type of view to which the notification subscription context is associated with. */
+  public contextViewType?: L.ContextViewType;
+  /** The type of user view to which the notification subscription context is associated with. */
+  public userContextViewType?: L.UserContextViewType;
   /** The contextual custom view associated with the notification subscription. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return this._customView?.id ? new CustomViewQuery(this._request).fetch(this._customView?.id) : undefined;
@@ -7359,6 +7454,7 @@ export class ProjectUpdate extends Request {
     this.isDiffHidden = data.isDiffHidden;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
     this.url = data.url;
+    this.health = data.health;
     this._project = data.project;
     this._user = data.user;
   }
@@ -7387,6 +7483,8 @@ export class ProjectUpdate extends Request {
   public updatedAt: Date;
   /** The URL to the project update. */
   public url: string;
+  /** The health of the project at the time of the update. */
+  public health: L.ProjectUpdateHealthType;
   /** The project that the update is associated with. */
   public get project(): LinearFetch<Project> | undefined {
     return new ProjectQuery(this._request).fetch(this._project.id);
@@ -8164,6 +8262,7 @@ export class SlackAsksSettings extends Request {
     this.slackChannelMapping = data.slackChannelMapping
       ? data.slackChannelMapping.map(node => new SlackChannelNameMapping(request, node))
       : undefined;
+    this.canAdministrate = data.canAdministrate;
   }
 
   /** Enterprise name of the connected Slack enterprise */
@@ -8176,6 +8275,8 @@ export class SlackAsksSettings extends Request {
   public teamName?: string;
   /** The mapping of Slack channel ID => Slack channel name for connected channels. */
   public slackChannelMapping?: SlackChannelNameMapping[];
+  /** The user role type that is allowed to manage Asks settings. */
+  public canAdministrate: L.UserRoleType;
 }
 /**
  * Tuple for mapping Slack channel IDs to names.
@@ -8283,11 +8384,13 @@ export class SlackPostSettings extends Request {
     this.channel = data.channel;
     this.channelId = data.channelId;
     this.configurationUrl = data.configurationUrl;
+    this.channelType = data.channelType ?? undefined;
   }
 
   public channel: string;
   public channelId: string;
   public configurationUrl: string;
+  public channelType?: L.SlackChannelType;
 }
 /**
  * Settings for the regular Slack integration.
@@ -8840,6 +8943,8 @@ export class TeamNotificationSubscription extends Request {
     this.id = data.id;
     this.notificationSubscriptionTypes = data.notificationSubscriptionTypes;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
+    this.contextViewType = data.contextViewType ?? undefined;
+    this.userContextViewType = data.userContextViewType ?? undefined;
     this._customView = data.customView ?? undefined;
     this._cycle = data.cycle ?? undefined;
     this._label = data.label ?? undefined;
@@ -8865,6 +8970,10 @@ export class TeamNotificationSubscription extends Request {
    *     been updated after creation.
    */
   public updatedAt: Date;
+  /** The type of view to which the notification subscription context is associated with. */
+  public contextViewType?: L.ContextViewType;
+  /** The type of user view to which the notification subscription context is associated with. */
+  public userContextViewType?: L.UserContextViewType;
   /** The contextual custom view associated with the notification subscription. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return this._customView?.id ? new CustomViewQuery(this._request).fetch(this._customView?.id) : undefined;
@@ -9198,6 +9307,7 @@ export class TriageResponsibility extends Request {
     this.manualSelection = data.manualSelection
       ? new TriageResponsibilityManualSelection(request, data.manualSelection)
       : undefined;
+    this.action = data.action;
     this._currentUser = data.currentUser ?? undefined;
     this._team = data.team;
   }
@@ -9216,6 +9326,8 @@ export class TriageResponsibility extends Request {
   public updatedAt: Date;
   /** Set of users used for triage responsibility. */
   public manualSelection?: TriageResponsibilityManualSelection;
+  /** The action to take when an issue is added to triage. */
+  public action: L.TriageResponsibilityAction;
   /** The user currently responsible for triage. */
   public get currentUser(): LinearFetch<User> | undefined {
     return this._currentUser?.id ? new UserQuery(this._request).fetch(this._currentUser?.id) : undefined;
@@ -9606,6 +9718,8 @@ export class UserNotificationSubscription extends Request {
     this.id = data.id;
     this.notificationSubscriptionTypes = data.notificationSubscriptionTypes;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
+    this.contextViewType = data.contextViewType ?? undefined;
+    this.userContextViewType = data.userContextViewType ?? undefined;
     this._customView = data.customView ?? undefined;
     this._cycle = data.cycle ?? undefined;
     this._label = data.label ?? undefined;
@@ -9631,6 +9745,10 @@ export class UserNotificationSubscription extends Request {
    *     been updated after creation.
    */
   public updatedAt: Date;
+  /** The type of view to which the notification subscription context is associated with. */
+  public contextViewType?: L.ContextViewType;
+  /** The type of user view to which the notification subscription context is associated with. */
+  public userContextViewType?: L.UserContextViewType;
   /** The contextual custom view associated with the notification subscription. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return this._customView?.id ? new CustomViewQuery(this._request).fetch(this._customView?.id) : undefined;
@@ -10111,6 +10229,11 @@ export class WorkflowDefinition extends Request {
     this.name = data.name;
     this.sortOrder = data.sortOrder;
     this.updatedAt = parseDate(data.updatedAt) ?? new Date();
+    this.contextViewType = data.contextViewType ?? undefined;
+    this.trigger = data.trigger;
+    this.triggerType = data.triggerType;
+    this.type = data.type;
+    this.userContextViewType = data.userContextViewType ?? undefined;
     this._creator = data.creator;
     this._customView = data.customView ?? undefined;
     this._cycle = data.cycle ?? undefined;
@@ -10145,6 +10268,16 @@ export class WorkflowDefinition extends Request {
    *     been updated after creation.
    */
   public updatedAt: Date;
+  /** The type of view to which this workflow's context is associated with. */
+  public contextViewType?: L.ContextViewType;
+  /** The type of the event that triggers off the workflow. */
+  public trigger: L.WorkflowTrigger;
+  /** The object type (e.g. Issue) that triggers this workflow. */
+  public triggerType: L.WorkflowTriggerType;
+  /** The type of the workflow. */
+  public type: L.WorkflowType;
+  /** The type of user view to which this workflow's context is associated with. */
+  public userContextViewType?: L.UserContextViewType;
   /** The user who created the workflow. */
   public get creator(): LinearFetch<User> | undefined {
     return new UserQuery(this._request).fetch(this._creator.id);


### PR DESCRIPTION
This PR adds support for enum types in the SDK generator.

Tried locally with a new build of the SDK to create and read `health` on `ProjectUpdate`. 

Resolves #500