### PR TITLE
Prefer current global fetch implementation over isomorphic-fetch if available

### DIFF
--- a/.changeset/warm-dancers-laugh.md
+++ b/.changeset/warm-dancers-laugh.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": patch
+---
+
+Prefer global fetch implementation over isomorphic-fetch if available

--- a/packages/sdk/src/graphql-client.ts
+++ b/packages/sdk/src/graphql-client.ts
@@ -67,7 +67,8 @@ export class LinearGraphQLClient {
     const { headers, ...others } = this.options;
     const body = JSON.stringify({ query, variables });
 
-    const response = await isoFetch(this.url, {
+    const fetch = globalThis.fetch ?? isoFetch;
+    const response = await fetch(this.url, {
       method: "POST",
       headers: {
         ...(typeof body === "string" ? { "Content-Type": "application/json" } : {}),


### PR DESCRIPTION
`isomorphic-unfetch` resolves & re-exports the global `fetch` at the time of import (if available). This means if you want to use something like MSW to intercept requests in testing, you need to get the order of imports/logic exactly right, or it will use the global `fetch` available at the time of import (& most likely make actual network requests)

Instead, when global fetch is available, we can use that directly (& allow the environment to inject a different implementation into the global scope, so things like MSW actually work)

Fixes LIN-38846