### PR TITLE
feat: helper to parse webhook payloads

### DIFF
--- a/.changeset/loose-cars-poke.md
+++ b/.changeset/loose-cars-poke.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": minor
+---
+
+Adds helper to parse webhook payloads

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,3 +1,6 @@
+import { DataWebhookPayload, EntityWebhookPayload, NotificationWebhookPayload } from "./_generated_documents";
+import { AppUserNotificationWebhookPayload } from "./_generated_sdk";
+
 /**
  * Input options for creating a Linear Client
  */
@@ -94,4 +97,18 @@ export interface LinearErrorRaw {
   request?: GraphQLRequestContext<Record<string, unknown>>;
   /** Error information for the response */
   response?: LinearRawResponse<unknown>;
+}
+
+/**
+ * A webhook payload for an app user notification webhook.
+ */
+export interface AppUserNotificationWebhookPayloadWithNotification extends AppUserNotificationWebhookPayload {
+  notification: NotificationWebhookPayload;
+}
+
+/**
+ * A webhook payload for an entity-specific webhook.
+ */
+export interface EntityWebhookPayloadWithEntityData extends EntityWebhookPayload {
+  data: DataWebhookPayload;
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,5 +1,5 @@
-import { DataWebhookPayload, EntityWebhookPayload, NotificationWebhookPayload } from "./_generated_documents";
-import { AppUserNotificationWebhookPayload } from "./_generated_sdk";
+import { DataWebhookPayload, NotificationWebhookPayload } from "./_generated_documents";
+import { AppUserNotificationWebhookPayload, EntityWebhookPayload } from "./_generated_sdk";
 
 /**
  * Input options for creating a Linear Client

--- a/packages/sdk/src/webhooks.ts
+++ b/packages/sdk/src/webhooks.ts
@@ -1,4 +1,27 @@
 import crypto from "crypto";
+import {
+  AttachmentWebhookPayload,
+  AuditEntryWebhookPayload,
+  CommentWebhookPayload,
+  CustomerNeedWebhookPayload,
+  CustomerWebhookPayload,
+  CycleWebhookPayload,
+  DocumentWebhookPayload,
+  InitiativeUpdateWebhookPayload,
+  IssueLabelWebhookPayload,
+  IssueWebhookPayload,
+  ProjectUpdateWebhookPayload,
+  ProjectWebhookPayload,
+  ReactionWebhookPayload,
+  UserWebhookPayload,
+} from "./_generated_documents";
+import {
+  AppUserTeamAccessChangedWebhookPayload,
+  InitiativeWebhookPayload,
+  IssueSlaWebhookPayload,
+  OAuthAppWebhookPayload,
+} from "./_generated_sdk";
+import { AppUserNotificationWebhookPayloadWithNotification, EntityWebhookPayloadWithEntityData } from "./types";
 
 export const LINEAR_WEBHOOK_SIGNATURE_HEADER = "linear-signature";
 export const LINEAR_WEBHOOK_TS_FIELD = "webhookTimestamp";
@@ -36,5 +59,115 @@ export class LinearWebhooks {
     }
 
     return true;
+  }
+
+  public parseData(
+    rawBody: Buffer,
+    signature: string,
+    timestamp?: number
+  ):
+    | EntityWebhookPayloadWithEntityData
+    | IssueSlaWebhookPayload
+    | OAuthAppWebhookPayload
+    | AppUserNotificationWebhookPayloadWithNotification
+    | AppUserTeamAccessChangedWebhookPayload {
+    const verified = this.verify(rawBody, signature, timestamp);
+    if (!verified) {
+      throw new Error("Invalid webhook signature");
+    }
+
+    const parsedBody = JSON.parse(rawBody.toString());
+    if (parsedBody.type === "IssueSLA") {
+      return parsedBody as IssueSlaWebhookPayload;
+    }
+    if (parsedBody.type === "OAuthApp") {
+      return parsedBody as OAuthAppWebhookPayload;
+    }
+    if (parsedBody.type === "AppUserNotification") {
+      return parsedBody as AppUserNotificationWebhookPayloadWithNotification;
+    }
+    if (parsedBody.type === "PermissionChange") {
+      return parsedBody as AppUserTeamAccessChangedWebhookPayload;
+    }
+    const entityWebhookPayload = parsedBody as EntityWebhookPayloadWithEntityData;
+    switch (entityWebhookPayload.type) {
+      case "Attachment":
+        return {
+          ...entityWebhookPayload,
+          data: entityWebhookPayload.data as AttachmentWebhookPayload,
+        };
+      case "AuditEntry":
+        return {
+          ...entityWebhookPayload,
+          data: entityWebhookPayload.data as AuditEntryWebhookPayload,
+        };
+      case "Comment":
+        return {
+          ...entityWebhookPayload,
+          data: entityWebhookPayload.data as CommentWebhookPayload,
+        };
+      case "Customer":
+        return {
+          ...entityWebhookPayload,
+          data: entityWebhookPayload.data as CustomerWebhookPayload,
+        };
+      case "CustomerNeed":
+        return {
+          ...entityWebhookPayload,
+          data: entityWebhookPayload.data as CustomerNeedWebhookPayload,
+        };
+      case "Cycle":
+        return {
+          ...entityWebhookPayload,
+          data: entityWebhookPayload.data as CycleWebhookPayload,
+        };
+      case "Document":
+        return {
+          ...entityWebhookPayload,
+          data: entityWebhookPayload.data as DocumentWebhookPayload,
+        };
+      case "Initiative":
+        return {
+          ...entityWebhookPayload,
+          data: entityWebhookPayload.data as InitiativeWebhookPayload,
+        };
+      case "InitiativeUpdate":
+        return {
+          ...entityWebhookPayload,
+          data: entityWebhookPayload.data as InitiativeUpdateWebhookPayload,
+        };
+      case "Issue":
+        return {
+          ...entityWebhookPayload,
+          data: entityWebhookPayload.data as IssueWebhookPayload,
+        };
+      case "IssueLabel":
+        return {
+          ...entityWebhookPayload,
+          data: entityWebhookPayload.data as IssueLabelWebhookPayload,
+        };
+      case "Project":
+        return {
+          ...entityWebhookPayload,
+          data: entityWebhookPayload.data as ProjectWebhookPayload,
+        };
+      case "ProjectUpdate":
+        return {
+          ...entityWebhookPayload,
+          data: entityWebhookPayload.data as ProjectUpdateWebhookPayload,
+        };
+      case "Reaction":
+        return {
+          ...entityWebhookPayload,
+          data: entityWebhookPayload.data as ReactionWebhookPayload,
+        };
+      case "User":
+        return {
+          ...entityWebhookPayload,
+          data: entityWebhookPayload.data as UserWebhookPayload,
+        };
+      default:
+        return entityWebhookPayload;
+    }
   }
 }


### PR DESCRIPTION
Adds ergonomics around parsing webhooks, especially given the awkwardness with union types which leads to `NotificationWebhookPayload` and `DataWebhookPayload` only living in `_generated_documents` and not `_generated_sdk`