### PR TITLE
Add attachment import for Trello import

### DIFF
--- a/.changeset/poor-plums-dress.md
+++ b/.changeset/poor-plums-dress.md
@@ -2,4 +2,4 @@
 "@linear/import": patch
 ---
 
-test
+Updates the import to allow for migrating attachments from Trello to native Linear attachments.

--- a/.changeset/poor-plums-dress.md
+++ b/.changeset/poor-plums-dress.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": patch
+---
+
+test

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "typescript": "~4.7.4"
   },
   "devDependencies": {
-    "@types/react-transition-group": "~4.4.5"
+    "@types/react-transition-group": "~4.4.5",
+    "ts-node": "^10.9.1"
   },
   "resolutions": {
     "graphql": "^15.4.0"

--- a/packages/import/rollup.config.js
+++ b/packages/import/rollup.config.js
@@ -5,6 +5,7 @@ import typescript from "@rollup/plugin-typescript";
 import gzip from "rollup-plugin-gzip";
 import { terser } from "rollup-plugin-terser";
 import { brotliCompressSync } from "zlib";
+import { builtinModules } from "module";
 
 const minPlugins =
   process.env.NODE_ENV === "development"
@@ -18,6 +19,33 @@ const minPlugins =
         }),
       ];
 
+const external = [
+  ...builtinModules,
+  ...builtinModules.map(m => `node:${m}`),
+  "@linear/sdk",
+  "chalk",
+  "inquirer",
+  "cli-progress",
+  "date-fns",
+  "lodash",
+  "ora",
+  "csvtojson",
+  "node-fetch",
+  // Explicit core fallbacks (sometimes not listed in builtinModules in older Node versions)
+  "fs",
+  "path",
+  "stream",
+  "events",
+  "url",
+  "zlib",
+  "util",
+  "tty",
+  "os",
+  "crypto",
+  "http",
+  "https",
+];
+
 export default [
   {
     input: "src/cli.ts",
@@ -29,7 +57,8 @@ export default [
         sourcemap: true,
       },
     ],
-    plugins: [typescript(), commonjs(), json()],
+    external,
+    plugins: [typescript(), commonjs({ ignoreDynamicRequires: true }), json()],
   },
   {
     input: "src/index.ts",
@@ -47,7 +76,17 @@ export default [
         sourcemap: true,
       },
     ],
-    plugins: [typescript(), resolve(), commonjs(), json(), ...minPlugins],
+    external,
+    plugins: [
+      typescript(),
+      resolve({
+        mainFields: ["main", "module", "browser"],
+        preferBuiltins: true,
+      }),
+      commonjs({ ignoreDynamicRequires: true }),
+      json(),
+      ...minPlugins,
+    ],
   },
   {
     input: "src/index.ts",
@@ -65,6 +104,7 @@ export default [
         sourcemap: true,
       },
     ],
+    external,
     plugins: [typescript()],
   },
 ];

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -7,7 +7,7 @@ import * as inquirer from "inquirer";
 import { uniq } from "lodash";
 import ora from "ora";
 import { handleLabels } from "./helpers/labelManager";
-import { Comment, Importer, ImportResult } from "./types";
+import { Attachment, Comment, Importer, ImportResult } from "./types";
 import { replaceImagesInMarkdown } from "./utils/replaceImages";
 
 type Id = string;
@@ -280,20 +280,24 @@ export const importIssues = async (apiKey: string, importer: Importer, apiUrl?: 
     const formattedDueDate = issue.dueDate ? format(issue.dueDate, "yyyy-MM-dd") : undefined;
 
     try {
-      const createdIssue = await createIssueWithRetries(client, {
-        teamId,
-        projectId: projectId as unknown as string,
-        title: issue.title,
-        description,
-        priority: issue.priority,
-        labelIds,
-        stateId,
-        assigneeId,
-        createdAt: issue.createdAt,
-        completedAt: issue.completedAt,
-        dueDate: formattedDueDate,
-        estimate: issue.estimate,
-      });
+      const createdIssue = await createIssueWithRetries(
+        client,
+        {
+          teamId,
+          projectId: projectId as unknown as string,
+          title: issue.title,
+          description,
+          priority: issue.priority,
+          labelIds,
+          stateId,
+          assigneeId,
+          createdAt: issue.createdAt,
+          completedAt: issue.completedAt,
+          dueDate: formattedDueDate,
+          estimate: issue.estimate,
+        },
+        issue.attachments
+      );
 
       if (issue.archived) {
         await (await createdIssue.issue)?.archive();
@@ -333,16 +337,85 @@ const buildComments = async (
 const createIssueWithRetries = async (
   client: LinearClient,
   input: Parameters<LinearClient["createIssue"]>[0],
+  attachments: Attachment[] = [],
   retries = 3
 ): ReturnType<LinearClient["createIssue"]> => {
+  const createAttachment = async (client: LinearClient, attachment: Attachment, issueId: string) => {
+    const sourceUrl = attachment.url;
+    const filenameFromUrl = (() => {
+      try {
+        const url = new URL(sourceUrl);
+        const pathname = url.pathname;
+        const last = pathname.split("/").filter(Boolean).pop();
+        return last || "attachment";
+      } catch {
+        return "attachment";
+      }
+    })();
+
+    const filename = attachment.name || filenameFromUrl;
+
+    const downloadResponse = await fetch(sourceUrl, {
+      headers: attachment.httpHeaders,
+    });
+    if (!downloadResponse.ok) {
+      const body = await downloadResponse.text().catch(() => "");
+      throw new Error(
+        `Failed to download attachment from URL (${downloadResponse.status}): ${sourceUrl}${body ? ` - ${body}` : ""}`
+      );
+    }
+
+    const arrayBuffer = await downloadResponse.arrayBuffer();
+    const fileBuffer = Buffer.from(arrayBuffer);
+    const contentType = downloadResponse.headers.get("content-type") || "application/octet-stream";
+
+    const uploadPayload = await client.fileUpload(contentType, filename, fileBuffer.length);
+    const uploadFile = uploadPayload.uploadFile;
+    if (!uploadFile) {
+      throw new Error("Upload payload missing uploadFile");
+    }
+
+    const headers: Record<string, string> = {};
+    for (const h of uploadFile.headers) {
+      headers[h.key] = h.value;
+    }
+    if (!headers["Content-Type"]) {
+      headers["Content-Type"] = uploadFile.contentType;
+    }
+
+    const uploadResponse = await fetch(uploadFile.uploadUrl, {
+      method: "PUT",
+      headers,
+      body: fileBuffer,
+    });
+    if (!uploadResponse.ok) {
+      const body = await uploadResponse.text().catch(() => "");
+      throw new Error(`Failed to upload file to Linear storage (${uploadResponse.status})${body ? ` - ${body}` : ""}`);
+    }
+
+    await client.createAttachment({
+      issueId,
+      title: filename,
+      url: uploadFile.assetUrl,
+    });
+  };
+
   try {
-    return await client.createIssue(input);
-  } catch (error) {
+    const createdIssuePayload = await client.createIssue(input);
+    const issue = await createdIssuePayload.issue;
+    const issueId = issue?.id;
+    console.log("attachments", attachments);
+    if (issueId && attachments && attachments.length > 0) {
+      await Promise.all(attachments.map(att => createAttachment(client, att, issueId)));
+    }
+
+    return createdIssuePayload;
+  } catch (error: any) {
     if (error.type === "Ratelimited" && retries > 0) {
       // Hard-coded to 1 minute for now; when we do LIN-17685, we can use the X-RateLimit-Endpoint-Requests-Remaining
       // header to find out how long to wait.
       await new Promise(resolve => setTimeout(resolve, 60000));
-      return createIssueWithRetries(client, input, retries - 1);
+      return createIssueWithRetries(client, input, attachments, retries - 1);
     } else {
       throw error;
     }

--- a/packages/import/src/importers/trelloJson/index.ts
+++ b/packages/import/src/importers/trelloJson/index.ts
@@ -10,7 +10,10 @@ export const trelloJsonImport = async (): Promise<Importer> => {
     answers.trelloFilePath,
     answers.mapListsToStatuses,
     answers.discardArchivedCards,
-    answers.discardArchivedLists
+    answers.discardArchivedLists,
+    answers.migrateAttachments,
+    answers.migrateAttachments ? answers.trelloApiKey || "" : "",
+    answers.migrateAttachments ? answers.trelloApiToken || "" : ""
   );
   return trelloImporter;
 };
@@ -20,6 +23,9 @@ interface TrelloImportAnswers {
   mapListsToStatuses: boolean;
   discardArchivedCards: boolean;
   discardArchivedLists: boolean;
+  migrateAttachments: boolean;
+  trelloApiKey: string;
+  trelloApiToken: string;
 }
 
 const questions = [
@@ -46,5 +52,26 @@ const questions = [
     name: "discardArchivedLists",
     message: "Would you like to discard the (possibly unarchived) cards within archived lists?",
     default: true,
+  },
+  {
+    type: "confirm",
+    name: "migrateAttachments",
+    message:
+      "Do you want to migrate attachments? (If yes, you need to provide your Trello API Key and Token otherwise the importer will simply include links to the trello attachments)",
+    default: false,
+  },
+  {
+    type: "string",
+    name: "trelloApiKey",
+    message: "Please enter your Trello API Key",
+    default: "",
+    when: (answers: TrelloImportAnswers) => answers.migrateAttachments,
+  },
+  {
+    type: "string",
+    name: "trelloApiToken",
+    message: "Please enter your Trello API Token",
+    default: "",
+    when: (answers: TrelloImportAnswers) => answers.migrateAttachments,
   },
 ];

--- a/packages/import/src/types.ts
+++ b/packages/import/src/types.ts
@@ -30,6 +30,17 @@ export interface Issue {
   archived?: boolean;
   /** Issue estimate */
   estimate?: number;
+  /** attachments */
+  attachments?: Attachment[];
+}
+
+export interface Attachment {
+  /** Attachment's URL */
+  url: string;
+  /** Attachment's name */
+  name: string;
+  /** Attachment's http headers */
+  httpHeaders?: Record<string, string>;
 }
 
 /** Issue comment */

--- a/packages/import/src/types.ts
+++ b/packages/import/src/types.ts
@@ -39,7 +39,7 @@ export interface Attachment {
   url: string;
   /** Attachment's name */
   name: string;
-  /** Attachment's http headers */
+  /** Optional HTTP headers to be used when downloading the attachment */
   httpHeaders?: Record<string, string>;
 }
 


### PR DESCRIPTION
This pull request enhances the Linear import tool by adding support for migrating attachments from Trello to native Linear attachments during Trello JSON imports. It introduces new prompts for users to opt into attachment migration and provide Trello API credentials, updates the import pipeline to upload and link attachments, and improves build configuration for better dependency handling.

**Trello Attachment Migration Support**

* Added an option in the Trello import flow to migrate attachments, prompting for Trello API Key and Token if selected (`packages/import/src/importers/trelloJson/index.ts`, `TrelloJsonImporter` class, types) [[1]](diffhunk://#diff-f1bc30b93d31cd0ba2f36e56ee363f5a903754138fdcdcc8d1204461091e4825R56-R76) [[2]](diffhunk://#diff-f1bc30b93d31cd0ba2f36e56ee363f5a903754138fdcdcc8d1204461091e4825L13-R16) [[3]](diffhunk://#diff-f1bc30b93d31cd0ba2f36e56ee363f5a903754138fdcdcc8d1204461091e4825R26-R28) [[4]](diffhunk://#diff-010ebd040baf4479a4e49aab1fa128d27a67e8d85c298a016029a5e32181b843L58-R69) [[5]](diffhunk://#diff-010ebd040baf4479a4e49aab1fa128d27a67e8d85c298a016029a5e32181b843R211-R213) [[6]](diffhunk://#diff-322542081d4fdedca7b8f6c2873f0c8c7eba097ba9d5b310768c9e8ade1301e9R33-R43).
* Updated the Trello importer to, when enabled, fetch, upload, and link attachments as native Linear attachments instead of just including Trello links in the issue description (`TrelloJsonImporter`, `importIssues.ts`) [[1]](diffhunk://#diff-010ebd040baf4479a4e49aab1fa128d27a67e8d85c298a016029a5e32181b843L137-R155) [[2]](diffhunk://#diff-010ebd040baf4479a4e49aab1fa128d27a67e8d85c298a016029a5e32181b843L155-R186) [[3]](diffhunk://#diff-c51a1dbc560b50f3461b0ba434b62e12270000d2c6622591b23f2a74c7f0c45bL10-R10) [[4]](diffhunk://#diff-c51a1dbc560b50f3461b0ba434b62e12270000d2c6622591b23f2a74c7f0c45bL283-R285) [[5]](diffhunk://#diff-c51a1dbc560b50f3461b0ba434b62e12270000d2c6622591b23f2a74c7f0c45bL296-R300) [[6]](diffhunk://#diff-c51a1dbc560b50f3461b0ba434b62e12270000d2c6622591b23f2a74c7f0c45bR340-R450).

**Import Pipeline Enhancements**

* Modified the import pipeline to accept and process attachments, uploading them to Linear and updating issue descriptions to reference the new asset URLs (`importIssues.ts`, types) [[1]](diffhunk://#diff-c51a1dbc560b50f3461b0ba434b62e12270000d2c6622591b23f2a74c7f0c45bR340-R450) [[2]](diffhunk://#diff-322542081d4fdedca7b8f6c2873f0c8c7eba097ba9d5b310768c9e8ade1301e9R33-R43).

**Build and Dependency Updates**

* Improved the Rollup build configuration to handle external dependencies and Node.js core modules more robustly, and added `ts-node` as a dev dependency (`rollup.config.js`, `package.json`) [[1]](diffhunk://#diff-c5bf95d663d1e13dac5adc2763957ac4f53e734aceedcfd4c0d2a48302b0efd5R8) [[2]](diffhunk://#diff-c5bf95d663d1e13dac5adc2763957ac4f53e734aceedcfd4c0d2a48302b0efd5R22-R48) [[3]](diffhunk://#diff-c5bf95d663d1e13dac5adc2763957ac4f53e734aceedcfd4c0d2a48302b0efd5L32-R61) [[4]](diffhunk://#diff-c5bf95d663d1e13dac5adc2763957ac4f53e734aceedcfd4c0d2a48302b0efd5L50-R89) [[5]](diffhunk://#diff-c5bf95d663d1e13dac5adc2763957ac4f53e734aceedcfd4c0d2a48302b0efd5R107) [[6]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L75-R76).

**Changelog**

* Added a changeset describing the new attachment migration feature for Trello imports (`.changeset/poor-plums-dress.md`).