### PR TITLE
fix: use format function to avoid literal actor string

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -47,7 +47,7 @@ jobs:
           # Use bot author for scheduled runs, and the triggering user (GitHub actor, as is typically the default
           # https://github.com/peter-evans/create-pull-request/blob/0edc001d28a2959cd7a6b505629f1d82f0a6e67d/action.yml#L32)
           # for manual runs
-          author: ${{ github.event_name == 'schedule' && 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' || '${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>' }}
+          author: ${{ github.event_name == 'schedule' && 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' || format('{0} <{1}+{0}@users.noreply.github.com>', github.actor, github.actor_id) }}
 
   notify-slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -60,7 +60,7 @@ jobs:
           # Use bot author for scheduled runs, and the triggering user (GitHub actor, as is typically the default
           # https://github.com/peter-evans/create-pull-request/blob/0edc001d28a2959cd7a6b505629f1d82f0a6e67d/action.yml#L32)
           # for manual runs
-          author: ${{ github.event_name == 'schedule' && 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' || '${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>' }}
+          author: ${{ github.event_name == 'schedule' && 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' || format('{0} <{1}+{0}@users.noreply.github.com>', github.actor, github.actor_id) }}
 
   notify-slack:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Couldn't interpolate within the `${{ }}` syntax before, so used the string literally by mistake:
https://github.com/linear/linear/actions/runs/19237330873/job/54990661002#step:8:60 (ended up falling back to just GH bot https://github.com/linear/linear/pull/931/commits)