### PR TITLE
chore: run 'pnpm dedupe' to clean up lock file

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,7 +163,7 @@ importers:
         version: 8.0.27(graphql@15.10.1)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
+        version: 12.3.0(rollup@2.79.2)(tslib@2.8.1)(typescript@4.7.4)
       auto-bind:
         specifier: 'catalog:'
         version: 4.0.0
@@ -213,7 +213,7 @@ importers:
     devDependencies:
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
+        version: 12.3.0(rollup@2.79.2)(tslib@2.8.1)(typescript@4.7.4)
       rimraf:
         specifier: 'catalog:'
         version: 3.0.2
@@ -249,7 +249,7 @@ importers:
         version: link:../codegen-sdk
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
+        version: 12.3.0(rollup@2.79.2)(tslib@2.8.1)(typescript@4.7.4)
       auto-bind:
         specifier: 'catalog:'
         version: 4.0.0
@@ -317,7 +317,7 @@ importers:
         version: 11.2.1(rollup@2.79.2)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
+        version: 12.3.0(rollup@2.79.2)(tslib@2.8.1)(typescript@4.7.4)
       '@types/cli-progress':
         specifier: ^3.11.5
         version: 3.11.6
@@ -344,7 +344,7 @@ importers:
         version: 7.0.2(rollup@2.79.2)
       ts-node:
         specifier: 'catalog:'
-        version: 10.9.2(@types/node@24.10.2)(typescript@5.9.3)
+        version: 10.9.2(@types/node@20.5.1)(typescript@4.7.4)
 
   packages/sdk:
     dependencies:
@@ -360,7 +360,7 @@ importers:
     devDependencies:
       '@graphql-codegen/cli':
         specifier: 'catalog:'
-        version: 2.16.5(@babel/core@7.28.5)(@types/node@20.5.1)(encoding@0.1.13)(enquirer@2.4.1)(graphql@15.10.1)(typescript@5.9.3)
+        version: 2.16.5(@babel/core@7.28.5)(@types/node@20.5.1)(encoding@0.1.13)(enquirer@2.4.1)(graphql@15.10.1)(typescript@4.7.4)
       '@graphql-codegen/introspection':
         specifier: ^2.2.0
         version: 2.2.3(encoding@0.1.13)(graphql@15.10.1)
@@ -399,7 +399,7 @@ importers:
         version: 11.2.1(rollup@2.79.2)
       '@rollup/plugin-typescript':
         specifier: ^12.1.4
-        version: 12.3.0(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)
+        version: 12.3.0(rollup@2.79.2)(tslib@2.8.1)(typescript@4.7.4)
       '@types/body-parser':
         specifier: ^1.19.6
         version: 1.19.6
@@ -447,7 +447,7 @@ importers:
         version: 7.0.2(rollup@2.79.2)
       ts-node:
         specifier: 'catalog:'
-        version: 10.9.2(@types/node@20.5.1)(typescript@5.9.3)
+        version: 10.9.2(@types/node@20.5.1)(typescript@4.7.4)
       type-fest:
         specifier: ^0.21.3
         version: 0.21.3
@@ -6798,7 +6798,7 @@ snapshots:
       '@types/node': 20.5.1
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.9.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.9.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@4.7.4))(typescript@5.9.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -6898,7 +6898,7 @@ snapshots:
 
   '@fastify/busboy@3.2.0': {}
 
-  '@graphql-codegen/cli@2.16.5(@babel/core@7.28.5)(@types/node@20.5.1)(encoding@0.1.13)(enquirer@2.4.1)(graphql@15.10.1)(typescript@5.9.3)':
+  '@graphql-codegen/cli@2.16.5(@babel/core@7.28.5)(@types/node@20.5.1)(encoding@0.1.13)(enquirer@2.4.1)(graphql@15.10.1)(typescript@4.7.4)':
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/template': 7.27.2
@@ -6919,7 +6919,7 @@ snapshots:
       chalk: 4.1.2
       chokidar: 3.6.0
       cosmiconfig: 7.1.0
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@7.1.0)(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@7.1.0)(ts-node@10.9.2(@types/node@20.5.1)(typescript@4.7.4))(typescript@4.7.4)
       debounce: 1.2.1
       detect-indent: 6.1.0
       graphql: 15.10.1
@@ -6932,7 +6932,7 @@ snapshots:
       shell-quote: 1.8.3
       string-env-interpolation: 1.0.1
       ts-log: 2.2.7
-      ts-node: 10.9.2(@types/node@20.5.1)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@20.5.1)(typescript@4.7.4)
       tslib: 2.8.1
       yaml: 1.10.2
       yargs: 17.7.2
@@ -7429,7 +7429,7 @@ snapshots:
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@15.10.1)
       graphql: 15.10.1
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   '@graphql-tools/wrap@7.0.8(graphql@15.10.1)':
     dependencies:
@@ -7592,7 +7592,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       collect-v8-coverage: 1.0.3
 
-  '@jest/test-sequencer@26.6.3(ts-node@10.9.2(@types/node@20.5.1)(typescript@4.7.4))':
+  '@jest/test-sequencer@26.6.3':
     dependencies:
       '@jest/test-result': 26.6.2
       graceful-fs: 4.2.11
@@ -7600,11 +7600,7 @@ snapshots:
       jest-runner: 26.6.3(ts-node@10.9.2(@types/node@20.5.1)(typescript@4.7.4))
       jest-runtime: 26.6.3(ts-node@10.9.2(@types/node@20.5.1)(typescript@4.7.4))
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   '@jest/transform@26.6.2':
     dependencies:
@@ -7849,11 +7845,11 @@ snapshots:
       resolve: 1.22.11
       rollup: 2.79.2
 
-  '@rollup/plugin-typescript@12.3.0(rollup@2.79.2)(tslib@2.8.1)(typescript@5.9.3)':
+  '@rollup/plugin-typescript@12.3.0(rollup@2.79.2)(tslib@2.8.1)(typescript@4.7.4)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@2.79.2)
       resolve: 1.22.11
-      typescript: 5.9.3
+      typescript: 4.7.4
     optionalDependencies:
       rollup: 2.79.2
       tslib: 2.8.1
@@ -8658,7 +8654,7 @@ snapshots:
   camel-case@4.1.2:
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.2.0
+      tslib: 2.8.1
 
   camelcase-keys@6.2.2:
     dependencies:
@@ -8957,14 +8953,14 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@7.1.0)(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@7.1.0)(ts-node@10.9.2(@types/node@20.5.1)(typescript@4.7.4))(typescript@4.7.4):
     dependencies:
       '@types/node': 20.5.1
       cosmiconfig: 7.1.0
-      ts-node: 10.9.2(@types/node@20.5.1)(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-node: 10.9.2(@types/node@20.5.1)(typescript@4.7.4)
+      typescript: 4.7.4
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.9.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.9.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@4.7.4))(typescript@5.9.3):
     dependencies:
       '@types/node': 20.5.1
       cosmiconfig: 8.3.6(typescript@5.9.3)
@@ -10831,7 +10827,7 @@ snapshots:
   jest-config@26.6.3(ts-node@10.9.2(@types/node@20.5.1)(typescript@4.7.4)):
     dependencies:
       '@babel/core': 7.28.5
-      '@jest/test-sequencer': 26.6.3(ts-node@10.9.2(@types/node@20.5.1)(typescript@4.7.4))
+      '@jest/test-sequencer': 26.6.3
       '@jest/types': 26.6.2
       babel-jest: 26.6.3(@babel/core@7.28.5)
       chalk: 4.1.2
@@ -12786,7 +12782,7 @@ snapshots:
       graphql: 15.10.1
       iterall: 1.3.0
       symbol-observable: 1.2.0
-      ws: 7.4.5
+      ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -12981,7 +12977,7 @@ snapshots:
 
   ts-log@2.2.7: {}
 
-  ts-node@10.9.2(@types/node@20.5.1)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@20.5.1)(typescript@4.7.4):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -12995,18 +12991,18 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 4.7.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@24.10.2)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@20.5.1)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 24.10.2
+      '@types/node': 20.5.1
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3


### PR DESCRIPTION
Dependabot is for some reason finding a dirty pnpm-lock file, and thinking it's bumping a couple versions of packages, when it's not? Both of those package versions (`express` 4.17.1 and `body-parser` 1.19.0) seem to implicitly come from the `graphql-faker` library we're using.
- https://github.com/linear/linear/pull/965/changes
- https://github.com/linear/linear/pull/966/changes

I ran `pnpm dedupe` locally to try to remove duplicate deps, and it seemed to make a few of the same changes to the lock-file and perhaps will appease dependabot?