### PR TITLE
fix: bare identifier UNMAPPED_MOCK_TYPE

### DIFF
--- a/packages/codegen-test/src/print-test.ts
+++ b/packages/codegen-test/src/print-test.ts
@@ -82,7 +82,7 @@ function printOperationArgs(operation: SdkOperation): string {
               ? `123`
               : arg.type === "number[]"
                 ? `[123]`
-                : "UNMAPPED_MOCK_TYPE"
+                : `"UNMAPPED_MOCK_TYPE"`
     )
     .filter(nonNullable);
 


### PR DESCRIPTION
Fixes a TypeScript compilation error in the generated test file by correcting the fallback mock value in the printOperationArgs function. The function generates code strings for test arguments, and the fallback case for unmapped argument types was outputting UNMAPPED_MOCK_TYPE as a bare identifier instead of a string literal. 

Unsure why it's showing up now, but CI tasks fails on it: https://github.com/linear/linear/actions/runs/18607990192

Towards PUB-42