### PR TITLE
chore: set github bot as actor for generated PRs and move to v7 of action

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Create dependencies pull request
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          sign-commits: true
           commit-message: "chore(release): update dependencies"
           title: "chore(release): update dependencies"
           body: "Update dependencies"

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Create schema pull request
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          sign-commits: true
           commit-message: "feat(sdk): update schema"
           title: "feat(sdk): update schema"
           body: "Update schema, regenerate types and SDK"


### PR DESCRIPTION
Rather than attributing the scheduled runs' schema updates to the person who set up these action initially

Looked at v6 -> v7 upgrade guides https://github.com/peter-evans/create-pull-request/blob/0edc001d28a2959cd7a6b505629f1d82f0a6e67d/docs/updating.md#updating-from-v6-to-v7, and switched to sign-commits and removed the seemingly unneeded `token` (since it should be used implicitly per those docs)