### PR TITLE
chore: update workspace config to use workspace version of TypeScript

### DIFF
--- a/linear.code-workspace
+++ b/linear.code-workspace
@@ -49,6 +49,7 @@
     "gitlens.hovers.currentLine.over": "line",
     "gitlens.codeLens.enabled": false,
     "gitlens.currentLine.enabled": false,
-    "typescript.tsdk": "node_modules/typescript/lib"
+    "typescript.tsdk": "./node_modules/typescript/lib",
+    "typescript.enablePromptUseWorkspaceTsdk": true,
   }
 }


### PR DESCRIPTION
Fixed config file. Otherwise it seems to love to complain about `suppressImplicitAnyIndexErrors` being removed in TS 5.0+