### PR TITLE
chore: add Slack notifications for failed CI jobs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,3 +49,18 @@ jobs:
 
       - name: Check for no generated changes
         run: git update-index --refresh && git diff-index HEAD
+  notify-slack:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build]
+    if: ${{ always() && github.ref_name == 'master' && contains(needs.*.result, 'failure') }}
+    steps:
+      - uses: ravsamhq/notify-slack-action@bca2d7f5660b833a27bda4f6b8bef389ebfefd25 # 2.3.0
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          notification_title: "SDK CI check failed on master branch"
+          message_format: ":x: Check failed in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}>"
+          footer: <{run_url}|View Run>
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -44,3 +44,18 @@ jobs:
           body: "Update dependencies"
           branch: dependencies
           base: master
+  notify-slack:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [dependencies]
+    if: ${{ always() && github.ref_name == 'master' && contains(needs.*.result, 'failure') }}
+    steps:
+      - uses: ravsamhq/notify-slack-action@bca2d7f5660b833a27bda4f6b8bef389ebfefd25 # 2.3.0
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          notification_title: "SDK CI check failed on master branch"
+          message_format: ":x: Check failed in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}>"
+          footer: <{run_url}|View Run>
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,3 +55,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  notify-slack:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [releast]
+    if: ${{ always() && github.ref_name == 'master' && contains(needs.*.result, 'failure') }}
+    steps:
+      - uses: ravsamhq/notify-slack-action@bca2d7f5660b833a27bda4f6b8bef389ebfefd25 # 2.3.0
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          notification_title: "SDK CI check failed on master branch"
+          message_format: ":x: Check failed in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}>"
+          footer: <{run_url}|View Run>
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -53,3 +53,18 @@ jobs:
           body: "Update schema, regenerate types and SDK"
           branch: schema
           base: master
+  notify-slack:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [schema]
+    if: ${{ always() && github.ref_name == 'master' && contains(needs.*.result, 'failure') }}
+    steps:
+      - uses: ravsamhq/notify-slack-action@bca2d7f5660b833a27bda4f6b8bef389ebfefd25 # 2.3.0
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          notification_title: "SDK CI check failed on master branch"
+          message_format: ":x: Check failed in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}>"
+          footer: <{run_url}|View Run>
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This matches what we have in our monorepo and we completely missed the build breaking here until someone tried to make another change.

I won't merge until we actually fix the build 🙂 