### PR TITLE
docs: Update "Get started"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,6 @@ Open source packages:
 # install dependencies
 yarn
 
-# link package dependencies
-yarn bootstrap
-
 # build all packages
 yarn build
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -61,9 +61,6 @@ Open source packages:
 # install dependencies
 yarn
 
-# link package dependencies
-yarn bootstrap
-
 # build all packages
 yarn build
 


### PR DESCRIPTION
The bootstrap step (probably lerna bootstrap) doesn't work, and isn't required.