### PR TITLE
chore: disable oxlint in workspace settings

### DIFF
--- a/linear.code-workspace
+++ b/linear.code-workspace
@@ -43,6 +43,7 @@
       "**/*.tsbuildinfo": true,
       "**/.size-snapshot.json": true,
     },
+    "oxc.enable": false,
     "typescript.tsdk": "./node_modules/typescript/lib",
     "typescript.enablePromptUseWorkspaceTsdk": true,
     "cSpell.words": ["uuidv4"],


### PR DESCRIPTION
In case the extension is installed and otherwise would run (since it is installed/recommended for our monorepo).