### PR TITLE
chore: fix return type for `parseData`

### DIFF
--- a/.changeset/swift-doodles-beam.md
+++ b/.changeset/swift-doodles-beam.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": minor
+---
+
+Fixed return type for webhook parsing function

--- a/package.json
+++ b/package.json
@@ -117,5 +117,6 @@
         "tsconfig": "tsconfig.json"
       }
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -117,6 +117,5 @@
         "tsconfig": "tsconfig.json"
       }
     }
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/packages/sdk/src/webhooks.ts
+++ b/packages/sdk/src/webhooks.ts
@@ -71,7 +71,8 @@ export class LinearWebhooks {
     | IssueSlaWebhookPayload
     | OAuthAppWebhookPayload
     | AppUserNotificationWebhookPayloadWithNotification
-    | AppUserTeamAccessChangedWebhookPayload {
+    | AppUserTeamAccessChangedWebhookPayload
+    | AgentContextEventWebhookPayload {
     const verified = this.verify(rawBody, signature, timestamp);
     if (!verified) {
       throw new Error("Invalid webhook signature");


### PR DESCRIPTION
Towards USP-8226