### PR TITLE
Rename labels on conflicts + order teams in importer cli

### DIFF
--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -20,6 +20,7 @@
   ],
   "scripts": {
     "cli": "ts-node src/cli",
+    "cli:local": "NODE_TLS_REJECT_UNAUTHORIZED=0 ts-node src/cli --local",
     "dev:import": "NODE_ENV=development yarn build:import",
     "build:import": "run-s build:clean build:rollup",
     "build:rollup": "npx rollup -c",

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "cli": "ts-node src/cli",
-    "cli:local": "NODE_TLS_REJECT_UNAUTHORIZED=0 ts-node src/cli --apiUrl https://api.linear.app/graphql",
+    "cli:local": "NODE_TLS_REJECT_UNAUTHORIZED=0 ts-node src/cli --apiUrl https://local.linear.dev:8090/graphql",
     "dev:import": "NODE_ENV=development yarn build:import",
     "build:import": "run-s build:clean build:rollup",
     "build:rollup": "npx rollup -c",

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "cli": "ts-node src/cli",
-    "cli:local": "NODE_TLS_REJECT_UNAUTHORIZED=0 ts-node src/cli --local",
+    "cli:local": "NODE_TLS_REJECT_UNAUTHORIZED=0 ts-node src/cli --apiUrl https://api.linear.app/graphql",
     "dev:import": "NODE_ENV=development yarn build:import",
     "build:import": "run-s build:clean build:rollup",
     "build:rollup": "npx rollup -c",

--- a/packages/import/src/cli.ts
+++ b/packages/import/src/cli.ts
@@ -97,7 +97,8 @@ inquirer.registerPrompt("filePath", require("inquirer-file-path"));
     }
 
     if (importer) {
-      const apiUrl = process.argv.includes("--local") ? "https://local.linear.dev:8090/graphql/" : undefined;
+      const apiUrlIndex = process.argv.indexOf("--apiUrl");
+      const apiUrl = apiUrlIndex > -1 ? process.argv[apiUrlIndex + 1] : undefined;
       await importIssues(importAnswers.linearApiKey, importer, apiUrl);
     }
   } catch (e) {

--- a/packages/import/src/cli.ts
+++ b/packages/import/src/cli.ts
@@ -97,7 +97,8 @@ inquirer.registerPrompt("filePath", require("inquirer-file-path"));
     }
 
     if (importer) {
-      await importIssues(importAnswers.linearApiKey, importer);
+      const apiUrl = process.argv.includes("--local") ? "https://local.linear.dev:8090/graphql/" : undefined;
+      await importIssues(importAnswers.linearApiKey, importer, apiUrl);
     }
   } catch (e) {
     // Deal with the fact the chain failed

--- a/packages/import/src/helpers/labelManager.ts
+++ b/packages/import/src/helpers/labelManager.ts
@@ -328,7 +328,7 @@ const createLabel = async (
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return (await response?.issueLabel)!.id;
   } catch {
-    // If the failed to create it's likely it's a name conflict, in which case we try one more time with a new name
+    // If the label failed to create it's likely it's a name conflict, in which case we try one more time with a new name
     const newName = renameConflictingLabel(name);
     const response = await client.createIssueLabel({ name: newName, description, color, teamId, parentId });
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/import/src/helpers/labelManager.ts
+++ b/packages/import/src/helpers/labelManager.ts
@@ -117,7 +117,7 @@ const handleIssueLabels = async (
       if (!actualLabelId) {
         // Check for naming conflicts
         const existingLabel = manager.getLabelByName(labelName, teamId);
-        const newLabelName = existingLabel ? `${labelName} (imported)` : labelName;
+        const newLabelName = existingLabel ? renameConflictingLabel(labelName) : labelName;
 
         actualLabelId = await createLabel(client, {
           name: newLabelName,
@@ -143,7 +143,7 @@ const handleIssueLabels = async (
 
     // Check for conflicts with existing group labels
     if (manager.getGroupLabel({ name: labelName })) {
-      rootLabelName = `${labelName} (imported)`;
+      rootLabelName = renameConflictingLabel(labelName);
     }
 
     // Check for existing root label
@@ -159,6 +159,8 @@ const handleIssueLabels = async (
     labelMapping[labelId] = { type: "root", id: actualLabelId, existedBeforeImport: rootLabel?.existedBeforeImport };
   }
 };
+
+const renameConflictingLabel = (labelName: string) => `${labelName} (imported)`;
 
 function parseLabelName(fullName: string): [string | undefined, string] {
   // Ensure every part is truncated to 80 characters
@@ -321,9 +323,17 @@ const createLabel = async (
     teamId: Id;
   }
 ) => {
-  const response = await client.createIssueLabel({ name, description, color, teamId, parentId });
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return (await response?.issueLabel)!.id;
+  try {
+    const response = await client.createIssueLabel({ name, description, color, teamId, parentId });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return (await response?.issueLabel)!.id;
+  } catch {
+    // If the failed to create it's likely it's a name conflict, in which case we try one more time with a new name
+    const newName = renameConflictingLabel(name);
+    const response = await client.createIssueLabel({ name: newName, description, color, teamId, parentId });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return (await response?.issueLabel)!.id;
+  }
 };
 
 const deleteLabel = async (client: LinearClient, labelId: Id) => {

--- a/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
+++ b/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
@@ -155,13 +155,12 @@ export class TrelloJsonImporter implements Importer {
         archived: card.closed || cardList?.closed,
       });
 
-      const allLabels =
-        card.labels?.map(label => ({
-          id: label.id,
-          color: mapLabelColor(label.color),
-          // Trello allows labels with no name and only a color value, but we must specify a name
-          name: label.name || `Trello-${label.color}`,
-        })) ?? [];
+      const allLabels = card.labels?.map(label => ({
+        id: label.id,
+        color: mapLabelColor(label.color),
+        // Trello allows labels with no name and only a color value, but we must specify a name
+        name: label.name || `Trello-${label.color}`,
+      })) ?? [];
 
       for (const label of allLabels) {
         const { id, ...labelData } = label;

--- a/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
+++ b/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
@@ -155,12 +155,13 @@ export class TrelloJsonImporter implements Importer {
         archived: card.closed || cardList?.closed,
       });
 
-      const allLabels = card.labels?.map(label => ({
-        id: label.id,
-        color: mapLabelColor(label.color),
-        // Trello allows labels with no name and only a color value, but we must specify a name
-        name: label.name || `Trello-${label.color}`,
-      })) ?? [];
+      const allLabels =
+        card.labels?.map(label => ({
+          id: label.id,
+          color: mapLabelColor(label.color),
+          // Trello allows labels with no name and only a color value, but we must specify a name
+          name: label.name || `Trello-${label.color}`,
+        })) ?? [];
 
       for (const label of allLabels) {
         const { id, ...labelData } = label;


### PR DESCRIPTION
- Fixes two cases where imports would fail due to label conflicts
  1. Importing to a parent team when a sub-team has a label with the same name would fail
  2. Importing a label where the team already has a `label` and `label (imported)` label would fail since we only rename it once
- Sorts the teams that are presented in the `linear-importer` CLI and show the parent team name for sub teams
- Add `cli:local` command that allows running the importer against local instance
