### PR TITLE
chore: add final webhook types

### DIFF
--- a/.changeset/_generated_schema_14662443.md
+++ b/.changeset/_generated_schema_14662443.md
@@ -1,0 +1,52 @@
+---
+"@linear/sdk": major
+---
+
+
+feat(schema): [breaking] Type 'BaseEntityWebhookPayload' was removed (BaseEntityWebhookPayload)
+
+feat(schema): [breaking] Field 'AppUserNotificationWebhookPayload.createdAt' changed type from 'String!' to 'DateTime!' (AppUserNotificationWebhookPayload.createdAt)
+
+feat(schema): [breaking] Field 'CommentWebhookPayload.documentContent' changed type from 'BaseEntityWebhookPayload' to 'DocumentContentChildWebhookPayload' (CommentWebhookPayload.documentContent)
+
+feat(schema): [dangerous] Input field 'reopenCaseStatus' was added to input object type 'SalesforceSettingsInput' (SalesforceSettingsInput.reopenCaseStatus)
+
+feat(schema): [non_breaking] Type 'AppUserTeamAccessChangedWebhookPayload' was added (AppUserTeamAccessChangedWebhookPayload)
+
+feat(schema): [non_breaking] Type 'AuditEntryWebhookPayload' was added (AuditEntryWebhookPayload)
+
+feat(schema): [non_breaking] Type 'BaseWebhookPayload' was added (BaseWebhookPayload)
+
+feat(schema): [non_breaking] Type 'CustomResourceWebhookPayload' was added (CustomResourceWebhookPayload)
+
+feat(schema): [non_breaking] Type 'DataWebhookPayload' was added (DataWebhookPayload)
+
+feat(schema): [non_breaking] Type 'DocumentContentChildWebhookPayload' was added (DocumentContentChildWebhookPayload)
+
+feat(schema): [non_breaking] Type 'DocumentWebhookPayload' was added (DocumentWebhookPayload)
+
+feat(schema): [non_breaking] Type 'EntityWebhookPayload' was added (EntityWebhookPayload)
+
+feat(schema): [non_breaking] Type 'IssueSlaWebhookPayload' was added (IssueSlaWebhookPayload)
+
+feat(schema): [non_breaking] Type 'OAuthAppWebhookPayload' was added (OAuthAppWebhookPayload)
+
+feat(schema): [non_breaking] Field 'AppUserNotificationWebhookPayload.action' description changed from 'The action of the notification.' to 'The type of action that triggered the webhook.' (AppUserNotificationWebhookPayload.action)
+
+feat(schema): [non_breaking] Field 'AppUserNotificationWebhookPayload.appUserId' description changed from 'The app user id of the webhook.' to 'ID of the app user the notification is for.' (AppUserNotificationWebhookPayload.appUserId)
+
+feat(schema): [non_breaking] Field 'AppUserNotificationWebhookPayload.createdAt' description changed from 'The timestamp the webhook was created at.' to 'The time the payload was created.' (AppUserNotificationWebhookPayload.createdAt)
+
+feat(schema): [non_breaking] Field 'AppUserNotificationWebhookPayload.notification' description changed from 'The notification of the webhook.' to 'Details of the notification.' (AppUserNotificationWebhookPayload.notification)
+
+feat(schema): [non_breaking] Field 'AppUserNotificationWebhookPayload.oauthClientId' description changed from 'The oauth client id of the webhook.' to 'ID of the OAuth client the app user is tied to.' (AppUserNotificationWebhookPayload.oauthClientId)
+
+feat(schema): [non_breaking] Field 'AppUserNotificationWebhookPayload.organizationId' description changed from 'The organization id of the webhook.' to 'ID of the organization for which the webhook belongs to.' (AppUserNotificationWebhookPayload.organizationId)
+
+feat(schema): [non_breaking] Field 'AppUserNotificationWebhookPayload.type' description changed from 'The type of the notification.' to 'The type of resource.' (AppUserNotificationWebhookPayload.type)
+
+feat(schema): [non_breaking] Description 'Complete payload for an app user notification webhook.' on type 'AppUserNotificationWebhookPayload' has changed to 'Payload for app user notification webhook events.' (AppUserNotificationWebhookPayload)
+
+feat(schema): [non_breaking] Field 'integrationSalesforceMetadataRefresh' was added to object type 'Mutation' (Mutation.integrationSalesforceMetadataRefresh)
+
+feat(schema): [non_breaking] Field 'Query._dummy' changed type from 'String' to 'String!' (Query._dummy)

--- a/.changeset/long-mails-hope.md
+++ b/.changeset/long-mails-hope.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": minor
+---
+
+Add EntityWebhookPayload and CustomResourceWebhookPayload

--- a/package.json
+++ b/package.json
@@ -117,5 +117,6 @@
         "tsconfig": "tsconfig.json"
       }
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -117,6 +117,5 @@
         "tsconfig": "tsconfig.json"
       }
     }
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/packages/sdk/Linear-Webhooks@current.graphql
+++ b/packages/sdk/Linear-Webhooks@current.graphql
@@ -3,27 +3,57 @@
 # !!!   DO NOT MODIFY THIS FILE BY YOURSELF   !!!
 # -----------------------------------------------
 
-"""Complete payload for an app user notification webhook."""
+"""Payload for app user notification webhook events."""
 type AppUserNotificationWebhookPayload {
-  """The action of the notification."""
+  """The type of action that triggered the webhook."""
   action: String!
 
-  """The app user id of the webhook."""
+  """ID of the app user the notification is for."""
   appUserId: String!
 
-  """The timestamp the webhook was created at."""
-  createdAt: String!
+  """The time the payload was created."""
+  createdAt: DateTime!
 
-  """The notification of the webhook."""
+  """Details of the notification."""
   notification: NotificationWebhookPayload!
 
-  """The oauth client id of the webhook."""
+  """ID of the OAuth client the app user is tied to."""
   oauthClientId: String!
 
-  """The organization id of the webhook."""
+  """ID of the organization for which the webhook belongs to."""
   organizationId: String!
 
-  """The type of the notification."""
+  """The type of resource."""
+  type: String!
+}
+
+"""Payload for app user team access change webhook events."""
+type AppUserTeamAccessChangedWebhookPayload {
+  """The type of action that triggered the webhook."""
+  action: String!
+
+  """IDs of the teams the app user was added to."""
+  addedTeamIds: [String!]!
+
+  """ID of the app user the notification is for."""
+  appUserId: String!
+
+  """Whether the app user can access all public teams."""
+  canAccessAllPublicTeams: Boolean!
+
+  """The time the payload was created."""
+  createdAt: DateTime!
+
+  """ID of the OAuth client the app user is tied to."""
+  oauthClientId: String!
+
+  """ID of the organization for which the webhook belongs to."""
+  organizationId: String!
+
+  """IDs of the teams the app user was removed from."""
+  removedTeamIds: [String!]!
+
+  """The type of resource."""
   type: String!
 }
 
@@ -77,10 +107,16 @@ type AttachmentWebhookPayload {
   url: String!
 }
 
-"""Base class for entity webhook payloads."""
-type BaseEntityWebhookPayload {
+"""Payload for an audit entry webhook."""
+type AuditEntryWebhookPayload {
+  """The ID of the user that caused the audit entry to be created."""
+  actorId: String
+
   """The time at which the entity was archived."""
   archivedAt: String
+
+  """Country code of request resulting to audit entry."""
+  countryCode: String
 
   """The time at which the entity was created."""
   createdAt: String!
@@ -88,8 +124,34 @@ type BaseEntityWebhookPayload {
   """The ID of the entity."""
   id: String!
 
+  """IP from actor when entry was recorded."""
+  ip: String
+
+  """Additional metadata related to the audit entry."""
+  metadata: JSONObject
+
+  """The ID of the organization that the audit entry belongs to."""
+  organizationId: String!
+
+  """
+  Additional information related to the request which performed the action.
+  """
+  requestInformation: JSONObject
+
+  """The type of the audit entry."""
+  type: String!
+
   """The time at which the entity was updated."""
   updatedAt: String!
+}
+
+"""Base fields for all webhook payloads."""
+type BaseWebhookPayload {
+  """The time the payload was created."""
+  createdAt: DateTime!
+
+  """ID of the organization for which the webhook belongs to."""
+  organizationId: String!
 }
 
 """Certain properties of a comment."""
@@ -131,7 +193,7 @@ type CommentWebhookPayload {
   createdAt: String!
 
   """The document content for this comment."""
-  documentContent: BaseEntityWebhookPayload
+  documentContent: DocumentContentChildWebhookPayload
 
   """The ID of the document content this comment belongs to."""
   documentContentId: String
@@ -201,6 +263,21 @@ type CommentWebhookPayload {
 
   """The ID of the user who created this comment."""
   userId: String
+}
+
+"""Payload for custom webhook resource events."""
+type CustomResourceWebhookPayload {
+  """The type of action that triggered the webhook."""
+  action: String!
+
+  """The time the payload was created."""
+  createdAt: DateTime!
+
+  """ID of the organization for which the webhook belongs to."""
+  organizationId: String!
+
+  """The type of resource."""
+  type: String!
 }
 
 """Certain properties of a customer."""
@@ -466,6 +543,14 @@ type CycleWebhookPayload {
   updatedAt: String!
 }
 
+"""Union type for all possible webhook entity data payloads"""
+union DataWebhookPayload = AttachmentWebhookPayload | AuditEntryWebhookPayload | CommentWebhookPayload | CustomerNeedWebhookPayload | CustomerWebhookPayload | CycleWebhookPayload | DocumentWebhookPayload | InitiativeUpdateWebhookPayload | InitiativeWebhookPayload | IssueLabelWebhookPayload | IssueWebhookPayload | ProjectUpdateWebhookPayload | ProjectWebhookPayload | ReactionWebhookPayload | UserWebhookPayload
+
+"""
+Represents a date and time in ISO 8601 format. Accepts shortcuts like `2021` to represent midnight Fri Jan 01 2021. Also accepts ISO 8601 durations strings which are added to the current date to create the represented date (e.g '-P2W1D' represents the date that was two weeks and 1 day ago) 
+"""
+scalar DateTime
+
 """Certain properties of a document."""
 type DocumentChildWebhookPayload {
   """The ID of the document."""
@@ -485,6 +570,102 @@ type DocumentChildWebhookPayload {
 
   """The title of the document."""
   title: String!
+}
+
+"""Certain properties of a document content."""
+type DocumentContentChildWebhookPayload {
+  """The document this document content belongs to."""
+  document: DocumentChildWebhookPayload
+
+  """The project this document belongs to."""
+  project: ProjectChildWebhookPayload
+}
+
+"""Payload for a document webhook."""
+type DocumentWebhookPayload {
+  """The time at which the entity was archived."""
+  archivedAt: String
+
+  """The color of the document."""
+  color: String
+
+  """The content of the document."""
+  content: String
+
+  """The time at which the entity was created."""
+  createdAt: String!
+
+  """The ID of the user who created the document."""
+  creatorId: String
+
+  """The description of the document."""
+  description: String
+
+  """The time at which the document was hidden."""
+  hiddenAt: String
+
+  """The icon of the document."""
+  icon: String
+
+  """The ID of the entity."""
+  id: String!
+
+  """The ID of the initiative this document belongs to."""
+  initiativeId: String
+
+  """The ID of the last template that was applied to this document."""
+  lastAppliedTemplateId: String
+
+  """The ID of the project this document belongs to."""
+  projectId: String
+
+  """The ID of the resource folder this document belongs to."""
+  resourceFolderId: String
+
+  """The document's unique URL slug."""
+  slugId: String!
+
+  """The order of the item in the resources list."""
+  sortOrder: Float!
+
+  """The IDs of the users who are subscribed to this document."""
+  subscriberIds: [String!]
+
+  """The title of the document."""
+  title: String!
+
+  """A flag that indicates whether the document is in the trash bin."""
+  trashed: Boolean
+
+  """The time at which the entity was updated."""
+  updatedAt: String!
+
+  """The ID of the user who last updated the document."""
+  updatedById: String
+}
+
+"""Payload for entity-related webhook events."""
+type EntityWebhookPayload {
+  """The type of action that triggered the webhook."""
+  action: String!
+
+  """The time the payload was created."""
+  createdAt: DateTime!
+
+  """The entity that was changed."""
+  data: DataWebhookPayload!
+
+  """ID of the organization for which the webhook belongs to."""
+  organizationId: String!
+
+  """The type of resource, i.e., the name of the entity."""
+  type: String!
+
+  """In case of an update event, previous values of all updated properties."""
+  updatedFrom: JSONObject
+
+  """URL for the entity."""
+  url: String
 }
 
 """Certain properties of an external user."""
@@ -1045,6 +1226,27 @@ type IssueNewCommentNotificationWebhookPayload {
   userId: String!
 }
 
+"""Payload for issue SLA webhook events."""
+type IssueSlaWebhookPayload {
+  """The type of action that triggered the webhook."""
+  action: String!
+
+  """The time the payload was created."""
+  createdAt: DateTime!
+
+  """The issue that the SLA event is about."""
+  issueData: IssueWebhookPayload!
+
+  """ID of the organization for which the webhook belongs to."""
+  organizationId: String!
+
+  """The type of resource."""
+  type: String!
+
+  """URL for the issue."""
+  url: String
+}
+
 """An issue status changed notification type."""
 scalar IssueStatusChangedNotificationType
 
@@ -1348,6 +1550,24 @@ The `JSONObject` scalar type represents arbitrary values as *embedded* JSON
 scalar JSONObject
 
 union NotificationWebhookPayload = IssueAssignedToYouNotificationWebhookPayload | IssueCommentMentionNotificationWebhookPayload | IssueCommentReactionNotificationWebhookPayload | IssueEmojiReactionNotificationWebhookPayload | IssueMentionNotificationWebhookPayload | IssueNewCommentNotificationWebhookPayload | IssueStatusChangedNotificationWebhookPayload | IssueUnassignedFromYouNotificationWebhookPayload | OtherNotificationWebhookPayload
+
+"""Payload for OAuth app webhook events."""
+type OAuthAppWebhookPayload {
+  """The type of action that triggered the webhook."""
+  action: String!
+
+  """The time the payload was created."""
+  createdAt: DateTime!
+
+  """Id of the OAuth client that was revoked."""
+  oauthClientId: String!
+
+  """ID of the organization for which the webhook belongs to."""
+  organizationId: String!
+
+  """The type of resource."""
+  type: String!
+}
 
 """Certain properties of an OAuth client."""
 type OauthClientChildWebhookPayload {
@@ -1762,6 +1982,10 @@ type ProjectWebhookPayload {
   url: String!
 }
 
+type Query {
+  _dummy: String!
+}
+
 """Payload for a reaction webhook."""
 type ReactionWebhookPayload {
   """The time at which the entity was archived."""
@@ -1908,5 +2132,3 @@ type WorkflowStateChildWebhookPayload {
   """The type of the workflow state."""
   type: String!
 }
-
-type Query { _dummy: String }

--- a/packages/sdk/src/_generated_documents.graphql
+++ b/packages/sdk/src/_generated_documents.graphql
@@ -3579,17 +3579,13 @@ fragment AuthenticationSessionResponse on AuthenticationSessionResponse {
   id
 }
 
-# Base class for entity webhook payloads.
-fragment BaseEntityWebhookPayload on BaseEntityWebhookPayload {
+# Base fields for all webhook payloads.
+fragment BaseWebhookPayload on BaseWebhookPayload {
   __typename
-  # The ID of the entity.
-  id
-  # The time at which the entity was archived.
-  archivedAt
-  # The time at which the entity was created.
+  # ID of the organization for which the webhook belongs to.
+  organizationId
+  # The time the payload was created.
   createdAt
-  # The time at which the entity was updated.
-  updatedAt
 }
 
 # Certain properties of a comment.
@@ -3676,6 +3672,19 @@ fragment CycleChildWebhookPayload on CycleChildWebhookPayload {
   number
   # The start date of the cycle.
   startsAt
+}
+
+# Certain properties of a document content.
+fragment DocumentContentChildWebhookPayload on DocumentContentChildWebhookPayload {
+  __typename
+  # The document this document content belongs to.
+  document {
+    ...DocumentChildWebhookPayload
+  }
+  # The project this document belongs to.
+  project {
+    ...ProjectChildWebhookPayload
+  }
 }
 
 # Certain properties of a document.
@@ -3892,23 +3901,6 @@ fragment IssueChildWebhookPayload on IssueChildWebhookPayload {
   identifier
   # The title of the issue.
   title
-}
-
-# Complete payload for an app user notification webhook.
-fragment AppUserNotificationWebhookPayload on AppUserNotificationWebhookPayload {
-  __typename
-  # The action of the notification.
-  action
-  # The app user id of the webhook.
-  appUserId
-  # The oauth client id of the webhook.
-  oauthClientId
-  # The organization id of the webhook.
-  organizationId
-  # The timestamp the webhook was created at.
-  createdAt
-  # The type of the notification.
-  type
 }
 
 # Contains requested archived model objects.
@@ -4392,6 +4384,21 @@ fragment UploadFile on UploadFile {
   metaData
 }
 
+# Payload for OAuth app webhook events.
+fragment OAuthAppWebhookPayload on OAuthAppWebhookPayload {
+  __typename
+  # ID of the organization for which the webhook belongs to.
+  organizationId
+  # Id of the OAuth client that was revoked.
+  oauthClientId
+  # The time the payload was created.
+  createdAt
+  # The type of action that triggered the webhook.
+  action
+  # The type of resource.
+  type
+}
+
 # Payload for a comment webhook.
 fragment CommentWebhookPayload on CommentWebhookPayload {
   __typename
@@ -4423,7 +4430,7 @@ fragment CommentWebhookPayload on CommentWebhookPayload {
   botActor
   # The document content for this comment.
   documentContent {
-    ...BaseEntityWebhookPayload
+    ...DocumentContentChildWebhookPayload
   }
   # The entity this comment is synced with.
   syncedWith
@@ -4604,6 +4611,51 @@ fragment CycleWebhookPayload on CycleWebhookPayload {
   scopeHistory
   # The total number of issues in the cycle after each day.
   issueCountHistory
+}
+
+# Payload for a document webhook.
+fragment DocumentWebhookPayload on DocumentWebhookPayload {
+  __typename
+  # A flag that indicates whether the document is in the trash bin.
+  trashed
+  # The ID of the entity.
+  id
+  # The ID of the initiative this document belongs to.
+  initiativeId
+  # The ID of the last template that was applied to this document.
+  lastAppliedTemplateId
+  # The ID of the project this document belongs to.
+  projectId
+  # The ID of the resource folder this document belongs to.
+  resourceFolderId
+  # The ID of the user who created the document.
+  creatorId
+  # The ID of the user who last updated the document.
+  updatedById
+  # The IDs of the users who are subscribed to this document.
+  subscriberIds
+  # The color of the document.
+  color
+  # The content of the document.
+  content
+  # The description of the document.
+  description
+  # The document's unique URL slug.
+  slugId
+  # The icon of the document.
+  icon
+  # The order of the item in the resources list.
+  sortOrder
+  # The time at which the document was hidden.
+  hiddenAt
+  # The time at which the entity was archived.
+  archivedAt
+  # The time at which the entity was created.
+  createdAt
+  # The time at which the entity was updated.
+  updatedAt
+  # The title of the document.
+  title
 }
 
 # Payload for a project update webhook.
@@ -4894,6 +4946,33 @@ fragment AttachmentWebhookPayload on AttachmentWebhookPayload {
   title
   # Whether attachments for the same source application should be grouped in the Linear UI.
   groupBySource
+}
+
+# Payload for an audit entry webhook.
+fragment AuditEntryWebhookPayload on AuditEntryWebhookPayload {
+  __typename
+  # Additional information related to the request which performed the action.
+  requestInformation
+  # Additional metadata related to the audit entry.
+  metadata
+  # Country code of request resulting to audit entry.
+  countryCode
+  # IP from actor when entry was recorded.
+  ip
+  # The ID of the entity.
+  id
+  # The ID of the organization that the audit entry belongs to.
+  organizationId
+  # The ID of the user that caused the audit entry to be created.
+  actorId
+  # The time at which the entity was archived.
+  archivedAt
+  # The time at which the entity was created.
+  createdAt
+  # The time at which the entity was updated.
+  updatedAt
+  # The type of the audit entry.
+  type
 }
 
 # Payload for an initiative update webhook.
@@ -5451,6 +5530,95 @@ fragment IssueWebhookPayload on IssueWebhookPayload {
   assignee {
     ...UserChildWebhookPayload
   }
+}
+
+# Payload for app user notification webhook events.
+fragment AppUserNotificationWebhookPayload on AppUserNotificationWebhookPayload {
+  __typename
+  # ID of the OAuth client the app user is tied to.
+  oauthClientId
+  # ID of the app user the notification is for.
+  appUserId
+  # ID of the organization for which the webhook belongs to.
+  organizationId
+  # The time the payload was created.
+  createdAt
+  # The type of action that triggered the webhook.
+  action
+  # The type of resource.
+  type
+}
+
+# Payload for app user team access change webhook events.
+fragment AppUserTeamAccessChangedWebhookPayload on AppUserTeamAccessChangedWebhookPayload {
+  __typename
+  # ID of the OAuth client the app user is tied to.
+  oauthClientId
+  # ID of the app user the notification is for.
+  appUserId
+  # ID of the organization for which the webhook belongs to.
+  organizationId
+  # IDs of the teams the app user was added to.
+  addedTeamIds
+  # IDs of the teams the app user was removed from.
+  removedTeamIds
+  # The time the payload was created.
+  createdAt
+  # The type of action that triggered the webhook.
+  action
+  # The type of resource.
+  type
+  # Whether the app user can access all public teams.
+  canAccessAllPublicTeams
+}
+
+# Payload for custom webhook resource events.
+fragment CustomResourceWebhookPayload on CustomResourceWebhookPayload {
+  __typename
+  # ID of the organization for which the webhook belongs to.
+  organizationId
+  # The time the payload was created.
+  createdAt
+  # The type of action that triggered the webhook.
+  action
+  # The type of resource.
+  type
+}
+
+# Payload for entity-related webhook events.
+fragment EntityWebhookPayload on EntityWebhookPayload {
+  __typename
+  # ID of the organization for which the webhook belongs to.
+  organizationId
+  # In case of an update event, previous values of all updated properties.
+  updatedFrom
+  # The time the payload was created.
+  createdAt
+  # The type of action that triggered the webhook.
+  action
+  # The type of resource, i.e., the name of the entity.
+  type
+  # URL for the entity.
+  url
+}
+
+# Payload for issue SLA webhook events.
+fragment IssueSlaWebhookPayload on IssueSlaWebhookPayload {
+  __typename
+  # ID of the organization for which the webhook belongs to.
+  organizationId
+  # The issue that the SLA event is about.
+  issueData {
+    ...IssueWebhookPayload
+  }
+  # The time the payload was created.
+  createdAt
+  # The type of action that triggered the webhook.
+  action
+  # The type of resource.
+  type
+  # URL for the issue.
+  url
 }
 
 # Public information of the OAuth application, plus whether the application has been authorized for

--- a/packages/sdk/src/_generated_documents.ts
+++ b/packages/sdk/src/_generated_documents.ts
@@ -148,22 +148,45 @@ export type AppUserAuthentication = {
   scope: Array<Scalars["String"]>;
 };
 
-/** Complete payload for an app user notification webhook. */
+/** Payload for app user notification webhook events. */
 export type AppUserNotificationWebhookPayload = {
   __typename?: "AppUserNotificationWebhookPayload";
-  /** The action of the notification. */
+  /** The type of action that triggered the webhook. */
   action: Scalars["String"];
-  /** The app user id of the webhook. */
+  /** ID of the app user the notification is for. */
   appUserId: Scalars["String"];
-  /** The timestamp the webhook was created at. */
-  createdAt: Scalars["String"];
-  /** The notification of the webhook. */
+  /** The time the payload was created. */
+  createdAt: Scalars["DateTime"];
+  /** Details of the notification. */
   notification: NotificationWebhookPayload;
-  /** The oauth client id of the webhook. */
+  /** ID of the OAuth client the app user is tied to. */
   oauthClientId: Scalars["String"];
-  /** The organization id of the webhook. */
+  /** ID of the organization for which the webhook belongs to. */
   organizationId: Scalars["String"];
-  /** The type of the notification. */
+  /** The type of resource. */
+  type: Scalars["String"];
+};
+
+/** Payload for app user team access change webhook events. */
+export type AppUserTeamAccessChangedWebhookPayload = {
+  __typename?: "AppUserTeamAccessChangedWebhookPayload";
+  /** The type of action that triggered the webhook. */
+  action: Scalars["String"];
+  /** IDs of the teams the app user was added to. */
+  addedTeamIds: Array<Scalars["String"]>;
+  /** ID of the app user the notification is for. */
+  appUserId: Scalars["String"];
+  /** Whether the app user can access all public teams. */
+  canAccessAllPublicTeams: Scalars["Boolean"];
+  /** The time the payload was created. */
+  createdAt: Scalars["DateTime"];
+  /** ID of the OAuth client the app user is tied to. */
+  oauthClientId: Scalars["String"];
+  /** ID of the organization for which the webhook belongs to. */
+  organizationId: Scalars["String"];
+  /** IDs of the teams the app user was removed from. */
+  removedTeamIds: Array<Scalars["String"]>;
+  /** The type of resource. */
   type: Scalars["String"];
 };
 
@@ -507,6 +530,33 @@ export type AuditEntryType = {
   type: Scalars["String"];
 };
 
+/** Payload for an audit entry webhook. */
+export type AuditEntryWebhookPayload = {
+  __typename?: "AuditEntryWebhookPayload";
+  /** The ID of the user that caused the audit entry to be created. */
+  actorId?: Maybe<Scalars["String"]>;
+  /** The time at which the entity was archived. */
+  archivedAt?: Maybe<Scalars["String"]>;
+  /** Country code of request resulting to audit entry. */
+  countryCode?: Maybe<Scalars["String"]>;
+  /** The time at which the entity was created. */
+  createdAt: Scalars["String"];
+  /** The ID of the entity. */
+  id: Scalars["String"];
+  /** IP from actor when entry was recorded. */
+  ip?: Maybe<Scalars["String"]>;
+  /** Additional metadata related to the audit entry. */
+  metadata?: Maybe<Scalars["JSONObject"]>;
+  /** The ID of the organization that the audit entry belongs to. */
+  organizationId: Scalars["String"];
+  /** Additional information related to the request which performed the action. */
+  requestInformation?: Maybe<Scalars["JSONObject"]>;
+  /** The type of the audit entry. */
+  type: Scalars["String"];
+  /** The time at which the entity was updated. */
+  updatedAt: Scalars["String"];
+};
+
 /** [INTERNAL] An OAuth userId/createdDate tuple */
 export type AuthMembership = {
   __typename?: "AuthMembership";
@@ -680,17 +730,13 @@ export type AuthorizingUser = {
   name: Scalars["String"];
 };
 
-/** Base class for entity webhook payloads. */
-export type BaseEntityWebhookPayload = {
-  __typename?: "BaseEntityWebhookPayload";
-  /** The time at which the entity was archived. */
-  archivedAt?: Maybe<Scalars["String"]>;
-  /** The time at which the entity was created. */
-  createdAt: Scalars["String"];
-  /** The ID of the entity. */
-  id: Scalars["String"];
-  /** The time at which the entity was updated. */
-  updatedAt: Scalars["String"];
+/** Base fields for all webhook payloads. */
+export type BaseWebhookPayload = {
+  __typename?: "BaseWebhookPayload";
+  /** The time the payload was created. */
+  createdAt: Scalars["DateTime"];
+  /** ID of the organization for which the webhook belongs to. */
+  organizationId: Scalars["String"];
 };
 
 /** Comparator for booleans. */
@@ -947,7 +993,7 @@ export type CommentWebhookPayload = {
   /** The time at which the entity was created. */
   createdAt: Scalars["String"];
   /** The document content for this comment. */
-  documentContent?: Maybe<BaseEntityWebhookPayload>;
+  documentContent?: Maybe<DocumentContentChildWebhookPayload>;
   /** The ID of the document content this comment belongs to. */
   documentContentId?: Maybe<Scalars["String"]>;
   /** When the comment was last edited. */
@@ -1086,6 +1132,19 @@ export type CreatedAtSort = {
   nulls?: Maybe<PaginationNulls>;
   /** The order for the individual sort */
   order?: Maybe<PaginationSortOrder>;
+};
+
+/** Payload for custom webhook resource events. */
+export type CustomResourceWebhookPayload = {
+  __typename?: "CustomResourceWebhookPayload";
+  /** The type of action that triggered the webhook. */
+  action: Scalars["String"];
+  /** The time the payload was created. */
+  createdAt: Scalars["DateTime"];
+  /** ID of the organization for which the webhook belongs to. */
+  organizationId: Scalars["String"];
+  /** The type of resource. */
+  type: Scalars["String"];
 };
 
 /** A custom view that has been saved by a user. */
@@ -2586,6 +2645,24 @@ export type Dashboard = Node & {
   widgets: Scalars["JSONObject"];
 };
 
+/** Union type for all possible webhook entity data payloads */
+export type DataWebhookPayload =
+  | AttachmentWebhookPayload
+  | AuditEntryWebhookPayload
+  | CommentWebhookPayload
+  | CustomerNeedWebhookPayload
+  | CustomerWebhookPayload
+  | CycleWebhookPayload
+  | DocumentWebhookPayload
+  | InitiativeUpdateWebhookPayload
+  | InitiativeWebhookPayload
+  | IssueLabelWebhookPayload
+  | IssueWebhookPayload
+  | ProjectUpdateWebhookPayload
+  | ProjectWebhookPayload
+  | ReactionWebhookPayload
+  | UserWebhookPayload;
+
 /** Comparator for dates. */
 export type DateComparator = {
   /** Equals constraint. */
@@ -2771,6 +2848,15 @@ export type DocumentContent = Node & {
    *     been updated after creation.
    */
   updatedAt: Scalars["DateTime"];
+};
+
+/** Certain properties of a document content. */
+export type DocumentContentChildWebhookPayload = {
+  __typename?: "DocumentContentChildWebhookPayload";
+  /** The document this document content belongs to. */
+  document?: Maybe<DocumentChildWebhookPayload>;
+  /** The project this document belongs to. */
+  project?: Maybe<ProjectChildWebhookPayload>;
 };
 
 export type DocumentContentHistoryPayload = {
@@ -3042,6 +3128,51 @@ export type DocumentUpdateInput = {
   title?: Maybe<Scalars["String"]>;
   /** Whether the document has been trashed. */
   trashed?: Maybe<Scalars["Boolean"]>;
+};
+
+/** Payload for a document webhook. */
+export type DocumentWebhookPayload = {
+  __typename?: "DocumentWebhookPayload";
+  /** The time at which the entity was archived. */
+  archivedAt?: Maybe<Scalars["String"]>;
+  /** The color of the document. */
+  color?: Maybe<Scalars["String"]>;
+  /** The content of the document. */
+  content?: Maybe<Scalars["String"]>;
+  /** The time at which the entity was created. */
+  createdAt: Scalars["String"];
+  /** The ID of the user who created the document. */
+  creatorId?: Maybe<Scalars["String"]>;
+  /** The description of the document. */
+  description?: Maybe<Scalars["String"]>;
+  /** The time at which the document was hidden. */
+  hiddenAt?: Maybe<Scalars["String"]>;
+  /** The icon of the document. */
+  icon?: Maybe<Scalars["String"]>;
+  /** The ID of the entity. */
+  id: Scalars["String"];
+  /** The ID of the initiative this document belongs to. */
+  initiativeId?: Maybe<Scalars["String"]>;
+  /** The ID of the last template that was applied to this document. */
+  lastAppliedTemplateId?: Maybe<Scalars["String"]>;
+  /** The ID of the project this document belongs to. */
+  projectId?: Maybe<Scalars["String"]>;
+  /** The ID of the resource folder this document belongs to. */
+  resourceFolderId?: Maybe<Scalars["String"]>;
+  /** The document's unique URL slug. */
+  slugId: Scalars["String"];
+  /** The order of the item in the resources list. */
+  sortOrder: Scalars["Float"];
+  /** The IDs of the users who are subscribed to this document. */
+  subscriberIds?: Maybe<Array<Scalars["String"]>>;
+  /** The title of the document. */
+  title: Scalars["String"];
+  /** A flag that indicates whether the document is in the trash bin. */
+  trashed?: Maybe<Scalars["Boolean"]>;
+  /** The time at which the entity was updated. */
+  updatedAt: Scalars["String"];
+  /** The ID of the user who last updated the document. */
+  updatedById?: Maybe<Scalars["String"]>;
 };
 
 /** A general purpose draft. Used for comments, project updates, etc. */
@@ -3355,6 +3486,25 @@ export type EntityExternalLinkUpdateInput = {
   /** The order of the item in the entities resources list. */
   sortOrder?: Maybe<Scalars["Float"]>;
   /** The URL of the link. */
+  url?: Maybe<Scalars["String"]>;
+};
+
+/** Payload for entity-related webhook events. */
+export type EntityWebhookPayload = {
+  __typename?: "EntityWebhookPayload";
+  /** The type of action that triggered the webhook. */
+  action: Scalars["String"];
+  /** The time the payload was created. */
+  createdAt: Scalars["DateTime"];
+  /** The entity that was changed. */
+  data: DataWebhookPayload;
+  /** ID of the organization for which the webhook belongs to. */
+  organizationId: Scalars["String"];
+  /** The type of resource, i.e., the name of the entity. */
+  type: Scalars["String"];
+  /** In case of an update event, previous values of all updated properties. */
+  updatedFrom?: Maybe<Scalars["JSONObject"]>;
+  /** URL for the entity. */
   url?: Maybe<Scalars["String"]>;
 };
 
@@ -7187,6 +7337,23 @@ export type IssueSearchResultEdge = {
   node: IssueSearchResult;
 };
 
+/** Payload for issue SLA webhook events. */
+export type IssueSlaWebhookPayload = {
+  __typename?: "IssueSlaWebhookPayload";
+  /** The type of action that triggered the webhook. */
+  action: Scalars["String"];
+  /** The time the payload was created. */
+  createdAt: Scalars["DateTime"];
+  /** The issue that the SLA event is about. */
+  issueData: IssueWebhookPayload;
+  /** ID of the organization for which the webhook belongs to. */
+  organizationId: Scalars["String"];
+  /** The type of resource. */
+  type: Scalars["String"];
+  /** URL for the issue. */
+  url?: Maybe<Scalars["String"]>;
+};
+
 /** Issue sorting options. */
 export type IssueSortInput = {
   /** Sort by assignee name */
@@ -8061,6 +8228,8 @@ export type Mutation = {
   integrationRequest: IntegrationRequestPayload;
   /** Integrates the organization with Salesforce. */
   integrationSalesforce: IntegrationPayload;
+  /** [INTERNAL] Refreshes the Salesforce integration metadata. */
+  integrationSalesforceMetadataRefresh: IntegrationPayload;
   /** Integrates the organization with Sentry. */
   integrationSentryConnect: IntegrationPayload;
   /**
@@ -9029,6 +9198,10 @@ export type MutationIntegrationSalesforceArgs = {
   code: Scalars["String"];
   redirectUri: Scalars["String"];
   subdomain: Scalars["String"];
+};
+
+export type MutationIntegrationSalesforceMetadataRefreshArgs = {
+  id: Scalars["String"];
 };
 
 export type MutationIntegrationSentryConnectArgs = {
@@ -10864,6 +11037,21 @@ export type NumberComparator = {
   neq?: Maybe<Scalars["Float"]>;
   /** Not-in-array constraint. */
   nin?: Maybe<Array<Scalars["Float"]>>;
+};
+
+/** Payload for OAuth app webhook events. */
+export type OAuthAppWebhookPayload = {
+  __typename?: "OAuthAppWebhookPayload";
+  /** The type of action that triggered the webhook. */
+  action: Scalars["String"];
+  /** The time the payload was created. */
+  createdAt: Scalars["DateTime"];
+  /** Id of the OAuth client that was revoked. */
+  oauthClientId: Scalars["String"];
+  /** ID of the organization for which the webhook belongs to. */
+  organizationId: Scalars["String"];
+  /** The type of resource. */
+  type: Scalars["String"];
 };
 
 /** The different requests statuses possible for an OAuth client approval request. */
@@ -14142,7 +14330,7 @@ export enum PushSubscriptionType {
 
 export type Query = {
   __typename?: "Query";
-  _dummy?: Maybe<Scalars["String"]>;
+  _dummy: Scalars["String"];
   /** All teams you the user can administrate. Administrable teams are teams whose settings the user can change, but to whose issues the user doesn't necessarily have access to. */
   administrableTeams: TeamConnection;
   /** All API keys for the user. */
@@ -15611,6 +15799,8 @@ export type SalesforceSettingsInput = {
   automateTicketReopeningOnComment?: Maybe<Scalars["Boolean"]>;
   /** Whether a ticket should be automatically reopened when its linked Linear issue is completed. */
   automateTicketReopeningOnCompletion?: Maybe<Scalars["Boolean"]>;
+  /** The Salesforce case status to use to reopen cases. */
+  reopenCaseStatus?: Maybe<Scalars["String"]>;
   /** Whether an internal message should be added when someone comments on an issue. */
   sendNoteOnComment?: Maybe<Scalars["Boolean"]>;
   /** Whether an internal message should be added when a Linear issue changes status (for status types except completed or canceled). */
@@ -19788,9 +19978,9 @@ export type AuthenticationSessionResponseFragment = { __typename: "Authenticatio
   | "id"
 >;
 
-export type BaseEntityWebhookPayloadFragment = { __typename: "BaseEntityWebhookPayload" } & Pick<
-  BaseEntityWebhookPayload,
-  "id" | "archivedAt" | "createdAt" | "updatedAt"
+export type BaseWebhookPayloadFragment = { __typename: "BaseWebhookPayload" } & Pick<
+  BaseWebhookPayload,
+  "organizationId" | "createdAt"
 >;
 
 export type CommentChildWebhookPayloadFragment = { __typename: "CommentChildWebhookPayload" } & Pick<
@@ -19822,6 +20012,11 @@ export type CycleChildWebhookPayloadFragment = { __typename: "CycleChildWebhookP
   CycleChildWebhookPayload,
   "id" | "endsAt" | "name" | "number" | "startsAt"
 >;
+
+export type DocumentContentChildWebhookPayloadFragment = { __typename: "DocumentContentChildWebhookPayload" } & {
+  document?: Maybe<{ __typename?: "DocumentChildWebhookPayload" } & DocumentChildWebhookPayloadFragment>;
+  project?: Maybe<{ __typename?: "ProjectChildWebhookPayload" } & ProjectChildWebhookPayloadFragment>;
+};
 
 export type DocumentChildWebhookPayloadFragment = { __typename: "DocumentChildWebhookPayload" } & Pick<
   DocumentChildWebhookPayload,
@@ -19906,11 +20101,6 @@ export type IssueChildWebhookPayloadFragment = { __typename: "IssueChildWebhookP
   IssueChildWebhookPayload,
   "id" | "teamId" | "url" | "identifier" | "title"
 > & { team: { __typename?: "TeamChildWebhookPayload" } & TeamChildWebhookPayloadFragment };
-
-export type AppUserNotificationWebhookPayloadFragment = { __typename: "AppUserNotificationWebhookPayload" } & Pick<
-  AppUserNotificationWebhookPayload,
-  "action" | "appUserId" | "oauthClientId" | "organizationId" | "createdAt" | "type"
->;
 
 export type ArchiveResponseFragment = { __typename: "ArchiveResponse" } & Pick<
   ArchiveResponse,
@@ -20222,6 +20412,11 @@ export type UploadFileFragment = { __typename: "UploadFile" } & Pick<
   "assetUrl" | "contentType" | "filename" | "uploadUrl" | "size" | "metaData"
 > & { headers: Array<{ __typename?: "UploadFileHeader" } & UploadFileHeaderFragment> };
 
+export type OAuthAppWebhookPayloadFragment = { __typename: "OAuthAppWebhookPayload" } & Pick<
+  OAuthAppWebhookPayload,
+  "organizationId" | "oauthClientId" | "createdAt" | "action" | "type"
+>;
+
 export type CommentWebhookPayloadFragment = { __typename: "CommentWebhookPayload" } & Pick<
   CommentWebhookPayload,
   | "resolvingCommentId"
@@ -20246,7 +20441,9 @@ export type CommentWebhookPayloadFragment = { __typename: "CommentWebhookPayload
   | "editedAt"
   | "resolvedAt"
 > & {
-    documentContent?: Maybe<{ __typename?: "BaseEntityWebhookPayload" } & BaseEntityWebhookPayloadFragment>;
+    documentContent?: Maybe<
+      { __typename?: "DocumentContentChildWebhookPayload" } & DocumentContentChildWebhookPayloadFragment
+    >;
     externalUser?: Maybe<{ __typename?: "ExternalUserChildWebhookPayload" } & ExternalUserChildWebhookPayloadFragment>;
     initiativeUpdate?: Maybe<
       { __typename?: "InitiativeUpdateChildWebhookPayload" } & InitiativeUpdateChildWebhookPayloadFragment
@@ -20327,6 +20524,30 @@ export type CycleWebhookPayloadFragment = { __typename: "CycleWebhookPayload" } 
   | "updatedAt"
   | "scopeHistory"
   | "issueCountHistory"
+>;
+
+export type DocumentWebhookPayloadFragment = { __typename: "DocumentWebhookPayload" } & Pick<
+  DocumentWebhookPayload,
+  | "trashed"
+  | "id"
+  | "initiativeId"
+  | "lastAppliedTemplateId"
+  | "projectId"
+  | "resourceFolderId"
+  | "creatorId"
+  | "updatedById"
+  | "subscriberIds"
+  | "color"
+  | "content"
+  | "description"
+  | "slugId"
+  | "icon"
+  | "sortOrder"
+  | "hiddenAt"
+  | "archivedAt"
+  | "createdAt"
+  | "updatedAt"
+  | "title"
 >;
 
 export type ProjectUpdateWebhookPayloadFragment = { __typename: "ProjectUpdateWebhookPayload" } & Pick<
@@ -20473,6 +20694,21 @@ export type AttachmentWebhookPayloadFragment = { __typename: "AttachmentWebhookP
   | "updatedAt"
   | "title"
   | "groupBySource"
+>;
+
+export type AuditEntryWebhookPayloadFragment = { __typename: "AuditEntryWebhookPayload" } & Pick<
+  AuditEntryWebhookPayload,
+  | "requestInformation"
+  | "metadata"
+  | "countryCode"
+  | "ip"
+  | "id"
+  | "organizationId"
+  | "actorId"
+  | "archivedAt"
+  | "createdAt"
+  | "updatedAt"
+  | "type"
 >;
 
 export type InitiativeUpdateWebhookPayloadFragment = { __typename: "InitiativeUpdateWebhookPayload" } & Pick<
@@ -20740,6 +20976,41 @@ export type IssueWebhookPayloadFragment = { __typename: "IssueWebhookPayload" } 
     creator?: Maybe<{ __typename?: "UserChildWebhookPayload" } & UserChildWebhookPayloadFragment>;
     assignee?: Maybe<{ __typename?: "UserChildWebhookPayload" } & UserChildWebhookPayloadFragment>;
   };
+
+export type AppUserNotificationWebhookPayloadFragment = { __typename: "AppUserNotificationWebhookPayload" } & Pick<
+  AppUserNotificationWebhookPayload,
+  "oauthClientId" | "appUserId" | "organizationId" | "createdAt" | "action" | "type"
+>;
+
+export type AppUserTeamAccessChangedWebhookPayloadFragment = {
+  __typename: "AppUserTeamAccessChangedWebhookPayload";
+} & Pick<
+  AppUserTeamAccessChangedWebhookPayload,
+  | "oauthClientId"
+  | "appUserId"
+  | "organizationId"
+  | "addedTeamIds"
+  | "removedTeamIds"
+  | "createdAt"
+  | "action"
+  | "type"
+  | "canAccessAllPublicTeams"
+>;
+
+export type CustomResourceWebhookPayloadFragment = { __typename: "CustomResourceWebhookPayload" } & Pick<
+  CustomResourceWebhookPayload,
+  "organizationId" | "createdAt" | "action" | "type"
+>;
+
+export type EntityWebhookPayloadFragment = { __typename: "EntityWebhookPayload" } & Pick<
+  EntityWebhookPayload,
+  "organizationId" | "updatedFrom" | "createdAt" | "action" | "type" | "url"
+>;
+
+export type IssueSlaWebhookPayloadFragment = { __typename: "IssueSlaWebhookPayload" } & Pick<
+  IssueSlaWebhookPayload,
+  "organizationId" | "createdAt" | "action" | "type" | "url"
+> & { issueData: { __typename?: "IssueWebhookPayload" } & IssueWebhookPayloadFragment };
 
 export type UserAuthorizedApplicationFragment = { __typename: "UserAuthorizedApplication" } & Pick<
   UserAuthorizedApplication,
@@ -30039,6 +30310,24 @@ export const AuthenticationSessionResponseFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<AuthenticationSessionResponseFragment, unknown>;
+export const BaseWebhookPayloadFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "BaseWebhookPayload" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "BaseWebhookPayload" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "organizationId" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<BaseWebhookPayloadFragment, unknown>;
 export const CustomerNeedChildWebhookPayloadFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -30096,28 +30385,6 @@ export const IntegrationChildWebhookPayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<IntegrationChildWebhookPayloadFragment, unknown>;
-export const AppUserNotificationWebhookPayloadFragmentDoc = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "FragmentDefinition",
-      name: { kind: "Name", value: "AppUserNotificationWebhookPayload" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "AppUserNotificationWebhookPayload" } },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "action" } },
-          { kind: "Field", name: { kind: "Name", value: "appUserId" } },
-          { kind: "Field", name: { kind: "Name", value: "oauthClientId" } },
-          { kind: "Field", name: { kind: "Name", value: "organizationId" } },
-          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
-          { kind: "Field", name: { kind: "Name", value: "type" } },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<AppUserNotificationWebhookPayloadFragment, unknown>;
 export const OrganizationDomainFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -30543,26 +30810,59 @@ export const ExternalEntitySlackMetadataFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<ExternalEntitySlackMetadataFragment, unknown>;
-export const BaseEntityWebhookPayloadFragmentDoc = {
+export const OAuthAppWebhookPayloadFragmentDoc = {
   kind: "Document",
   definitions: [
     {
       kind: "FragmentDefinition",
-      name: { kind: "Name", value: "BaseEntityWebhookPayload" },
-      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "BaseEntityWebhookPayload" } },
+      name: { kind: "Name", value: "OAuthAppWebhookPayload" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "OAuthAppWebhookPayload" } },
       selectionSet: {
         kind: "SelectionSet",
         selections: [
           { kind: "Field", name: { kind: "Name", value: "__typename" } },
-          { kind: "Field", name: { kind: "Name", value: "id" } },
-          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "organizationId" } },
+          { kind: "Field", name: { kind: "Name", value: "oauthClientId" } },
           { kind: "Field", name: { kind: "Name", value: "createdAt" } },
-          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "action" } },
+          { kind: "Field", name: { kind: "Name", value: "type" } },
         ],
       },
     },
   ],
-} as unknown as DocumentNode<BaseEntityWebhookPayloadFragment, unknown>;
+} as unknown as DocumentNode<OAuthAppWebhookPayloadFragment, unknown>;
+export const DocumentContentChildWebhookPayloadFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "DocumentContentChildWebhookPayload" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "DocumentContentChildWebhookPayload" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "document" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "DocumentChildWebhookPayload" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "project" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProjectChildWebhookPayload" } }],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DocumentContentChildWebhookPayloadFragment, unknown>;
 export const ExternalUserChildWebhookPayloadFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -30660,7 +30960,9 @@ export const CommentWebhookPayloadFragmentDoc = {
             name: { kind: "Name", value: "documentContent" },
             selectionSet: {
               kind: "SelectionSet",
-              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "BaseEntityWebhookPayload" } }],
+              selections: [
+                { kind: "FragmentSpread", name: { kind: "Name", value: "DocumentContentChildWebhookPayload" } },
+              ],
             },
           },
           { kind: "Field", name: { kind: "Name", value: "syncedWith" } },
@@ -30970,6 +31272,42 @@ export const CycleWebhookPayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<CycleWebhookPayloadFragment, unknown>;
+export const DocumentWebhookPayloadFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "DocumentWebhookPayload" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "DocumentWebhookPayload" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "trashed" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "initiativeId" } },
+          { kind: "Field", name: { kind: "Name", value: "lastAppliedTemplateId" } },
+          { kind: "Field", name: { kind: "Name", value: "projectId" } },
+          { kind: "Field", name: { kind: "Name", value: "resourceFolderId" } },
+          { kind: "Field", name: { kind: "Name", value: "creatorId" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedById" } },
+          { kind: "Field", name: { kind: "Name", value: "subscriberIds" } },
+          { kind: "Field", name: { kind: "Name", value: "color" } },
+          { kind: "Field", name: { kind: "Name", value: "content" } },
+          { kind: "Field", name: { kind: "Name", value: "description" } },
+          { kind: "Field", name: { kind: "Name", value: "slugId" } },
+          { kind: "Field", name: { kind: "Name", value: "icon" } },
+          { kind: "Field", name: { kind: "Name", value: "sortOrder" } },
+          { kind: "Field", name: { kind: "Name", value: "hiddenAt" } },
+          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "title" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DocumentWebhookPayloadFragment, unknown>;
 export const ProjectUpdateWebhookPayloadFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -31287,6 +31625,33 @@ export const UserWebhookPayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<UserWebhookPayloadFragment, unknown>;
+export const AuditEntryWebhookPayloadFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "AuditEntryWebhookPayload" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "AuditEntryWebhookPayload" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "requestInformation" } },
+          { kind: "Field", name: { kind: "Name", value: "metadata" } },
+          { kind: "Field", name: { kind: "Name", value: "countryCode" } },
+          { kind: "Field", name: { kind: "Name", value: "ip" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "organizationId" } },
+          { kind: "Field", name: { kind: "Name", value: "actorId" } },
+          { kind: "Field", name: { kind: "Name", value: "archivedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "type" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<AuditEntryWebhookPayloadFragment, unknown>;
 export const InitiativeUpdateWebhookPayloadFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -31826,6 +32191,95 @@ export const IssueUnassignedFromYouNotificationWebhookPayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<IssueUnassignedFromYouNotificationWebhookPayloadFragment, unknown>;
+export const AppUserNotificationWebhookPayloadFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "AppUserNotificationWebhookPayload" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "AppUserNotificationWebhookPayload" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "oauthClientId" } },
+          { kind: "Field", name: { kind: "Name", value: "appUserId" } },
+          { kind: "Field", name: { kind: "Name", value: "organizationId" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "action" } },
+          { kind: "Field", name: { kind: "Name", value: "type" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<AppUserNotificationWebhookPayloadFragment, unknown>;
+export const AppUserTeamAccessChangedWebhookPayloadFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "AppUserTeamAccessChangedWebhookPayload" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "AppUserTeamAccessChangedWebhookPayload" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "oauthClientId" } },
+          { kind: "Field", name: { kind: "Name", value: "appUserId" } },
+          { kind: "Field", name: { kind: "Name", value: "organizationId" } },
+          { kind: "Field", name: { kind: "Name", value: "addedTeamIds" } },
+          { kind: "Field", name: { kind: "Name", value: "removedTeamIds" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "action" } },
+          { kind: "Field", name: { kind: "Name", value: "type" } },
+          { kind: "Field", name: { kind: "Name", value: "canAccessAllPublicTeams" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<AppUserTeamAccessChangedWebhookPayloadFragment, unknown>;
+export const CustomResourceWebhookPayloadFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CustomResourceWebhookPayload" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "CustomResourceWebhookPayload" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "organizationId" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "action" } },
+          { kind: "Field", name: { kind: "Name", value: "type" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<CustomResourceWebhookPayloadFragment, unknown>;
+export const EntityWebhookPayloadFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "EntityWebhookPayload" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "EntityWebhookPayload" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "organizationId" } },
+          { kind: "Field", name: { kind: "Name", value: "updatedFrom" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "action" } },
+          { kind: "Field", name: { kind: "Name", value: "type" } },
+          { kind: "Field", name: { kind: "Name", value: "url" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<EntityWebhookPayloadFragment, unknown>;
 export const CycleChildWebhookPayloadFragmentDoc = {
   kind: "Document",
   definitions: [
@@ -32034,6 +32488,35 @@ export const IssueWebhookPayloadFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<IssueWebhookPayloadFragment, unknown>;
+export const IssueSlaWebhookPayloadFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "IssueSlaWebhookPayload" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "IssueSlaWebhookPayload" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "organizationId" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "issueData" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "IssueWebhookPayload" } }],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "action" } },
+          { kind: "Field", name: { kind: "Name", value: "type" } },
+          { kind: "Field", name: { kind: "Name", value: "url" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<IssueSlaWebhookPayloadFragment, unknown>;
 export const UserAuthorizedApplicationFragmentDoc = {
   kind: "Document",
   definitions: [

--- a/packages/sdk/src/_generated_sdk.ts
+++ b/packages/sdk/src/_generated_sdk.ts
@@ -290,7 +290,7 @@ export class ApiKeyPayload extends Request {
   public apiKey: ApiKey;
 }
 /**
- * Complete payload for an app user notification webhook.
+ * Payload for app user notification webhook events.
  *
  * @param data - L.AppUserNotificationWebhookPayloadFragment response data
  */
@@ -298,23 +298,60 @@ export class AppUserNotificationWebhookPayload {
   public constructor(data: L.AppUserNotificationWebhookPayloadFragment) {
     this.action = data.action;
     this.appUserId = data.appUserId;
-    this.createdAt = data.createdAt;
+    this.createdAt = parseDate(data.createdAt) ?? new Date();
     this.oauthClientId = data.oauthClientId;
     this.organizationId = data.organizationId;
     this.type = data.type;
   }
 
-  /** The action of the notification. */
+  /** The type of action that triggered the webhook. */
   public action: string;
-  /** The app user id of the webhook. */
+  /** ID of the app user the notification is for. */
   public appUserId: string;
-  /** The timestamp the webhook was created at. */
-  public createdAt: string;
-  /** The oauth client id of the webhook. */
+  /** The time the payload was created. */
+  public createdAt: Date;
+  /** ID of the OAuth client the app user is tied to. */
   public oauthClientId: string;
-  /** The organization id of the webhook. */
+  /** ID of the organization for which the webhook belongs to. */
   public organizationId: string;
-  /** The type of the notification. */
+  /** The type of resource. */
+  public type: string;
+}
+/**
+ * Payload for app user team access change webhook events.
+ *
+ * @param data - L.AppUserTeamAccessChangedWebhookPayloadFragment response data
+ */
+export class AppUserTeamAccessChangedWebhookPayload {
+  public constructor(data: L.AppUserTeamAccessChangedWebhookPayloadFragment) {
+    this.action = data.action;
+    this.addedTeamIds = data.addedTeamIds;
+    this.appUserId = data.appUserId;
+    this.canAccessAllPublicTeams = data.canAccessAllPublicTeams;
+    this.createdAt = parseDate(data.createdAt) ?? new Date();
+    this.oauthClientId = data.oauthClientId;
+    this.organizationId = data.organizationId;
+    this.removedTeamIds = data.removedTeamIds;
+    this.type = data.type;
+  }
+
+  /** The type of action that triggered the webhook. */
+  public action: string;
+  /** IDs of the teams the app user was added to. */
+  public addedTeamIds: string[];
+  /** ID of the app user the notification is for. */
+  public appUserId: string;
+  /** Whether the app user can access all public teams. */
+  public canAccessAllPublicTeams: boolean;
+  /** The time the payload was created. */
+  public createdAt: Date;
+  /** ID of the OAuth client the app user is tied to. */
+  public oauthClientId: string;
+  /** ID of the organization for which the webhook belongs to. */
+  public organizationId: string;
+  /** IDs of the teams the app user was removed from. */
+  public removedTeamIds: string[];
+  /** The type of resource. */
   public type: string;
 }
 /**
@@ -749,6 +786,49 @@ export class AuditEntryType extends Request {
   public type: string;
 }
 /**
+ * Payload for an audit entry webhook.
+ *
+ * @param data - L.AuditEntryWebhookPayloadFragment response data
+ */
+export class AuditEntryWebhookPayload {
+  public constructor(data: L.AuditEntryWebhookPayloadFragment) {
+    this.actorId = data.actorId ?? undefined;
+    this.archivedAt = data.archivedAt ?? undefined;
+    this.countryCode = data.countryCode ?? undefined;
+    this.createdAt = data.createdAt;
+    this.id = data.id;
+    this.ip = data.ip ?? undefined;
+    this.metadata = data.metadata ?? undefined;
+    this.organizationId = data.organizationId;
+    this.requestInformation = data.requestInformation ?? undefined;
+    this.type = data.type;
+    this.updatedAt = data.updatedAt;
+  }
+
+  /** The ID of the user that caused the audit entry to be created. */
+  public actorId?: string;
+  /** The time at which the entity was archived. */
+  public archivedAt?: string;
+  /** Country code of request resulting to audit entry. */
+  public countryCode?: string;
+  /** The time at which the entity was created. */
+  public createdAt: string;
+  /** The ID of the entity. */
+  public id: string;
+  /** IP from actor when entry was recorded. */
+  public ip?: string;
+  /** Additional metadata related to the audit entry. */
+  public metadata?: L.Scalars["JSONObject"];
+  /** The ID of the organization that the audit entry belongs to. */
+  public organizationId: string;
+  /** Additional information related to the request which performed the action. */
+  public requestInformation?: L.Scalars["JSONObject"];
+  /** The type of the audit entry. */
+  public type: string;
+  /** The time at which the entity was updated. */
+  public updatedAt: string;
+}
+/**
  * An organization. Organizations are root-level objects that contain users and teams.
  *
  * @param request - function to call the graphql client
@@ -969,26 +1049,20 @@ export class AuthorizingUser extends Request {
   public name: string;
 }
 /**
- * Base class for entity webhook payloads.
+ * Base fields for all webhook payloads.
  *
- * @param data - L.BaseEntityWebhookPayloadFragment response data
+ * @param data - L.BaseWebhookPayloadFragment response data
  */
-export class BaseEntityWebhookPayload {
-  public constructor(data: L.BaseEntityWebhookPayloadFragment) {
-    this.archivedAt = data.archivedAt ?? undefined;
-    this.createdAt = data.createdAt;
-    this.id = data.id;
-    this.updatedAt = data.updatedAt;
+export class BaseWebhookPayload {
+  public constructor(data: L.BaseWebhookPayloadFragment) {
+    this.createdAt = parseDate(data.createdAt) ?? new Date();
+    this.organizationId = data.organizationId;
   }
 
-  /** The time at which the entity was archived. */
-  public archivedAt?: string;
-  /** The time at which the entity was created. */
-  public createdAt: string;
-  /** The ID of the entity. */
-  public id: string;
-  /** The time at which the entity was updated. */
-  public updatedAt: string;
+  /** The time the payload was created. */
+  public createdAt: Date;
+  /** ID of the organization for which the webhook belongs to. */
+  public organizationId: string;
 }
 /**
  * A comment associated with an issue.
@@ -1260,7 +1334,9 @@ export class CommentWebhookPayload {
     this.syncedWith = data.syncedWith ?? undefined;
     this.updatedAt = data.updatedAt;
     this.userId = data.userId ?? undefined;
-    this.documentContent = data.documentContent ? new BaseEntityWebhookPayload(data.documentContent) : undefined;
+    this.documentContent = data.documentContent
+      ? new DocumentContentChildWebhookPayload(data.documentContent)
+      : undefined;
     this.externalUser = data.externalUser ? new ExternalUserChildWebhookPayload(data.externalUser) : undefined;
     this.initiativeUpdate = data.initiativeUpdate
       ? new InitiativeUpdateChildWebhookPayload(data.initiativeUpdate)
@@ -1314,7 +1390,7 @@ export class CommentWebhookPayload {
   /** The ID of the user who created this comment. */
   public userId?: string;
   /** The document content for this comment. */
-  public documentContent?: BaseEntityWebhookPayload;
+  public documentContent?: DocumentContentChildWebhookPayload;
   /** The external user who created this comment. */
   public externalUser?: ExternalUserChildWebhookPayload;
   /** The initiative update this comment belongs to. */
@@ -1373,6 +1449,28 @@ export class CreateOrJoinOrganizationResponse extends Request {
 
   public organization: AuthOrganization;
   public user: AuthUser;
+}
+/**
+ * Payload for custom webhook resource events.
+ *
+ * @param data - L.CustomResourceWebhookPayloadFragment response data
+ */
+export class CustomResourceWebhookPayload {
+  public constructor(data: L.CustomResourceWebhookPayloadFragment) {
+    this.action = data.action;
+    this.createdAt = parseDate(data.createdAt) ?? new Date();
+    this.organizationId = data.organizationId;
+    this.type = data.type;
+  }
+
+  /** The type of action that triggered the webhook. */
+  public action: string;
+  /** The time the payload was created. */
+  public createdAt: Date;
+  /** ID of the organization for which the webhook belongs to. */
+  public organizationId: string;
+  /** The type of resource. */
+  public type: string;
 }
 /**
  * A custom view that has been saved by a user.
@@ -3419,6 +3517,22 @@ export class DocumentContent extends Request {
   }
 }
 /**
+ * Certain properties of a document content.
+ *
+ * @param data - L.DocumentContentChildWebhookPayloadFragment response data
+ */
+export class DocumentContentChildWebhookPayload {
+  public constructor(data: L.DocumentContentChildWebhookPayloadFragment) {
+    this.document = data.document ? new DocumentChildWebhookPayload(data.document) : undefined;
+    this.project = data.project ? new ProjectChildWebhookPayload(data.project) : undefined;
+  }
+
+  /** The document this document content belongs to. */
+  public document?: DocumentChildWebhookPayload;
+  /** The project this document belongs to. */
+  public project?: ProjectChildWebhookPayload;
+}
+/**
  * DocumentContentHistoryPayload model
  *
  * @param request - function to call the graphql client
@@ -3716,6 +3830,76 @@ export class DocumentSearchResult extends Request {
   public get updatedById(): string | undefined {
     return this._updatedBy?.id;
   }
+}
+/**
+ * Payload for a document webhook.
+ *
+ * @param data - L.DocumentWebhookPayloadFragment response data
+ */
+export class DocumentWebhookPayload {
+  public constructor(data: L.DocumentWebhookPayloadFragment) {
+    this.archivedAt = data.archivedAt ?? undefined;
+    this.color = data.color ?? undefined;
+    this.content = data.content ?? undefined;
+    this.createdAt = data.createdAt;
+    this.creatorId = data.creatorId ?? undefined;
+    this.description = data.description ?? undefined;
+    this.hiddenAt = data.hiddenAt ?? undefined;
+    this.icon = data.icon ?? undefined;
+    this.id = data.id;
+    this.initiativeId = data.initiativeId ?? undefined;
+    this.lastAppliedTemplateId = data.lastAppliedTemplateId ?? undefined;
+    this.projectId = data.projectId ?? undefined;
+    this.resourceFolderId = data.resourceFolderId ?? undefined;
+    this.slugId = data.slugId;
+    this.sortOrder = data.sortOrder;
+    this.subscriberIds = data.subscriberIds ?? undefined;
+    this.title = data.title;
+    this.trashed = data.trashed ?? undefined;
+    this.updatedAt = data.updatedAt;
+    this.updatedById = data.updatedById ?? undefined;
+  }
+
+  /** The time at which the entity was archived. */
+  public archivedAt?: string;
+  /** The color of the document. */
+  public color?: string;
+  /** The content of the document. */
+  public content?: string;
+  /** The time at which the entity was created. */
+  public createdAt: string;
+  /** The ID of the user who created the document. */
+  public creatorId?: string;
+  /** The description of the document. */
+  public description?: string;
+  /** The time at which the document was hidden. */
+  public hiddenAt?: string;
+  /** The icon of the document. */
+  public icon?: string;
+  /** The ID of the entity. */
+  public id: string;
+  /** The ID of the initiative this document belongs to. */
+  public initiativeId?: string;
+  /** The ID of the last template that was applied to this document. */
+  public lastAppliedTemplateId?: string;
+  /** The ID of the project this document belongs to. */
+  public projectId?: string;
+  /** The ID of the resource folder this document belongs to. */
+  public resourceFolderId?: string;
+  /** The document's unique URL slug. */
+  public slugId: string;
+  /** The order of the item in the resources list. */
+  public sortOrder: number;
+  /** The IDs of the users who are subscribed to this document. */
+  public subscriberIds?: string[];
+  /** The title of the document. */
+  public title: string;
+  /** A flag that indicates whether the document is in the trash bin. */
+  public trashed?: boolean;
+  /** The time at which the entity was updated. */
+  public updatedAt: string;
+  /** The ID of the user who last updated the document. */
+  public updatedById?: string;
 }
 /**
  * A general purpose draft. Used for comments, project updates, etc.
@@ -4256,6 +4440,34 @@ export class EntityExternalLinkPayload extends Request {
   public get entityExternalLinkId(): string | undefined {
     return this._entityExternalLink?.id;
   }
+}
+/**
+ * Payload for entity-related webhook events.
+ *
+ * @param data - L.EntityWebhookPayloadFragment response data
+ */
+export class EntityWebhookPayload {
+  public constructor(data: L.EntityWebhookPayloadFragment) {
+    this.action = data.action;
+    this.createdAt = parseDate(data.createdAt) ?? new Date();
+    this.organizationId = data.organizationId;
+    this.type = data.type;
+    this.updatedFrom = data.updatedFrom ?? undefined;
+    this.url = data.url ?? undefined;
+  }
+
+  /** The type of action that triggered the webhook. */
+  public action: string;
+  /** The time the payload was created. */
+  public createdAt: Date;
+  /** ID of the organization for which the webhook belongs to. */
+  public organizationId: string;
+  /** The type of resource, i.e., the name of the entity. */
+  public type: string;
+  /** In case of an update event, previous values of all updated properties. */
+  public updatedFrom?: L.Scalars["JSONObject"];
+  /** URL for the entity. */
+  public url?: string;
 }
 /**
  * Information about an external entity.
@@ -8773,6 +8985,34 @@ export class IssueSearchResult extends Request {
   }
 }
 /**
+ * Payload for issue SLA webhook events.
+ *
+ * @param data - L.IssueSlaWebhookPayloadFragment response data
+ */
+export class IssueSlaWebhookPayload {
+  public constructor(data: L.IssueSlaWebhookPayloadFragment) {
+    this.action = data.action;
+    this.createdAt = parseDate(data.createdAt) ?? new Date();
+    this.organizationId = data.organizationId;
+    this.type = data.type;
+    this.url = data.url ?? undefined;
+    this.issueData = new IssueWebhookPayload(data.issueData);
+  }
+
+  /** The type of action that triggered the webhook. */
+  public action: string;
+  /** The time the payload was created. */
+  public createdAt: Date;
+  /** ID of the organization for which the webhook belongs to. */
+  public organizationId: string;
+  /** The type of resource. */
+  public type: string;
+  /** URL for the issue. */
+  public url?: string;
+  /** The issue that the SLA event is about. */
+  public issueData: IssueWebhookPayload;
+}
+/**
  * Payload for a terminal issue status change notification.
  *
  * @param data - L.IssueStatusChangedNotificationWebhookPayloadFragment response data
@@ -10084,6 +10324,31 @@ export class NotificationSubscriptionPayload extends Request {
   public lastSyncId: number;
   /** Whether the operation was successful. */
   public success: boolean;
+}
+/**
+ * Payload for OAuth app webhook events.
+ *
+ * @param data - L.OAuthAppWebhookPayloadFragment response data
+ */
+export class OAuthAppWebhookPayload {
+  public constructor(data: L.OAuthAppWebhookPayloadFragment) {
+    this.action = data.action;
+    this.createdAt = parseDate(data.createdAt) ?? new Date();
+    this.oauthClientId = data.oauthClientId;
+    this.organizationId = data.organizationId;
+    this.type = data.type;
+  }
+
+  /** The type of action that triggered the webhook. */
+  public action: string;
+  /** The time the payload was created. */
+  public createdAt: Date;
+  /** Id of the OAuth client that was revoked. */
+  public oauthClientId: string;
+  /** ID of the organization for which the webhook belongs to. */
+  public organizationId: string;
+  /** The type of resource. */
+  public type: string;
 }
 /**
  * Request to install OAuth clients on organizations and the response to the request.

--- a/packages/sdk/src/schema.graphql
+++ b/packages/sdk/src/schema.graphql
@@ -169,35 +169,77 @@ type AppUserAuthentication {
 }
 
 """
-Complete payload for an app user notification webhook.
+Payload for app user notification webhook events.
 """
 type AppUserNotificationWebhookPayload {
   """
-  The action of the notification.
+  The type of action that triggered the webhook.
   """
   action: String!
   """
-  The app user id of the webhook.
+  ID of the app user the notification is for.
   """
   appUserId: String!
   """
-  The timestamp the webhook was created at.
+  The time the payload was created.
   """
-  createdAt: String!
+  createdAt: DateTime!
   """
-  The notification of the webhook.
+  Details of the notification.
   """
   notification: NotificationWebhookPayload!
   """
-  The oauth client id of the webhook.
+  ID of the OAuth client the app user is tied to.
   """
   oauthClientId: String!
   """
-  The organization id of the webhook.
+  ID of the organization for which the webhook belongs to.
   """
   organizationId: String!
   """
-  The type of the notification.
+  The type of resource.
+  """
+  type: String!
+}
+
+"""
+Payload for app user team access change webhook events.
+"""
+type AppUserTeamAccessChangedWebhookPayload {
+  """
+  The type of action that triggered the webhook.
+  """
+  action: String!
+  """
+  IDs of the teams the app user was added to.
+  """
+  addedTeamIds: [String!]!
+  """
+  ID of the app user the notification is for.
+  """
+  appUserId: String!
+  """
+  Whether the app user can access all public teams.
+  """
+  canAccessAllPublicTeams: Boolean!
+  """
+  The time the payload was created.
+  """
+  createdAt: DateTime!
+  """
+  ID of the OAuth client the app user is tied to.
+  """
+  oauthClientId: String!
+  """
+  ID of the organization for which the webhook belongs to.
+  """
+  organizationId: String!
+  """
+  IDs of the teams the app user was removed from.
+  """
+  removedTeamIds: [String!]!
+  """
+  The type of resource.
   """
   type: String!
 }
@@ -786,6 +828,56 @@ type AuditEntryType {
 }
 
 """
+Payload for an audit entry webhook.
+"""
+type AuditEntryWebhookPayload {
+  """
+  The ID of the user that caused the audit entry to be created.
+  """
+  actorId: String
+  """
+  The time at which the entity was archived.
+  """
+  archivedAt: String
+  """
+  Country code of request resulting to audit entry.
+  """
+  countryCode: String
+  """
+  The time at which the entity was created.
+  """
+  createdAt: String!
+  """
+  The ID of the entity.
+  """
+  id: String!
+  """
+  IP from actor when entry was recorded.
+  """
+  ip: String
+  """
+  Additional metadata related to the audit entry.
+  """
+  metadata: JSONObject
+  """
+  The ID of the organization that the audit entry belongs to.
+  """
+  organizationId: String!
+  """
+  Additional information related to the request which performed the action.
+  """
+  requestInformation: JSONObject
+  """
+  The type of the audit entry.
+  """
+  type: String!
+  """
+  The time at which the entity was updated.
+  """
+  updatedAt: String!
+}
+
+"""
 [INTERNAL] An OAuth userId/createdDate tuple
 """
 type AuthMembership {
@@ -1087,25 +1179,17 @@ type AuthorizingUser {
 }
 
 """
-Base class for entity webhook payloads.
+Base fields for all webhook payloads.
 """
-type BaseEntityWebhookPayload {
+type BaseWebhookPayload {
   """
-  The time at which the entity was archived.
+  The time the payload was created.
   """
-  archivedAt: String
+  createdAt: DateTime!
   """
-  The time at which the entity was created.
+  ID of the organization for which the webhook belongs to.
   """
-  createdAt: String!
-  """
-  The ID of the entity.
-  """
-  id: String!
-  """
-  The time at which the entity was updated.
-  """
-  updatedAt: String!
+  organizationId: String!
 }
 
 """
@@ -1578,7 +1662,7 @@ type CommentWebhookPayload {
   """
   The document content for this comment.
   """
-  documentContent: BaseEntityWebhookPayload
+  documentContent: DocumentContentChildWebhookPayload
   """
   The ID of the document content this comment belongs to.
   """
@@ -1816,6 +1900,28 @@ input CreatedAtSort {
   The order for the individual sort
   """
   order: PaginationSortOrder
+}
+
+"""
+Payload for custom webhook resource events.
+"""
+type CustomResourceWebhookPayload {
+  """
+  The type of action that triggered the webhook.
+  """
+  action: String!
+  """
+  The time the payload was created.
+  """
+  createdAt: DateTime!
+  """
+  ID of the organization for which the webhook belongs to.
+  """
+  organizationId: String!
+  """
+  The type of resource.
+  """
+  type: String!
 }
 
 """
@@ -4460,6 +4566,26 @@ type Dashboard implements Node {
 }
 
 """
+Union type for all possible webhook entity data payloads
+"""
+union DataWebhookPayload =
+  | AttachmentWebhookPayload
+  | AuditEntryWebhookPayload
+  | CommentWebhookPayload
+  | CustomerNeedWebhookPayload
+  | CustomerWebhookPayload
+  | CycleWebhookPayload
+  | DocumentWebhookPayload
+  | InitiativeUpdateWebhookPayload
+  | InitiativeWebhookPayload
+  | IssueLabelWebhookPayload
+  | IssueWebhookPayload
+  | ProjectUpdateWebhookPayload
+  | ProjectWebhookPayload
+  | ReactionWebhookPayload
+  | UserWebhookPayload
+
+"""
 Comparator for dates.
 """
 input DateComparator {
@@ -4790,6 +4916,20 @@ type DocumentContent implements Node {
       been updated after creation.
   """
   updatedAt: DateTime!
+}
+
+"""
+Certain properties of a document content.
+"""
+type DocumentContentChildWebhookPayload {
+  """
+  The document this document content belongs to.
+  """
+  document: DocumentChildWebhookPayload
+  """
+  The project this document belongs to.
+  """
+  project: ProjectChildWebhookPayload
 }
 
 type DocumentContentHistoryPayload {
@@ -5270,6 +5410,92 @@ input DocumentUpdateInput {
   Whether the document has been trashed.
   """
   trashed: Boolean
+}
+
+"""
+Payload for a document webhook.
+"""
+type DocumentWebhookPayload {
+  """
+  The time at which the entity was archived.
+  """
+  archivedAt: String
+  """
+  The color of the document.
+  """
+  color: String
+  """
+  The content of the document.
+  """
+  content: String
+  """
+  The time at which the entity was created.
+  """
+  createdAt: String!
+  """
+  The ID of the user who created the document.
+  """
+  creatorId: String
+  """
+  The description of the document.
+  """
+  description: String
+  """
+  The time at which the document was hidden.
+  """
+  hiddenAt: String
+  """
+  The icon of the document.
+  """
+  icon: String
+  """
+  The ID of the entity.
+  """
+  id: String!
+  """
+  The ID of the initiative this document belongs to.
+  """
+  initiativeId: String
+  """
+  The ID of the last template that was applied to this document.
+  """
+  lastAppliedTemplateId: String
+  """
+  The ID of the project this document belongs to.
+  """
+  projectId: String
+  """
+  The ID of the resource folder this document belongs to.
+  """
+  resourceFolderId: String
+  """
+  The document's unique URL slug.
+  """
+  slugId: String!
+  """
+  The order of the item in the resources list.
+  """
+  sortOrder: Float!
+  """
+  The IDs of the users who are subscribed to this document.
+  """
+  subscriberIds: [String!]
+  """
+  The title of the document.
+  """
+  title: String!
+  """
+  A flag that indicates whether the document is in the trash bin.
+  """
+  trashed: Boolean
+  """
+  The time at which the entity was updated.
+  """
+  updatedAt: String!
+  """
+  The ID of the user who last updated the document.
+  """
+  updatedById: String
 }
 
 """
@@ -5768,6 +5994,40 @@ input EntityExternalLinkUpdateInput {
   sortOrder: Float
   """
   The URL of the link.
+  """
+  url: String
+}
+
+"""
+Payload for entity-related webhook events.
+"""
+type EntityWebhookPayload {
+  """
+  The type of action that triggered the webhook.
+  """
+  action: String!
+  """
+  The time the payload was created.
+  """
+  createdAt: DateTime!
+  """
+  The entity that was changed.
+  """
+  data: DataWebhookPayload!
+  """
+  ID of the organization for which the webhook belongs to.
+  """
+  organizationId: String!
+  """
+  The type of resource, i.e., the name of the entity.
+  """
+  type: String!
+  """
+  In case of an update event, previous values of all updated properties.
+  """
+  updatedFrom: JSONObject
+  """
+  URL for the entity.
   """
   url: String
 }
@@ -12722,6 +12982,36 @@ type IssueSearchResultEdge {
 }
 
 """
+Payload for issue SLA webhook events.
+"""
+type IssueSlaWebhookPayload {
+  """
+  The type of action that triggered the webhook.
+  """
+  action: String!
+  """
+  The time the payload was created.
+  """
+  createdAt: DateTime!
+  """
+  The issue that the SLA event is about.
+  """
+  issueData: IssueWebhookPayload!
+  """
+  ID of the organization for which the webhook belongs to.
+  """
+  organizationId: String!
+  """
+  The type of resource.
+  """
+  type: String!
+  """
+  URL for the issue.
+  """
+  url: String
+}
+
+"""
 Issue sorting options.
 """
 input IssueSortInput {
@@ -15384,6 +15674,15 @@ type Mutation {
     The Salesforce installation subdomain.
     """
     subdomain: String!
+  ): IntegrationPayload!
+  """
+  [INTERNAL] Refreshes the Salesforce integration metadata.
+  """
+  integrationSalesforceMetadataRefresh(
+    """
+    The ID of the integration to refresh metadata for.
+    """
+    id: String!
   ): IntegrationPayload!
   """
   Integrates the organization with Sentry.
@@ -19265,6 +19564,32 @@ input NumberComparator {
   Not-in-array constraint.
   """
   nin: [Float!]
+}
+
+"""
+Payload for OAuth app webhook events.
+"""
+type OAuthAppWebhookPayload {
+  """
+  The type of action that triggered the webhook.
+  """
+  action: String!
+  """
+  The time the payload was created.
+  """
+  createdAt: DateTime!
+  """
+  Id of the OAuth client that was revoked.
+  """
+  oauthClientId: String!
+  """
+  ID of the organization for which the webhook belongs to.
+  """
+  organizationId: String!
+  """
+  The type of resource.
+  """
+  type: String!
 }
 
 """
@@ -25185,7 +25510,7 @@ enum PushSubscriptionType {
 }
 
 type Query {
-  _dummy: String
+  _dummy: String!
   """
   All teams you the user can administrate. Administrable teams are teams whose settings the user can change, but to whose issues the user doesn't necessarily have access to.
   """
@@ -28004,6 +28329,10 @@ input SalesforceSettingsInput {
   Whether a ticket should be automatically reopened when its linked Linear issue is completed.
   """
   automateTicketReopeningOnCompletion: Boolean
+  """
+  The Salesforce case status to use to reopen cases.
+  """
+  reopenCaseStatus: String
   """
   Whether an internal message should be added when someone comments on an issue.
   """

--- a/packages/sdk/src/schema.json
+++ b/packages/sdk/src/schema.json
@@ -728,11 +728,11 @@
       {
         "kind": "OBJECT",
         "name": "AppUserNotificationWebhookPayload",
-        "description": "Complete payload for an app user notification webhook.",
+        "description": "Payload for app user notification webhook events.",
         "fields": [
           {
             "name": "action",
-            "description": "The action of the notification.",
+            "description": "The type of action that triggered the webhook.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -748,7 +748,7 @@
           },
           {
             "name": "appUserId",
-            "description": "The app user id of the webhook.",
+            "description": "ID of the app user the notification is for.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -764,14 +764,14 @@
           },
           {
             "name": "createdAt",
-            "description": "The timestamp the webhook was created at.",
+            "description": "The time the payload was created.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "DateTime",
                 "ofType": null
               }
             },
@@ -780,7 +780,7 @@
           },
           {
             "name": "notification",
-            "description": "The notification of the webhook.",
+            "description": "Details of the notification.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -796,7 +796,7 @@
           },
           {
             "name": "oauthClientId",
-            "description": "The oauth client id of the webhook.",
+            "description": "ID of the OAuth client the app user is tied to.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -812,7 +812,7 @@
           },
           {
             "name": "organizationId",
-            "description": "The organization id of the webhook.",
+            "description": "ID of the organization for which the webhook belongs to.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -828,7 +828,178 @@
           },
           {
             "name": "type",
-            "description": "The type of the notification.",
+            "description": "The type of resource.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppUserTeamAccessChangedWebhookPayload",
+        "description": "Payload for app user team access change webhook events.",
+        "fields": [
+          {
+            "name": "action",
+            "description": "The type of action that triggered the webhook.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "addedTeamIds",
+            "description": "IDs of the teams the app user was added to.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUserId",
+            "description": "ID of the app user the notification is for.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canAccessAllPublicTeams",
+            "description": "Whether the app user can access all public teams.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time the payload was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "oauthClientId",
+            "description": "ID of the OAuth client the app user is tied to.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationId",
+            "description": "ID of the organization for which the webhook belongs to.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "removedTeamIds",
+            "description": "IDs of the teams the app user was removed from.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "The type of resource.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3008,6 +3179,169 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AuditEntryWebhookPayload",
+        "description": "Payload for an audit entry webhook.",
+        "fields": [
+          {
+            "name": "actorId",
+            "description": "The ID of the user that caused the audit entry to be created.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "archivedAt",
+            "description": "The time at which the entity was archived.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "countryCode",
+            "description": "Country code of request resulting to audit entry.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time at which the entity was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "The ID of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ip",
+            "description": "IP from actor when entry was recorded.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metadata",
+            "description": "Additional metadata related to the audit entry.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationId",
+            "description": "The ID of the organization that the audit entry belongs to.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestInformation",
+            "description": "Additional information related to the request which performed the action.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "The type of the audit entry.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The time at which the entity was updated.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "AuthMembership",
         "description": "[INTERNAL] An OAuth userId/createdDate tuple",
         "fields": [
@@ -4136,31 +4470,19 @@
       },
       {
         "kind": "OBJECT",
-        "name": "BaseEntityWebhookPayload",
-        "description": "Base class for entity webhook payloads.",
+        "name": "BaseWebhookPayload",
+        "description": "Base fields for all webhook payloads.",
         "fields": [
           {
-            "name": "archivedAt",
-            "description": "The time at which the entity was archived.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "createdAt",
-            "description": "The time at which the entity was created.",
+            "description": "The time the payload was created.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "DateTime",
                 "ofType": null
               }
             },
@@ -4168,24 +4490,8 @@
             "deprecationReason": null
           },
           {
-            "name": "id",
-            "description": "The ID of the entity.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatedAt",
-            "description": "The time at which the entity was updated.",
+            "name": "organizationId",
+            "description": "ID of the organization for which the webhook belongs to.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5791,7 +6097,7 @@
             "args": [],
             "type": {
               "kind": "OBJECT",
-              "name": "BaseEntityWebhookPayload",
+              "name": "DocumentContentChildWebhookPayload",
               "ofType": null
             },
             "isDeprecated": false,
@@ -6580,6 +6886,81 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CustomResourceWebhookPayload",
+        "description": "Payload for custom webhook resource events.",
+        "fields": [
+          {
+            "name": "action",
+            "description": "The type of action that triggered the webhook.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time the payload was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationId",
+            "description": "ID of the organization for which the webhook belongs to.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "The type of resource.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -15874,6 +16255,92 @@
         "possibleTypes": null
       },
       {
+        "kind": "UNION",
+        "name": "DataWebhookPayload",
+        "description": "Union type for all possible webhook entity data payloads",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "AttachmentWebhookPayload",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "AuditEntryWebhookPayload",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "CommentWebhookPayload",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "CustomerNeedWebhookPayload",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "CustomerWebhookPayload",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "CycleWebhookPayload",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "DocumentWebhookPayload",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "InitiativeUpdateWebhookPayload",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "InitiativeWebhookPayload",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "IssueLabelWebhookPayload",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "IssueWebhookPayload",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ProjectUpdateWebhookPayload",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ProjectWebhookPayload",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ReactionWebhookPayload",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "UserWebhookPayload",
+            "ofType": null
+          }
+        ]
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "DateComparator",
         "description": "Comparator for dates.",
@@ -17003,6 +17470,41 @@
             "ofType": null
           }
         ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DocumentContentChildWebhookPayload",
+        "description": "Certain properties of a document content.",
+        "fields": [
+          {
+            "name": "document",
+            "description": "The document this document content belongs to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "DocumentChildWebhookPayload",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project",
+            "description": "The project this document belongs to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ProjectChildWebhookPayload",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -18731,6 +19233,289 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DocumentWebhookPayload",
+        "description": "Payload for a document webhook.",
+        "fields": [
+          {
+            "name": "archivedAt",
+            "description": "The time at which the entity was archived.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "color",
+            "description": "The color of the document.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "content",
+            "description": "The content of the document.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time at which the entity was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "creatorId",
+            "description": "The ID of the user who created the document.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "The description of the document.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hiddenAt",
+            "description": "The time at which the document was hidden.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "icon",
+            "description": "The icon of the document.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "The ID of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "initiativeId",
+            "description": "The ID of the initiative this document belongs to.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastAppliedTemplateId",
+            "description": "The ID of the last template that was applied to this document.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectId",
+            "description": "The ID of the project this document belongs to.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "resourceFolderId",
+            "description": "The ID of the resource folder this document belongs to.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slugId",
+            "description": "The document's unique URL slug.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sortOrder",
+            "description": "The order of the item in the resources list.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subscriberIds",
+            "description": "The IDs of the users who are subscribed to this document.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": "The title of the document.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "trashed",
+            "description": "A flag that indicates whether the document is in the trash bin.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The time at which the entity was updated.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedById",
+            "description": "The ID of the user who last updated the document.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -20740,6 +21525,121 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EntityWebhookPayload",
+        "description": "Payload for entity-related webhook events.",
+        "fields": [
+          {
+            "name": "action",
+            "description": "The type of action that triggered the webhook.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time the payload was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "data",
+            "description": "The entity that was changed.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "UNION",
+                "name": "DataWebhookPayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationId",
+            "description": "ID of the organization for which the webhook belongs to.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "The type of resource, i.e., the name of the entity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedFrom",
+            "description": "In case of an update event, previous values of all updated properties.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": "URL for the entity.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -45114,6 +46014,109 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "IssueSlaWebhookPayload",
+        "description": "Payload for issue SLA webhook events.",
+        "fields": [
+          {
+            "name": "action",
+            "description": "The type of action that triggered the webhook.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time the payload was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issueData",
+            "description": "The issue that the SLA event is about.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IssueWebhookPayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationId",
+            "description": "ID of the organization for which the webhook belongs to.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "The type of resource.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": "URL for the issue.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "IssueSortInput",
         "description": "Issue sorting options.",
@@ -56988,6 +57991,39 @@
             "deprecationReason": null
           },
           {
+            "name": "integrationSalesforceMetadataRefresh",
+            "description": "[INTERNAL] Refreshes the Salesforce integration metadata.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The ID of the integration to refresh metadata for.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "IntegrationPayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "integrationDelete",
             "description": "Deletes an integration.",
             "args": [
@@ -68808,6 +69844,97 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "OAuthAppWebhookPayload",
+        "description": "Payload for OAuth app webhook events.",
+        "fields": [
+          {
+            "name": "action",
+            "description": "The type of action that triggered the webhook.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time the payload was created.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "oauthClientId",
+            "description": "Id of the OAuth client that was revoked.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationId",
+            "description": "ID of the organization for which the webhook belongs to.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "The type of resource.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -89777,9 +90904,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -99983,6 +101114,18 @@
           {
             "name": "url",
             "description": "The Salesforce instance URL.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "reopenCaseStatus",
+            "description": "The Salesforce case status to use to reopen cases.",
             "type": {
               "kind": "SCALAR",
               "name": "String",


### PR DESCRIPTION
Adds the last few types (audit entry, document, document content) and wrappers for entity webhooks and custom resource webhooks