### PR TITLE
refactor: avoid parsing webhook payloads twice and unify methods

### DIFF
--- a/.changeset/clever-parents-lick.md
+++ b/.changeset/clever-parents-lick.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": minor
+---
+
+LinearWebhookClient.parseData now utilizes the payload's timestamp in verification


### PR DESCRIPTION
Noticed our webhook handler was parsing the payload to extract the timestamp, then verifying, then parsing the payload again. Now it's all-in-one. This keeps the `timestamp` param to `parseData` just for the sake of backwards compatibility, but seems we should always use the payload's timestamp in practice. 

Caveat: if someone wants to re-parse some prior old webhook data, this will now fail since it requires the timestamp to be recent for its validation. Maybe annoying/problematic? If so, can bring back `parseVerifiedPayload` for use in our handler and just avoid its double-parsing differently.

Review with whitespace ignored

cc @guillaumelachaud since I see you authored this back in the day, in case there's some reason _not_ to do this by default.