### PR TITLE
chore: ensure CI runs for PRs for github-actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     # Avoid redundant builds for PRs/pushes: run on push OR automated PRs only, and not for external PRs
-    if: ${{ github.event_name != 'pull_request' || github.actor == 'github-actions[bot]' }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login == 'github-actions[bot]' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
e.g. here https://github.com/linear/linear/pull/920 it didn't run, since I triggered the workflow manually so was the `actor`, but we still want CI in these scenarios.