### PR TITLE
Fix failing schema GitHub action by building modules before use

### DIFF
--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -58,7 +58,6 @@ jobs:
 
       - name: Create schema pull request
         uses: peter-evans/create-pull-request@v7
-        if: false
         with:
           sign-commits: true
           commit-message: "feat(sdk): update schema"


### PR DESCRIPTION
The nightly [schema action](https://github.com/linear/linear/actions/runs/20216762081/job/58031032661) is currently failing because `ts-node` cannot locate the `@linear/codegen-doc` package. This started happening after #969 because pnpm workspaces don't do the global aliasing that yarn workspaces did. To fix this issue we just have to build the packages before using them.

Successfully completed schema run: https://github.com/linear/linear/actions/runs/20241519530
