### PR TITLE
feat: add support for issue estimates in CLI importer

### DIFF
--- a/.changeset/quick-pants-attack.md
+++ b/.changeset/quick-pants-attack.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": minor
+---
+
+feat: add support for issue estimates in CLI importer

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -333,6 +333,7 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
       createdAt: issue.createdAt,
       completedAt: issue.completedAt,
       dueDate: formattedDueDate,
+      estimate: issue.estimate,
     });
 
     if (issue.archived) {

--- a/packages/import/src/importers/jiraCsv/JiraCsvImporter.ts
+++ b/packages/import/src/importers/jiraCsv/JiraCsvImporter.ts
@@ -5,6 +5,9 @@ const j2m = require("jira2md");
 
 type JiraPriority = "Highest" | "High" | "Medium" | "Low" | "Lowest";
 
+// There are many estimates field in Jira. Use the one that comes as the default in new projects.
+const estimateCustomField = "Custom field (Story point estimate)";
+
 interface JiraIssueType {
   Description: string;
   Status: string;
@@ -16,7 +19,7 @@ interface JiraIssueType {
   Assignee: string;
   Created: string;
   Release: string;
-  "Custom field (Story Points)"?: string;
+  [estimateCustomField]?: string;
 }
 
 /**
@@ -83,6 +86,7 @@ export class JiraCsvImporter implements Importer {
       const release = row.Release && row.Release.length > 0 ? `Release: ${row.Release}` : undefined;
       const assigneeId = row.Assignee && row.Assignee.length > 0 ? row.Assignee : undefined;
       const status = row.Status;
+      const estimate = row[estimateCustomField] ? parseInt(row[estimateCustomField]) : undefined;
 
       const labels = [type];
       if (release) {
@@ -97,6 +101,7 @@ export class JiraCsvImporter implements Importer {
         url,
         assigneeId,
         labels,
+        estimate,
       });
 
       for (const lab of labels) {

--- a/packages/import/src/importers/jiraCsv/JiraCsvImporter.ts
+++ b/packages/import/src/importers/jiraCsv/JiraCsvImporter.ts
@@ -1,5 +1,6 @@
 import csv from "csvtojson";
 import { Importer, ImportResult } from "../../types";
+import { safeParseInt } from "../../utils/parseInt";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const j2m = require("jira2md");
 
@@ -86,7 +87,7 @@ export class JiraCsvImporter implements Importer {
       const release = row.Release && row.Release.length > 0 ? `Release: ${row.Release}` : undefined;
       const assigneeId = row.Assignee && row.Assignee.length > 0 ? row.Assignee : undefined;
       const status = row.Status;
-      const estimate = row[estimateCustomField] ? parseInt(row[estimateCustomField]) : undefined;
+      const estimate = safeParseInt(row[estimateCustomField]);
 
       const labels = [type];
       if (release) {

--- a/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
+++ b/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
@@ -80,6 +80,7 @@ export class LinearCsvImporter implements Importer {
         createdAt: !!row.Created ? new Date(row.Created) : undefined,
         completedAt: !!row.Completed ? new Date(row.Completed) : undefined,
         startedAt: !!row.Started ? new Date(row.Started) : undefined,
+        estimate: !!row.Estimate ? parseInt(row.Estimate) : undefined,
         labels,
       });
 

--- a/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
+++ b/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
@@ -1,5 +1,6 @@
 import csv from "csvtojson";
 import { Importer, ImportResult } from "../../types";
+import { safeParseInt } from "../../utils/parseInt";
 
 type LinearPriority = "No priority" | "Urgent" | "High" | "Medium" | "Low";
 
@@ -80,7 +81,7 @@ export class LinearCsvImporter implements Importer {
         createdAt: !!row.Created ? new Date(row.Created) : undefined,
         completedAt: !!row.Completed ? new Date(row.Completed) : undefined,
         startedAt: !!row.Started ? new Date(row.Started) : undefined,
-        estimate: !!row.Estimate ? parseInt(row.Estimate) : undefined,
+        estimate: safeParseInt(row.Estimate),
         labels,
       });
 

--- a/packages/import/src/importers/pivotalCsv/PivotalCsvImporter.ts
+++ b/packages/import/src/importers/pivotalCsv/PivotalCsvImporter.ts
@@ -79,7 +79,7 @@ export class PivotalCsvImporter implements Importer {
       const mdDesc = j2m.to_markdown(row.Description);
       const description = url ? `${mdDesc}\n\n[View original issue in Pivotal](${url})` : mdDesc;
 
-      // const priority = parseInt(row['Estimate']) || undefined;
+      const estimate = parseInt(row["Estimate"]);
 
       const tags = row.Labels.split(",");
 
@@ -99,6 +99,7 @@ export class PivotalCsvImporter implements Importer {
         assigneeId,
         labels,
         createdAt,
+        estimate,
       });
 
       for (const lab of labels) {

--- a/packages/import/src/importers/pivotalCsv/PivotalCsvImporter.ts
+++ b/packages/import/src/importers/pivotalCsv/PivotalCsvImporter.ts
@@ -1,5 +1,6 @@
 import csv from "csvtojson";
 import { Importer, ImportResult } from "../../types";
+import { safeParseInt } from "../../utils/parseInt";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const j2m = require("jira2md");
 
@@ -79,7 +80,7 @@ export class PivotalCsvImporter implements Importer {
       const mdDesc = j2m.to_markdown(row.Description);
       const description = url ? `${mdDesc}\n\n[View original issue in Pivotal](${url})` : mdDesc;
 
-      const estimate = parseInt(row["Estimate"]);
+      const estimate = safeParseInt(row["Estimate"]);
 
       const tags = row.Labels.split(",");
 

--- a/packages/import/src/importers/shortcutCsv/ShortcutCsvImporter.ts
+++ b/packages/import/src/importers/shortcutCsv/ShortcutCsvImporter.ts
@@ -19,7 +19,6 @@ interface ShortcutIssueType {
   moved_at: Date;
   completed_at: Date;
   estimate: number;
-  external_ticket_count: number;
   external_tickets: string[];
   is_blocked: boolean;
   is_a_blocker: boolean;
@@ -39,13 +38,13 @@ interface ShortcutIssueType {
 
 const parseBooleanColumn = (item: string) => item == "TRUE";
 const parseStringArrayColumn = (item: string) => item.split(";").filter(s => s.length > 0);
-const parseInt = (item: string) => Number.parseInt(item) || 0;
+const parseInt = (item: string) => (item ? Number.parseInt(item) : undefined);
 const parseDate = (item: string, _: any, __: any, row: string[]) => {
   if (item.length <= 0) {
     return null;
   }
   // Inoptimal method for finding the timezone UTC offset, we parse it from the UTC offset column in this row each time
-  const utcOffset = row.find(c => /[+-]([01]\d|2[0-4])(:?[0-5]\d)?/g.test(c)) || "";
+  const utcOffset = row.find(c => /^[+-]([01]\d|2[0-4])(:?[0-5]\d)?$/g.test(c)) || "";
   return new Date(item + " " + utcOffset);
 };
 
@@ -58,7 +57,6 @@ const colParser = {
   moved_at: parseDate,
   completed_at: parseDate,
   estimate: parseInt,
-  external_ticket_count: parseInt,
   external_tickets: parseStringArrayColumn,
   is_blocked: parseBooleanColumn,
   is_a_blocker: parseBooleanColumn,
@@ -143,6 +141,8 @@ export class ShortcutCsvImporter implements Importer {
 
       const completedAt = row.completed_at;
 
+      const estimate = row.estimate;
+
       importData.issues.push({
         title,
         description,
@@ -152,6 +152,7 @@ export class ShortcutCsvImporter implements Importer {
         labels,
         createdAt,
         completedAt,
+        estimate,
       });
 
       for (const lab of labels) {

--- a/packages/import/src/importers/shortcutCsv/ShortcutCsvImporter.ts
+++ b/packages/import/src/importers/shortcutCsv/ShortcutCsvImporter.ts
@@ -2,6 +2,7 @@
 /* eslint-disable eqeqeq */
 import csv from "csvtojson";
 import { Importer, ImportResult } from "../../types";
+import { safeParseInt } from "../../utils/parseInt";
 
 type ShortcutStoryType = "feature" | "bug" | "chore";
 
@@ -38,7 +39,6 @@ interface ShortcutIssueType {
 
 const parseBooleanColumn = (item: string) => item == "TRUE";
 const parseStringArrayColumn = (item: string) => item.split(";").filter(s => s.length > 0);
-const parseInt = (item: string) => (item ? Number.parseInt(item) : undefined);
 const parseDate = (item: string, _: any, __: any, row: string[]) => {
   if (item.length <= 0) {
     return null;
@@ -56,7 +56,7 @@ const colParser = {
   updated_at: parseDate,
   moved_at: parseDate,
   completed_at: parseDate,
-  estimate: parseInt,
+  estimate: safeParseInt,
   external_tickets: parseStringArrayColumn,
   is_blocked: parseBooleanColumn,
   is_a_blocker: parseBooleanColumn,

--- a/packages/import/src/types.ts
+++ b/packages/import/src/types.ts
@@ -26,6 +26,8 @@ export interface Issue {
   startedAt?: Date;
   /** Whether issue is archived */
   archived?: boolean;
+  /** Issue estimate */
+  estimate?: number;
 }
 
 /** Issue comment */

--- a/packages/import/src/utils/parseInt.ts
+++ b/packages/import/src/utils/parseInt.ts
@@ -1,0 +1,11 @@
+/**
+ * Safely parses an integer. Returns undefined if the value is undefined or not a number.
+ */
+export const safeParseInt = (number?: string): number | undefined => {
+  if (number === undefined) {
+    return undefined;
+  }
+
+  const int = parseInt(number);
+  return isNaN(int) ? undefined : int;
+};


### PR DESCRIPTION
Add (actual) support for issue estimates in CLI importer. There were some pieces of estimate support in place but nothing end-to-end. 

- Linear: `Estimate` was defined in `LinearIssueType` but unused
- Jira: `Custom field (Story Points)` was defined but not used. Switched to looking for column `Custom field (Story point estimate)` which appears to be the standard when creating a new Jira Project.
- Shortcut: Using `estimate` field. 
- Pivotal: Uncommenting/fixing the existing estimate support (no context behind why it was as-is)
- Asana/Trello/Github: no concept of estimates

Resolves #606 