### PR TITLE
chore: update import readme about gitlab

### DIFF
--- a/.changeset/ninety-rocks-play.md
+++ b/.changeset/ninety-rocks-play.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": patch
+---
+
+chore: update import readme about gitlab

--- a/packages/import/README.md
+++ b/packages/import/README.md
@@ -138,11 +138,9 @@ Following fields are supported:
 - `Time Estimate` - Issue estimate
 
 <!-- AUTO-GENERATED-CONTENT:START (TEXT_SECTION:id=license&src=../../README.md) -->
-
 ## License
 
 <br/>
 
 Licensed under the [MIT License](./LICENSE).
-
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/packages/import/README.md
+++ b/packages/import/README.md
@@ -118,16 +118,31 @@ Following fields are supported:
 - `Status` - Issue state (workflow)
 - `Assignee` - Issue assignee (user's full name)
 - `Labels` - Added as a label
-## Todo
 
-- [x] Automatic image uploads
-- [ ] Assignees (pick from a list)
-- [ ] Created at (requires API change)
+### GitLab CSV
+
+GitLab issues can be imported into a Linear team from the CSV export file.
+Go to your project in GitLab. Select Plan > Issues from the left sidebar. Use filters if you want to narrow down the list. In the upper right, click Actions (⋮) > Export as CSV.
+
+Following fields are supported:
+
+- `Title` - Issue title
+- `Description` - Issue description
+- `State`: - Issue workflow state
+- `Labels` - Added as a label
+- `URL`: - Added as a link in the issue description
+- `Created At`: Issue creation date
+- `Due Date`: Issue due date
+- `Closed At`: Issue completion date
+- `Weight`: Issue priority;
+- `Time Estimate` - Issue estimate
 
 <!-- AUTO-GENERATED-CONTENT:START (TEXT_SECTION:id=license&src=../../README.md) -->
+
 ## License
 
 <br/>
 
 Licensed under the [MIT License](./LICENSE).
+
 <!-- AUTO-GENERATED-CONTENT:END -->


### PR DESCRIPTION
Update the CLI importer readme to mention GitLab CSVs. Also removes outdated todo list.