### PR TITLE
fix: null check for labels when importing linear CSV

### DIFF
--- a/.changeset/rude-ants-look.md
+++ b/.changeset/rude-ants-look.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": patch
+---
+
+Fix CSV import when Labels field is omitted

--- a/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
+++ b/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
@@ -68,8 +68,8 @@ export class LinearCsvImporter implements Importer {
       if (!!row.Archived) {
         continue;
       }
-      
-      const tags = row.Labels ? row.Labels.split(', ') : [];
+
+      const tags = row.Labels ? row.Labels.split(", ") : [];
       const labels = tags.filter(tag => !!tag);
 
       importData.issues.push({

--- a/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
+++ b/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
@@ -68,8 +68,8 @@ export class LinearCsvImporter implements Importer {
       if (!!row.Archived) {
         continue;
       }
-
-      const tags = row.Labels.split(", ");
+      
+      const tags = row.Labels ? row.Labels.split(', ') : [];
       const labels = tags.filter(tag => !!tag);
 
       importData.issues.push({


### PR DESCRIPTION
Currently there is not an explicit requirement for the Labels field to be required in a Linear import, however there is no null (undefined) check for this.

This results in the following error when a Linear CSV with no labels is attempted to be imported:

```
TypeError: Cannot read properties of undefined (reading 'split')
    at LinearCsvImporter.<anonymous> (/opt/homebrew/lib/node_modules/@linear/import/dist/cli.js:1288:41)
    at Generator.next (<anonymous>)
    at fulfilled (/opt/homebrew/lib/node_modules/@linear/import/dist/cli.js:72:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

This change simply checks the presence of Labels before trying to split, if there are no labels in the CSV, then just make it an empty array.