### PR TITLE
chore: use OIDC instead of token to publish packages to npm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
       checks: write
       pull-requests: write
       statuses: read
+      id-token: write # Required for OIDC (https://docs.npmjs.com/trusted-publishers#github-actions-configuration)
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -26,6 +27,11 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "18"
+          registry-url: "https://registry.npmjs.org"
+
+      # Ensure npm 11.5.1 or later is installed (https://docs.npmjs.com/trusted-publishers#github-actions-configuration)
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: yarn
@@ -54,7 +60,7 @@ jobs:
           title: "chore(release): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   notify-slack:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
Per [https://docs.npmjs.com/trusted-publishers](https://docs.npmjs.com/trusted-publishers), [https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/](https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/)

I'm not *100%* confident that this will work with `changesets/action` publishing, vs using `npm publish` ourselves directly, but I'll try with a dummy change to the importer or something to start.