### PR TITLE
fix(import): ensure that Markdown images are on their own line

### DIFF
--- a/.changeset/beige-shoes-pump.md
+++ b/.changeset/beige-shoes-pump.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": patch
+---
+
+fix(import): ensure that Markdown images are on their own line

--- a/packages/import/src/utils/replaceImages.ts
+++ b/packages/import/src/utils/replaceImages.ts
@@ -29,7 +29,7 @@ export const replaceImagesInMarkdown = async (
     const title = args[0];
     const url = args[1];
     const uploadedUrl = await replaceImageUrl(client, url + effectiveURLSuffix);
-    return `![${title}](${uploadedUrl})`;
+    return `\n![${title}](${uploadedUrl})\n`;
   });
 
   // HTML tags


### PR DESCRIPTION
They already will be in a real Linear export, but we can also handle this directly when replacing image URLs. Consecutive newlines should be collapsed anyway, so this works for the already-on-its-own-line case too.