### PR TITLE
feat: add support for `completedAt` date in CLI importer

### DIFF
--- a/.changeset/loud-bobcats-grab.md
+++ b/.changeset/loud-bobcats-grab.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": major
+---
+
+feat: add support for `completedAt` date in CLI importer

--- a/packages/codegen-doc/src/print.ts
+++ b/packages/codegen-doc/src/print.ts
@@ -137,7 +137,7 @@ export function printPascal(str?: string): string {
  * Print a ternary expression if the _if arg is defined, otherwise print the _then
  */
 export function printTernary(_if?: string, _then?: string, _else = "undefined"): string {
-  return _if ? `${_if} ? ${_then} : ${_else}` : _then ?? "";
+  return _if ? `${_if} ? ${_then} : ${_else}` : (_then ?? "");
 }
 
 /**

--- a/packages/codegen-doc/src/types.ts
+++ b/packages/codegen-doc/src/types.ts
@@ -5,7 +5,7 @@ import {
   GraphQLSchema,
   InterfaceTypeDefinitionNode,
   ObjectTypeDefinitionNode,
-  EnumTypeDefinitionNode
+  EnumTypeDefinitionNode,
 } from "graphql";
 
 /**

--- a/packages/codegen-doc/src/utils.ts
+++ b/packages/codegen-doc/src/utils.ts
@@ -19,14 +19,14 @@ export function reduceTypeName(type: string | NameNode | NonNullTypeNode | Named
   return typeof type === "string"
     ? type
     : type.kind === Kind.NON_NULL_TYPE
-    ? reduceTypeName(type.type)
-    : type.kind === Kind.NAMED_TYPE
-    ? reduceTypeName(type.name)
-    : type.kind === Kind.NAME
-    ? reduceTypeName(type.value)
-    : type.kind === Kind.LIST_TYPE
-    ? reduceTypeName(type.type)
-    : "UNKNOWN_TYPE_NAME";
+      ? reduceTypeName(type.type)
+      : type.kind === Kind.NAMED_TYPE
+        ? reduceTypeName(type.name)
+        : type.kind === Kind.NAME
+          ? reduceTypeName(type.value)
+          : type.kind === Kind.LIST_TYPE
+            ? reduceTypeName(type.type)
+            : "UNKNOWN_TYPE_NAME";
 }
 
 /**
@@ -38,14 +38,14 @@ export function reduceListType(
   return typeof type === "string"
     ? undefined
     : type.kind === Kind.NON_NULL_TYPE
-    ? reduceListType(type.type)
-    : type.kind === Kind.NAMED_TYPE
-    ? undefined
-    : type.kind === Kind.NAME
-    ? undefined
-    : type.kind === Kind.LIST_TYPE
-    ? reduceTypeName(type.type)
-    : undefined;
+      ? reduceListType(type.type)
+      : type.kind === Kind.NAMED_TYPE
+        ? undefined
+        : type.kind === Kind.NAME
+          ? undefined
+          : type.kind === Kind.LIST_TYPE
+            ? reduceTypeName(type.type)
+            : undefined;
 }
 
 /**
@@ -57,14 +57,14 @@ export function reduceNonNullType(
   return typeof type === "string"
     ? undefined
     : type.kind === Kind.NON_NULL_TYPE
-    ? reduceTypeName(type.type)
-    : type.kind === Kind.NAMED_TYPE
-    ? undefined
-    : type.kind === Kind.NAME
-    ? undefined
-    : type.kind === Kind.LIST_TYPE
-    ? undefined
-    : undefined;
+      ? reduceTypeName(type.type)
+      : type.kind === Kind.NAMED_TYPE
+        ? undefined
+        : type.kind === Kind.NAME
+          ? undefined
+          : type.kind === Kind.LIST_TYPE
+            ? undefined
+            : undefined;
 }
 
 /**

--- a/packages/codegen-sdk/src/model-visitor.ts
+++ b/packages/codegen-sdk/src/model-visitor.ts
@@ -28,7 +28,8 @@ import {
 import { Sdk } from "./constants";
 import { printNamespaced } from "./print";
 import {
-  SdkConnectionField, SdkEnumField,
+  SdkConnectionField,
+  SdkEnumField,
   SdkInterfaceField,
   SdkListField,
   SdkModel,
@@ -194,7 +195,7 @@ export class ModelVisitor {
 
         /** Identify enum fields */
         const enumField = findEnum(this._context, node);
-        if(enumField) {
+        if (enumField) {
           return {
             __typename: SdkModelFieldType.enum,
             node,

--- a/packages/codegen-sdk/src/parse-operation.ts
+++ b/packages/codegen-sdk/src/parse-operation.ts
@@ -130,11 +130,11 @@ export function parseOperations(
     /** Identify whether the response is an interface type and collect all interface implementations. */
     const returnsInterface = context.interfaces?.some(i => i.name.value === modelName);
     const implementations: string[] = returnsInterface
-      ? context.interfaceImplementations[modelName]?.map((imp: ObjectTypeDefinitionNode) => imp.name.value) ?? []
+      ? (context.interfaceImplementations[modelName]?.map((imp: ObjectTypeDefinitionNode) => imp.name.value) ?? [])
       : [];
 
     /** If the return is an interface, we can return any implementation. */
-    const returnValue = returnsInterface ? [...implementations, modelName].join(" | ") : listType ?? modelName;
+    const returnValue = returnsInterface ? [...implementations, modelName].join(" | ") : (listType ?? modelName);
 
     /** Store printable type names */
     const print: SdkOperationPrint = {

--- a/packages/codegen-sdk/src/print-connection.ts
+++ b/packages/codegen-sdk/src/print-connection.ts
@@ -234,7 +234,7 @@ export function printConnectionModel(context: SdkPluginContext, model: SdkModel)
 
   const implementations: string[] =
     returnsInterface && modelType
-      ? context.interfaceImplementations[modelType]?.map((imp: ObjectTypeDefinitionNode) => imp.name.value) ?? []
+      ? (context.interfaceImplementations[modelType]?.map((imp: ObjectTypeDefinitionNode) => imp.name.value) ?? [])
       : [];
 
   const returnValue = returnsInterface ? [...implementations, modelType].join(" | ") : modelType;

--- a/packages/codegen-sdk/src/print-model.ts
+++ b/packages/codegen-sdk/src/print-model.ts
@@ -127,7 +127,7 @@ function printModel(context: SdkPluginContext, model: SdkModel): string {
                   )
                 : undefined
             )
-          )
+          ),
         ])}
       }
 

--- a/packages/codegen-sdk/src/print-operation.ts
+++ b/packages/codegen-sdk/src/print-operation.ts
@@ -74,8 +74,9 @@ function printOperationCall(context: SdkPluginContext, operation: SdkOperation):
   const returnsInterface = context.interfaces?.some(i => i.name.value === operation.print.model);
 
   const implementations: string[] = returnsInterface
-    ? context.interfaceImplementations[operation.print.model]?.map((imp: ObjectTypeDefinitionNode) => imp.name.value) ??
-      []
+    ? (context.interfaceImplementations[operation.print.model]?.map(
+        (imp: ObjectTypeDefinitionNode) => imp.name.value
+      ) ?? [])
     : [];
 
   const operationCall = operation.print.list
@@ -87,31 +88,31 @@ function printOperationCall(context: SdkPluginContext, operation: SdkOperation):
           }
         })`
     : isConnectionModel(operation.model)
-    ? `return new ${operation.print.model}(${printList([
-        `this._${Sdk.REQUEST_NAME}`,
-        `${Sdk.CONNECTION_NAME} => this.${Sdk.FETCH_NAME}(${printList([
-          ...operation.requiredArgs.args.filter(arg => !parentArgNames.includes(arg.name)).map(arg => arg.name),
-          `${Sdk.CONNECTION_DEFAULT}({
+      ? `return new ${operation.print.model}(${printList([
+          `this._${Sdk.REQUEST_NAME}`,
+          `${Sdk.CONNECTION_NAME} => this.${Sdk.FETCH_NAME}(${printList([
+            ...operation.requiredArgs.args.filter(arg => !parentArgNames.includes(arg.name)).map(arg => arg.name),
+            `${Sdk.CONNECTION_DEFAULT}({
             ${printList([
               ...optionalArgs.map(arg => `...this._${arg.name}`),
               `...${Sdk.VARIABLE_NAME}`,
               `...${Sdk.CONNECTION_NAME}`,
             ])}
           })`,
-        ])})`,
-        Sdk.DATA_NAME,
-      ])})`
-    : returnsInterface
-    ? printObjectInstantiationSwitch(implementations, operation)
-    : printObjectInstantiation(operation);
+          ])})`,
+          Sdk.DATA_NAME,
+        ])})`
+      : returnsInterface
+        ? printObjectInstantiationSwitch(implementations, operation)
+        : printObjectInstantiation(operation);
 
   const isNullableConnectionOperation = isConnectionModel(operation.model) && !operation.nonNull;
 
   return printLines([
     `public async ${Sdk.FETCH_NAME}(${operation.fetchArgs.printInput}): ${operation.print.promise} {
       const ${Sdk.RESPONSE_NAME} = await this._${Sdk.REQUEST_NAME}<${responseType}, ${
-      operation.print.variables
-    }>(${printList([operation.print.document, printOperationArgs(operation)])})
+        operation.print.variables
+      }>(${printList([operation.print.document, printOperationArgs(operation)])})
         ${printSet(`const ${Sdk.DATA_NAME}`, `${operation.print.responsePath}`)}
         ${isNullableConnectionOperation ? `if(${Sdk.DATA_NAME}){` : ""}
         ${operationCall}

--- a/packages/codegen-sdk/src/print.ts
+++ b/packages/codegen-sdk/src/print.ts
@@ -6,5 +6,5 @@ import { SdkPluginConfig } from "./types";
  * Prepend the import namespace if required
  */
 export function printNamespaced(context: PluginContext<SdkPluginConfig>, name?: string): string {
-  return context.config.documentFile ? printList([Sdk.NAMESPACE, name], ".") : name ?? "UNNAMED_IMPORT";
+  return context.config.documentFile ? printList([Sdk.NAMESPACE, name], ".") : (name ?? "UNNAMED_IMPORT");
 }

--- a/packages/codegen-sdk/src/types.ts
+++ b/packages/codegen-sdk/src/types.ts
@@ -129,7 +129,7 @@ export enum SdkModelFieldType {
   list = "SdkListField ",
   scalarList = "SdkScalarListField",
   connection = "SdkConnectionField",
-  enum = "SdkEnumField"
+  enum = "SdkEnumField",
 }
 
 /**
@@ -209,7 +209,6 @@ export interface SdkListField extends Omit<SdkScalarField, "__typename"> {
 export interface SdkEnumField extends Omit<SdkScalarField, "__typename"> {
   __typename: SdkModelFieldType.enum;
 }
-
 
 /**
  * One of the model field types

--- a/packages/codegen-test/src/print-test.ts
+++ b/packages/codegen-test/src/print-test.ts
@@ -163,7 +163,7 @@ function printConnectionQueryTest(context: SdkPluginContext, operation: SdkOpera
 
   const itemField = itemOperation?.print.field;
   const itemSdkKey = itemOperation?.path.join("_");
-  const itemOperations = itemSdkKey ? context.sdkDefinitions[itemSdkKey]?.operations ?? [] : [];
+  const itemOperations = itemSdkKey ? (context.sdkDefinitions[itemSdkKey]?.operations ?? []) : [];
   const itemType = printList([Sdk.NAMESPACE, itemOperation?.print.model], ".");
   const itemArgs = itemOperation?.requiredArgs.args ?? [];
   const itemQueries = itemOperation?.model?.fields.query ?? [];
@@ -173,7 +173,7 @@ function printConnectionQueryTest(context: SdkPluginContext, operation: SdkOpera
   const returnsInterface = modelName ? context.interfaces?.some(i => i.name.value === modelName) : false;
   const implementations: string[] =
     returnsInterface && modelName
-      ? context.interfaceImplementations[modelName]?.map((imp: ObjectTypeDefinitionNode) => imp.name.value) ?? []
+      ? (context.interfaceImplementations[modelName]?.map((imp: ObjectTypeDefinitionNode) => imp.name.value) ?? [])
       : [];
   const itemTypes = printList([itemType, ...implementations.map(imp => printList([Sdk.NAMESPACE, imp], "."))], " | ");
 

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -307,7 +307,7 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
 
     const issueAssigneeId = issue.assigneeId?.toLowerCase();
     const existingAssigneeId: string | undefined = !!issueAssigneeId
-      ? existingUserMapByEmail[issueAssigneeId] ?? existingUserMapByName[issueAssigneeId]
+      ? (existingUserMapByEmail[issueAssigneeId] ?? existingUserMapByName[issueAssigneeId])
       : undefined;
 
     let assigneeId: string | undefined;
@@ -331,6 +331,7 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
       stateId,
       assigneeId,
       createdAt: issue.createdAt,
+      completedAt: issue.completedAt,
       dueDate: formattedDueDate,
     });
 

--- a/packages/import/src/importers/asanaCsv/AsanaCsvImporter.ts
+++ b/packages/import/src/importers/asanaCsv/AsanaCsvImporter.ts
@@ -82,6 +82,10 @@ export class AsanaCsvImporter implements Importer {
 
       const labels = tags.filter(tag => !!tag);
 
+      const createdAt = row["Created At"] ? new Date(row["Created At"]) : undefined;
+
+      const completedAt = row["Completed At"] ? new Date(row["Completed At"]) : undefined;
+
       importData.issues.push({
         title,
         description,
@@ -91,6 +95,8 @@ export class AsanaCsvImporter implements Importer {
         assigneeId,
         labels,
         dueDate,
+        createdAt,
+        completedAt,
       });
 
       for (const lab of labels) {

--- a/packages/import/src/importers/jiraCsv/JiraCsvImporter.ts
+++ b/packages/import/src/importers/jiraCsv/JiraCsvImporter.ts
@@ -76,8 +76,8 @@ export class JiraCsvImporter implements Importer {
         mdDesc && url
           ? `${mdDesc}\n\n[View original issue in Jira](${url})`
           : url
-          ? `[View original issue in Jira](${url})`
-          : undefined;
+            ? `[View original issue in Jira](${url})`
+            : undefined;
       const priority = mapPriority(row.Priority);
       const type = `Type: ${row["Issue Type"]}`;
       const release = row.Release && row.Release.length > 0 ? `Release: ${row.Release}` : undefined;

--- a/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
+++ b/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
@@ -77,6 +77,7 @@ export class LinearCsvImporter implements Importer {
         priority: mapPriority(row.Priority),
         status: row.Status,
         assigneeId: row.Assignee,
+        createdAt: !!row.Created ? new Date(row.Created) : undefined,
         completedAt: !!row.Completed ? new Date(row.Completed) : undefined,
         startedAt: !!row.Started ? new Date(row.Started) : undefined,
         labels,

--- a/packages/import/src/importers/shortcutCsv/ShortcutCsvImporter.ts
+++ b/packages/import/src/importers/shortcutCsv/ShortcutCsvImporter.ts
@@ -79,7 +79,11 @@ const colParser = {
  * @param apiToken  A Shortcut API token (https://app.shortcut.com/settings/account/api-tokens)
  */
 export class ShortcutCsvImporter implements Importer {
-  public constructor(private filePath: string, workspaceSlug: string, private apiToken: string) {
+  public constructor(
+    private filePath: string,
+    workspaceSlug: string,
+    private apiToken: string
+  ) {
     this.shortcutBaseURL = "https://app.shortcut.com/" + workspaceSlug;
   }
 
@@ -137,6 +141,8 @@ export class ShortcutCsvImporter implements Importer {
 
       const createdAt = row.created_at;
 
+      const completedAt = row.completed_at;
+
       importData.issues.push({
         title,
         description,
@@ -145,6 +151,7 @@ export class ShortcutCsvImporter implements Importer {
         assigneeId,
         labels,
         createdAt,
+        completedAt,
       });
 
       for (const lab of labels) {

--- a/packages/sdk/naming-override/index.js
+++ b/packages/sdk/naming-override/index.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const changeCaseAll = require("change-case-all");
 
 // Sometimes we have two queries with the same case. If we do, add the query names here (PascalCased), and we'll perform
@@ -11,15 +12,15 @@ const incorrectCase = ["SLADayCountType"];
 // Object containing counters of how many times we've seen each DuplicateQueryNameArgs type.
 const deduplicate = Object.fromEntries(duplicateQueries.map(query => [`Query${query}Args`, 0]));
 
-exports.case = (type) => {
+exports.case = type => {
   if (type in deduplicate) {
     if (deduplicate[type] > 0) {
       type = type + deduplicate[type];
     }
-    deduplicate[type] += 1
+    deduplicate[type] += 1;
   }
-  if(incorrectCase.includes(type)) {
+  if (incorrectCase.includes(type)) {
     return type;
   }
-  return changeCaseAll.pascalCase(type)
-}
+  return changeCaseAll.pascalCase(type);
+};

--- a/packages/sdk/scripts/update-scalars.ts
+++ b/packages/sdk/scripts/update-scalars.ts
@@ -5,9 +5,12 @@ function updateScalars() {
   try {
     const results = replaceInFileSync({
       files: "src/_generated_documents.ts",
-      from: [...Doc.SCALAR_STRING_NAMES, ...Doc.SCALAR_DATE_NAMES, ...Doc.SCALAR_JSON_NAMES, ...Doc.SCALAR_DATE_OR_STRING_NAMES].map(
-        name => `${name}: any`
-      ),
+      from: [
+        ...Doc.SCALAR_STRING_NAMES,
+        ...Doc.SCALAR_DATE_NAMES,
+        ...Doc.SCALAR_JSON_NAMES,
+        ...Doc.SCALAR_DATE_OR_STRING_NAMES,
+      ].map(name => `${name}: any`),
       to: match => {
         const name = match?.split(":")?.[0];
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -31,7 +31,7 @@ function parseClientOptions({
         ? accessToken.startsWith("Bearer ")
           ? accessToken
           : `Bearer ${accessToken}`
-        : apiKey ?? "",
+        : (apiKey ?? ""),
       /** Use configured headers */
       ...headers,
       /** Override any user agent with the sdk name and version */

--- a/packages/sdk/src/error.ts
+++ b/packages/sdk/src/error.ts
@@ -218,14 +218,14 @@ export function parseLinearError(error?: LinearErrorRaw | LinearError): LinearEr
     (status === 403
       ? LinearErrorType.Forbidden
       : status === 429
-      ? LinearErrorType.Ratelimited
-      : `${status}`.startsWith("4")
-      ? LinearErrorType.AuthenticationError
-      : status === 500
-      ? LinearErrorType.InternalError
-      : `${status}`.startsWith("5")
-      ? LinearErrorType.NetworkError
-      : LinearErrorType.Unknown);
+        ? LinearErrorType.Ratelimited
+        : `${status}`.startsWith("4")
+          ? LinearErrorType.AuthenticationError
+          : status === 500
+            ? LinearErrorType.InternalError
+            : `${status}`.startsWith("5")
+              ? LinearErrorType.NetworkError
+              : LinearErrorType.Unknown);
 
   const LinearErrorConstructor = errorConstructorMap[type] ?? LinearError;
 


### PR DESCRIPTION
Adds support for `completedAt` date with supported importers: Asana, Linear and Shortcut.

Jira is left out as it currently doesn't import any dates. Jira CSVs do not come with a standard format and are dependent of the locale of the instance that generates them.

Github, Trello and Pivotal do not have or do not expose a concept of completion date through their API or CSV exports.

PR also includes linter updates that were not committed before. 