### PR TITLE
fix: map DateTimeOrDuration scalar to string | Date type

### DIFF
--- a/.changeset/little-pots-flow.md
+++ b/.changeset/little-pots-flow.md
@@ -1,0 +1,6 @@
+---
+"@linear/codegen-doc": minor
+"@linear/sdk": minor
+---
+
+fix: map DateTimeOrDuration scalar to string | Date type

--- a/packages/codegen-doc/src/constants.ts
+++ b/packages/codegen-doc/src/constants.ts
@@ -18,4 +18,6 @@ export const Doc = {
   SCALAR_DATE_TYPE: "Date",
   SCALAR_JSON_NAMES: ["JSON"],
   SCALAR_JSON_TYPE: "Record<string, unknown>",
+  SCALAR_DATE_OR_STRING_NAMES: ["DateTimeOrDuration"],
+  SCALAR_DATE_OR_STRING_TYPE: "Date | string",
 };

--- a/packages/codegen-doc/src/scalar.ts
+++ b/packages/codegen-doc/src/scalar.ts
@@ -20,6 +20,8 @@ export function printTypescriptScalar(name: string, namespace?: string): string 
       return Doc.SCALAR_DATE_TYPE;
     } else if (Doc.SCALAR_JSON_NAMES.includes(name)) {
       return Doc.SCALAR_JSON_TYPE;
+    } else if (Doc.SCALAR_DATE_OR_STRING_NAMES.includes(name)) {
+      return Doc.SCALAR_DATE_OR_STRING_TYPE;
     } else {
       return `${printList([namespace, "Scalars"], ".")}['${name}']`;
     }

--- a/packages/sdk/scripts/update-scalars.ts
+++ b/packages/sdk/scripts/update-scalars.ts
@@ -5,7 +5,7 @@ function updateScalars() {
   try {
     const results = replaceInFileSync({
       files: "src/_generated_documents.ts",
-      from: [...Doc.SCALAR_STRING_NAMES, ...Doc.SCALAR_DATE_NAMES, ...Doc.SCALAR_JSON_NAMES].map(
+      from: [...Doc.SCALAR_STRING_NAMES, ...Doc.SCALAR_DATE_NAMES, ...Doc.SCALAR_JSON_NAMES, ...Doc.SCALAR_DATE_OR_STRING_NAMES].map(
         name => `${name}: any`
       ),
       to: match => {
@@ -17,6 +17,8 @@ function updateScalars() {
           return `${name}: ${Doc.SCALAR_DATE_TYPE}`;
         } else if (Doc.SCALAR_JSON_NAMES.includes(name)) {
           return `${name}: ${Doc.SCALAR_JSON_TYPE}`;
+        } else if (Doc.SCALAR_DATE_OR_STRING_NAMES.includes(name)) {
+          return `${name}: ${Doc.SCALAR_DATE_OR_STRING_TYPE}`;
         } else {
           return match;
         }

--- a/packages/sdk/src/_generated_documents.ts
+++ b/packages/sdk/src/_generated_documents.ts
@@ -13,7 +13,7 @@ export type Scalars = {
   /** Represents a date and time in ISO 8601 format. Accepts shortcuts like `2021` to represent midnight Fri Jan 01 2021. Also accepts ISO 8601 durations strings which are added to the current date to create the represented date (e.g '-P2W1D' represents the date that was two weeks and 1 day ago) */
   DateTime: Date;
   /** Represents a date and time in ISO 8601 format. Accepts shortcuts like `2021` to represent midnight Fri Jan 01 2021. Also accepts ISO 8601 durations strings which are added to the current date to create the represented date (e.g '-P2W1D' represents the date that was two weeks and 1 day ago) */
-  DateTimeOrDuration: any;
+  DateTimeOrDuration: Date | string;
   /** The `JSON` scalar type represents arbitrary values as *stringified* JSON */
   JSON: Record<string, unknown>;
   /** The `JSONObject` scalar type represents arbitrary values as *embedded* JSON */


### PR DESCRIPTION
This will allow breaking change from 21.0.0 to be a drop-in replacement instead.