### PR TITLE
refactor: avoid parsing webhook payloads twice in handler

### DIFF
--- a/.changeset/clever-parents-lick.md
+++ b/.changeset/clever-parents-lick.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": patch
+---
+
+Removed a redundant `parseData` call from handlers returned by `LinearWebhookClient.createHandler`.

--- a/packages/sdk/src/_tests/LinearWebhooks.test.ts
+++ b/packages/sdk/src/_tests/LinearWebhooks.test.ts
@@ -22,40 +22,59 @@ describe("webhooks", () => {
       type: "Comment",
       url: "https://linear.app/issue/LIN-1778/foo-bar#comment-77217de3-fb52-4dad-bb9a-b356beb93de8",
       createdAt: "2020-01-23T12:53:18.084Z",
-      webhookTimestamp: 1677611643000,
+      webhookTimestamp: new Date().getTime(),
     };
 
     rawBody = Buffer.from(JSON.stringify(requestBody));
     parsedBody = JSON.parse(rawBody.toString());
   });
 
-  it("incorrect signature, should fail verification", async () => {
-    const webhook = new LinearWebhookClient("SECRET");
-    const signature = crypto.createHmac("sha256", "WRONG_SECRET").update(rawBody).digest("hex");
-    expect(() => webhook.verify(rawBody, signature)).toThrowError("Invalid webhook signature");
+  describe("verify", () => {
+    it("incorrect signature, should fail verification", async () => {
+      const webhook = new LinearWebhookClient("SECRET");
+      const signature = crypto.createHmac("sha256", "WRONG_SECRET").update(rawBody).digest("hex");
+      expect(() => webhook.verify(rawBody, signature)).toThrowError("Invalid webhook signature");
+    });
+
+    it("correct signature, invalid timestamp should fail verification", async () => {
+      const webhook = new LinearWebhookClient("SECRET");
+      const signature = crypto.createHmac("sha256", "SECRET").update(rawBody).digest("hex");
+      const invalidTimestamp = new Date().getTime() - 1_000_000;
+      expect(() => webhook.verify(rawBody, signature, invalidTimestamp)).toThrowError("Invalid webhook timestamp");
+    });
+
+    it("correct signature, no timestamp, should pass verification", async () => {
+      const webhook = new LinearWebhookClient("SECRET");
+      const signature = crypto.createHmac("sha256", "SECRET").update(rawBody).digest("hex");
+      expect(() => webhook.verify(rawBody, signature)).toBeTruthy();
+    });
+
+    it("correct signature, correct timestamp should pass verification", async () => {
+      const webhook = new LinearWebhookClient("SECRET");
+      const signature = crypto.createHmac("sha256", "SECRET").update(rawBody).digest("hex");
+      expect(() => webhook.verify(rawBody, signature, parsedBody[LINEAR_WEBHOOK_TS_FIELD])).toBeTruthy();
+    });
   });
 
-  it("correct signature, incorrect timestamp should fail verification", async () => {
-    const webhook = new LinearWebhookClient("SECRET");
-    const signature = crypto.createHmac("sha256", "SECRET").update(rawBody).digest("hex");
-    expect(() => webhook.verify(rawBody, signature, parsedBody[LINEAR_WEBHOOK_TS_FIELD])).toThrowError(
-      "Invalid webhook timestamp"
-    );
-  });
+  describe("parseData", () => {
+    it("should return the parsed payload if valid", () => {
+      const client = new LinearWebhookClient("SECRET");
+      const signature = crypto.createHmac("sha256", "SECRET").update(rawBody).digest("hex");
+      const payload = client.parseData(rawBody, signature);
+      expect(payload).toEqual(parsedBody);
+    });
 
-  it("correct signature, no timestamp, should pass verification", async () => {
-    const webhook = new LinearWebhookClient("SECRET");
-    const signature = crypto.createHmac("sha256", "SECRET").update(rawBody).digest("hex");
-    expect(() => webhook.verify(rawBody, signature)).toBeTruthy();
-  });
+    it("should throw an error if the signature is invalid", () => {
+      const client = new LinearWebhookClient("SECRET");
+      const signature = crypto.createHmac("sha256", "WRONG_SIGNATURE").update(rawBody).digest("hex");
+      expect(() => client.parseData(rawBody, signature)).toThrowError("Invalid webhook signature");
+    });
 
-  it("correct signature, correct timestamp should pass verification", async () => {
-    requestBody.webhookTimestamp = new Date().getTime();
-    rawBody = Buffer.from(JSON.stringify(requestBody));
-    parsedBody = JSON.parse(rawBody.toString());
-
-    const webhook = new LinearWebhookClient("SECRET");
-    const signature = crypto.createHmac("sha256", "SECRET").update(rawBody).digest("hex");
-    expect(() => webhook.verify(rawBody, signature, parsedBody[LINEAR_WEBHOOK_TS_FIELD])).toBeTruthy();
+    it("should throw an error if the timestamp is invalid", () => {
+      const client = new LinearWebhookClient("SECRET");
+      const signature = crypto.createHmac("sha256", "SECRET").update(rawBody).digest("hex");
+      const invalidTimestamp = new Date().getTime() - 1_000_000;
+      expect(() => client.parseData(rawBody, signature, invalidTimestamp)).toThrowError("Invalid webhook timestamp");
+    });
   });
 });


### PR DESCRIPTION
Our webhook handler was parsing the payload to extract the timestamp, then verifying, then parsing the payload again. Tweaked to avoid this and DRY up parsing logic.