### PR TITLE
Add `webhookId` and `webhookTimestamp` fields to all webhook payload types

### DIFF
--- a/.changeset/sour-bears-sniff.md
+++ b/.changeset/sour-bears-sniff.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": patch
+---
+
+Added `webhookId` and `webhookTimestamp` fields to all webhook payload types

--- a/packages/sdk/src/_tests/webhook-handler.test.ts
+++ b/packages/sdk/src/_tests/webhook-handler.test.ts
@@ -4,7 +4,12 @@ import getPort from "get-port";
 import http from "http";
 import { v4 as uuidv4 } from "uuid";
 import { describe, expect, it } from "vitest";
-import { LINEAR_WEBHOOK_SIGNATURE_HEADER, LinearWebhookClient } from "../webhooks/index.js";
+import {
+  LINEAR_WEBHOOK_SIGNATURE_HEADER,
+  LinearWebhookClient,
+  LinearWebhookPayload,
+  LinearWebhookEventTypeMap,
+} from "../webhooks/index.js";
 
 export interface SignedBody {
   body: Buffer;
@@ -217,6 +222,26 @@ describe("webhooks handlers", () => {
       server.close();
       handler.removeAllListeners();
     }
+  });
+});
+
+describe("webhook payload type", () => {
+  it("contains a webhookId field", () => {
+    type PayloadWebhookId = LinearWebhookPayload["webhookId"];
+    type EventTypeWebhookId = LinearWebhookEventTypeMap[keyof LinearWebhookEventTypeMap]["webhookId"];
+
+    // Here we are testing that these keys exist on the base webhook types, and that they are equal. The runtime
+    // comparisons of these strings are a no-op, but type errors will be caught by build:types.
+    expect<PayloadWebhookId>("").toBe<EventTypeWebhookId>("");
+  });
+
+  it("contains a webhookTimestamp field", () => {
+    type PayloadWebhookId = LinearWebhookPayload["webhookTimestamp"];
+    type EventTypeWebhookId = LinearWebhookEventTypeMap[keyof LinearWebhookEventTypeMap]["webhookTimestamp"];
+
+    // Here we are testing that these keys exist on the base webhook types, and that they are equal. The runtime
+    // comparisons of these numbers are a no-op, but type errors will be caught by build:types.
+    expect<PayloadWebhookId>(0).toBe<EventTypeWebhookId>(0);
   });
 });
 

--- a/packages/sdk/src/webhooks/types.ts
+++ b/packages/sdk/src/webhooks/types.ts
@@ -5,13 +5,13 @@ import {
   AppUserTeamAccessChangedWebhookPayload as AppUserTeamAccessChangedWebhookPayloadType,
   AttachmentWebhookPayload,
   AuditEntryWebhookPayload,
+  EntityWebhookPayload as BaseEntityWebhookPayload,
   CommentWebhookPayload,
   CustomerNeedWebhookPayload,
   CustomerWebhookPayload,
   CycleWebhookPayload,
   DataWebhookPayload,
   DocumentWebhookPayload,
-  EntityWebhookPayload,
   InitiativeUpdateWebhookPayload,
   InitiativeWebhookPayload,
   IssueLabelWebhookPayload,
@@ -24,6 +24,17 @@ import {
   ReactionWebhookPayload,
   UserWebhookPayload,
 } from "../_generated_documents.js";
+
+// These two fields are added to every webhook payload before being sent but are not represented in the GraphQL schema.
+// See: https://linear.app/developers/webhooks#other-events-payload
+type WebhookExtras = {
+  /** ID uniquely identifying this webhook. */
+  webhookId: string;
+  /** UNIX timestamp when the webhook was sent. */
+  webhookTimestamp: number;
+};
+
+type EntityWebhookPayload = BaseEntityWebhookPayload & WebhookExtras;
 
 /**
  * Union type representing all possible Linear webhook payloads.
@@ -142,10 +153,11 @@ export interface LinearWebhookHandler {
 /**
  * A webhook payload for an app user notification webhook.
  */
-export interface AppUserNotificationWebhookPayloadWithNotification extends AppUserNotificationWebhookPayload {
-  notification: NotificationWebhookPayload;
-  type: "AppUserNotification";
-}
+export type AppUserNotificationWebhookPayloadWithNotification = WebhookExtras &
+  AppUserNotificationWebhookPayload & {
+    notification: NotificationWebhookPayload;
+    type: "AppUserNotification";
+  };
 
 /**
  * A webhook payload for an entity-specific webhook.
@@ -297,27 +309,31 @@ export type EntityWebhookPayloadWithUserData = EntityWebhookPayload & {
 /**
  * A webhook payload for an Agent Session Event webhook.
  */
-export type AgentSessionEventWebhookPayload = AgentSessionEventWebhookPayloadType & {
-  type: "AgentSessionEvent";
-};
+export type AgentSessionEventWebhookPayload = WebhookExtras &
+  AgentSessionEventWebhookPayloadType & {
+    type: "AgentSessionEvent";
+  };
 
 /**
  * A webhook payload for an Issue SLA webhook with a narrowed `type`.
  */
-export type IssueSlaWebhookPayload = IssueSlaWebhookPayloadType & {
-  type: "IssueSLA";
-};
+export type IssueSlaWebhookPayload = WebhookExtras &
+  IssueSlaWebhookPayloadType & {
+    type: "IssueSLA";
+  };
 
 /**
  * A webhook payload for an OAuth App webhook with a narrowed `type`.
  */
-export type OAuthAppWebhookPayload = OAuthAppWebhookPayloadType & {
-  type: "OAuthApp";
-};
+export type OAuthAppWebhookPayload = WebhookExtras &
+  OAuthAppWebhookPayloadType & {
+    type: "OAuthApp";
+  };
 
 /**
  * A webhook payload for an App User Team Access Changed webhook with a narrowed `type`.
  */
-export type AppUserTeamAccessChangedWebhookPayload = AppUserTeamAccessChangedWebhookPayloadType & {
-  type: "PermissionChange";
-};
+export type AppUserTeamAccessChangedWebhookPayload = WebhookExtras &
+  AppUserTeamAccessChangedWebhookPayloadType & {
+    type: "PermissionChange";
+  };


### PR DESCRIPTION
These two fields are always added by Linear when delivering webhooks, and are [present in the Linear documentation]. However they are not represented in the public GraphQL schema, meaning they are not picked up by the SDK code generation. This diff is a **type-only** change that adds both fields to all webhook payload types. I also did my best to add a test for this, ensuring any newly created webhook payload types don't forget to include `WebhookExtras`. 
