### PR TITLE
Remove explicit DOM typing

### DIFF
--- a/.changeset/few-deer-design.md
+++ b/.changeset/few-deer-design.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": minor
+---
+
+Removed explicit including of DOM types

--- a/packages/sdk/src/index_umd.ts
+++ b/packages/sdk/src/index_umd.ts
@@ -1,5 +1,3 @@
-/// <reference lib="dom"/>
-
 export * as LinearDocument from "./_generated_documents";
 export * from "./_generated_sdk";
 export * from "./client";


### PR DESCRIPTION
I created two test projects, one with a browser env and one with a node.js env and testing this build and types work correctly in both. I also verified that before this change the node.js project was polluted with the global DOM types and it isn't anymore after this change.