### PR TITLE
chore: remove author logic since signed-commits uses bot author regardless

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -44,10 +44,6 @@ jobs:
           body: "Update dependencies"
           branch: dependencies
           base: master
-          # Use bot author for scheduled runs, and the triggering user (GitHub actor, as is typically the default
-          # https://github.com/peter-evans/create-pull-request/blob/0edc001d28a2959cd7a6b505629f1d82f0a6e67d/action.yml#L32)
-          # for manual runs
-          author: ${{ github.event_name == 'schedule' && 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' || format('{0} <{1}+{0}@users.noreply.github.com>', github.actor, github.actor_id) }}
 
   notify-slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -57,10 +57,6 @@ jobs:
           body: "Update schema, regenerate types and SDK"
           branch: schema
           base: master
-          # Use bot author for scheduled runs, and the triggering user (GitHub actor, as is typically the default
-          # https://github.com/peter-evans/create-pull-request/blob/0edc001d28a2959cd7a6b505629f1d82f0a6e67d/action.yml#L32)
-          # for manual runs
-          author: ${{ github.event_name == 'schedule' && 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' || format('{0} <{1}+{0}@users.noreply.github.com>', github.actor, github.actor_id) }}
 
   notify-slack:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The last update #932 fixed the issue such that `author` was formatted correctly in the git commands (https://github.com/linear/linear/actions/runs/19239701196/job/54998983834), but it turns out that using signed commits forces the github bot to be the author regardless per logic [here](https://github.com/peter-evans/create-pull-request/blob/0edc001d28a2959cd7a6b505629f1d82f0a6e67d/src/create-pull-request.ts#L210-L220), as can be seen in the [resultant commit](https://github.com/linear/linear/pull/933/commits/da4bdfb57cb44b79a3cb60e3132166272fb5fba9).

Signed commits are nice as an additional verification, and "authorship" isn't meaningful here (original change in #928 was aiming to remove it for scheduled stuff anyway), so this keeps signed commits and removes the now-ignored `author` stuff.

Sorry for the churn on this inconsequential thing!