### PR TITLE
fix: use flat keys to parse Pivotal CSVs

### DIFF
--- a/.changeset/breezy-carpets-shave.md
+++ b/.changeset/breezy-carpets-shave.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": patch
+---
+
+fix: use flat keys to parse Pictoval CSVs

--- a/.changeset/breezy-carpets-shave.md
+++ b/.changeset/breezy-carpets-shave.md
@@ -2,4 +2,4 @@
 "@linear/import": patch
 ---
 
-fix: use flat keys to parse Pictoval CSVs
+fix: use flat keys to parse Pivotal CSVs

--- a/packages/import/src/importers/pivotalCsv/PivotalCsvImporter.ts
+++ b/packages/import/src/importers/pivotalCsv/PivotalCsvImporter.ts
@@ -48,7 +48,7 @@ export class PivotalCsvImporter implements Importer {
   }
 
   public import = async (): Promise<ImportResult> => {
-    const data = (await csv().fromFile(this.filePath)) as PivotalIssueType[];
+    const data = (await csv({ flatKeys: true }).fromFile(this.filePath)) as PivotalIssueType[];
 
     const importData: ImportResult = {
       issues: [],


### PR DESCRIPTION
Pivotal uses dotted keys in CSV headers to represent multiple assignees:

```
| Owned By | Owned By.1 | Owned By.2 |
| -------- | ---------- | ---------- |
| John Doe | Jane Smith |            |
```

The default behavior for `csv2json` with the above input is to interpret this as JSON Path. It will create a field called `Owned By`, which is an array, and where elements `1` and `2` are set, and element at index `0` is undefined.
```
[undefined, "Jane Smith", ""]
```

Not only does this break the importer, as `assigneeId` is an array instead of the expected string, but we also lose the value of the first task owner.

Setting the `flatKeys` flag to `true` allows to bypass this behavior ([docs](https://www.npmjs.com/package/csvtojson#parameters)). The importer will only look at the first `Owned By` column, which is what we want to import.

