### PR TITLE
fix: strip leading single quotes from Linear CSVs before importing

### DIFF
--- a/.changeset/many-yaks-hammer.md
+++ b/.changeset/many-yaks-hammer.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": minor
+---
+
+fix: strip leading single quotes from Linear CSVs before importing

--- a/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
+++ b/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
@@ -72,8 +72,8 @@ export class LinearCsvImporter implements Importer {
       const labels = tags.filter(tag => !!tag);
 
       importData.issues.push({
-        title: row.Title,
-        description: row.Description,
+        title: stripLeadingSingleQuote(row.Title),
+        description: stripLeadingSingleQuote(row.Description),
         priority: mapPriority(row.Priority),
         status: row.Status,
         assigneeId: row.Assignee,
@@ -97,6 +97,12 @@ export class LinearCsvImporter implements Importer {
   // -- Private interface
 
   private filePath: string;
+}
+
+// Linear CSV exports add a single quote to the beginning of text fields when that field could otherwise be interpreted
+// as a formula. When we're sending the data to the API, we need to strip that leading single quote.
+function stripLeadingSingleQuote(input: string): string {
+  return input.replace(/^'([+\-=@])/, "$1");
 }
 
 const mapPriority = (input: LinearPriority): number => {


### PR DESCRIPTION
We add these so that spreadsheets don't treat the value as a formula, but if we don't remove them before importing, then the created issue will be broken.