### PR TITLE
Fix import resolution from node ESM contexts

### DIFF
--- a/.changeset/sharp-showers-mate.md
+++ b/.changeset/sharp-showers-mate.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": minor
+---
+
+Fix import resolution from node ESM contexts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,6 +36,10 @@ jobs:
       - name: Run tests
         run: yarn test
 
+      - name: Validate CJS and ESM resolution for SDK
+        # Catch issues like https://github.com/linear/linear/issues/830
+        run: npx @arethetypeswrong/cli@0.18.2 --pack packages/sdk
+
       - name: Compare schema for changes
         uses: kamilkisiela/graphql-inspector@master
         with:

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -10,14 +10,12 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index-es.min.js",
-      "require": "./dist/index-cjs.min.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index-cjs.min.js"
     },
     "./webhooks": {
-      "import": "./dist/webhooks/index-es.min.js",
-      "require": "./dist/webhooks/index-cjs.min.js",
-      "types": "./dist/webhooks/index.d.ts"
+      "types": "./dist/webhooks/index.d.ts",
+      "default": "./dist/webhooks/index-cjs.min.js"
     }
   },
   "repository": "https://github.com/linear/linear",
@@ -26,7 +24,8 @@
     "yarn": "1.x"
   },
   "files": [
-    "dist"
+    "dist",
+    "webhooks"
   ],
   "scripts": {
     "build:clean": "npx rimraf -G dist .rollup-cache tsconfig.tsbuildinfo",

--- a/packages/sdk/webhooks/package.json
+++ b/packages/sdk/webhooks/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@linear/sdk/webhooks",
+  "private": true,
+  "types": "../dist/webhooks/index.d.ts",
+  "default": "../dist/webhooks/index-cjs.min.js"
+}


### PR DESCRIPTION
Fixes https://github.com/linear/linear/issues/830, LIN-40569

This also adds `arethetypeswrong` (https://arethetypeswrong.github.io/) as a part of Build CI as an extra measure to ensure our exports are set up well. Demo of it failing before pushing the fix [here](https://github.com/linear/linear/actions/runs/16818931312/job/47641894084).

Locally I used [yalc](https://github.com/wclr/yalc) and tested `node myfile.mjs` importing from both `"@linear/sdk"` and `"@linear/sdk/webhooks"`, which I confirmed worked.

@itsmingjie would you be able to double-check your Bun/Express example against this and confirm it's still working?