### PR TITLE
chore: update webhook schema

### DIFF
--- a/.changeset/twenty-boxes-love.md
+++ b/.changeset/twenty-boxes-love.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": minor
+---
+
+feat(schema): Types AgentContextEventWebhookPayload and AgentContextWebhookPayload were added

--- a/packages/sdk/Linear-Webhooks@current.graphql
+++ b/packages/sdk/Linear-Webhooks@current.graphql
@@ -3,6 +3,90 @@
 # !!!   DO NOT MODIFY THIS FILE BY YOURSELF   !!!
 # -----------------------------------------------
 
+"""Payload for agent context webhook events."""
+type AgentContextEventWebhookPayload {
+  """The type of action that triggered the webhook."""
+  action: String!
+
+  """The agent context that the event belongs to."""
+  agentContext: AgentContextWebhookPayload!
+
+  """ID of the app user the agent context belongs to."""
+  appUserId: String!
+
+  """The comment that was created."""
+  comment: CommentWebhookPayload
+
+  """The time the payload was created."""
+  createdAt: DateTime!
+
+  """ID of the OAuth client the app user is tied to."""
+  oauthClientId: String!
+
+  """ID of the organization for which the webhook belongs to."""
+  organizationId: String!
+
+  """The type of resource."""
+  type: String!
+}
+
+"""Payload for an agent context webhook."""
+type AgentContextWebhookPayload {
+  """The ID of the agent that the agent context belongs to."""
+  appUserId: String!
+
+  """The time at which the entity was archived."""
+  archivedAt: String
+
+  """The comment this agent context is associated with."""
+  comment: CommentChildWebhookPayload
+
+  """The ID of the comment this agent context is associated with."""
+  commentId: String
+
+  """The time at which the entity was created."""
+  createdAt: String!
+
+  """The user that created the agent context."""
+  creator: UserChildWebhookPayload!
+
+  """The ID of the user that created the agent context."""
+  creatorId: String!
+
+  """The time the agent context ended."""
+  endedAt: String
+
+  """The ID of the entity."""
+  id: String!
+
+  """The issue this agent context is associated with."""
+  issue: IssueWithDescriptionChildWebhookPayload
+
+  """The ID of the issue this agent context is associated with."""
+  issueId: String
+
+  """The ID of the organization that the agent context belongs to."""
+  organizationId: String!
+
+  """Metadata about the external source that created this agent context."""
+  sourceMetadata: JSONObject
+
+  """The time the agent context started working."""
+  startedAt: String
+
+  """The current status of the agent context."""
+  status: String!
+
+  """A summary of the activities in this context."""
+  summary: String
+
+  """The type of the agent context."""
+  type: String!
+
+  """The time at which the entity was updated."""
+  updatedAt: String!
+}
+
 """Payload for app user notification webhook events."""
 type AppUserNotificationWebhookPayload {
   """The type of action that triggered the webhook."""
@@ -544,7 +628,7 @@ type CycleWebhookPayload {
 }
 
 """Union type for all possible webhook entity data payloads"""
-union DataWebhookPayload = AttachmentWebhookPayload | AuditEntryWebhookPayload | CommentWebhookPayload | CustomerNeedWebhookPayload | CustomerWebhookPayload | CycleWebhookPayload | DocumentWebhookPayload | InitiativeUpdateWebhookPayload | InitiativeWebhookPayload | IssueLabelWebhookPayload | IssueWebhookPayload | ProjectUpdateWebhookPayload | ProjectWebhookPayload | ReactionWebhookPayload | UserWebhookPayload
+union DataWebhookPayload = AgentContextWebhookPayload | AttachmentWebhookPayload | AuditEntryWebhookPayload | CommentWebhookPayload | CustomerNeedWebhookPayload | CustomerWebhookPayload | CycleWebhookPayload | DocumentWebhookPayload | InitiativeUpdateWebhookPayload | InitiativeWebhookPayload | IssueLabelWebhookPayload | IssueWebhookPayload | ProjectUpdateWebhookPayload | ProjectWebhookPayload | ReactionWebhookPayload | UserWebhookPayload
 
 """
 Represents a date and time in ISO 8601 format. Accepts shortcuts like `2021` to represent midnight Fri Jan 01 2021. Also accepts ISO 8601 durations strings which are added to the current date to create the represented date (e.g '-P2W1D' represents the date that was two weeks and 1 day ago) 


### PR DESCRIPTION
Adds in `AgentContext`-related webhook schema. 

_[Internal] These entities are currently not in use by production app._ 