### PR TITLE
Add actions/stale workflow to automatically cleanup old issues

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          debug-only: true
-          operations-per-run: 1000
           days-before-stale: 180
           stale-issue-message: "This issue has seen no recent activity and has been automatically closed for house-keeping purposes."
           stale-pr-message: "This PR has seen no recent activity and has been automatically closed for house-keeping purposes."


### PR DESCRIPTION
Adds a job to periodically run [`actions/stale`](https://github.com/actions/stale) that will comment on and close issues and PRs that haven't had any activity in the past 6 months. My [dry run](https://github.com/linear/linear/actions/runs/20250094789/job/58139903079?pr=979) would have marked 14 issues and 4 PRs as stale. The 6 month window is pretty large, so the impact is minimal. Note comments reset the stale window, so even if the issue / PR has been open for >6 months, active ones should still not be closed.

For the stale message I just copied the one the TypeScript bot uses.