### PR TITLE
fix: do not package `LinearWebhooks` in UMD module

### DIFF
--- a/.changeset/cuddly-nights-leave.md
+++ b/.changeset/cuddly-nights-leave.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": patch
+---
+
+fix: do not package `LinearWebhooks` in UMD module

--- a/packages/sdk/rollup.config.js
+++ b/packages/sdk/rollup.config.js
@@ -76,7 +76,7 @@ export default [
     plugins: nodePlugins,
   },
   {
-    input: "src/index.ts",
+    input: "src/index_umd.ts",
     output: [
       {
         dir: "./",
@@ -91,7 +91,7 @@ export default [
     plugins: [...browserPlugins, ...minPlugins],
   },
   {
-    input: "src/index.ts",
+    input: "src/index_umd.ts",
     output: [
       {
         dir: "./",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,9 +1,2 @@
-/// <reference lib="dom"/>
-
-export * from "./client";
-export * from "./error";
-export * from "./graphql-client";
-export * from "./types";
-export * as LinearDocument from "./_generated_documents";
-export * from "./_generated_sdk";
+export * from "./index_umd";
 export * from "./webhooks";

--- a/packages/sdk/src/index_umd.ts
+++ b/packages/sdk/src/index_umd.ts
@@ -1,0 +1,8 @@
+/// <reference lib="dom"/>
+
+export * as LinearDocument from "./_generated_documents";
+export * from "./_generated_sdk";
+export * from "./client";
+export * from "./error";
+export * from "./graphql-client";
+export * from "./types";


### PR DESCRIPTION
The UMD module currently cannot be used in a browser directly as it imports nodejs's `crypto` module. This is used by `LinearWebhooks` to decode webhooks headers signatures when used in a nodejs context.

We could work with `crypto-browserify` and `node-browserify` polyfills to provide browser compatible version, but I'm not sure it's really worth it? The `LinearWebhooks` is meant to be used as an Express middleware, not in a browser environment. This PR provides a second entrypoint for rollup to build the UMD module without the `LinearWebhooks` export.