### PR TITLE
fix(sdk): ensure that internal interfaces are not generated

### DIFF
--- a/packages/codegen-doc/src/context-visitor.ts
+++ b/packages/codegen-doc/src/context-visitor.ts
@@ -9,6 +9,7 @@ import {
   ScalarTypeDefinitionNode,
 } from "graphql";
 import { OperationType, PluginConfig, PluginContext } from "./types";
+import { nodeHasSkipComment } from "./utils";
 
 /**
  * Graphql-codegen visitor for processing the ast and generating fragments
@@ -53,8 +54,10 @@ export class ContextVisitor<Config extends PluginConfig> {
           .filter(interfaceDefinition => !["Node", "Entity"].includes(interfaceDefinition.name.value))
           .map(interfaceDefinition => [
             interfaceDefinition.name.value,
-            this._objects.filter(objectDefinition =>
-              objectDefinition.interfaces?.some(i => i.name.value === interfaceDefinition.name.value)
+            this._objects.filter(
+              objectDefinition =>
+                !nodeHasSkipComment({ config: this._config } as unknown as PluginContext, objectDefinition) &&
+                objectDefinition.interfaces?.some(i => i.name.value === interfaceDefinition.name.value)
             ),
           ])
       ),


### PR DESCRIPTION
This fixes one error (the `schema` job is [failing](https://github.com/linear/linear/actions/runs/12877733687/job/35902640454) because of it; PostNotification is being generated despite being internal).

CI passes on this PR, but I get this locally:

```
 npx tsc --project tsconfig.check.json
packages/import/src/importIssues.ts:290:7 - error TS2345: Argument of type '{ teamId: string; projectId: string; title: string; description: string | undefined; priority: IssuePriority | undefined; labelIds: string[] | undefined; stateId: string | undefined; ... 4 more ...; estimate: number | undefined; }' is not assignable to parameter of type 'IssueCreateInput'.
  Object literal may only specify known properties, and 'completedAt' does not exist in type 'IssueCreateInput'.

290       completedAt: issue.completedAt,
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error in packages/import/src/importIssues.ts:290
```

Which I don't understand, as every definition of IssueCreateInput I can see _does_ have `completedAt`.