### PR TITLE
feat: add gitlab csv importer, support label groups

### DIFF
--- a/packages/import/src/cli.ts
+++ b/packages/import/src/cli.ts
@@ -11,6 +11,7 @@ import { pivotalCsvImport } from "./importers/pivotalCsv";
 import { shortcutCsvImport } from "./importers/shortcutCsv";
 import { trelloJsonImport } from "./importers/trelloJson";
 import { ImportAnswers } from "./types";
+import { gitlabCsvImporter } from "./importers/gitlabCsv";
 
 inquirer.registerPrompt("filePath", require("inquirer-file-path"));
 
@@ -30,6 +31,10 @@ inquirer.registerPrompt("filePath", require("inquirer-file-path"));
           {
             name: "GitHub",
             value: "github",
+          },
+          {
+            name: "GitLab (CSV export)",
+            value: "gitlabCsv",
           },
           {
             name: "Jira (CSV export)",
@@ -64,6 +69,9 @@ inquirer.registerPrompt("filePath", require("inquirer-file-path"));
     switch (importAnswers.service) {
       case "github":
         importer = await githubImport();
+        break;
+      case "gitlabCsv":
+        importer = await gitlabCsvImporter();
         break;
       case "jiraCsv":
         importer = await jiraCsvImport();

--- a/packages/import/src/helpers/labelManager.ts
+++ b/packages/import/src/helpers/labelManager.ts
@@ -6,266 +6,278 @@ type Id = string;
 const WORKSPACE_ID = "workspace";
 
 class LabelManager {
-    private nameToLabel: Record<string, { [teamId: Id | typeof WORKSPACE_ID]: Label }> = {};
-    private idToLabel: Record<Id, { [teamId: Id | typeof WORKSPACE_ID]: Label }> = {};
+  private nameToLabel: Record<string, { [teamId: Id | typeof WORKSPACE_ID]: Label }> = {};
+  private idToLabel: Record<Id, { [teamId: Id | typeof WORKSPACE_ID]: Label }> = {};
 
-    public constructor(
-        existingLabels: IssueLabel[],
-        private teamId: Id
-    ) {
-        this.initializeLabels(existingLabels);
+  public constructor(
+    existingLabels: IssueLabel[],
+    private teamId: Id
+  ) {
+    this.initializeLabels(existingLabels);
+  }
+
+  public getLabelByName(name: string, teamId: Id | typeof WORKSPACE_ID): Label | undefined {
+    return this.nameToLabel[name.toLowerCase()]?.[teamId] ?? this.nameToLabel[name]?.[WORKSPACE_ID];
+  }
+
+  public getLabelById(id: Id, teamId: Id | typeof WORKSPACE_ID): Label | undefined {
+    return this.idToLabel[id]?.[teamId] ?? this.idToLabel[id]?.[WORKSPACE_ID];
+  }
+
+  private getLabel<T>(props: { name: string } | { id: Id }, checkInstance: (label: Label) => boolean): T | undefined {
+    let label: Label | undefined;
+    if ("name" in props) {
+      label = this.getLabelByName(props.name, this.teamId);
+    } else {
+      label = this.getLabelById(props.id, this.teamId);
     }
+    return (label && checkInstance(label) ? label : undefined) as T | undefined;
+  }
 
-    public getLabelByName(name: string, teamId: Id | typeof WORKSPACE_ID): Label | undefined {
-        return this.nameToLabel[name.toLowerCase()]?.[teamId] ?? this.nameToLabel[name]?.[WORKSPACE_ID];
+  public getGroupLabel(props: { name: string } | { id: Id }): LabelGroup | undefined {
+    return this.getLabel<LabelGroup>(props, label => label instanceof LabelGroup);
+  }
+
+  public getRootLabel(props: { name: string } | { id: Id }): Label | undefined {
+    return this.getLabel<Label>(props, label => label instanceof Label);
+  }
+
+  public addLabel(props: { label: Label; parent?: LabelGroup; teamId?: Id | typeof WORKSPACE_ID }) {
+    const { label, parent, teamId = this.teamId } = props;
+
+    this.nameToLabel[label.name.toLowerCase()] = { [teamId]: label };
+    this.idToLabel[label.id] = { [teamId]: label };
+
+    if (parent) {
+      parent.addLabel(label.name, label.id);
     }
+  }
 
-    public getLabelById(id: Id, teamId: Id | typeof WORKSPACE_ID): Label | undefined {
-        return this.idToLabel[id]?.[teamId] ?? this.idToLabel[id]?.[WORKSPACE_ID];
-    }
+  private async initializeLabels(existingLabels: IssueLabel[]) {
+    // We want to process groups first.
+    existingLabels.sort(a => (a.isGroup ? -1 : 1));
 
-    private getLabel<T>(props: { name: string } | { id: Id }, checkInstance: (label: Label) => boolean): T | undefined {
-        let label: Label | undefined;
-        if ("name" in props) {
-            label = this.getLabelByName(props.name, this.teamId);
-        } else {
-            label = this.getLabelById(props.id, this.teamId);
-        }
-        return (label && checkInstance(label) ? label : undefined) as T | undefined;
-    }
+    for (const existingLabel of existingLabels) {
+      const labelName = existingLabel.name?.toLowerCase();
+      const teamId = (await existingLabel.team)?.id ?? WORKSPACE_ID;
 
-    public getGroupLabel(props: { name: string } | { id: Id }): LabelGroup | undefined {
-        return this.getLabel<LabelGroup>(props, label => label instanceof LabelGroup);
-    }
-
-    public getRootLabel(props: { name: string } | { id: Id }): Label | undefined {
-        return this.getLabel<Label>(props, label => label instanceof Label);
-    }
-
-    public addLabel(props: { label: Label; parent?: LabelGroup; teamId?: Id | typeof WORKSPACE_ID }) {
-        const { label, parent, teamId = this.teamId } = props;
-
-        this.nameToLabel[label.name.toLowerCase()] = { [teamId]: label };
-        this.idToLabel[label.id] = { [teamId]: label };
+      if (existingLabel.isGroup && labelName && existingLabel.id) {
+        const group = new LabelGroup(existingLabel.id, labelName);
+        this.addLabel({ label: group, teamId });
+      } else if (labelName && existingLabel.id) {
+        const parent = await existingLabel.parent;
 
         if (parent) {
-            parent.addLabel(label.name, label.id);
+          const group = this.idToLabel[parent.id]?.[teamId] as LabelGroup;
+          this.addLabel({ label: new Label(existingLabel.id, labelName), parent: group, teamId });
+        } else {
+          this.addLabel({ label: new Label(existingLabel.id, labelName), teamId });
         }
+      }
     }
-
-    private async initializeLabels(existingLabels: IssueLabel[]) {
-        // We want to process groups first.
-        existingLabels.sort(a => (a.isGroup ? -1 : 1));
-
-        for (const existingLabel of existingLabels) {
-            const labelName = existingLabel.name?.toLowerCase();
-            const teamId = (await existingLabel.team)?.id ?? WORKSPACE_ID;
-
-            if (existingLabel.isGroup && labelName && existingLabel.id) {
-                const group = new LabelGroup(existingLabel.id, labelName);
-                this.addLabel({ label: group, teamId });
-            } else if (labelName && existingLabel.id) {
-                const parent = await existingLabel.parent;
-
-                if (parent) {
-                    const group = this.idToLabel[parent.id]?.[teamId] as LabelGroup;
-                    this.addLabel({ label: new Label(existingLabel.id, labelName), parent: group, teamId });
-                } else {
-                    this.addLabel({ label: new Label(existingLabel.id, labelName), teamId });
-                }
-            }
-        }
-    }
+  }
 }
 
 const createLabel = async (
-    client: LinearClient,
-    {
-        name,
-        description,
-        color,
-        parentId,
-        teamId,
-    }: {
-        name: string;
-        description?: string;
-        color?: string;
-        parentId?: Id;
-        teamId: Id;
-    }
+  client: LinearClient,
+  {
+    name,
+    description,
+    color,
+    parentId,
+    teamId,
+  }: {
+    name: string;
+    description?: string;
+    color?: string;
+    parentId?: Id;
+    teamId: Id;
+  }
 ) => {
-    const response = await client.createIssueLabel({ name, description, color, teamId, parentId });
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return (await response?.issueLabel)!.id;
+  const response = await client.createIssueLabel({ name, description, color, teamId, parentId });
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return (await response?.issueLabel)!.id;
+};
+
+const deleteLabel = async (client: LinearClient, labelId: Id) => {
+  await client.deleteIssueLabel(labelId);
 };
 
 export const handleLabels = async (
-    client: LinearClient,
-    importData: ImportResult,
-    teamId: string,
-    existingLabels: IssueLabel[]
+  client: LinearClient,
+  importData: ImportResult,
+  teamId: string,
+  existingLabels: IssueLabel[]
 ): Promise<Record<string, { type: "root" | "parent" | "child"; id: Id }>> => {
-    const manager = new LabelManager(existingLabels, teamId);
-    const labelMapping: Record<string, { type: "root" | "parent" | "child"; id: Id }> = {};
+  const manager = new LabelManager(existingLabels, teamId);
+  const labelMapping: Record<string, { type: "root" | "parent" | "child"; id: Id }> = {};
 
-    for (const issue of importData.issues) {
-        const labels = issue.labels;
-        if (!labels) {
-            continue;
-        }
-
-        await handleIssueLabels(client, manager, teamId, importData, labels, labelMapping);
+  for (const issue of importData.issues) {
+    const labels = issue.labels;
+    if (!labels) {
+      continue;
     }
 
-    return labelMapping;
+    await handleIssueLabels(client, manager, teamId, importData, labels, labelMapping);
+  }
+
+  return labelMapping;
 };
 
 const handleIssueLabels = async (
-    client: LinearClient,
-    manager: LabelManager,
-    teamId: Id,
-    importData: ImportResult,
-    issueLabelIds: string[],
-    labelMapping: Record<string, { type: "root" | "parent" | "child"; id: Id }>
+  client: LinearClient,
+  manager: LabelManager,
+  teamId: Id,
+  importData: ImportResult,
+  issueLabelIds: string[],
+  labelMapping: Record<string, { type: "root" | "parent" | "child"; id: Id }>
 ) => {
-    let actualLabelId: Id | undefined;
-    // Track which groups are used to prevent multiple labels from same group
-    const usedGroups = new Set<string>();
+  let actualLabelId: Id | undefined;
+  // Track which groups are used to prevent multiple labels from same group
+  const usedGroups = new Set<string>();
 
-    for (const labelId of issueLabelIds) {
-        const labelData = importData.labels[labelId];
-        const parsed = parseLabelName(labelData.name);
-        const group = parsed[0];
-        let labelName = parsed[1];
+  for (const labelId of issueLabelIds) {
+    const labelData = importData.labels[labelId];
+    const parsed = parseLabelName(labelData.name);
+    const group = parsed[0];
+    let labelName = parsed[1];
 
-        // If this label's group is already used in this issue,
-        // or if it was previously mapped as a child label and its group is in use,
-        // create/use a root label with the full name
-        if (group && (usedGroups.has(group) || (labelMapping[labelId]?.type === "child" && usedGroups.has(group)))) {
-            const fullName = labelData.name;
-            actualLabelId = manager.getLabelByName(fullName, teamId)?.id;
+    // If this label's group is already used in this issue,
+    // or if it was previously mapped as a child label and its group is in use,
+    // create/use a root label with the full name
+    if (group && (usedGroups.has(group) || (labelMapping[labelId]?.type === "child" && usedGroups.has(group)))) {
+      const fullName = labelData.name;
+      actualLabelId = manager.getLabelByName(fullName, teamId)?.id;
 
-            if (!actualLabelId) {
-                actualLabelId = await createLabel(client, { name: fullName, teamId });
-                const rootLabel = new Label(actualLabelId, fullName);
-                manager.addLabel({ label: rootLabel, teamId });
-            }
+      // If this was previously a child label, delete it before converting to root
+      if (labelMapping[labelId]?.type === "child") {
+        await deleteLabel(client, labelMapping[labelId].id);
+      }
 
-            labelMapping[labelId] = { type: "root", id: actualLabelId };
-            continue;
-        }
+      if (!actualLabelId) {
+        actualLabelId = await createLabel(client, { name: fullName, teamId });
+        const rootLabel = new Label(actualLabelId, fullName);
+        manager.addLabel({ label: rootLabel, teamId });
+      }
 
-        // If we already have a mapping for this label and it's not a conflicting child label,
-        // use it and track the group
-        if (labelMapping[labelId]) {
-            if (group) {
-                usedGroups.add(group);
-            }
-            continue;
-        }
-
-        let groupLabel = group ? manager.getGroupLabel({ name: group }) : undefined;
-
-        if (group) {
-            if (!groupLabel) {
-                // Check if the group name conflicts with an existing root label
-                const rootLabelConflict = manager.getRootLabel({ name: group });
-                if (rootLabelConflict) {
-                    // Create the group label with a modified name
-                    const groupName = `${group} (imported)`;
-                    const groupId = await createLabel(client, { name: groupName, teamId });
-                    groupLabel = new LabelGroup(groupId, groupName);
-                    manager.addLabel({ label: groupLabel, teamId });
-                } else {
-                    // Create new group label
-                    const groupId = await createLabel(client, { name: group, teamId });
-                    groupLabel = new LabelGroup(groupId, group);
-                    manager.addLabel({ label: groupLabel, teamId });
-                }
-            }
-
-            usedGroups.add(group);
-        }
-
-        // Handle the child label if we have a valid group
-        if (groupLabel) {
-            actualLabelId = groupLabel.labels[labelName];
-
-            if (!actualLabelId) {
-                // Check for naming conflicts
-                const existingLabel = manager.getLabelByName(labelName, teamId);
-                const newLabelName = existingLabel ? `${labelName} (imported)` : labelName;
-
-                actualLabelId = await createLabel(client, {
-                    name: newLabelName,
-                    parentId: groupLabel.id,
-                    teamId,
-                });
-
-                const subgroupLabel = new SubgroupLabel(actualLabelId, newLabelName);
-                manager.addLabel({ label: subgroupLabel, parent: groupLabel, teamId });
-            }
-
-            labelMapping[labelId] = { type: "child", id: actualLabelId };
-            continue;
-        }
-
-        // Handle as root label
-        labelName = labelData.name;
-        let rootLabelName = labelName;
-
-        // Check for conflicts with existing group labels
-        if (manager.getGroupLabel({ name: labelName })) {
-            rootLabelName = `${labelName} (imported)`;
-        }
-
-        // Check for existing root label
-        actualLabelId = manager.getLabelByName(rootLabelName, teamId)?.id;
-
-        if (!actualLabelId) {
-            actualLabelId = await createLabel(client, { name: rootLabelName, teamId });
-            const rootLabel = new Label(actualLabelId, rootLabelName);
-            manager.addLabel({ label: rootLabel, teamId });
-        }
-
-        labelMapping[labelId] = { type: "root", id: actualLabelId };
+      labelMapping[labelId] = { type: "root", id: actualLabelId };
+      continue;
     }
+
+    // If we already have a mapping for this label and it's not a conflicting child label,
+    // use it and track the group
+    if (labelMapping[labelId]) {
+      if (group) {
+        usedGroups.add(group);
+      }
+      continue;
+    }
+
+    let groupLabel = group ? manager.getGroupLabel({ name: group }) : undefined;
+
+    if (group) {
+      if (!groupLabel) {
+        // Check if the group name conflicts with an existing root label
+        const rootLabelConflict = manager.getRootLabel({ name: group });
+        if (rootLabelConflict) {
+          // Create the group label with a modified name
+          const groupName = `${group} (imported)`;
+          const groupId = await createLabel(client, { name: groupName, teamId });
+          groupLabel = new LabelGroup(groupId, groupName);
+          manager.addLabel({ label: groupLabel, teamId });
+        } else {
+          // Create new group label
+          const groupId = await createLabel(client, { name: group, teamId });
+          groupLabel = new LabelGroup(groupId, group);
+          manager.addLabel({ label: groupLabel, teamId });
+        }
+      }
+
+      usedGroups.add(group);
+    }
+
+    // Handle the child label if we have a valid group
+    if (groupLabel) {
+      actualLabelId = groupLabel.labels[labelName];
+
+      if (!actualLabelId) {
+        // Check for naming conflicts
+        const existingLabel = manager.getLabelByName(labelName, teamId);
+        const newLabelName = existingLabel ? `${labelName} (imported)` : labelName;
+
+        actualLabelId = await createLabel(client, {
+          name: newLabelName,
+          parentId: groupLabel.id,
+          teamId,
+        });
+
+        const subgroupLabel = new SubgroupLabel(actualLabelId, newLabelName);
+        manager.addLabel({ label: subgroupLabel, parent: groupLabel, teamId });
+      }
+
+      labelMapping[labelId] = { type: "child", id: actualLabelId };
+      continue;
+    }
+
+    // Handle as root label
+    labelName = labelData.name;
+    let rootLabelName = labelName;
+
+    // Check for conflicts with existing group labels
+    if (manager.getGroupLabel({ name: labelName })) {
+      rootLabelName = `${labelName} (imported)`;
+    }
+
+    // Check for existing root label
+    actualLabelId = manager.getLabelByName(rootLabelName, teamId)?.id;
+
+    if (!actualLabelId) {
+      actualLabelId = await createLabel(client, { name: rootLabelName, teamId });
+      const rootLabel = new Label(actualLabelId, rootLabelName);
+      manager.addLabel({ label: rootLabel, teamId });
+    }
+
+    labelMapping[labelId] = { type: "root", id: actualLabelId };
+  }
 };
 
 function parseLabelName(fullName: string): [string | undefined, string] {
-    const parts = fullName.split("/");
-    let group: string | undefined;
-    let subgroup: string;
+  const parts = fullName.split("/");
+  let group: string | undefined;
+  let subgroup: string;
 
-    if (parts.length > 1) {
-        subgroup = parts.pop() as string;
-        group = parts.join("/");
-    } else {
-        group = undefined;
-        subgroup = fullName;
-    }
+  if (parts.length > 1) {
+    subgroup = parts.pop() as string;
+    group = parts.join("/");
+  } else {
+    group = undefined;
+    subgroup = fullName;
+  }
 
-    // Ensure every part is truncated to 80 characters
-    return [group, subgroup].map(part => part ? _.truncate(part.trim(), { length: 80 }) : undefined) as [string | undefined, string];
+  // Ensure every part is truncated to 80 characters
+  return [group, subgroup].map(part => (part ? _.truncate(part.trim(), { length: 80 }) : undefined)) as [
+    string | undefined,
+    string,
+  ];
 }
 
 class Label {
-    public constructor(
-        public id: Id,
-        public name: string
-    ) { }
+  public constructor(
+    public id: Id,
+    public name: string
+  ) {}
 }
 
 class LabelGroup extends Label {
-    public labels: Record<string, Id> = {};
+  public labels: Record<string, Id> = {};
 
-    public constructor(id: Id, name: string) {
-        super(id, name);
-    }
+  public constructor(id: Id, name: string) {
+    super(id, name);
+  }
 
-    public addLabel(name: string, id: Id) {
-        this.labels[name.toLowerCase()] = id;
-    }
+  public addLabel(name: string, id: Id) {
+    this.labels[name.toLowerCase()] = id;
+  }
 }
 
-class SubgroupLabel extends Label { }
+class SubgroupLabel extends Label {}

--- a/packages/import/src/helpers/labelManager.ts
+++ b/packages/import/src/helpers/labelManager.ts
@@ -5,113 +5,26 @@ import _ from "lodash";
 type Id = string;
 const WORKSPACE_ID = "workspace";
 
-class LabelManager {
-  private nameToLabel: Record<string, { [teamId: Id | typeof WORKSPACE_ID]: Label }> = {};
-  private idToLabel: Record<Id, { [teamId: Id | typeof WORKSPACE_ID]: Label }> = {};
+type LabelType = "root" | "parent" | "child";
 
-  public constructor(
-    existingLabels: IssueLabel[],
-    private teamId: Id
-  ) {
-    this.initializeLabels(existingLabels);
-  }
-
-  public getLabelByName(name: string, teamId: Id | typeof WORKSPACE_ID): Label | undefined {
-    return this.nameToLabel[name.toLowerCase()]?.[teamId] ?? this.nameToLabel[name]?.[WORKSPACE_ID];
-  }
-
-  public getLabelById(id: Id, teamId: Id | typeof WORKSPACE_ID): Label | undefined {
-    return this.idToLabel[id]?.[teamId] ?? this.idToLabel[id]?.[WORKSPACE_ID];
-  }
-
-  private getLabel<T>(props: { name: string } | { id: Id }, checkInstance: (label: Label) => boolean): T | undefined {
-    let label: Label | undefined;
-    if ("name" in props) {
-      label = this.getLabelByName(props.name, this.teamId);
-    } else {
-      label = this.getLabelById(props.id, this.teamId);
-    }
-    return (label && checkInstance(label) ? label : undefined) as T | undefined;
-  }
-
-  public getGroupLabel(props: { name: string } | { id: Id }): LabelGroup | undefined {
-    return this.getLabel<LabelGroup>(props, label => label instanceof LabelGroup);
-  }
-
-  public getRootLabel(props: { name: string } | { id: Id }): Label | undefined {
-    return this.getLabel<Label>(props, label => label instanceof Label);
-  }
-
-  public addLabel(props: { label: Label; parent?: LabelGroup; teamId?: Id | typeof WORKSPACE_ID }) {
-    const { label, parent, teamId = this.teamId } = props;
-
-    this.nameToLabel[label.name.toLowerCase()] = { [teamId]: label };
-    this.idToLabel[label.id] = { [teamId]: label };
-
-    if (parent) {
-      parent.addLabel(label.name, label.id);
-    }
-  }
-
-  private async initializeLabels(existingLabels: IssueLabel[]) {
-    // We want to process groups first.
-    existingLabels.sort(a => (a.isGroup ? -1 : 1));
-
-    for (const existingLabel of existingLabels) {
-      const labelName = existingLabel.name?.toLowerCase();
-      const teamId = (await existingLabel.team)?.id ?? WORKSPACE_ID;
-
-      if (existingLabel.isGroup && labelName && existingLabel.id) {
-        const group = new LabelGroup(existingLabel.id, labelName);
-        this.addLabel({ label: group, teamId });
-      } else if (labelName && existingLabel.id) {
-        const parent = await existingLabel.parent;
-
-        if (parent) {
-          const group = this.idToLabel[parent.id]?.[teamId] as LabelGroup;
-          this.addLabel({ label: new Label(existingLabel.id, labelName), parent: group, teamId });
-        } else {
-          this.addLabel({ label: new Label(existingLabel.id, labelName), teamId });
-        }
-      }
-    }
-  }
-}
-
-const createLabel = async (
-  client: LinearClient,
-  {
-    name,
-    description,
-    color,
-    parentId,
-    teamId,
-  }: {
-    name: string;
-    description?: string;
-    color?: string;
-    parentId?: Id;
-    teamId: Id;
-  }
-) => {
-  const response = await client.createIssueLabel({ name, description, color, teamId, parentId });
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return (await response?.issueLabel)!.id;
-};
-
-const deleteLabel = async (client: LinearClient, labelId: Id) => {
-  await client.deleteIssueLabel(labelId);
-};
-
+/**
+ * Handle importing labels
+ *
+ * @param client Linear client instance to use for API requests
+ * @param importData Import data containing issues and labels
+ * @param teamId Team ID being imported to
+ * @param existingLabels Existing labels in the team and workspace
+ */
 export const handleLabels = async (
   client: LinearClient,
   importData: ImportResult,
   teamId: string,
   existingLabels: IssueLabel[]
-): Promise<Record<string, { type: "root" | "parent" | "child"; id: Id }>> => {
+): Promise<Record<string, { type: LabelType; id: Id }>> => {
   const manager = new LabelManager(existingLabels, teamId);
-  const labelMapping: Record<string, { type: "root" | "parent" | "child"; id: Id }> = {};
+  const labelMapping: Record<string, { type: LabelType; id: Id }> = {};
 
+  // We process issues instead of labels to validate issue <> label constraints (e.g. only one label from a group)
   for (const issue of importData.issues) {
     const labels = issue.labels;
     if (!labels) {
@@ -142,9 +55,8 @@ const handleIssueLabels = async (
     const group = parsed[0];
     let labelName = parsed[1];
 
-    // If this label's group is already used in this issue,
-    // or if it was previously mapped as a child label and its group is in use,
-    // create/use a root label with the full name
+    // If this label's group is already used in this issue, or if it was previously mapped as a child label
+    // and its group is in use, create/use a root label with the full name.
     if (group && (usedGroups.has(group) || (labelMapping[labelId]?.type === "child" && usedGroups.has(group)))) {
       const fullName = labelData.name;
       actualLabelId = manager.getLabelByName(fullName, teamId)?.id;
@@ -183,12 +95,12 @@ const handleIssueLabels = async (
           // Create the group label with a modified name
           const groupName = `${group} (imported)`;
           const groupId = await createLabel(client, { name: groupName, teamId });
-          groupLabel = new LabelGroup(groupId, groupName);
+          groupLabel = new GroupLabel(groupId, groupName);
           manager.addLabel({ label: groupLabel, teamId });
         } else {
           // Create new group label
           const groupId = await createLabel(client, { name: group, teamId });
-          groupLabel = new LabelGroup(groupId, group);
+          groupLabel = new GroupLabel(groupId, group);
           manager.addLabel({ label: groupLabel, teamId });
         }
       }
@@ -242,7 +154,8 @@ const handleIssueLabels = async (
 };
 
 function parseLabelName(fullName: string): [string | undefined, string] {
-  const parts = fullName.split("/");
+  // Ensure every part is truncated to 80 characters
+  const parts = fullName.split("/").map(part => _.truncate(part.trim(), { length: 80 }));
   let group: string | undefined;
   let subgroup: string;
 
@@ -254,13 +167,142 @@ function parseLabelName(fullName: string): [string | undefined, string] {
     subgroup = fullName;
   }
 
-  // Ensure every part is truncated to 80 characters
-  return [group, subgroup].map(part => (part ? _.truncate(part.trim(), { length: 80 }) : undefined)) as [
-    string | undefined,
-    string,
-  ];
+  return [group, subgroup] as [string | undefined, string];
 }
 
+class LabelManager {
+  private nameToLabel: Record<string, { [teamId: Id | typeof WORKSPACE_ID]: Label }> = {};
+  private idToLabel: Record<Id, { [teamId: Id | typeof WORKSPACE_ID]: Label }> = {};
+
+  public constructor(
+    existingLabels: IssueLabel[],
+    private teamId: Id
+  ) {
+    this.initializeLabels(existingLabels);
+  }
+
+  /**
+   * Retrieve a label by name in either the workspace or specified team
+   *
+   * @param name Label name
+   * @param teamId Team ID to search in
+   * @returns Label instance if found
+   */
+  public getLabelByName(name: string, teamId: Id | typeof WORKSPACE_ID): Label | undefined {
+    return this.nameToLabel[name.toLowerCase()]?.[teamId] ?? this.nameToLabel[name]?.[WORKSPACE_ID];
+  }
+
+  /**
+   * Retrieve a label by its ID in either the workspace or specified team
+   *
+   * @param name Label ID
+   * @param teamId Team ID to search in
+   * @returns Label instance if found
+   */
+  public getLabelById(id: Id, teamId: Id | typeof WORKSPACE_ID): Label | undefined {
+    return this.idToLabel[id]?.[teamId] ?? this.idToLabel[id]?.[WORKSPACE_ID];
+  }
+
+  /**
+   * Retrieve a group label by name or ID in either the workspace or specified team
+   *
+   * @param props Object containing either name or ID
+   * @returns GroupLabel instance if found
+   */
+  public getGroupLabel(props: { name: string } | { id: Id }): GroupLabel | undefined {
+    return this.getLabel(props, GroupLabel);
+  }
+
+  /**
+   * Retrieve a root label by name or ID in either the workspace or specified team
+   *
+   * @param props Object containing either name or ID
+   * @returns Label instance if found
+   */
+  public getRootLabel(props: { name: string } | { id: Id }): Label | undefined {
+    return this.getLabel(props, Label);
+  }
+
+  /**
+   * Adds a label to the manager
+   *
+   * @param props Object label, its parent (if any), and team ID (defaults to the current teamId)
+   */
+  public addLabel(props: { label: Label; parent?: GroupLabel; teamId?: Id | typeof WORKSPACE_ID }) {
+    const { label, parent, teamId = this.teamId } = props;
+
+    this.nameToLabel[label.name.toLowerCase()] = { [teamId]: label };
+    this.idToLabel[label.id] = { [teamId]: label };
+
+    if (parent) {
+      parent.addLabel(label.name, label.id);
+    }
+  }
+
+  private getLabel<T extends typeof Label>(
+    props: { name: string } | { id: Id },
+    instanceType: T
+  ): InstanceType<T> | undefined {
+    let label: Label | undefined;
+    if ("name" in props) {
+      label = this.getLabelByName(props.name, this.teamId);
+    } else {
+      label = this.getLabelById(props.id, this.teamId);
+    }
+    return (label && label instanceof instanceType ? label : undefined) as InstanceType<T> | undefined;
+  }
+
+  private async initializeLabels(existingLabels: IssueLabel[]) {
+    // We want to process groups first.
+    existingLabels.sort(a => (a.isGroup ? -1 : 1));
+
+    for (const existingLabel of existingLabels) {
+      const labelName = existingLabel.name?.toLowerCase();
+      const teamId = (await existingLabel.team)?.id ?? WORKSPACE_ID;
+
+      if (existingLabel.isGroup && labelName && existingLabel.id) {
+        const group = new GroupLabel(existingLabel.id, labelName);
+        this.addLabel({ label: group, teamId });
+      } else if (labelName && existingLabel.id) {
+        const parent = await existingLabel.parent;
+
+        if (parent) {
+          const group = this.idToLabel[parent.id]?.[teamId] as GroupLabel;
+          this.addLabel({ label: new Label(existingLabel.id, labelName), parent: group, teamId });
+        } else {
+          this.addLabel({ label: new Label(existingLabel.id, labelName), teamId });
+        }
+      }
+    }
+  }
+}
+
+const createLabel = async (
+  client: LinearClient,
+  {
+    name,
+    description,
+    color,
+    parentId,
+    teamId,
+  }: {
+    name: string;
+    description?: string;
+    color?: string;
+    parentId?: Id;
+    teamId: Id;
+  }
+) => {
+  const response = await client.createIssueLabel({ name, description, color, teamId, parentId });
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return (await response?.issueLabel)!.id;
+};
+
+const deleteLabel = async (client: LinearClient, labelId: Id) => {
+  await client.deleteIssueLabel(labelId);
+};
+
+// A root label
 class Label {
   public constructor(
     public id: Id,
@@ -268,7 +310,8 @@ class Label {
   ) {}
 }
 
-class LabelGroup extends Label {
+// A label group (parent label)
+class GroupLabel extends Label {
   public labels: Record<string, Id> = {};
 
   public constructor(id: Id, name: string) {
@@ -280,4 +323,5 @@ class LabelGroup extends Label {
   }
 }
 
+// A label in a group (child label)
 class SubgroupLabel extends Label {}

--- a/packages/import/src/helpers/labelManager.ts
+++ b/packages/import/src/helpers/labelManager.ts
@@ -3,166 +3,269 @@ import { ImportResult } from "../types";
 import _ from "lodash";
 
 type Id = string;
+const WORKSPACE_ID = "workspace";
 
 class LabelManager {
-  public constructor(existingLabels: IssueLabel[]) {
-    this.existingLabelMap = {};
-    this.existingLabelGroupsMap = {};
-    this.existingGroupIdLabelMap = {};
+    private nameToLabel: Record<string, { [teamId: Id | typeof WORKSPACE_ID]: Label }> = {};
+    private idToLabel: Record<Id, { [teamId: Id | typeof WORKSPACE_ID]: Label }> = {};
 
-    this.processExistingLabels(existingLabels);
-  }
-
-  public getGroupLabelId(groupName: string): Id | undefined {
-    return this.existingLabelGroupsMap[groupName.toLowerCase()];
-  }
-
-  public getLabelId(labelName: string): Id | undefined {
-    return this.existingLabelMap[labelName.toLowerCase()];
-  }
-
-  public doesRootLabelExist(labelName: string): boolean {
-    return !!this.existingLabelMap[labelName.toLowerCase()];
-  }
-
-  public addGroup(groupName: string, groupLabelId: Id): void {
-    this.existingLabelGroupsMap[groupName.toLowerCase()] = groupLabelId;
-    this.existingGroupIdLabelMap[groupLabelId] = {};
-  }
-
-  public addGroupLabel(groupId: Id, labelName: string, labelId: Id): void {
-    this.existingGroupIdLabelMap[groupId][labelName.toLowerCase()] = labelId;
-  }
-
-  public addLabel(labelName: string, labelId: Id): void {
-    this.existingLabelMap[labelName.toLowerCase()] = labelId;
-  }
-
-  public getGroupLabel(groupId: Id, labelName: string): Id | undefined {
-    return this.existingGroupIdLabelMap[groupId][labelName.toLowerCase()];
-  }
-
-  private processExistingLabels(existingLabels: IssueLabel[]) {
-    for (const label of existingLabels) {
-      const labelName = label.name?.toLowerCase();
-      if (label.isGroup) {
-        if (labelName && label.id && !this.existingLabelGroupsMap[labelName]) {
-          this.existingLabelGroupsMap[labelName] = label.id;
-        }
-      } else {
-        if (labelName && label.id && !this.existingLabelMap[labelName]) {
-          this.existingLabelMap[labelName] = label.id;
-        }
-      }
+    public constructor(
+        existingLabels: IssueLabel[],
+        private teamId: Id
+    ) {
+        this.initializeLabels(existingLabels);
     }
-  }
 
-  private existingLabelMap: { [name: string]: string };
-  private existingLabelGroupsMap: { [name: string]: string };
-  private existingGroupIdLabelMap: { [id: Id]: { [name: string]: Id } };
+    public getLabelByName(name: string, teamId: Id | typeof WORKSPACE_ID): Label | undefined {
+        return this.nameToLabel[name.toLowerCase()]?.[teamId] ?? this.nameToLabel[name]?.[WORKSPACE_ID];
+    }
+
+    public getLabelById(id: Id, teamId: Id | typeof WORKSPACE_ID): Label | undefined {
+        return this.idToLabel[id]?.[teamId] ?? this.idToLabel[id]?.[WORKSPACE_ID];
+    }
+
+    private getLabel<T>(props: { name: string } | { id: Id }, checkInstance: (label: Label) => boolean): T | undefined {
+        let label: Label | undefined;
+        if ("name" in props) {
+            label = this.getLabelByName(props.name, this.teamId);
+        } else {
+            label = this.getLabelById(props.id, this.teamId);
+        }
+        return (label && checkInstance(label) ? label : undefined) as T | undefined;
+    }
+
+    public getGroupLabel(props: { name: string } | { id: Id }): LabelGroup | undefined {
+        return this.getLabel<LabelGroup>(props, label => label instanceof LabelGroup);
+    }
+
+    public getRootLabel(props: { name: string } | { id: Id }): Label | undefined {
+        return this.getLabel<Label>(props, label => label instanceof Label);
+    }
+
+    public addLabel(props: { label: Label; parent?: LabelGroup; teamId?: Id | typeof WORKSPACE_ID }) {
+        const { label, parent, teamId = this.teamId } = props;
+
+        this.nameToLabel[label.name.toLowerCase()] = { [teamId]: label };
+        this.idToLabel[label.id] = { [teamId]: label };
+
+        if (parent) {
+            parent.addLabel(label.name, label.id);
+        }
+    }
+
+    private async initializeLabels(existingLabels: IssueLabel[]) {
+        // We want to process groups first.
+        existingLabels.sort(a => (a.isGroup ? -1 : 1));
+
+        for (const existingLabel of existingLabels) {
+            const labelName = existingLabel.name?.toLowerCase();
+            const teamId = (await existingLabel.team)?.id ?? WORKSPACE_ID;
+
+            if (existingLabel.isGroup && labelName && existingLabel.id) {
+                const group = new LabelGroup(existingLabel.id, labelName);
+                this.addLabel({ label: group, teamId });
+            } else if (labelName && existingLabel.id) {
+                const parent = await existingLabel.parent;
+
+                if (parent) {
+                    const group = this.idToLabel[parent.id]?.[teamId] as LabelGroup;
+                    this.addLabel({ label: new Label(existingLabel.id, labelName), parent: group, teamId });
+                } else {
+                    this.addLabel({ label: new Label(existingLabel.id, labelName), teamId });
+                }
+            }
+        }
+    }
 }
 
-export const handleLabels = async (
-  client: LinearClient,
-  data: ImportResult,
-  teamId: string,
-  existingLabels: IssueLabel[]
-): Promise<{ [identifier: string]: string }> => {
-  const manager = new LabelManager(existingLabels);
-  const { labels } = data;
-
-  const createLabel = async ({
-    name,
-    description,
-    color,
-    parentId,
-  }: {
-    name: string;
-    description?: string;
-    color?: string;
-    parentId?: string;
-  }) => {
-    const labelResponse = await client.createIssueLabel({
-      name,
-      description,
-      color,
-      teamId,
-      parentId,
-    });
-
-    const issueLabel = await labelResponse?.issueLabel;
-    return issueLabel?.id;
-  };
-
-  // Create labels and mapping to source data
-  const labelMapping = {} as { [identifier: string]: Id };
-
-  for (const labelId of Object.keys(labels)) {
-    const label = labels[labelId];
-    let labelName = _.truncate(label.name.trim(), { length: 80 });
-
-    let groupLabelId: string | undefined;
-    // Handle label groups
-    if (labelName.indexOf("/") !== -1) {
-      const parts = labelName.split("/");
-      const group = parts.slice(0, -1).join("/");
-      const subgroup = parts[parts.length - 1];
-
-      groupLabelId = manager.getGroupLabelId(group);
-      const rootLabelExists = manager.doesRootLabelExist(group);
-
-      // Label group does not exist, create it
-      if (!groupLabelId) {
-        groupLabelId = await createLabel({
-          name: rootLabelExists ? `${group} (group)` : group,
-          color: label.color,
-          description: label.description,
-        });
-
-        if (groupLabelId) {
-          manager.addGroup(group, groupLabelId);
-        }
-      }
-
-      labelName = subgroup; // Use the subgroup name for the actual label
+const createLabel = async (
+    client: LinearClient,
+    {
+        name,
+        description,
+        color,
+        parentId,
+        teamId,
+    }: {
+        name: string;
+        description?: string;
+        color?: string;
+        parentId?: Id;
+        teamId: Id;
     }
-
-    let actualLabelId: string | undefined;
-    if (groupLabelId) {
-      // If we have a group label, check if we've already created the subgroup label
-      actualLabelId = manager.getGroupLabel(groupLabelId, labelName);
-    } else {
-      // Check if this label matches with an existing group label
-      if (manager.getGroupLabelId(labelName)) {
-        // This label has matched with an existing group label. We cannot re-use the label as-is, it will be renamed.
-        actualLabelId = undefined;
-        labelName = `${labelName} (imported)`;
-      }
-
-      // Check if this label matches with an existing root label
-      actualLabelId = manager.getLabelId(labelName);
-    }
-
-    if (!actualLabelId) {
-      // We haven't found an existing label, create it
-      actualLabelId = await createLabel({
-        name: labelName,
-        color: label.color,
-        description: label.description,
-        parentId: groupLabelId,
-      });
-
-      if (groupLabelId && actualLabelId) {
-        manager.addGroupLabel(groupLabelId, labelName, actualLabelId);
-      } else if (actualLabelId) {
-        manager.addLabel(labelName, actualLabelId);
-      }
-    }
-
-    if (actualLabelId) {
-      labelMapping[labelId] = actualLabelId;
-    }
-  }
-
-  return labelMapping;
+) => {
+    const response = await client.createIssueLabel({ name, description, color, teamId, parentId });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return (await response?.issueLabel)!.id;
 };
+
+export const handleLabels = async (
+    client: LinearClient,
+    importData: ImportResult,
+    teamId: string,
+    existingLabels: IssueLabel[]
+): Promise<Record<string, { type: "root" | "parent" | "child"; id: Id }>> => {
+    const manager = new LabelManager(existingLabels, teamId);
+    const labelMapping: Record<string, { type: "root" | "parent" | "child"; id: Id }> = {};
+
+    for (const issue of importData.issues) {
+        const labels = issue.labels;
+        if (!labels) {
+            continue;
+        }
+
+        await handleIssueLabels(client, manager, teamId, importData, labels, labelMapping);
+    }
+
+    return labelMapping;
+};
+
+const handleIssueLabels = async (
+    client: LinearClient,
+    manager: LabelManager,
+    teamId: Id,
+    importData: ImportResult,
+    issueLabelIds: string[],
+    labelMapping: Record<string, { type: "root" | "parent" | "child"; id: Id }>
+) => {
+    let actualLabelId: Id | undefined;
+    // Track which groups are used to prevent multiple labels from same group
+    const usedGroups = new Set<string>();
+
+    for (const labelId of issueLabelIds) {
+        const labelData = importData.labels[labelId];
+        const parsed = parseLabelName(labelData.name);
+        const group = parsed[0];
+        let labelName = parsed[1];
+
+        // If this label's group is already used in this issue,
+        // or if it was previously mapped as a child label and its group is in use,
+        // create/use a root label with the full name
+        if (group && (usedGroups.has(group) || (labelMapping[labelId]?.type === "child" && usedGroups.has(group)))) {
+            const fullName = labelData.name;
+            actualLabelId = manager.getLabelByName(fullName, teamId)?.id;
+
+            if (!actualLabelId) {
+                actualLabelId = await createLabel(client, { name: fullName, teamId });
+                const rootLabel = new Label(actualLabelId, fullName);
+                manager.addLabel({ label: rootLabel, teamId });
+            }
+
+            labelMapping[labelId] = { type: "root", id: actualLabelId };
+            continue;
+        }
+
+        // If we already have a mapping for this label and it's not a conflicting child label,
+        // use it and track the group
+        if (labelMapping[labelId]) {
+            if (group) {
+                usedGroups.add(group);
+            }
+            continue;
+        }
+
+        let groupLabel = group ? manager.getGroupLabel({ name: group }) : undefined;
+
+        if (group) {
+            if (!groupLabel) {
+                // Check if the group name conflicts with an existing root label
+                const rootLabelConflict = manager.getRootLabel({ name: group });
+                if (rootLabelConflict) {
+                    // Create the group label with a modified name
+                    const groupName = `${group} (imported)`;
+                    const groupId = await createLabel(client, { name: groupName, teamId });
+                    groupLabel = new LabelGroup(groupId, groupName);
+                    manager.addLabel({ label: groupLabel, teamId });
+                } else {
+                    // Create new group label
+                    const groupId = await createLabel(client, { name: group, teamId });
+                    groupLabel = new LabelGroup(groupId, group);
+                    manager.addLabel({ label: groupLabel, teamId });
+                }
+            }
+
+            usedGroups.add(group);
+        }
+
+        // Handle the child label if we have a valid group
+        if (groupLabel) {
+            actualLabelId = groupLabel.labels[labelName];
+
+            if (!actualLabelId) {
+                // Check for naming conflicts
+                const existingLabel = manager.getLabelByName(labelName, teamId);
+                const newLabelName = existingLabel ? `${labelName} (imported)` : labelName;
+
+                actualLabelId = await createLabel(client, {
+                    name: newLabelName,
+                    parentId: groupLabel.id,
+                    teamId,
+                });
+
+                const subgroupLabel = new SubgroupLabel(actualLabelId, newLabelName);
+                manager.addLabel({ label: subgroupLabel, parent: groupLabel, teamId });
+            }
+
+            labelMapping[labelId] = { type: "child", id: actualLabelId };
+            continue;
+        }
+
+        // Handle as root label
+        labelName = labelData.name;
+        let rootLabelName = labelName;
+
+        // Check for conflicts with existing group labels
+        if (manager.getGroupLabel({ name: labelName })) {
+            rootLabelName = `${labelName} (imported)`;
+        }
+
+        // Check for existing root label
+        actualLabelId = manager.getLabelByName(rootLabelName, teamId)?.id;
+
+        if (!actualLabelId) {
+            actualLabelId = await createLabel(client, { name: rootLabelName, teamId });
+            const rootLabel = new Label(actualLabelId, rootLabelName);
+            manager.addLabel({ label: rootLabel, teamId });
+        }
+
+        labelMapping[labelId] = { type: "root", id: actualLabelId };
+    }
+};
+
+function parseLabelName(fullName: string): [string | undefined, string] {
+    const parts = fullName.split("/");
+    let group: string | undefined;
+    let subgroup: string;
+
+    if (parts.length > 1) {
+        subgroup = parts.pop() as string;
+        group = parts.join("/");
+    } else {
+        group = undefined;
+        subgroup = fullName;
+    }
+
+    // Ensure every part is truncated to 80 characters
+    return [group, subgroup].map(part => part ? _.truncate(part.trim(), { length: 80 }) : undefined) as [string | undefined, string];
+}
+
+class Label {
+    public constructor(
+        public id: Id,
+        public name: string
+    ) { }
+}
+
+class LabelGroup extends Label {
+    public labels: Record<string, Id> = {};
+
+    public constructor(id: Id, name: string) {
+        super(id, name);
+    }
+
+    public addLabel(name: string, id: Id) {
+        this.labels[name.toLowerCase()] = id;
+    }
+}
+
+class SubgroupLabel extends Label { }

--- a/packages/import/src/helpers/labelManager.ts
+++ b/packages/import/src/helpers/labelManager.ts
@@ -1,0 +1,168 @@
+import { IssueLabel, LinearClient } from "@linear/sdk";
+import { ImportResult } from "../types";
+import _ from "lodash";
+
+type Id = string;
+
+class LabelManager {
+  public constructor(existingLabels: IssueLabel[]) {
+    this.existingLabelMap = {};
+    this.existingLabelGroupsMap = {};
+    this.existingGroupIdLabelMap = {};
+
+    this.processExistingLabels(existingLabels);
+  }
+
+  public getGroupLabelId(groupName: string): Id | undefined {
+    return this.existingLabelGroupsMap[groupName.toLowerCase()];
+  }
+
+  public getLabelId(labelName: string): Id | undefined {
+    return this.existingLabelMap[labelName.toLowerCase()];
+  }
+
+  public doesRootLabelExist(labelName: string): boolean {
+    return !!this.existingLabelMap[labelName.toLowerCase()];
+  }
+
+  public addGroup(groupName: string, groupLabelId: Id): void {
+    this.existingLabelGroupsMap[groupName.toLowerCase()] = groupLabelId;
+    this.existingGroupIdLabelMap[groupLabelId] = {};
+  }
+
+  public addGroupLabel(groupId: Id, labelName: string, labelId: Id): void {
+    this.existingGroupIdLabelMap[groupId][labelName.toLowerCase()] = labelId;
+  }
+
+  public addLabel(labelName: string, labelId: Id): void {
+    this.existingLabelMap[labelName.toLowerCase()] = labelId;
+  }
+
+  public getGroupLabel(groupId: Id, labelName: string): Id | undefined {
+    return this.existingGroupIdLabelMap[groupId][labelName.toLowerCase()];
+  }
+
+  private processExistingLabels(existingLabels: IssueLabel[]) {
+    for (const label of existingLabels) {
+      const labelName = label.name?.toLowerCase();
+      if (label.isGroup) {
+        if (labelName && label.id && !this.existingLabelGroupsMap[labelName]) {
+          this.existingLabelGroupsMap[labelName] = label.id;
+        }
+      } else {
+        if (labelName && label.id && !this.existingLabelMap[labelName]) {
+          this.existingLabelMap[labelName] = label.id;
+        }
+      }
+    }
+  }
+
+  private existingLabelMap: { [name: string]: string };
+  private existingLabelGroupsMap: { [name: string]: string };
+  private existingGroupIdLabelMap: { [id: Id]: { [name: string]: Id } };
+}
+
+export const handleLabels = async (
+  client: LinearClient,
+  data: ImportResult,
+  teamId: string,
+  existingLabels: IssueLabel[]
+): Promise<{ [identifier: string]: string }> => {
+  const manager = new LabelManager(existingLabels);
+  const { labels } = data;
+
+  const createLabel = async ({
+    name,
+    description,
+    color,
+    parentId,
+  }: {
+    name: string;
+    description?: string;
+    color?: string;
+    parentId?: string;
+  }) => {
+    const labelResponse = await client.createIssueLabel({
+      name,
+      description,
+      color,
+      teamId,
+      parentId,
+    });
+
+    const issueLabel = await labelResponse?.issueLabel;
+    return issueLabel?.id;
+  };
+
+  // Create labels and mapping to source data
+  const labelMapping = {} as { [identifier: string]: Id };
+
+  for (const labelId of Object.keys(labels)) {
+    const label = labels[labelId];
+    let labelName = _.truncate(label.name.trim(), { length: 80 });
+
+    let groupLabelId: string | undefined;
+    // Handle label groups
+    if (labelName.indexOf("/") !== -1) {
+      const parts = labelName.split("/");
+      const group = parts.slice(0, -1).join("/");
+      const subgroup = parts[parts.length - 1];
+
+      groupLabelId = manager.getGroupLabelId(group);
+      const rootLabelExists = manager.doesRootLabelExist(group);
+
+      // Label group does not exist, create it
+      if (!groupLabelId) {
+        groupLabelId = await createLabel({
+          name: rootLabelExists ? `${group} (group)` : group,
+          color: label.color,
+          description: label.description,
+        });
+
+        if (groupLabelId) {
+          manager.addGroup(group, groupLabelId);
+        }
+      }
+
+      labelName = subgroup; // Use the subgroup name for the actual label
+    }
+
+    let actualLabelId: string | undefined;
+    if (groupLabelId) {
+      // If we have a group label, check if we've already created the subgroup label
+      actualLabelId = manager.getGroupLabel(groupLabelId, labelName);
+    } else {
+      // Check if this label matches with an existing group label
+      if (manager.getGroupLabelId(labelName)) {
+        // This label has matched with an existing group label. We cannot re-use the label as-is, it will be renamed.
+        actualLabelId = undefined;
+        labelName = `${labelName} (imported)`;
+      }
+
+      // Check if this label matches with an existing root label
+      actualLabelId = manager.getLabelId(labelName);
+    }
+
+    if (!actualLabelId) {
+      // We haven't found an existing label, create it
+      actualLabelId = await createLabel({
+        name: labelName,
+        color: label.color,
+        description: label.description,
+        parentId: groupLabelId,
+      });
+
+      if (groupLabelId && actualLabelId) {
+        manager.addGroupLabel(groupLabelId, labelName, actualLabelId);
+      } else if (actualLabelId) {
+        manager.addLabel(labelName, actualLabelId);
+      }
+    }
+
+    if (actualLabelId) {
+      labelMapping[labelId] = actualLabelId;
+    }
+  }
+
+  return labelMapping;
+};

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -245,7 +245,7 @@ export const importIssues = async (apiKey: string, importer: Importer): Promise<
         ? await buildComments(client, issueDescription || "", issue.comments, importData)
         : issueDescription;
 
-    const labelIds = issue.labels ? uniq(issue.labels.map(labelId => labelMapping[labelId])) : undefined;
+    const labelIds = issue.labels ? uniq(issue.labels.map(labelId => labelMapping[labelId].id)) : undefined;
 
     let stateId = !!issue.status ? existingStateMap[issue.status.toLowerCase()] : undefined;
     // Create a new state since one doesn't already exist with this name

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -6,19 +6,9 @@ import * as inquirer from "inquirer";
 import { uniq } from "lodash";
 import { Comment, Importer, ImportResult } from "./types";
 import { replaceImagesInMarkdown } from "./utils/replaceImages";
+import { handleLabels } from "./helpers/labelManager";
 import { Presets, SingleBar } from "cli-progress";
 import ora from "ora";
-
-import { setGlobalDispatcher, Agent } from "undici";
-import { handleLabels } from "./helpers/labelManager";
-
-setGlobalDispatcher(
-  new Agent({
-    connect: {
-      rejectUnauthorized: false,
-    },
-  })
-);
 
 type Id = string;
 
@@ -49,7 +39,7 @@ const defaultStateColors: Record<IssueStatus, string> = {
  * Import issues into Linear via the API.
  */
 export const importIssues = async (apiKey: string, importer: Importer): Promise<void> => {
-  const client = new LinearClient({ apiKey, apiUrl: "https://local.linear.dev:8090/graphql" });
+  const client = new LinearClient({ apiKey });
   const importData = await importer.import();
 
   const viewerQuery = await client.viewer;

--- a/packages/import/src/importers/asanaCsv/AsanaCsvImporter.ts
+++ b/packages/import/src/importers/asanaCsv/AsanaCsvImporter.ts
@@ -1,5 +1,5 @@
 import csv from "csvtojson";
-import { Importer, ImportResult } from "../../types";
+import { Importer, ImportResult, IssuePriority } from "../../types";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const j2m = require("jira2md");
 
@@ -117,8 +117,8 @@ export class AsanaCsvImporter implements Importer {
   private organizationName?: string;
 }
 
-const mapPriority = (input: AsanaPriority): number => {
-  const priorityMap = {
+const mapPriority = (input: AsanaPriority) => {
+  const priorityMap: { [k: string]: IssuePriority } = {
     High: 2,
     Med: 3,
     Low: 4,

--- a/packages/import/src/importers/gitlabCsv/GitlabCsvImporter.ts
+++ b/packages/import/src/importers/gitlabCsv/GitlabCsvImporter.ts
@@ -1,0 +1,102 @@
+import csv from "csvtojson";
+import { Importer, ImportResult } from "../../types";
+import { safeParseInt } from "../../utils/parseInt";
+
+type GitLabStatus = "opened" | "closed";
+
+interface GitLabIssueType {
+  Title: string;
+  Description: string;
+  URL: string;
+  State: GitLabStatus;
+  Labels: string;
+  "Due Date": string;
+  "Created At (UTC)": string;
+  "Closed At (UTC)": string;
+  Weight: string;
+  "Time Estimate": string;
+}
+
+/**
+ * Import issues from GitLab CSV export.
+ *
+ * @param filePath  path to csv file
+ */
+export class GitLabCsvImporter implements Importer {
+  public constructor(filePath: string) {
+    this.filePath = filePath;
+  }
+
+  public get name(): string {
+    return "Linear (CSV)";
+  }
+
+  public get defaultTeamName(): string {
+    return "Linear";
+  }
+
+  public import = async (): Promise<ImportResult> => {
+    const data = (await csv().fromFile(this.filePath)) as GitLabIssueType[];
+
+    const importData: ImportResult = {
+      issues: [],
+      labels: {},
+      users: {},
+      statuses: {},
+    };
+
+    const weights = new Set(data.map(r => safeParseInt(r.Weight)).filter(w => !!w)) as Set<number>;
+    const normalizedWeights = normalizeWeights(weights);
+
+    for (const row of data) {
+      const labels = row.Labels.split(",").filter(tag => !!tag);
+      const weight = safeParseInt(row.Weight);
+      const estimate = safeParseInt(row["Time Estimate"]);
+
+      importData.issues.push({
+        title: row.Title,
+        description: `${row.Description}\n\n[Original issue](${row.URL})`,
+        status: row.State === "closed" ? "Completed" : "Backlog",
+        createdAt: !!row["Created At (UTC)"] ? new Date(row["Created At (UTC)"]) : undefined,
+        completedAt: row.State === "closed" && !!row["Closed At (UTC)"] ? new Date(row["Closed At (UTC)"]) : undefined,
+        labels,
+        priority: !!weight ? normalizedWeights.get(weight) : undefined,
+        dueDate: !!row["Due Date"] ? new Date(row["Due Date"]) : undefined,
+        estimate: !!estimate ? estimate : undefined,
+      });
+
+      for (const lab of labels) {
+        if (!importData.labels[lab]) {
+          importData.labels[lab] = {
+            name: lab,
+          };
+        }
+      }
+    }
+
+    return importData;
+  };
+
+  // -- Private interface
+
+  private filePath: string;
+}
+
+// Map weights to a normalized range of 0-4, with 0 being the highest weight. Answer with a map of original to normalized.
+const normalizeWeights = (weights: Set<number>) => {
+  const res: Map<number, number> = new Map();
+
+  const sortedWeights = Array.from(weights).sort((a, b) => a - b);
+  const max = sortedWeights[sortedWeights.length - 1];
+  const min = sortedWeights[0];
+
+  for (const weight of sortedWeights) {
+    if (max === min) {
+      res.set(weight, 0);
+    } else {
+      res.set(weight, Math.round(((max - weight) / (max - min)) * 4));
+    }
+  }
+
+  return res;
+};

--- a/packages/import/src/importers/gitlabCsv/GitlabCsvImporter.ts
+++ b/packages/import/src/importers/gitlabCsv/GitlabCsvImporter.ts
@@ -1,5 +1,5 @@
 import csv from "csvtojson";
-import { Importer, ImportResult } from "../../types";
+import { Importer, ImportResult, IssuePriority } from "../../types";
 import { safeParseInt } from "../../utils/parseInt";
 
 type GitLabStatus = "opened" | "closed";
@@ -28,7 +28,7 @@ export class GitLabCsvImporter implements Importer {
   }
 
   public get name(): string {
-    return "Linear (CSV)";
+    return "GitLab (CSV)";
   }
 
   public get defaultTeamName(): string {
@@ -82,9 +82,9 @@ export class GitLabCsvImporter implements Importer {
   private filePath: string;
 }
 
-// Map weights to a normalized range of 0-4, with 0 being the highest weight. Answer with a map of original to normalized.
+// Map weights to a normalized range of 0-4, with 0 being the highest weight.
 const normalizeWeights = (weights: Set<number>) => {
-  const res: Map<number, number> = new Map();
+  const res: Map<number, IssuePriority> = new Map();
 
   const sortedWeights = Array.from(weights).sort((a, b) => a - b);
   const max = sortedWeights[sortedWeights.length - 1];
@@ -92,9 +92,10 @@ const normalizeWeights = (weights: Set<number>) => {
 
   for (const weight of sortedWeights) {
     if (max === min) {
-      res.set(weight, 0);
+      // Handle division by zero
+      res.set(weight, 1);
     } else {
-      res.set(weight, Math.round(((max - weight) / (max - min)) * 4));
+      res.set(weight, Math.round(((max - weight) / (max - min)) * 4) as IssuePriority);
     }
   }
 

--- a/packages/import/src/importers/gitlabCsv/index.ts
+++ b/packages/import/src/importers/gitlabCsv/index.ts
@@ -1,0 +1,24 @@
+import * as inquirer from "inquirer";
+
+import { Importer } from "../../types";
+import { GitLabCsvImporter } from "./GitlabCsvImporter";
+
+const BASE_PATH = process.cwd();
+
+export const gitlabCsvImporter = async (): Promise<Importer> => {
+  const answers = await inquirer.prompt<GitLabImportAnswers>(questions);
+  return new GitLabCsvImporter(answers.csvFilePath);
+};
+
+interface GitLabImportAnswers {
+  csvFilePath: string;
+}
+
+const questions = [
+  {
+    basePath: BASE_PATH,
+    type: "filePath",
+    name: "csvFilePath",
+    message: "Select your exported CSV file of GitLab issues",
+  },
+];

--- a/packages/import/src/importers/jiraCsv/JiraCsvImporter.ts
+++ b/packages/import/src/importers/jiraCsv/JiraCsvImporter.ts
@@ -1,5 +1,5 @@
 import csv from "csvtojson";
-import { Importer, ImportResult } from "../../types";
+import { Importer, ImportResult, IssuePriority } from "../../types";
 import { safeParseInt } from "../../utils/parseInt";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const j2m = require("jira2md");
@@ -125,7 +125,7 @@ export class JiraCsvImporter implements Importer {
 }
 
 const mapPriority = (input: JiraPriority): number => {
-  const priorityMap = {
+  const priorityMap: { [k: string]: IssuePriority } = {
     Highest: 1,
     High: 2,
     Medium: 3,

--- a/packages/import/src/importers/jiraCsv/JiraCsvImporter.ts
+++ b/packages/import/src/importers/jiraCsv/JiraCsvImporter.ts
@@ -124,7 +124,7 @@ export class JiraCsvImporter implements Importer {
   private jiraSiteName?: string;
 }
 
-const mapPriority = (input: JiraPriority): number => {
+const mapPriority = (input: JiraPriority): IssuePriority => {
   const priorityMap: { [k: string]: IssuePriority } = {
     Highest: 1,
     High: 2,

--- a/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
+++ b/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
@@ -1,5 +1,5 @@
 import csv from "csvtojson";
-import { Importer, ImportResult } from "../../types";
+import { Importer, ImportResult, IssuePriority } from "../../types";
 import { safeParseInt } from "../../utils/parseInt";
 
 type LinearPriority = "No priority" | "Urgent" | "High" | "Medium" | "Low";
@@ -108,8 +108,8 @@ function stripLeadingSingleQuote(input: string): string {
   return input.replace(/^'([+\-=@])/, "$1");
 }
 
-const mapPriority = (input: LinearPriority): number => {
-  const priorityMap = {
+const mapPriority = (input: LinearPriority) => {
+  const priorityMap: { [k: string]: IssuePriority } = {
     "No priority": 0,
     Urgent: 1,
     High: 2,

--- a/packages/import/src/types.ts
+++ b/packages/import/src/types.ts
@@ -1,3 +1,5 @@
+export type IssuePriority = 0 | 1 | 2 | 3 | 4;
+
 /** Issue. */
 export interface Issue {
   /** Issue title */
@@ -8,8 +10,8 @@ export interface Issue {
   status?: string;
   /** Assigned user */
   assigneeId?: string;
-  /** Issue's priority from 0-4, with 0 being the most important. Undefined for non-prioritized. */
-  priority?: number;
+  /** Issue's priority from 0 to 4 – 1 being the highest, and 0/undefined being no priority. */
+  priority?: IssuePriority;
   /** Issue's comments */
   comments?: Comment[];
   /** Issue's label IDs */


### PR DESCRIPTION
This PR adds a GitLab CSV importer following the format documented here: https://docs.gitlab.com/ee/user/project/issues/csv_export.html#columns.

It also adds support for creating label groups that match a format of `<group name>/<label name>`

<hr />

Tested with the following CSV:

```
Title,Description,Issue ID,URL,State,Author,Author Username,Assignee,Assignee Username,Confidential,Locked,Due Date,Created At (UTC),Updated At (UTC),Closed At (UTC),Milestone,Weight,Labels,Time Estimate,Time Spent,Epic ID,Epic Title
Test issue,,1,https://gitlab.com/linear-development/test/-/issues/1,Open,Mufeez Amjad,mufeez-amjad,Mufeez Amjad,mufeez-amjad,No,No,2024-11-21,2024-11-07 04:02:12,2024-11-07 04:02:12,,,20,"Frameworks:TypeScript:Triage/P1,test/starter",0,0,,
Test issue 2,,2,https://gitlab.com/linear-development/test/-/issues/1,Open,Mufeez Amjad,mufeez-amjad,Mufeez Amjad,mufeez-amjad,No,No,2024-11-21,2024-11-07 04:02:12,2024-11-07 04:02:12,,,20,"Frameworks:TypeScript:Triage/P0,test/starter",0,0,,
Test issue 3,,3,https://gitlab.com/linear-development/test/-/issues/1,Open,Mufeez Amjad,mufeez-amjad,Mufeez Amjad,mufeez-amjad,No,No,2024-11-21,2024-11-07 04:02:12,2024-11-07 04:02:12,,,20,"Frameworks:TypeScript:Triage/P0,Frameworks:TypeScript:Triage/P1",0,0,,
Test issue 4,,4,https://gitlab.com/linear-development/test/-/issues/1,Open,Mufeez Amjad,mufeez-amjad,Mufeez Amjad,mufeez-amjad,No,No,2024-11-21,2024-11-07 04:02:12,2024-11-07 04:02:12,,,20,"test",0,0,,
```

The above CSV tests the happy path in addition to the following:
1. Root label conflicting with a parent label (test vs test/starter)
2. \>1 labels from a group applied to an issue

![CleanShot 2024-11-10 at 16 33 02@2x](https://github.com/user-attachments/assets/193627ab-5daf-410a-ab15-61592794bfcc)


