### PR TITLE
feat: add support for Height CSVs in CLI importer

### DIFF
--- a/.changeset/rare-jobs-accept.md
+++ b/.changeset/rare-jobs-accept.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": minor
+---
+
+feat: added support for Height CSVs in CLI importer

--- a/packages/import/src/cli.ts
+++ b/packages/import/src/cli.ts
@@ -5,13 +5,14 @@ import * as inquirer from "inquirer";
 import { importIssues } from "./importIssues";
 import { asanaCsvImport } from "./importers/asanaCsv";
 import { githubImport } from "./importers/github";
+import { gitlabCsvImporter } from "./importers/gitlabCsv";
+import { heightCsvImport } from "./importers/heightCsv";
 import { jiraCsvImport } from "./importers/jiraCsv";
 import { linearCsvImporter } from "./importers/linearCsv";
 import { pivotalCsvImport } from "./importers/pivotalCsv";
 import { shortcutCsvImport } from "./importers/shortcutCsv";
 import { trelloJsonImport } from "./importers/trelloJson";
 import { ImportAnswers } from "./types";
-import { gitlabCsvImporter } from "./importers/gitlabCsv";
 
 inquirer.registerPrompt("filePath", require("inquirer-file-path"));
 
@@ -57,6 +58,10 @@ inquirer.registerPrompt("filePath", require("inquirer-file-path"));
             value: "trelloJson",
           },
           {
+            name: "Height (CSV export)",
+            value: "heightCsv",
+          },
+          {
             name: "Linear (CSV export)",
             value: "linearCsv",
           },
@@ -87,6 +92,9 @@ inquirer.registerPrompt("filePath", require("inquirer-file-path"));
         break;
       case "trelloJson":
         importer = await trelloJsonImport();
+        break;
+      case "heightCsv":
+        importer = await heightCsvImport();
         break;
       case "linearCsv":
         importer = await linearCsvImporter();

--- a/packages/import/src/importers/heightCsv/HeightCsvImporter.ts
+++ b/packages/import/src/importers/heightCsv/HeightCsvImporter.ts
@@ -1,0 +1,110 @@
+import csv from "csvtojson";
+import { Importer, ImportResult, IssuePriority } from "../../types";
+
+type HeightPriority = "Critical" | "High" | "Medium" | "Low";
+
+interface HeightIssueType {
+  Description: string;
+  Status: string;
+  Priority: HeightPriority;
+  Tags: string;
+  Tasks: string;
+  Type: "task" | "project";
+  Assignees: string;
+  "Created at": string;
+  "Completed at": string;
+}
+
+/**
+ * Import issues from a Height CSV export.
+ *
+ * @param filePath Path to CSV file
+ */
+export class HeightCsvImporter implements Importer {
+  public constructor(filePath: string) {
+    this.filePath = filePath;
+  }
+
+  public get name(): string {
+    return "Height (CSV)";
+  }
+
+  public get defaultTeamName(): string {
+    return "Height";
+  }
+
+  public import = async (): Promise<ImportResult> => {
+    const data = (await csv().fromFile(this.filePath)) as HeightIssueType[];
+
+    const importData: ImportResult = {
+      issues: [],
+      labels: {},
+      users: {},
+      statuses: {},
+    };
+
+    const statuses = Array.from(new Set(data.map(row => row.Status)));
+    const assignees = Array.from(new Set(data.flatMap(row => row.Assignees.split(",")))).filter(
+      assignee => assignee.length > 0
+    );
+
+    for (const user of assignees) {
+      importData.users[user] = {
+        name: user,
+      };
+    }
+    for (const status of statuses) {
+      if (importData.statuses?.[status]) {
+        importData.statuses[status] = {
+          name: status,
+        };
+      }
+    }
+
+    for (const row of data) {
+      if (row.Type === "project") {
+        continue;
+      }
+      const priority = mapPriority(row.Priority);
+      const assigneeId = row.Assignees?.split(",")?.[0];
+      const status = row.Status;
+
+      const labels = row.Tags.length > 0 ? row.Tags.split(",").map(tag => tag.trim()) : [];
+
+      importData.issues.push({
+        title: row.Tasks,
+        description: row.Description,
+        status,
+        priority,
+        assigneeId,
+        createdAt: new Date(`${row["Created at"]}Z`),
+        completedAt: row["Completed at"] ? new Date(`${row["Completed at"]}Z`) : undefined,
+        labels,
+      });
+
+      for (const lab of labels) {
+        if (!importData.labels[lab]) {
+          importData.labels[lab] = {
+            name: lab,
+          };
+        }
+      }
+    }
+
+    return importData;
+  };
+
+  // -- Private interface
+
+  private filePath: string;
+}
+
+const mapPriority = (input: HeightPriority): IssuePriority => {
+  const priorityMap: Record<HeightPriority, IssuePriority> = {
+    Critical: 1,
+    High: 2,
+    Medium: 3,
+    Low: 4,
+  };
+  return priorityMap[input] || 0;
+};

--- a/packages/import/src/importers/heightCsv/index.ts
+++ b/packages/import/src/importers/heightCsv/index.ts
@@ -1,0 +1,24 @@
+import * as inquirer from "inquirer";
+import { Importer } from "../../types";
+import { HeightCsvImporter } from "./HeightCsvImporter";
+
+const BASE_PATH = process.cwd();
+
+export const heightCsvImport = async (): Promise<Importer> => {
+  const answers = await inquirer.prompt<HeightImportAnswers>(questions);
+  const heightImporter = new HeightCsvImporter(answers.heightFilePath);
+  return heightImporter;
+};
+
+interface HeightImportAnswers {
+  heightFilePath: string;
+}
+
+const questions = [
+  {
+    basePath: BASE_PATH,
+    type: "filePath",
+    name: "heightFilePath",
+    message: "Select your exported CSV file of Height issues",
+  },
+];


### PR DESCRIPTION
Adds support for Height CSVs in CLI importer.

### Fields
 -  Description: a markdown description
 -  Status: the Tasks status
 -  Priority: the Task priority. Tasks have two priorities, one for the project, one for the company. Unfortunately, both columns have the same name. The parser picks up the last one only, which the one for the company level. Users will have to remove the column from the CSV if they want to pick the other one, or we can make it configurable
  - Tags: A comma separated list of labels
  - Tasks: The task title. There's a plural in the column name but have found no evidence so far that this could be a comma separated list of task titles.
  - Type: "task" | "project". We only import tasks.
  - Assignees: Height supports multiple assignees. We only support using the first one.
  "Created at"/"Completed at": Dates, provided without a timezone information, in non ISO-8601 format. They appear to be UTC.


### Open questions
 - [ ] How to handle images/videos. There is currently no documented way to publicly access them