### PR TITLE
Add explicit `null` typing to GraphQL nullable fields

### DIFF
--- a/.changeset/slow-rocks-teach.md
+++ b/.changeset/slow-rocks-teach.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": minor
+---
+
+Represent GraphQL nullable fields using `undefined | null`, rather than just `undefined`

--- a/packages/codegen-sdk/src/print-model.ts
+++ b/packages/codegen-sdk/src/print-model.ts
@@ -165,31 +165,46 @@ function printModel(context: SdkPluginContext, model: SdkModel): string {
         printDebug("fields.scalar"),
         printLines(
           model.fields.scalar.map(field =>
-            printModelField(field, `public ${field.name}${field.nonNull ? "" : "?"}: ${field.type}`)
+            printModelField(
+              field,
+              `public ${field.name}${field.nonNull ? "" : "?"}: ${field.type}${field.nonNull ? "" : " | null"}`
+            )
           )
         ),
         printDebug("fields.scalarList"),
         printLines(
           model.fields.scalarList.map(field =>
-            printModelField(field, `public ${field.name}${field.nonNull ? "" : "?"}: ${field.type}`)
+            printModelField(
+              field,
+              `public ${field.name}${field.nonNull ? "" : "?"}: ${field.type}${field.nonNull ? "" : " | null"}`
+            )
           )
         ),
         printDebug("fields.list"),
         printLines(
           model.fields.list.map(field =>
-            printModelField(field, `public ${field.name}${field.nonNull ? "" : "?"}: ${field.listType}[]`)
+            printModelField(
+              field,
+              `public ${field.name}${field.nonNull ? "" : "?"}: ${field.listType}[]${field.nonNull ? "" : " | null"}`
+            )
           )
         ),
         printDebug("fields.object"),
         printLines(
           model.fields.object.map((field /** Ignore objects returned by an operation */) =>
-            printModelField(field, `public ${field.name}${field.nonNull ? "" : "?"}: ${field.object.name.value}`)
+            printModelField(
+              field,
+              `public ${field.name}${field.nonNull ? "" : "?"}: ${field.object.name.value}${field.nonNull ? "" : " | null"}`
+            )
           )
         ),
         printDebug("fields.enum"),
         printLines(
           model.fields.enum.map(field =>
-            printModelField(field, `public ${field.name}${field.nonNull ? "" : "?"}: ${field.type}`)
+            printModelField(
+              field,
+              `public ${field.name}${field.nonNull ? "" : "?"}: ${field.type}${field.nonNull ? "" : " | null"}`
+            )
           )
         ),
         printDebug("fields.union"),
@@ -199,7 +214,10 @@ function printModel(context: SdkPluginContext, model: SdkModel): string {
               // Skip webhook payload union types as they are manually typed
               return undefined;
             }
-            return printModelField(field, `public ${field.name}${field.nonNull ? "" : "?"}: ${field.type}`);
+            return printModelField(
+              field,
+              `public ${field.name}${field.nonNull ? "" : "?"}: ${field.type}${field.nonNull ? "" : " | null"}`
+            );
           })
         ),
       ])}

--- a/packages/codegen-test/src/print-test.ts
+++ b/packages/codegen-test/src/print-test.ts
@@ -136,7 +136,7 @@ function printOperationArgs(context: SdkPluginContext, operation: SdkOperation):
  * Prints the type with array and undefined check
  */
 function printResponseType(type: string, listType?: string) {
-  return `${type}${listType ? "[]" : ""} | undefined`;
+  return `${type}${listType ? "[]" : ""} | undefined | null`;
 }
 
 /**
@@ -157,7 +157,7 @@ function printModelQueryTest(context: SdkPluginContext, operation: SdkOperation,
     operation.name,
     [`Test ${operation.name} query`],
     printLines([
-      sdkOperations.length ? `let _${fieldName}: ${fieldType} | undefined` : undefined,
+      sdkOperations.length ? `let _${fieldName}: ${fieldType} | undefined | null` : undefined,
       "\n",
       printComment([`Test the ${sdkKey || "root"} model query for ${operation.name}`]),
       printIt(
@@ -240,13 +240,13 @@ function printConnectionQueryTest(context: SdkPluginContext, operation: SdkOpera
     printLines([
       itemOperation
         ? printLines([
-            `let _${itemField}: ${itemTypes} | undefined`,
-            ...(itemArgs.map(arg => `let _${itemField}_${arg.name}: ${arg.type} | undefined`) ?? []),
+            `let _${itemField}: ${itemTypes} | undefined | null`,
+            ...(itemArgs.map(arg => `let _${itemField}_${arg.name}: ${arg.type} | undefined | null`) ?? []),
             ...(optionalIdArg && itemArgs.length === 0
               ? [
                   `let _${itemField}_${optionalIdArg.variable.name.value}: ${lowerCase(
                     reduceTypeName(optionalIdArg.type)
-                  )} | undefined`,
+                  )} | undefined | null`,
                 ]
               : []),
             "\n",

--- a/packages/sdk/src/_generated_sdk.ts
+++ b/packages/sdk/src/_generated_sdk.ts
@@ -196,16 +196,16 @@ export class ActorBot extends Request {
   }
 
   /** A url pointing to the avatar representing this bot. */
-  public avatarUrl?: string;
-  public id?: string;
+  public avatarUrl?: string | null;
+  public id?: string | null;
   /** The display name of the bot. */
-  public name?: string;
+  public name?: string | null;
   /** The sub type of the bot. */
-  public subType?: string;
+  public subType?: string | null;
   /** The type of bot. */
   public type: string;
   /** The display name of the external user on behalf of which the bot acted. */
-  public userDisplayName?: string;
+  public userDisplayName?: string | null;
 }
 /**
  * An activity within an agent context.
@@ -235,7 +235,7 @@ export class AgentActivity extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Whether the activity is ephemeral, and should disappear after the next agent activity. */
@@ -243,16 +243,16 @@ export class AgentActivity extends Request {
   /** The unique identifier of the entity. */
   public id: string;
   /** Metadata about this agent activity's signal. */
-  public signalMetadata?: Record<string, unknown>;
+  public signalMetadata?: Record<string, unknown> | null;
   /** Metadata about the external source that created this agent activity. */
-  public sourceMetadata?: Record<string, unknown>;
+  public sourceMetadata?: Record<string, unknown> | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   public updatedAt: Date;
   /** An optional modifier that provides additional instructions on how the activity should be interpreted. */
-  public signal?: L.AgentActivitySignal;
+  public signal?: L.AgentActivitySignal | null;
   /** The content of the activity */
   public content: L.AgentActivityContent;
   /** The agent session this activity belongs to. */
@@ -305,7 +305,7 @@ export class AgentActivityActionContent extends Request {
   /** The parameters for the action, e.g. a file path, a keyword, etc. */
   public parameter: string;
   /** The result of the action in Markdown format. */
-  public result?: string;
+  public result?: string | null;
   /** The type of activity. */
   public type: L.AgentActivityType;
 }
@@ -471,7 +471,7 @@ export class AgentActivityWebhookPayload {
   /** The ID of the agent session that this activity belongs to. */
   public agentSessionId: string;
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The content of the agent activity. */
   public content: L.Scalars["JSONObject"];
   /** The time at which the entity was created. */
@@ -479,15 +479,15 @@ export class AgentActivityWebhookPayload {
   /** The ID of the entity. */
   public id: string;
   /** An optional modifier that provides additional instructions on how the activity should be interpreted. */
-  public signal?: string;
+  public signal?: string | null;
   /** Metadata about this agent activity's signal. */
-  public signalMetadata?: L.Scalars["JSONObject"];
+  public signalMetadata?: L.Scalars["JSONObject"] | null;
   /** The ID of the comment this activity is linked to. */
-  public sourceCommentId?: string;
+  public sourceCommentId?: string | null;
   /** The time at which the entity was updated. */
   public updatedAt: string;
   /** The ID of the user who created this agent activity. */
-  public userId?: string;
+  public userId?: string | null;
 }
 /**
  * A session for agent activities and state management.
@@ -527,25 +527,25 @@ export class AgentSession extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The time the agent session was dismissed. */
-  public dismissedAt?: Date;
+  public dismissedAt?: Date | null;
   /** The time the agent session ended. */
-  public endedAt?: Date;
+  public endedAt?: Date | null;
   /** The URL of an external agent-hosted page associated with this session. */
-  public externalLink?: string;
+  public externalLink?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** A dynamically updated list of the agent's execution strategy. */
-  public plan?: Record<string, unknown>;
+  public plan?: Record<string, unknown> | null;
   /** Metadata about the external source that created this agent session. */
-  public sourceMetadata?: Record<string, unknown>;
+  public sourceMetadata?: Record<string, unknown> | null;
   /** The time the agent session started. */
-  public startedAt?: Date;
+  public startedAt?: Date | null;
   /** A summary of the activities in this session. */
-  public summary?: string;
+  public summary?: string | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
@@ -668,7 +668,7 @@ export class AgentSessionEventWebhookPayload {
   /** ID of the organization for which the webhook belongs to. */
   public organizationId: string;
   /** A formatted prompt string containing the relevant context for the agent session, including issue details, comments, and guidance. Present only for `created` events. */
-  public promptContext?: string;
+  public promptContext?: string | null;
   /** The type of resource. */
   public type: string;
   /** The ID of the webhook that sent this event. */
@@ -676,11 +676,11 @@ export class AgentSessionEventWebhookPayload {
   /** Unix timestamp in milliseconds when the webhook was sent. */
   public webhookTimestamp: number;
   /** Guidance to inform the agent's behavior, which comes from configuration at the level of the workspace, parent teams, and/or current team for this session. The nearest team-specific guidance should take highest precendence. */
-  public guidance?: GuidanceRuleWebhookPayload[];
+  public guidance?: GuidanceRuleWebhookPayload[] | null;
   /** The previous comments in the thread before this agent was mentioned and the session was initiated, if any. Present only for `created` events where the session was initiated by mentioning the agent in a child comment of a thread. */
-  public previousComments?: CommentChildWebhookPayload[];
+  public previousComments?: CommentChildWebhookPayload[] | null;
   /** The agent activity that was created. */
-  public agentActivity?: AgentActivityWebhookPayload;
+  public agentActivity?: AgentActivityWebhookPayload | null;
   /** The agent session that the event belongs to. */
   public agentSession: AgentSessionWebhookPayload;
 }
@@ -744,41 +744,41 @@ export class AgentSessionWebhookPayload {
   /** The ID of the agent that the agent session belongs to. */
   public appUserId: string;
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The ID of the root comment of the thread this agent session is attached to. */
-  public commentId?: string;
+  public commentId?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the human user responsible for the agent session. Unset if the session was initiated via automation or by an agent user, with no responsible human user. */
-  public creatorId?: string;
+  public creatorId?: string | null;
   /** The time the agent session ended. */
-  public endedAt?: string;
+  public endedAt?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The ID of the issue this agent session is associated with. */
-  public issueId?: string;
+  public issueId?: string | null;
   /** The ID of the organization that the agent session belongs to. */
   public organizationId: string;
   /** The ID of the comment that this agent session was spawned from, if from a different thread. */
-  public sourceCommentId?: string;
+  public sourceCommentId?: string | null;
   /** Metadata about the external source that created this agent session. */
-  public sourceMetadata?: L.Scalars["JSONObject"];
+  public sourceMetadata?: L.Scalars["JSONObject"] | null;
   /** The time the agent session started working. */
-  public startedAt?: string;
+  public startedAt?: string | null;
   /** The current status of the agent session. */
   public status: string;
   /** A summary of the activities in this session. */
-  public summary?: string;
+  public summary?: string | null;
   /** The type of the agent session. */
   public type: string;
   /** The time at which the entity was updated. */
   public updatedAt: string;
   /** The root comment of the thread this agent session is attached to. */
-  public comment?: CommentChildWebhookPayload;
+  public comment?: CommentChildWebhookPayload | null;
   /** The human user responsible for the agent session. Unset if the session was initiated via automation or by an agent user, with no responsible human user. */
-  public creator?: UserChildWebhookPayload;
+  public creator?: UserChildWebhookPayload | null;
   /** The issue this agent session is associated with. */
-  public issue?: IssueWithDescriptionChildWebhookPayload;
+  public issue?: IssueWithDescriptionChildWebhookPayload | null;
 }
 /**
  * AI prompt rules for a team.
@@ -799,7 +799,7 @@ export class AiPromptRules extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -916,7 +916,7 @@ export class Application extends Request {
   /** OAuth application's client ID. */
   public clientId: string;
   /** Information about the application. */
-  public description?: string;
+  public description?: string | null;
   /** Name of the developer. */
   public developer: string;
   /** Url of the developer (homepage or docs). */
@@ -924,7 +924,7 @@ export class Application extends Request {
   /** OAuth application's ID. */
   public id: string;
   /** Image of the application. */
-  public imageUrl?: string;
+  public imageUrl?: string | null;
   /** Application name. */
   public name: string;
 }
@@ -1038,9 +1038,9 @@ export class Attachment extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The body data of the attachment, if any. */
-  public bodyData?: string;
+  public bodyData?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Indicates if attachments for the same source application should be grouped in the Linear UI. */
@@ -1050,11 +1050,11 @@ export class Attachment extends Request {
   /** Custom metadata related to the attachment. */
   public metadata: L.Scalars["JSONObject"];
   /** Information about the source which created the attachment. */
-  public source?: L.Scalars["JSONObject"];
+  public source?: L.Scalars["JSONObject"] | null;
   /** An accessor helper to source.type, defines the source type of the attachment. */
-  public sourceType?: string;
+  public sourceType?: string | null;
   /** Content for the subtitle line in the Linear attachment widget. */
-  public subtitle?: string;
+  public subtitle?: string | null;
   /** Content for the title line in the Linear attachment widget. */
   public title: string;
   /**
@@ -1202,13 +1202,13 @@ export class AttachmentWebhookPayload {
   }
 
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the creator of the attachment. */
-  public creatorId?: string;
+  public creatorId?: string | null;
   /** The ID of the non-Linear user who created the attachment. */
-  public externalUserCreatorId?: string;
+  public externalUserCreatorId?: string | null;
   /** Whether attachments for the same source application should be grouped in the Linear UI. */
   public groupBySource: boolean;
   /** The ID of the entity. */
@@ -1218,13 +1218,13 @@ export class AttachmentWebhookPayload {
   /** Custom metadata related to the attachment. */
   public metadata: L.Scalars["JSONObject"];
   /** The ID of the issue this attachment belonged to originally. */
-  public originalIssueId?: string;
+  public originalIssueId?: string | null;
   /** Information about the source which created the attachment. */
-  public source?: L.Scalars["JSONObject"];
+  public source?: L.Scalars["JSONObject"] | null;
   /** The source type of the attachment. */
-  public sourceType?: string;
+  public sourceType?: string | null;
   /** Optional subtitle of the attachment. */
-  public subtitle?: string;
+  public subtitle?: string | null;
   /** The title of the attachment. */
   public title: string;
   /** The time at which the entity was updated. */
@@ -1257,21 +1257,21 @@ export class AuditEntry extends Request {
   }
 
   /** The ID of the user that caused the audit entry to be created. */
-  public actorId?: string;
+  public actorId?: string | null;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** Country code of request resulting to audit entry. */
-  public countryCode?: string;
+  public countryCode?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
   public id: string;
   /** IP from actor when entry was recorded. */
-  public ip?: string;
+  public ip?: string | null;
   /** Additional metadata related to the audit entry. */
-  public metadata?: L.Scalars["JSONObject"];
+  public metadata?: L.Scalars["JSONObject"] | null;
   /** Additional information related to the request which performed the action. */
-  public requestInformation?: L.Scalars["JSONObject"];
+  public requestInformation?: L.Scalars["JSONObject"] | null;
   public type: string;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
@@ -1347,23 +1347,23 @@ export class AuditEntryWebhookPayload {
   }
 
   /** The ID of the user that caused the audit entry to be created. */
-  public actorId?: string;
+  public actorId?: string | null;
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** Country code of request resulting to audit entry. */
-  public countryCode?: string;
+  public countryCode?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the entity. */
   public id: string;
   /** IP from actor when entry was recorded. */
-  public ip?: string;
+  public ip?: string | null;
   /** Additional metadata related to the audit entry. */
-  public metadata?: L.Scalars["JSONObject"];
+  public metadata?: L.Scalars["JSONObject"] | null;
   /** The ID of the organization that the audit entry belongs to. */
   public organizationId: string;
   /** Additional information related to the request which performed the action. */
-  public requestInformation?: L.Scalars["JSONObject"];
+  public requestInformation?: L.Scalars["JSONObject"] | null;
   /** The type of the audit entry. */
   public type: string;
   /** The time at which the entity was updated. */
@@ -1400,23 +1400,23 @@ export class AuthIdentityProvider extends Request {
   /** The unique identifier of the entity. */
   public id: string;
   /** The issuer's custom entity ID. */
-  public issuerEntityId?: string;
+  public issuerEntityId?: string | null;
   /** The SAML priority used to pick default workspace in SAML SP initiated flow, when same domain is claimed for SAML by multiple workspaces. Lower priority value means higher preference. */
-  public priority?: number;
+  public priority?: number | null;
   /** Whether SAML authentication is enabled for organization. */
   public samlEnabled: boolean;
   /** Whether SCIM provisioning is enabled for organization. */
   public scimEnabled: boolean;
   /** The service provider (Linear) custom entity ID. Defaults to https://auth.linear.app/sso */
-  public spEntityId?: string;
+  public spEntityId?: string | null;
   /** Binding method for authentication call. Can be either `post` (default) or `redirect`. */
-  public ssoBinding?: string;
+  public ssoBinding?: string | null;
   /** Sign in endpoint URL for the identity provider. */
-  public ssoEndpoint?: string;
+  public ssoEndpoint?: string | null;
   /** The algorithm of the Signing Certificate. Can be one of `sha1`, `sha256` (default), or `sha512`. */
-  public ssoSignAlgo?: string;
+  public ssoSignAlgo?: string | null;
   /** X.509 Signing Certificate in string form. */
-  public ssoSigningCert?: string;
+  public ssoSigningCert?: string | null;
   /** The type of identity provider. */
   public type: L.IdentityProviderType;
 }
@@ -1451,13 +1451,13 @@ export class AuthOrganization extends Request {
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The time at which deletion of the organization was requested. */
-  public deletionRequestedAt?: Date;
+  public deletionRequestedAt?: Date | null;
   /** Whether the organization is enabled. Used as a superuser tool to lock down the org. */
   public enabled: boolean;
   /** The unique identifier of the entity. */
   public id: string;
   /** The organization's logo URL. */
-  public logoUrl?: string;
+  public logoUrl?: string | null;
   /** The organization's name. */
   public name: string;
   /** Previously used URL keys for the organization (last 3 are kept and redirected). */
@@ -1472,7 +1472,7 @@ export class AuthOrganization extends Request {
   public serviceId: string;
   /** The organization's unique URL key. */
   public urlKey: string;
-  public userCount?: number;
+  public userCount?: number | null;
   /** The feature release channel the organization belongs to. */
   public releaseChannel: L.ReleaseChannel;
 }
@@ -1501,19 +1501,19 @@ export class AuthResolverResponse extends Request {
   }
 
   /** Should the signup flow allow access for the domain. */
-  public allowDomainAccess?: boolean;
+  public allowDomainAccess?: boolean | null;
   /** Email for the authenticated account. */
   public email: string;
   /** User account ID. */
   public id: string;
   /** ID of the organization last accessed by the user. */
-  public lastUsedOrganizationId?: string;
+  public lastUsedOrganizationId?: string | null;
   /** Application token. */
-  public token?: string;
+  public token?: string | null;
   /** List of organizations allowing this user account to join automatically. */
-  public availableOrganizations?: AuthOrganization[];
+  public availableOrganizations?: AuthOrganization[] | null;
   /** List of organization available to this user account but locked due to the current auth method. */
-  public lockedOrganizations?: AuthOrganization[];
+  public lockedOrganizations?: AuthOrganization[] | null;
   /** List of locked users that are locked by login restrictions */
   public lockedUsers: AuthUser[];
   /** List of active users that belong to the user account. */
@@ -1543,7 +1543,7 @@ export class AuthUser extends Request {
   /** Whether the user is active. */
   public active: boolean;
   /** An URL to the user's avatar image. */
-  public avatarUrl?: string;
+  public avatarUrl?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The user's display (nick) name. Unique within each organization. */
@@ -1591,40 +1591,40 @@ export class AuthenticationSessionResponse extends Request {
   }
 
   /** Used web browser. */
-  public browserType?: string;
+  public browserType?: string | null;
   /** Client used for the session */
-  public client?: string;
+  public client?: string | null;
   /** Country codes of all seen locations. */
   public countryCodes: string[];
   /** The time at which the entity was created. */
   public createdAt: Date;
   public id: string;
   /** IP address. */
-  public ip?: string;
+  public ip?: string | null;
   /** Identifies the session used to make the request. */
   public isCurrentSession: boolean;
   /** When was the session last seen */
-  public lastActiveAt?: Date;
+  public lastActiveAt?: Date | null;
   /** Human readable location */
-  public location?: string;
+  public location?: string | null;
   /** Location city name. */
-  public locationCity?: string;
+  public locationCity?: string | null;
   /** Location country name. */
-  public locationCountry?: string;
+  public locationCountry?: string | null;
   /** Location country code. */
-  public locationCountryCode?: string;
+  public locationCountryCode?: string | null;
   /** Location region code. */
-  public locationRegionCode?: string;
+  public locationRegionCode?: string | null;
   /** Name of the session, derived from the client and operating system */
   public name: string;
   /** Operating system used for the session */
-  public operatingSystem?: string;
+  public operatingSystem?: string | null;
   /** Service used for logging in. */
-  public service?: string;
+  public service?: string | null;
   /** Date when the session was last updated. */
   public updatedAt: Date;
   /** Session's user-agent. */
-  public userAgent?: string;
+  public userAgent?: string | null;
   /** Type of application used to authenticate. */
   public type: L.AuthenticationSessionType;
 }
@@ -1702,33 +1702,33 @@ export class Comment extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The comment content in markdown format. */
   public body: string;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The ID of the document content that the comment is associated with. */
-  public documentContentId?: string;
+  public documentContentId?: string | null;
   /** The time user edited the comment. */
-  public editedAt?: Date;
+  public editedAt?: Date | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The ID of the initiative update that the comment is associated with. */
-  public initiativeUpdateId?: string;
+  public initiativeUpdateId?: string | null;
   /** The ID of the issue that the comment is associated with. */
-  public issueId?: string;
+  public issueId?: string | null;
   /** The ID of the parent comment under which the current comment is nested. */
-  public parentId?: string;
+  public parentId?: string | null;
   /** The ID of the project update that the comment is associated with. */
-  public projectUpdateId?: string;
+  public projectUpdateId?: string | null;
   /** The text that this comment references. Only defined for inline comments. */
-  public quotedText?: string;
+  public quotedText?: string | null;
   /** Emoji reaction summary, grouped by emoji type. */
   public reactionData: L.Scalars["JSONObject"];
   /** The time the resolvingUser resolved the thread. */
-  public resolvedAt?: Date;
+  public resolvedAt?: Date | null;
   /** The ID of the comment that resolved the thread. */
-  public resolvingCommentId?: string;
+  public resolvingCommentId?: string | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
@@ -1739,13 +1739,13 @@ export class Comment extends Request {
   /** Reactions associated with the comment. */
   public reactions: Reaction[];
   /** The external services the comment is synced with. */
-  public syncedWith?: ExternalEntityInfo[];
+  public syncedWith?: ExternalEntityInfo[] | null;
   /** The bot that created the comment. */
-  public botActor?: ActorBot;
+  public botActor?: ActorBot | null;
   /** The document content that the comment is associated with. */
-  public documentContent?: DocumentContent;
+  public documentContent?: DocumentContent | null;
   /** The external thread that the comment is synced with. */
-  public externalThread?: SyncedExternalThread;
+  public externalThread?: SyncedExternalThread | null;
   /** Agent session associated with this comment. */
   public get agentSession(): LinearFetch<AgentSession> | undefined {
     return this._agentSession?.id ? new AgentSessionQuery(this._request).fetch(this._agentSession?.id) : undefined;
@@ -1842,17 +1842,17 @@ export class CommentChildWebhookPayload {
   /** The body of the comment. */
   public body: string;
   /** The ID of the document content this comment belongs to. */
-  public documentContentId?: string;
+  public documentContentId?: string | null;
   /** The ID of the comment. */
   public id: string;
   /** The ID of the initiative update this comment belongs to. */
-  public initiativeUpdateId?: string;
+  public initiativeUpdateId?: string | null;
   /** The ID of the issue this comment belongs to. */
-  public issueId?: string;
+  public issueId?: string | null;
   /** The ID of the project update this comment belongs to. */
-  public projectUpdateId?: string;
+  public projectUpdateId?: string | null;
   /** The ID of the user who created this comment. */
-  public userId?: string;
+  public userId?: string | null;
 }
 /**
  * CommentConnection model
@@ -1946,61 +1946,61 @@ export class CommentWebhookPayload {
   }
 
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The body of the comment. */
   public body: string;
   /** The bot actor data for this comment. */
-  public botActor?: string;
+  public botActor?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the document content this comment belongs to. */
-  public documentContentId?: string;
+  public documentContentId?: string | null;
   /** When the comment was last edited. */
-  public editedAt?: string;
+  public editedAt?: string | null;
   /** The ID of the external user who created this comment. */
-  public externalUserId?: string;
+  public externalUserId?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The ID of the initiative update this comment belongs to. */
-  public initiativeUpdateId?: string;
+  public initiativeUpdateId?: string | null;
   /** The ID of the issue this comment belongs to. */
-  public issueId?: string;
+  public issueId?: string | null;
   /** The ID of the parent comment. */
-  public parentId?: string;
+  public parentId?: string | null;
   /** The ID of the post this comment belongs to. */
-  public postId?: string;
+  public postId?: string | null;
   /** The ID of the project update this comment belongs to. */
-  public projectUpdateId?: string;
+  public projectUpdateId?: string | null;
   /** The quoted text in this comment. */
-  public quotedText?: string;
+  public quotedText?: string | null;
   /** The reaction data for this comment. */
   public reactionData: L.Scalars["JSONObject"];
   /** When the comment was resolved. */
-  public resolvedAt?: string;
+  public resolvedAt?: string | null;
   /** The ID of the comment that resolved this comment. */
-  public resolvingCommentId?: string;
+  public resolvingCommentId?: string | null;
   /** The ID of the user who resolved this comment. */
-  public resolvingUserId?: string;
+  public resolvingUserId?: string | null;
   /** The entity this comment is synced with. */
-  public syncedWith?: L.Scalars["JSONObject"];
+  public syncedWith?: L.Scalars["JSONObject"] | null;
   /** The time at which the entity was updated. */
   public updatedAt: string;
   /** The ID of the user who created this comment. */
-  public userId?: string;
+  public userId?: string | null;
   /** The document content for this comment. */
-  public documentContent?: DocumentContentChildWebhookPayload;
+  public documentContent?: DocumentContentChildWebhookPayload | null;
   /** The external user who created this comment. */
-  public externalUser?: ExternalUserChildWebhookPayload;
+  public externalUser?: ExternalUserChildWebhookPayload | null;
   /** The initiative update this comment belongs to. */
-  public initiativeUpdate?: InitiativeUpdateChildWebhookPayload;
+  public initiativeUpdate?: InitiativeUpdateChildWebhookPayload | null;
   /** The issue this comment belongs to. */
-  public issue?: IssueChildWebhookPayload;
+  public issue?: IssueChildWebhookPayload | null;
   /** The parent comment. */
-  public parent?: CommentChildWebhookPayload;
+  public parent?: CommentChildWebhookPayload | null;
   /** The project update this comment belongs to. */
-  public projectUpdate?: ProjectUpdateChildWebhookPayload;
+  public projectUpdate?: ProjectUpdateChildWebhookPayload | null;
   /** The user who created this comment. */
-  public user?: UserChildWebhookPayload;
+  public user?: UserChildWebhookPayload | null;
 }
 /**
  * ContactPayload model
@@ -2122,31 +2122,31 @@ export class CustomView extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The color of the icon of the custom view. */
-  public color?: string;
+  public color?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The description of the custom view. */
-  public description?: string;
+  public description?: string | null;
   /** The filter applied to feed items in the custom view. */
-  public feedItemFilterData?: L.Scalars["JSONObject"];
+  public feedItemFilterData?: L.Scalars["JSONObject"] | null;
   /** The filter applied to issues in the custom view. */
   public filterData: L.Scalars["JSONObject"];
   /** The filters applied to issues in the custom view. */
   public filters: L.Scalars["JSONObject"];
   /** The icon of the custom view. */
-  public icon?: string;
+  public icon?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The filter applied to initiatives in the custom view. */
-  public initiativeFilterData?: L.Scalars["JSONObject"];
+  public initiativeFilterData?: L.Scalars["JSONObject"] | null;
   /** The model name of the custom view. */
   public modelName: string;
   /** The name of the custom view. */
   public name: string;
   /** The filter applied to projects in the custom view. */
-  public projectFilterData?: L.Scalars["JSONObject"];
+  public projectFilterData?: L.Scalars["JSONObject"] | null;
   /** Whether the custom view is shared with everyone in the organization. */
   public shared: boolean;
   /** The custom view's unique URL slug. */
@@ -2157,11 +2157,11 @@ export class CustomView extends Request {
    */
   public updatedAt: Date;
   /** The organizations default view preferences for this custom view. */
-  public organizationViewPreferences?: ViewPreferences;
+  public organizationViewPreferences?: ViewPreferences | null;
   /** The current users view preferences for this custom view. */
-  public userViewPreferences?: ViewPreferences;
+  public userViewPreferences?: ViewPreferences | null;
   /** The calculated view preferences values for this custom view. */
-  public viewPreferencesValues?: ViewPreferencesValues;
+  public viewPreferencesValues?: ViewPreferencesValues | null;
   /** The user who created the custom view. */
   public get creator(): LinearFetch<User> | undefined {
     return new UserQuery(this._request).fetch(this._creator.id);
@@ -2300,7 +2300,7 @@ export class CustomViewNotificationSubscription extends Request {
   /** Whether the subscription is active or not. */
   public active: boolean;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -2313,9 +2313,9 @@ export class CustomViewNotificationSubscription extends Request {
    */
   public updatedAt: Date;
   /** The type of view to which the notification subscription context is associated with. */
-  public contextViewType?: L.ContextViewType;
+  public contextViewType?: L.ContextViewType | null;
   /** The type of user view to which the notification subscription context is associated with. */
-  public userContextViewType?: L.UserContextViewType;
+  public userContextViewType?: L.UserContextViewType | null;
   /** The custom view subscribed to. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return new CustomViewQuery(this._request).fetch(this._customView.id);
@@ -2433,11 +2433,11 @@ export class CustomViewSuggestionPayload extends Request {
   }
 
   /** The suggested view description. */
-  public description?: string;
+  public description?: string | null;
   /** The suggested view icon. */
-  public icon?: string;
+  public icon?: string | null;
   /** The suggested view name. */
-  public name?: string;
+  public name?: string | null;
 }
 /**
  * A customer whose needs will be tied to issues or projects.
@@ -2477,7 +2477,7 @@ export class Customer extends Request {
   /** The approximate number of needs of the customer. */
   public approximateNeedCount: number;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The domains associated with this customer. */
@@ -2487,17 +2487,17 @@ export class Customer extends Request {
   /** The unique identifier of the entity. */
   public id: string;
   /** The customer's logo URL. */
-  public logoUrl?: string;
+  public logoUrl?: string | null;
   /** The ID of the main source, when a customer has multiple sources. Must be one of externalIds. */
-  public mainSourceId?: string;
+  public mainSourceId?: string | null;
   /** The customer's name. */
   public name: string;
   /** The annual revenue generated by the customer. */
-  public revenue?: number;
+  public revenue?: number | null;
   /** The size of the customer. */
-  public size?: number;
+  public size?: number | null;
   /** The ID of the Slack channel used to interact with the customer. */
-  public slackChannelId?: string;
+  public slackChannelId?: string | null;
   /** The customer's unique URL slug. */
   public slugId: string;
   /**
@@ -2633,9 +2633,9 @@ export class CustomerNeed extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The need content in markdown format. */
-  public body?: string;
+  public body?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -2648,9 +2648,9 @@ export class CustomerNeed extends Request {
    */
   public updatedAt: Date;
   /** The URL of the underlying attachment, if any */
-  public url?: string;
+  public url?: string | null;
   /** The project attachment this need is referencing. */
-  public projectAttachment?: ProjectAttachment;
+  public projectAttachment?: ProjectAttachment | null;
   /** The attachment this need is referencing. */
   public get attachment(): LinearFetch<Attachment> | undefined {
     return this._attachment?.id ? new AttachmentQuery(this._request).fetch(this._attachment?.id) : undefined;
@@ -2773,15 +2773,15 @@ export class CustomerNeedChildWebhookPayload {
   }
 
   /** The ID of the attachment this need is referencing. */
-  public attachmentId?: string;
+  public attachmentId?: string | null;
   /** The ID of the customer that this need is attached to. */
-  public customerId?: string;
+  public customerId?: string | null;
   /** The ID of the customer need. */
   public id: string;
   /** The ID of the issue this need is referencing. */
-  public issueId?: string;
+  public issueId?: string | null;
   /** The ID of the project this need is referencing. */
-  public projectId?: string;
+  public projectId?: string | null;
 }
 /**
  * CustomerNeedConnection model
@@ -2841,7 +2841,7 @@ export class CustomerNeedNotification extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Related customer need. */
@@ -2850,24 +2850,24 @@ export class CustomerNeedNotification extends Request {
    * The time at when an email reminder for this notification was sent to the user. Null, if no email
    *     reminder has been sent.
    */
-  public emailedAt?: Date;
+  public emailedAt?: Date | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The time at when the user marked the notification as read. Null, if the the user hasn't read the notification */
-  public readAt?: Date;
+  public readAt?: Date | null;
   /** The time until a notification will be snoozed. After that it will appear in the inbox again. */
-  public snoozedUntilAt?: Date;
+  public snoozedUntilAt?: Date | null;
   /** Notification type. */
   public type: string;
   /** The time at which a notification was unsnoozed.. */
-  public unsnoozedAt?: Date;
+  public unsnoozedAt?: Date | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   public updatedAt: Date;
   /** The bot that caused the notification. */
-  public botActor?: ActorBot;
+  public botActor?: ActorBot | null;
   /** The category of the notification. */
   public category: L.NotificationCategory;
   /** The user that caused the notification. */
@@ -3006,41 +3006,41 @@ export class CustomerNeedWebhookPayload {
   }
 
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The ID of the attachment this need is referencing. */
-  public attachmentId?: string;
+  public attachmentId?: string | null;
   /** The body of the need in Markdown format. */
-  public body?: string;
+  public body?: string | null;
   /** The ID of the comment this need is referencing. */
-  public commentId?: string;
+  public commentId?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the creator of the customer need. */
-  public creatorId?: string;
+  public creatorId?: string | null;
   /** The ID of the customer that this need is attached to. */
-  public customerId?: string;
+  public customerId?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The ID of the issue this need is referencing. */
-  public issueId?: string;
+  public issueId?: string | null;
   /** The issue ID this customer need was originally created on. Will be undefined if the customer need hasn't been moved. */
-  public originalIssueId?: string;
+  public originalIssueId?: string | null;
   /** The priority of the need. */
   public priority: number;
   /** The ID of the project attachment this need is referencing. */
-  public projectAttachmentId?: string;
+  public projectAttachmentId?: string | null;
   /** The ID of the project this need is referencing. */
-  public projectId?: string;
+  public projectId?: string | null;
   /** The time at which the entity was updated. */
   public updatedAt: string;
   /** The attachment this need is referencing. */
-  public attachment?: AttachmentWebhookPayload;
+  public attachment?: AttachmentWebhookPayload | null;
   /** The customer that this need is attached to. */
-  public customer?: CustomerChildWebhookPayload;
+  public customer?: CustomerChildWebhookPayload | null;
   /** The issue this need is referencing. */
-  public issue?: IssueChildWebhookPayload;
+  public issue?: IssueChildWebhookPayload | null;
   /** The project this need is referencing. */
-  public project?: ProjectChildWebhookPayload;
+  public project?: ProjectChildWebhookPayload | null;
 }
 /**
  * A customer related notification.
@@ -3075,7 +3075,7 @@ export class CustomerNotification extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Related customer. */
@@ -3084,24 +3084,24 @@ export class CustomerNotification extends Request {
    * The time at when an email reminder for this notification was sent to the user. Null, if no email
    *     reminder has been sent.
    */
-  public emailedAt?: Date;
+  public emailedAt?: Date | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The time at when the user marked the notification as read. Null, if the the user hasn't read the notification */
-  public readAt?: Date;
+  public readAt?: Date | null;
   /** The time until a notification will be snoozed. After that it will appear in the inbox again. */
-  public snoozedUntilAt?: Date;
+  public snoozedUntilAt?: Date | null;
   /** Notification type. */
   public type: string;
   /** The time at which a notification was unsnoozed.. */
-  public unsnoozedAt?: Date;
+  public unsnoozedAt?: Date | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   public updatedAt: Date;
   /** The bot that caused the notification. */
-  public botActor?: ActorBot;
+  public botActor?: ActorBot | null;
   /** The category of the notification. */
   public category: L.NotificationCategory;
   /** The user that caused the notification. */
@@ -3176,7 +3176,7 @@ export class CustomerNotificationSubscription extends Request {
   /** Whether the subscription is active or not. */
   public active: boolean;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -3189,9 +3189,9 @@ export class CustomerNotificationSubscription extends Request {
    */
   public updatedAt: Date;
   /** The type of view to which the notification subscription context is associated with. */
-  public contextViewType?: L.ContextViewType;
+  public contextViewType?: L.ContextViewType | null;
   /** The type of user view to which the notification subscription context is associated with. */
-  public userContextViewType?: L.UserContextViewType;
+  public userContextViewType?: L.UserContextViewType | null;
   /** The contextual custom view associated with the notification subscription. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return this._customView?.id ? new CustomViewQuery(this._request).fetch(this._customView?.id) : undefined;
@@ -3316,13 +3316,13 @@ export class CustomerStatus extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The UI color of the status as a HEX string. */
   public color: string;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Description of the status. */
-  public description?: string;
+  public description?: string | null;
   /** The display name of the status. */
   public displayName: string;
   /** The unique identifier of the entity. */
@@ -3337,7 +3337,7 @@ export class CustomerStatus extends Request {
    */
   public updatedAt: Date;
   /** The type of the customer status. */
-  public type?: L.CustomerStatusType;
+  public type?: L.CustomerStatusType | null;
 
   /** Creates a new customer status. */
   public create(input: L.CustomerStatusCreateInput) {
@@ -3370,7 +3370,7 @@ export class CustomerStatusChildWebhookPayload {
   /** The color of the customer status. */
   public color: string;
   /** The description of the customer status. */
-  public description?: string;
+  public description?: string | null;
   /** The display name of the customer status. */
   public displayName: string;
   /** The ID of the customer status. */
@@ -3378,7 +3378,7 @@ export class CustomerStatusChildWebhookPayload {
   /** The name of the customer status. */
   public name: string;
   /** The type of the customer status. */
-  public type?: string;
+  public type?: string | null;
 }
 /**
  * CustomerStatusConnection model
@@ -3451,13 +3451,13 @@ export class CustomerTier extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The UI color of the tier as a HEX string. */
   public color: string;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Description of the tier. */
-  public description?: string;
+  public description?: string | null;
   /** The display name of the tier. */
   public displayName: string;
   /** The unique identifier of the entity. */
@@ -3502,7 +3502,7 @@ export class CustomerTierChildWebhookPayload {
   /** The color of the customer tier. */
   public color: string;
   /** The description of the customer tier. */
-  public description?: string;
+  public description?: string | null;
   /** The display name of the customer tier. */
   public displayName: string;
   /** The ID of the customer tier. */
@@ -3592,7 +3592,7 @@ export class CustomerWebhookPayload {
   /** The approximate number of needs of the customer. */
   public approximateNeedCount: number;
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The domains associated with this customer. */
@@ -3602,33 +3602,33 @@ export class CustomerWebhookPayload {
   /** The ID of the entity. */
   public id: string;
   /** The customer's logo URL. */
-  public logoUrl?: string;
+  public logoUrl?: string | null;
   /** The ID of the main source, when a customer has multiple sources. Must be one of externalIds. */
-  public mainSourceId?: string;
+  public mainSourceId?: string | null;
   /** The name of the customer. */
   public name: string;
   /** The ID of the user who owns the customer. */
-  public ownerId?: string;
+  public ownerId?: string | null;
   /** The annual revenue generated by the customer. */
-  public revenue?: number;
+  public revenue?: number | null;
   /** The size of the customer. */
-  public size?: number;
+  public size?: number | null;
   /** The ID of the Slack channel used to interact with the customer. */
-  public slackChannelId?: string;
+  public slackChannelId?: string | null;
   /** The customer's unique URL slug. */
   public slugId: string;
   /** The ID of the customer status. */
-  public statusId?: string;
+  public statusId?: string | null;
   /** The ID of the customer tier. */
-  public tierId?: string;
+  public tierId?: string | null;
   /** The time at which the entity was updated. */
   public updatedAt: string;
   /** The URL of the customer. */
   public url: string;
   /** The customer status. */
-  public status?: CustomerStatusChildWebhookPayload;
+  public status?: CustomerStatusChildWebhookPayload | null;
   /** The customer tier. */
-  public tier?: CustomerTierChildWebhookPayload;
+  public tier?: CustomerTierChildWebhookPayload | null;
 }
 /**
  * A set of issues to be resolved in a specified amount of time.
@@ -3669,11 +3669,11 @@ export class Cycle extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the cycle was automatically archived by the auto pruning process. */
-  public autoArchivedAt?: Date;
+  public autoArchivedAt?: Date | null;
   /** The completion time of the cycle. If null, the cycle hasn't been completed. */
-  public completedAt?: Date;
+  public completedAt?: Date | null;
   /** The number of completed issues in the cycle after each day. */
   public completedIssueCountHistory: number[];
   /** The number of completed estimation points after each day. */
@@ -3681,7 +3681,7 @@ export class Cycle extends Request {
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The cycle's description. */
-  public description?: string;
+  public description?: string | null;
   /** The end time of the cycle. */
   public endsAt: Date;
   /** The unique identifier of the entity. */
@@ -3701,7 +3701,7 @@ export class Cycle extends Request {
   /** The total number of issues in the cycle after each day. */
   public issueCountHistory: number[];
   /** The custom name of the cycle. */
-  public name?: string;
+  public name?: string | null;
   /** The number of the cycle. */
   public number: number;
   /** The overall progress of the cycle. This is the (completed estimate points + 0.25 * in progress estimate points) / total estimate points. */
@@ -3800,7 +3800,7 @@ export class CycleChildWebhookPayload {
   /** The ID of the cycle. */
   public id: string;
   /** The name of the cycle. */
-  public name?: string;
+  public name?: string | null;
   /** The number of the cycle. */
   public number: number;
   /** The start date of the cycle. */
@@ -3868,7 +3868,7 @@ export class CycleNotificationSubscription extends Request {
   /** Whether the subscription is active or not. */
   public active: boolean;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -3881,9 +3881,9 @@ export class CycleNotificationSubscription extends Request {
    */
   public updatedAt: Date;
   /** The type of view to which the notification subscription context is associated with. */
-  public contextViewType?: L.ContextViewType;
+  public contextViewType?: L.ContextViewType | null;
   /** The type of user view to which the notification subscription context is associated with. */
-  public userContextViewType?: L.UserContextViewType;
+  public userContextViewType?: L.UserContextViewType | null;
   /** The contextual custom view associated with the notification subscription. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return this._customView?.id ? new CustomViewQuery(this._request).fetch(this._customView?.id) : undefined;
@@ -4015,11 +4015,11 @@ export class CycleWebhookPayload {
   }
 
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The time at which the cycle was automatically archived by the auto pruning process. */
-  public autoArchivedAt?: string;
+  public autoArchivedAt?: string | null;
   /** The completion time of the cycle. If null, the cycle hasn't been completed. */
-  public completedAt?: string;
+  public completedAt?: string | null;
   /** The number of completed issues in the cycle after each day. */
   public completedIssueCountHistory: number[];
   /** The number of completed estimation points after each day. */
@@ -4027,7 +4027,7 @@ export class CycleWebhookPayload {
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The cycle's description. */
-  public description?: string;
+  public description?: string | null;
   /** The end date of the cycle. */
   public endsAt: string;
   /** The ID of the entity. */
@@ -4035,11 +4035,11 @@ export class CycleWebhookPayload {
   /** The number of in progress estimation points after each day. */
   public inProgressScopeHistory: number[];
   /** The ID of the cycle inherited from. */
-  public inheritedFromId?: string;
+  public inheritedFromId?: string | null;
   /** The total number of issues in the cycle after each day. */
   public issueCountHistory: number[];
   /** The name of the cycle. */
-  public name?: string;
+  public name?: string | null;
   /** The number of the cycle. */
   public number: number;
   /** The total number of estimation points after each day. */
@@ -4113,19 +4113,19 @@ export class Document extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The color of the icon. */
-  public color?: string;
+  public color?: string | null;
   /** The documents content in markdown format. */
-  public content?: string;
+  public content?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The ID of the document content associated with the document. */
-  public documentContentId?: string;
+  public documentContentId?: string | null;
   /** The time at which the document was hidden. Null if the entity has not been hidden. */
-  public hiddenAt?: Date;
+  public hiddenAt?: Date | null;
   /** The icon of the document. */
-  public icon?: string;
+  public icon?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The document's unique URL slug. */
@@ -4135,7 +4135,7 @@ export class Document extends Request {
   /** The document title. */
   public title: string;
   /** A flag that indicates whether the document is in the trash bin. */
-  public trashed?: boolean;
+  public trashed?: boolean | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
@@ -4261,15 +4261,15 @@ export class DocumentChildWebhookPayload {
   /** The ID of the document. */
   public id: string;
   /** The ID of the initiative this document belongs to. */
-  public initiativeId?: string;
+  public initiativeId?: string | null;
   /** The ID of the project this document belongs to. */
-  public projectId?: string;
+  public projectId?: string | null;
   /** The title of the document. */
   public title: string;
   /** The initiative this document belongs to. */
-  public initiative?: InitiativeChildWebhookPayload;
+  public initiative?: InitiativeChildWebhookPayload | null;
   /** The project this document belongs to. */
-  public project?: ProjectChildWebhookPayload;
+  public project?: ProjectChildWebhookPayload | null;
 }
 /**
  * DocumentConnection model
@@ -4323,24 +4323,24 @@ export class DocumentContent extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The document content in markdown format. */
-  public content?: string;
+  public content?: string | null;
   /** The document content state as a base64 encoded string. */
-  public contentState?: string;
+  public contentState?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
   public id: string;
   /** The time at which the document content was restored from a previous version. */
-  public restoredAt?: Date;
+  public restoredAt?: Date | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   public updatedAt: Date;
   /** The AI prompt rules that the content is associated with. */
-  public aiPromptRules?: AiPromptRules;
+  public aiPromptRules?: AiPromptRules | null;
   /** The document that the content is associated with. */
   public get document(): LinearFetch<Document> | undefined {
     return this._document?.id ? new DocumentQuery(this._request).fetch(this._document?.id) : undefined;
@@ -4396,9 +4396,9 @@ export class DocumentContentChildWebhookPayload {
   }
 
   /** The document this document content belongs to. */
-  public document?: DocumentChildWebhookPayload;
+  public document?: DocumentChildWebhookPayload | null;
   /** The project this document belongs to. */
-  public project?: ProjectChildWebhookPayload;
+  public project?: ProjectChildWebhookPayload | null;
 }
 /**
  * DocumentContentHistoryPayload model
@@ -4434,7 +4434,7 @@ export class DocumentContentHistoryType extends Request {
   }
 
   /** The ID of the author of the change. */
-  public actorIds?: string[];
+  public actorIds?: string[] | null;
   /** The date when the document content history snapshot was taken. This can be different than createdAt since the content is captured from its state at the previously known updatedAt timestamp in the case of an update. On document create, these timestamps can be the same. */
   public contentDataSnapshotAt: Date;
   /** The date when the document content history entry was created. */
@@ -4476,9 +4476,9 @@ export class DocumentNotification extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** Related comment ID. Null if the notification is not related to a comment. */
-  public commentId?: string;
+  public commentId?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Related document ID. */
@@ -4487,28 +4487,28 @@ export class DocumentNotification extends Request {
    * The time at when an email reminder for this notification was sent to the user. Null, if no email
    *     reminder has been sent.
    */
-  public emailedAt?: Date;
+  public emailedAt?: Date | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Related parent comment ID. Null if the notification is not related to a comment. */
-  public parentCommentId?: string;
+  public parentCommentId?: string | null;
   /** Name of the reaction emoji related to the notification. */
-  public reactionEmoji?: string;
+  public reactionEmoji?: string | null;
   /** The time at when the user marked the notification as read. Null, if the the user hasn't read the notification */
-  public readAt?: Date;
+  public readAt?: Date | null;
   /** The time until a notification will be snoozed. After that it will appear in the inbox again. */
-  public snoozedUntilAt?: Date;
+  public snoozedUntilAt?: Date | null;
   /** Notification type. */
   public type: string;
   /** The time at which a notification was unsnoozed.. */
-  public unsnoozedAt?: Date;
+  public unsnoozedAt?: Date | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   public updatedAt: Date;
   /** The bot that caused the notification. */
-  public botActor?: ActorBot;
+  public botActor?: ActorBot | null;
   /** The category of the notification. */
   public category: L.NotificationCategory;
   /** The user that caused the notification. */
@@ -4629,19 +4629,19 @@ export class DocumentSearchResult extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The color of the icon. */
-  public color?: string;
+  public color?: string | null;
   /** The documents content in markdown format. */
-  public content?: string;
+  public content?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The ID of the document content associated with the document. */
-  public documentContentId?: string;
+  public documentContentId?: string | null;
   /** The time at which the document was hidden. Null if the entity has not been hidden. */
-  public hiddenAt?: Date;
+  public hiddenAt?: Date | null;
   /** The icon of the document. */
-  public icon?: string;
+  public icon?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Metadata related to search result. */
@@ -4653,7 +4653,7 @@ export class DocumentSearchResult extends Request {
   /** The document title. */
   public title: string;
   /** A flag that indicates whether the document is in the trash bin. */
-  public trashed?: boolean;
+  public trashed?: boolean | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
@@ -4742,45 +4742,45 @@ export class DocumentWebhookPayload {
   }
 
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The color of the document. */
-  public color?: string;
+  public color?: string | null;
   /** The content of the document. */
-  public content?: string;
+  public content?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the user who created the document. */
-  public creatorId?: string;
+  public creatorId?: string | null;
   /** The description of the document. */
-  public description?: string;
+  public description?: string | null;
   /** The time at which the document was hidden. */
-  public hiddenAt?: string;
+  public hiddenAt?: string | null;
   /** The icon of the document. */
-  public icon?: string;
+  public icon?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The ID of the initiative this document belongs to. */
-  public initiativeId?: string;
+  public initiativeId?: string | null;
   /** The ID of the last template that was applied to this document. */
-  public lastAppliedTemplateId?: string;
+  public lastAppliedTemplateId?: string | null;
   /** The ID of the project this document belongs to. */
-  public projectId?: string;
+  public projectId?: string | null;
   /** The ID of the resource folder this document belongs to. */
-  public resourceFolderId?: string;
+  public resourceFolderId?: string | null;
   /** The document's unique URL slug. */
   public slugId: string;
   /** The order of the item in the resources list. */
   public sortOrder: number;
   /** The IDs of the users who are subscribed to this document. */
-  public subscriberIds?: string[];
+  public subscriberIds?: string[] | null;
   /** The title of the document. */
   public title: string;
   /** A flag that indicates whether the document is in the trash bin. */
-  public trashed?: boolean;
+  public trashed?: boolean | null;
   /** The time at which the entity was updated. */
   public updatedAt: string;
   /** The ID of the user who last updated the document. */
-  public updatedById?: string;
+  public updatedById?: string | null;
 }
 /**
  * A general purpose draft. Used for comments, project updates, etc.
@@ -4820,13 +4820,13 @@ export class Draft extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The text content as a Prosemirror document. */
   public bodyData: Record<string, unknown>;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Additional properties for the draft. */
-  public data?: L.Scalars["JSONObject"];
+  public data?: L.Scalars["JSONObject"] | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Whether the draft was autogenerated for the user. */
@@ -4976,7 +4976,7 @@ export class EmailIntakeAddress extends Request {
   /** Unique email address user name (before @) used for incoming email. */
   public address: string;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Whether issues created from that email address will be turned into customer requests. */
@@ -4984,25 +4984,25 @@ export class EmailIntakeAddress extends Request {
   /** Whether the email address is enabled. */
   public enabled: boolean;
   /** The email address used to forward emails to the intake address. */
-  public forwardingEmailAddress?: string;
+  public forwardingEmailAddress?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The auto-reply message for issue canceled. If not set, the default reply will be used. */
-  public issueCanceledAutoReply?: string;
+  public issueCanceledAutoReply?: string | null;
   /** Whether the auto-reply for issue canceled is enabled. */
   public issueCanceledAutoReplyEnabled: boolean;
   /** The auto-reply message for issue completed. If not set, the default reply will be used. */
-  public issueCompletedAutoReply?: string;
+  public issueCompletedAutoReply?: string | null;
   /** Whether the auto-reply for issue completed is enabled. */
   public issueCompletedAutoReplyEnabled: boolean;
   /** The auto-reply message for issue created. If not set, the default reply will be used. */
-  public issueCreatedAutoReply?: string;
+  public issueCreatedAutoReply?: string | null;
   /** Whether the auto-reply for issue created is enabled. */
   public issueCreatedAutoReplyEnabled: boolean;
   /** Whether email replies are enabled. */
   public repliesEnabled: boolean;
   /** The name to be used for outgoing emails. */
-  public senderName?: string;
+  public senderName?: string | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
@@ -5011,7 +5011,7 @@ export class EmailIntakeAddress extends Request {
   /** Whether the commenter's name is included in the email replies. */
   public useUserNamesInReplies: boolean;
   /** The SES domain identity that the email address is associated with. */
-  public sesDomainIdentity?: SesDomainIdentity;
+  public sesDomainIdentity?: SesDomainIdentity | null;
   /** The type of the email address. */
   public type: L.EmailIntakeAddressType;
   /** The user who created the email intake address. */
@@ -5140,7 +5140,7 @@ export class Emoji extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -5244,7 +5244,7 @@ export class Entity extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -5279,7 +5279,7 @@ export class EntityExternalLink extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -5401,9 +5401,9 @@ export class EntityWebhookPayload {
   /** The type of resource, i.e., the name of the entity. */
   public type: string;
   /** In case of an update event, previous values of all updated properties. */
-  public updatedFrom?: L.Scalars["JSONObject"];
+  public updatedFrom?: L.Scalars["JSONObject"] | null;
   /** URL for the entity. */
-  public url?: string;
+  public url?: string | null;
   /** The ID of the webhook that sent this event. */
   public webhookId: string;
   /** Unix timestamp in milliseconds when the webhook was sent. */
@@ -5428,7 +5428,7 @@ export class ExternalEntityInfo extends Request {
   /** The name of the service this entity is synced with. */
   public service: L.ExternalSyncService;
   /** Metadata about the external entity. */
-  public metadata?: L.ExternalEntityInfoMetadata;
+  public metadata?: L.ExternalEntityInfoMetadata | null;
 }
 /**
  * Metadata about the external GitHub entity.
@@ -5445,11 +5445,11 @@ export class ExternalEntityInfoGithubMetadata extends Request {
   }
 
   /** The number of the issue. */
-  public number?: number;
+  public number?: number | null;
   /** The owner of the repository. */
-  public owner?: string;
+  public owner?: string | null;
   /** The repository name. */
-  public repo?: string;
+  public repo?: string | null;
 }
 /**
  * Metadata about the external Jira entity.
@@ -5466,11 +5466,11 @@ export class ExternalEntityInfoJiraMetadata extends Request {
   }
 
   /** The key of the Jira issue. */
-  public issueKey?: string;
+  public issueKey?: string | null;
   /** The id of the Jira issue type. */
-  public issueTypeId?: string;
+  public issueTypeId?: string | null;
   /** The id of the Jira project. */
-  public projectId?: string;
+  public projectId?: string | null;
 }
 /**
  * Metadata about the external Slack entity.
@@ -5488,13 +5488,13 @@ export class ExternalEntitySlackMetadata extends Request {
   }
 
   /** The id of the Slack channel. */
-  public channelId?: string;
+  public channelId?: string | null;
   /** The name of the Slack channel. */
-  public channelName?: string;
+  public channelName?: string | null;
   /** Whether the entity originated from Slack (not Linear). */
   public isFromSlack: boolean;
   /** The URL of the Slack message. */
-  public messageUrl?: string;
+  public messageUrl?: string | null;
 }
 /**
  * An external authenticated (e.g., through Slack) user which doesn't have a Linear account, but can create and update entities in Linear from the external system that authenticated them.
@@ -5517,19 +5517,19 @@ export class ExternalUser extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** An URL to the external user's avatar image. */
-  public avatarUrl?: string;
+  public avatarUrl?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The external user's display name. Unique within each organization. Can match the display name of an actual user. */
   public displayName: string;
   /** The external user's email address. */
-  public email?: string;
+  public email?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The last time the external user was seen interacting with Linear. */
-  public lastSeen?: Date;
+  public lastSeen?: Date | null;
   /** The external user's full name. */
   public name: string;
   /**
@@ -5611,7 +5611,7 @@ export class Facet extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -5624,7 +5624,7 @@ export class Facet extends Request {
    */
   public updatedAt: Date;
   /** The owning page. */
-  public sourcePage?: L.FacetPageSource;
+  public sourcePage?: L.FacetPageSource | null;
   /** The owning feed user. */
   public get sourceFeedUser(): LinearFetch<User> | undefined {
     return this._sourceFeedUser?.id ? new UserQuery(this._request).fetch(this._sourceFeedUser?.id) : undefined;
@@ -5747,15 +5747,15 @@ export class Favorite extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The name of the folder. Only applies to favorites of type folder. */
-  public folderName?: string;
+  public folderName?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The type of favorited predefined view. */
-  public predefinedViewType?: string;
+  public predefinedViewType?: string | null;
   /** The order of the item in the favorites list. */
   public sortOrder: number;
   /** The type of the favorite. */
@@ -5766,11 +5766,11 @@ export class Favorite extends Request {
    */
   public updatedAt: Date;
   /** URL of the favorited entity. Folders return 'null' value. */
-  public url?: string;
+  public url?: string | null;
   /** The targeted tab of the initiative. */
-  public initiativeTab?: L.InitiativeTab;
+  public initiativeTab?: L.InitiativeTab | null;
   /** The targeted tab of the project. */
-  public projectTab?: L.ProjectTab;
+  public projectTab?: L.ProjectTab | null;
   /** The favorited custom view. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return this._customView?.id ? new CustomViewQuery(this._request).fetch(this._customView?.id) : undefined;
@@ -5966,11 +5966,11 @@ export class FetchDataPayload extends Request {
   }
 
   /** The fetched data based on the natural language query. */
-  public data?: L.Scalars["JSONObject"];
+  public data?: L.Scalars["JSONObject"] | null;
   /** The filters used to fetch the data. */
-  public filters?: L.Scalars["JSONObject"];
+  public filters?: L.Scalars["JSONObject"] | null;
   /** The GraphQL query used to fetch the data. */
-  public query?: string;
+  public query?: string | null;
   /** Whether the fetch operation was successful. */
   public success: boolean;
 }
@@ -6042,9 +6042,9 @@ export class GitAutomationState extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** [DEPRECATED] The target branch, if null, the automation will be triggered on any branch. */
-  public branchPattern?: string;
+  public branchPattern?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -6055,7 +6055,7 @@ export class GitAutomationState extends Request {
    */
   public updatedAt: Date;
   /** The target branch associated to this automation state. */
-  public targetBranch?: GitAutomationTargetBranch;
+  public targetBranch?: GitAutomationTargetBranch | null;
   /** The event that triggers the automation. */
   public event: L.GitAutomationStates;
   /** The associated workflow state. */
@@ -6151,7 +6151,7 @@ export class GitAutomationTargetBranch extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The target branch pattern. */
   public branchPattern: string;
   /** The time at which the entity was created. */
@@ -6368,7 +6368,7 @@ export class IdentityProvider extends Request {
   /** Whether users are allowed to change their name and display name even if SCIM is enabled. */
   public allowNameChange: boolean;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Whether the identity provider is the default identity provider migrated from organization level settings. */
@@ -6376,23 +6376,23 @@ export class IdentityProvider extends Request {
   /** The unique identifier of the entity. */
   public id: string;
   /** The issuer's custom entity ID. */
-  public issuerEntityId?: string;
+  public issuerEntityId?: string | null;
   /** The SAML priority used to pick default workspace in SAML SP initiated flow, when same domain is claimed for SAML by multiple workspaces. Lower priority value means higher preference. */
-  public priority?: number;
+  public priority?: number | null;
   /** Whether SAML authentication is enabled for organization. */
   public samlEnabled: boolean;
   /** Whether SCIM provisioning is enabled for organization. */
   public scimEnabled: boolean;
   /** The service provider (Linear) custom entity ID. Defaults to https://auth.linear.app/sso */
-  public spEntityId?: string;
+  public spEntityId?: string | null;
   /** Binding method for authentication call. Can be either `post` (default) or `redirect`. */
-  public ssoBinding?: string;
+  public ssoBinding?: string | null;
   /** Sign in endpoint URL for the identity provider. */
-  public ssoEndpoint?: string;
+  public ssoEndpoint?: string | null;
   /** The algorithm of the Signing Certificate. Can be one of `sha1`, `sha256` (default), or `sha512`. */
-  public ssoSignAlgo?: string;
+  public ssoSignAlgo?: string | null;
   /** X.509 Signing Certificate in string form. */
-  public ssoSigningCert?: string;
+  public ssoSigningCert?: string | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
@@ -6420,7 +6420,7 @@ export class ImageUploadFromUrlPayload extends Request {
   /** Whether the operation was successful. */
   public success: boolean;
   /** The URL containing the image. */
-  public url?: string;
+  public url?: string | null;
 }
 /**
  * An initiative to group projects.
@@ -6471,21 +6471,21 @@ export class Initiative extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The initiative's color. */
-  public color?: string;
+  public color?: string | null;
   /** The time at which the initiative was moved into completed status. */
-  public completedAt?: Date;
+  public completedAt?: Date | null;
   /** The initiative's content in markdown format. */
-  public content?: string;
+  public content?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The description of the initiative. */
-  public description?: string;
+  public description?: string | null;
   /** The time at which the initiative health was updated. */
-  public healthUpdatedAt?: Date;
+  public healthUpdatedAt?: Date | null;
   /** The icon of the initiative. */
-  public icon?: string;
+  public icon?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The name of the initiative. */
@@ -6495,17 +6495,17 @@ export class Initiative extends Request {
   /** The sort order of the initiative within the organization. */
   public sortOrder: number;
   /** The time at which the initiative was moved into active status. */
-  public startedAt?: Date;
+  public startedAt?: Date | null;
   /** The estimated completion date of the initiative. */
-  public targetDate?: L.Scalars["TimelessDate"];
+  public targetDate?: L.Scalars["TimelessDate"] | null;
   /** A flag that indicates whether the initiative is in the trash bin. */
-  public trashed?: boolean;
+  public trashed?: boolean | null;
   /** The frequency at which to prompt for updates. When not set, reminders are inherited from workspace. */
-  public updateReminderFrequency?: number;
+  public updateReminderFrequency?: number | null;
   /** The n-weekly frequency at which to prompt for updates. When not set, reminders are inherited from workspace. */
-  public updateReminderFrequencyInWeeks?: number;
+  public updateReminderFrequencyInWeeks?: number | null;
   /** The hour at which to prompt for updates. */
-  public updateRemindersHour?: number;
+  public updateRemindersHour?: number | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
@@ -6514,17 +6514,17 @@ export class Initiative extends Request {
   /** Initiative URL. */
   public url: string;
   /** The content of the initiative description. */
-  public documentContent?: DocumentContent;
+  public documentContent?: DocumentContent | null;
   /** The resolution of the reminder frequency. */
   public frequencyResolution: L.FrequencyResolutionType;
   /** The health of the initiative. */
-  public health?: L.InitiativeUpdateHealthType;
+  public health?: L.InitiativeUpdateHealthType | null;
   /** The status of the initiative. One of Planned, Active, Completed */
   public status: L.InitiativeStatus;
   /** The resolution of the initiative's estimated completion date. */
-  public targetDateResolution?: L.DateResolutionType;
+  public targetDateResolution?: L.DateResolutionType | null;
   /** The day at which to prompt for updates. */
-  public updateRemindersDay?: L.Day;
+  public updateRemindersDay?: L.Day | null;
   /** The user who created the initiative. */
   public get creator(): LinearFetch<User> | undefined {
     return this._creator?.id ? new UserQuery(this._request).fetch(this._creator?.id) : undefined;
@@ -6707,7 +6707,7 @@ export class InitiativeHistory extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The events that happened while recording that history. */
@@ -6794,41 +6794,41 @@ export class InitiativeNotification extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** Related comment ID. Null if the notification is not related to a comment. */
-  public commentId?: string;
+  public commentId?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /**
    * The time at when an email reminder for this notification was sent to the user. Null, if no email
    *     reminder has been sent.
    */
-  public emailedAt?: Date;
+  public emailedAt?: Date | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Related initiative ID. */
   public initiativeId: string;
   /** Related initiative update ID. */
-  public initiativeUpdateId?: string;
+  public initiativeUpdateId?: string | null;
   /** Related parent comment ID. Null if the notification is not related to a comment. */
-  public parentCommentId?: string;
+  public parentCommentId?: string | null;
   /** Name of the reaction emoji related to the notification. */
-  public reactionEmoji?: string;
+  public reactionEmoji?: string | null;
   /** The time at when the user marked the notification as read. Null, if the the user hasn't read the notification */
-  public readAt?: Date;
+  public readAt?: Date | null;
   /** The time until a notification will be snoozed. After that it will appear in the inbox again. */
-  public snoozedUntilAt?: Date;
+  public snoozedUntilAt?: Date | null;
   /** Notification type. */
   public type: string;
   /** The time at which a notification was unsnoozed.. */
-  public unsnoozedAt?: Date;
+  public unsnoozedAt?: Date | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   public updatedAt: Date;
   /** The bot that caused the notification. */
-  public botActor?: ActorBot;
+  public botActor?: ActorBot | null;
   /** The category of the notification. */
   public category: L.NotificationCategory;
   /** The user that caused the notification. */
@@ -6925,7 +6925,7 @@ export class InitiativeNotificationSubscription extends Request {
   /** Whether the subscription is active or not. */
   public active: boolean;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -6938,9 +6938,9 @@ export class InitiativeNotificationSubscription extends Request {
    */
   public updatedAt: Date;
   /** The type of view to which the notification subscription context is associated with. */
-  public contextViewType?: L.ContextViewType;
+  public contextViewType?: L.ContextViewType | null;
   /** The type of user view to which the notification subscription context is associated with. */
-  public userContextViewType?: L.UserContextViewType;
+  public userContextViewType?: L.UserContextViewType | null;
   /** The contextual custom view associated with the notification subscription. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return this._customView?.id ? new CustomViewQuery(this._request).fetch(this._customView?.id) : undefined;
@@ -7067,7 +7067,7 @@ export class InitiativeRelation extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -7181,7 +7181,7 @@ export class InitiativeToProject extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -7306,7 +7306,7 @@ export class InitiativeUpdate extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The update content in markdown format. */
   public body: string;
   /** Number of comments associated with the initiative update. */
@@ -7314,11 +7314,11 @@ export class InitiativeUpdate extends Request {
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The diff between the current update and the previous one. */
-  public diff?: L.Scalars["JSONObject"];
+  public diff?: L.Scalars["JSONObject"] | null;
   /** The diff between the current update and the previous one, formatted as markdown. */
-  public diffMarkdown?: string;
+  public diffMarkdown?: string | null;
   /** The time the update was edited. */
-  public editedAt?: Date;
+  public editedAt?: Date | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Whether initiative update diff should be hidden. */
@@ -7521,7 +7521,7 @@ export class InitiativeUpdateWebhookPayload {
   }
 
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The body of the initiative update. */
   public body: string;
   /** The body data of the initiative update. */
@@ -7543,7 +7543,7 @@ export class InitiativeUpdateWebhookPayload {
   /** The time at which the entity was updated. */
   public updatedAt: string;
   /** The URL of the initiative update. */
-  public url?: string;
+  public url?: string | null;
   /** The user id of the initiative update. */
   public userId: string;
   /** The initiative that the initiative update belongs to. */
@@ -7599,73 +7599,73 @@ export class InitiativeWebhookPayload {
   }
 
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The color of the initiative. */
-  public color?: string;
+  public color?: string | null;
   /** When the initiative was completed. */
-  public completedAt?: string;
+  public completedAt?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the user who created the initiative. */
-  public creatorId?: string;
+  public creatorId?: string | null;
   /** The description of the initiative. */
   public description: string;
   /** The resolution of the update reminder frequency. */
   public frequencyResolution: string;
   /** The health status of the initiative. */
-  public health?: string;
+  public health?: string | null;
   /** When the health status was last updated. */
-  public healthUpdatedAt?: string;
+  public healthUpdatedAt?: string | null;
   /** The icon of the initiative. */
-  public icon?: string;
+  public icon?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The ID of the last update for this initiative. */
-  public lastUpdateId?: string;
+  public lastUpdateId?: string | null;
   /** The name of the initiative. */
   public name: string;
   /** The ID of the organization this initiative belongs to. */
   public organizationId: string;
   /** The ID of the user who owns the initiative. */
-  public ownerId?: string;
+  public ownerId?: string | null;
   /** The unique slug identifier of the initiative. */
   public slugId: string;
   /** The sort order of the initiative within the organization. */
   public sortOrder: number;
   /** When the initiative was started. */
-  public startedAt?: string;
+  public startedAt?: string | null;
   /** The current status of the initiative. */
   public status: string;
   /** The target date of the initiative. */
-  public targetDate?: string;
+  public targetDate?: string | null;
   /** The resolution of the target date. */
-  public targetDateResolution?: string;
+  public targetDateResolution?: string | null;
   /** Whether the initiative is trashed. */
-  public trashed?: boolean;
+  public trashed?: boolean | null;
   /** The frequency of update reminders. */
-  public updateReminderFrequency?: number;
+  public updateReminderFrequency?: number | null;
   /** The frequency of update reminders in weeks. */
-  public updateReminderFrequencyInWeeks?: number;
+  public updateReminderFrequencyInWeeks?: number | null;
   /** The day of the week for update reminders. */
-  public updateRemindersDay?: number;
+  public updateRemindersDay?: number | null;
   /** The hour of the day for update reminders. */
-  public updateRemindersHour?: number;
+  public updateRemindersHour?: number | null;
   /** The time at which the entity was updated. */
   public updatedAt: string;
   /** The URL of the initiative. */
   public url: string;
   /** The projects associated with the initiative. */
-  public projects?: ProjectChildWebhookPayload[];
+  public projects?: ProjectChildWebhookPayload[] | null;
   /** The sub-initiatives associated with the initiative. */
-  public subInitiatives?: InitiativeChildWebhookPayload[];
+  public subInitiatives?: InitiativeChildWebhookPayload[] | null;
   /** The user who created the initiative. */
-  public creator?: UserChildWebhookPayload;
+  public creator?: UserChildWebhookPayload | null;
   /** The last update for this initiative. */
-  public lastUpdate?: InitiativeUpdateChildWebhookPayload;
+  public lastUpdate?: InitiativeUpdateChildWebhookPayload | null;
   /** The user who owns the initiative. */
-  public owner?: UserChildWebhookPayload;
+  public owner?: UserChildWebhookPayload | null;
   /** The parent initiative associated with the initiative. */
-  public parentInitiative?: InitiativeChildWebhookPayload;
+  public parentInitiative?: InitiativeChildWebhookPayload | null;
 }
 /**
  * An integration with an external service.
@@ -7689,7 +7689,7 @@ export class Integration extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -7803,7 +7803,7 @@ export class IntegrationHasScopesPayload extends Request {
   /** Whether the integration has the required scopes. */
   public hasAllScopes: boolean;
   /** The missing scopes. */
-  public missingScopes?: string[];
+  public missingScopes?: string[] | null;
 }
 /**
  * IntegrationPayload model
@@ -7889,11 +7889,11 @@ export class IntegrationTemplate extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** ID of the foreign entity in the external integration this template is for, e.g., Slack channel ID. */
-  public foreignEntityId?: string;
+  public foreignEntityId?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /**
@@ -8013,42 +8013,42 @@ export class IntegrationsSettings extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
   public id: string;
   /** Whether to send a Slack message when a initiate update is created. */
-  public slackInitiativeUpdateCreated?: boolean;
+  public slackInitiativeUpdateCreated?: boolean | null;
   /** Whether to send a Slack message when a new issue is added to triage. */
-  public slackIssueAddedToTriage?: boolean;
+  public slackIssueAddedToTriage?: boolean | null;
   /** Whether to send a Slack message when an issue is added to the custom view. */
-  public slackIssueAddedToView?: boolean;
+  public slackIssueAddedToView?: boolean | null;
   /** Whether to send a Slack message when a new issue is created for the project or the team. */
-  public slackIssueCreated?: boolean;
+  public slackIssueCreated?: boolean | null;
   /** Whether to send a Slack message when a comment is created on any of the project or team's issues. */
-  public slackIssueNewComment?: boolean;
+  public slackIssueNewComment?: boolean | null;
   /** Whether to send a Slack message when an SLA is breached. */
-  public slackIssueSlaBreached?: boolean;
+  public slackIssueSlaBreached?: boolean | null;
   /** Whether to send a Slack message when an SLA is at high risk. */
-  public slackIssueSlaHighRisk?: boolean;
+  public slackIssueSlaHighRisk?: boolean | null;
   /** Whether to send a Slack message when any of the project or team's issues has a change in status. */
-  public slackIssueStatusChangedAll?: boolean;
+  public slackIssueStatusChangedAll?: boolean | null;
   /** Whether to send a Slack message when any of the project or team's issues change to completed or cancelled. */
-  public slackIssueStatusChangedDone?: boolean;
+  public slackIssueStatusChangedDone?: boolean | null;
   /** Whether to send a Slack message when a project update is created. */
-  public slackProjectUpdateCreated?: boolean;
+  public slackProjectUpdateCreated?: boolean | null;
   /** Whether to send a new project update to team Slack channels. */
-  public slackProjectUpdateCreatedToTeam?: boolean;
+  public slackProjectUpdateCreatedToTeam?: boolean | null;
   /** Whether to send a new project update to workspace Slack channel. */
-  public slackProjectUpdateCreatedToWorkspace?: boolean;
+  public slackProjectUpdateCreatedToWorkspace?: boolean | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   public updatedAt: Date;
   /** The type of view to which the integration settings context is associated with. */
-  public contextViewType?: L.ContextViewType;
+  public contextViewType?: L.ContextViewType | null;
   /** Initiative which those settings apply to. */
   public get initiative(): LinearFetch<Initiative> | undefined {
     return this._initiative?.id ? new InitiativeQuery(this._request).fetch(this._initiative?.id) : undefined;
@@ -8202,35 +8202,35 @@ export class Issue extends Request {
   }
 
   /** The time at which the issue was added to a cycle. */
-  public addedToCycleAt?: Date;
+  public addedToCycleAt?: Date | null;
   /** The time at which the issue was added to a project. */
-  public addedToProjectAt?: Date;
+  public addedToProjectAt?: Date | null;
   /** The time at which the issue was added to a team. */
-  public addedToTeamAt?: Date;
+  public addedToTeamAt?: Date | null;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the issue was automatically archived by the auto pruning process. */
-  public autoArchivedAt?: Date;
+  public autoArchivedAt?: Date | null;
   /** The time at which the issue was automatically closed by the auto pruning process. */
-  public autoClosedAt?: Date;
+  public autoClosedAt?: Date | null;
   /** The order of the item in its column on the board. */
   public boardOrder: number;
   /** Suggested branch name for the issue. */
   public branchName: string;
   /** The time at which the issue was moved into canceled state. */
-  public canceledAt?: Date;
+  public canceledAt?: Date | null;
   /** The time at which the issue was moved into completed state. */
-  public completedAt?: Date;
+  public completedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Returns the number of Attachment resources which are created by customer support ticketing systems (e.g. Zendesk). */
   public customerTicketCount: number;
   /** The issue's description in markdown format. */
-  public description?: string;
+  public description?: string | null;
   /** The date at which the issue is due. */
-  public dueDate?: L.Scalars["TimelessDate"];
+  public dueDate?: L.Scalars["TimelessDate"] | null;
   /** The estimate of the complexity of the issue.. */
-  public estimate?: number;
+  public estimate?: number | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Issue's human readable identifier (e.g. ENG-123). */
@@ -8250,31 +8250,31 @@ export class Issue extends Request {
   /** Emoji reaction summary, grouped by emoji type. */
   public reactionData: L.Scalars["JSONObject"];
   /** The time at which the issue's SLA will breach. */
-  public slaBreachesAt?: Date;
+  public slaBreachesAt?: Date | null;
   /** The time at which the issue's SLA will enter high risk state. */
-  public slaHighRiskAt?: Date;
+  public slaHighRiskAt?: Date | null;
   /** The time at which the issue's SLA will enter medium risk state. */
-  public slaMediumRiskAt?: Date;
+  public slaMediumRiskAt?: Date | null;
   /** The time at which the issue's SLA began. */
-  public slaStartedAt?: Date;
+  public slaStartedAt?: Date | null;
   /** The type of SLA set on the issue. Calendar days or business days. */
-  public slaType?: string;
+  public slaType?: string | null;
   /** The time until an issue will be snoozed in Triage view. */
-  public snoozedUntilAt?: Date;
+  public snoozedUntilAt?: Date | null;
   /** The order of the item in relation to other items in the organization. */
   public sortOrder: number;
   /** The time at which the issue was moved into started state. */
-  public startedAt?: Date;
+  public startedAt?: Date | null;
   /** The time at which the issue entered triage. */
-  public startedTriageAt?: Date;
+  public startedTriageAt?: Date | null;
   /** The order of the item in the sub-issue list. Only set if the issue has a parent. */
-  public subIssueSortOrder?: number;
+  public subIssueSortOrder?: number | null;
   /** The issue's title. */
   public title: string;
   /** A flag that indicates whether the issue is in the trash bin. */
-  public trashed?: boolean;
+  public trashed?: boolean | null;
   /** The time at which the issue left triage. */
-  public triagedAt?: Date;
+  public triagedAt?: Date | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
@@ -8285,11 +8285,11 @@ export class Issue extends Request {
   /** Reactions associated with the issue. */
   public reactions: Reaction[];
   /** The external services the issue is synced with. */
-  public syncedWith?: ExternalEntityInfo[];
+  public syncedWith?: ExternalEntityInfo[] | null;
   /** The bot that created the issue, if applicable. */
-  public botActor?: ActorBot;
+  public botActor?: ActorBot | null;
   /** Integration type that created this issue, if applicable. */
-  public integrationSourceType?: L.IntegrationService;
+  public integrationSourceType?: L.IntegrationService | null;
   /** The external user who requested creation of the Asks issue on behalf of the creator. */
   public get asksExternalUserRequester(): LinearFetch<ExternalUser> | undefined {
     return this._asksExternalUserRequester?.id
@@ -8555,13 +8555,13 @@ export class IssueAssignedToYouNotificationWebhookPayload {
   }
 
   /** The ID of the actor who caused the notification. */
-  public actorId?: string;
+  public actorId?: string | null;
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the external user who caused the notification. */
-  public externalUserActorId?: string;
+  public externalUserActorId?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The ID of the issue this notification belongs to. */
@@ -8573,7 +8573,7 @@ export class IssueAssignedToYouNotificationWebhookPayload {
   /** The ID of the user who received the notification. */
   public userId: string;
   /** The actor who caused the notification. */
-  public actor?: UserChildWebhookPayload;
+  public actor?: UserChildWebhookPayload | null;
   /** The issue this notification belongs to. */
   public issue: IssueWithDescriptionChildWebhookPayload;
 }
@@ -8651,21 +8651,21 @@ export class IssueCommentMentionNotificationWebhookPayload {
   }
 
   /** The ID of the actor who caused the notification. */
-  public actorId?: string;
+  public actorId?: string | null;
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The ID of the comment this notification belongs to. */
   public commentId: string;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the external user who caused the notification. */
-  public externalUserActorId?: string;
+  public externalUserActorId?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The ID of the issue this notification belongs to. */
   public issueId: string;
   /** The ID of the parent comment for the comment this notification belongs to. */
-  public parentCommentId?: string;
+  public parentCommentId?: string | null;
   /** An issue comment mention notification type. */
   public type: "issueCommentMention";
   /** The time at which the entity was updated. */
@@ -8673,13 +8673,13 @@ export class IssueCommentMentionNotificationWebhookPayload {
   /** The ID of the user who received the notification. */
   public userId: string;
   /** The actor who caused the notification. */
-  public actor?: UserChildWebhookPayload;
+  public actor?: UserChildWebhookPayload | null;
   /** The comment this notification belongs to. */
   public comment: CommentChildWebhookPayload;
   /** The issue this notification belongs to. */
   public issue: IssueWithDescriptionChildWebhookPayload;
   /** The parent comment for the comment this notification belongs to. */
-  public parentComment?: CommentChildWebhookPayload;
+  public parentComment?: CommentChildWebhookPayload | null;
 }
 /**
  * Payload for an issue comment reaction notification.
@@ -8707,21 +8707,21 @@ export class IssueCommentReactionNotificationWebhookPayload {
   }
 
   /** The ID of the actor who caused the notification. */
-  public actorId?: string;
+  public actorId?: string | null;
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The ID of the comment this notification belongs to. */
   public commentId: string;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the external user who caused the notification. */
-  public externalUserActorId?: string;
+  public externalUserActorId?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The ID of the issue this notification belongs to. */
   public issueId: string;
   /** The ID of the parent comment for the comment this notification belongs to. */
-  public parentCommentId?: string;
+  public parentCommentId?: string | null;
   /** The emoji of the reaction this notification is for. */
   public reactionEmoji: string;
   /** An issue comment reaction notification type. */
@@ -8731,13 +8731,13 @@ export class IssueCommentReactionNotificationWebhookPayload {
   /** The ID of the user who received the notification. */
   public userId: string;
   /** The actor who caused the notification. */
-  public actor?: UserChildWebhookPayload;
+  public actor?: UserChildWebhookPayload | null;
   /** The comment this notification belongs to. */
   public comment: CommentChildWebhookPayload;
   /** The issue this notification belongs to. */
   public issue: IssueWithDescriptionChildWebhookPayload;
   /** The parent comment for the comment this notification belongs to. */
-  public parentComment?: CommentChildWebhookPayload;
+  public parentComment?: CommentChildWebhookPayload | null;
 }
 /**
  * IssueConnection model
@@ -8782,13 +8782,13 @@ export class IssueEmojiReactionNotificationWebhookPayload {
   }
 
   /** The ID of the actor who caused the notification. */
-  public actorId?: string;
+  public actorId?: string | null;
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the external user who caused the notification. */
-  public externalUserActorId?: string;
+  public externalUserActorId?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The ID of the issue this notification belongs to. */
@@ -8802,7 +8802,7 @@ export class IssueEmojiReactionNotificationWebhookPayload {
   /** The ID of the user who received the notification. */
   public userId: string;
   /** The actor who caused the notification. */
-  public actor?: UserChildWebhookPayload;
+  public actor?: UserChildWebhookPayload | null;
   /** The issue this notification belongs to. */
   public issue: IssueWithDescriptionChildWebhookPayload;
 }
@@ -8820,9 +8820,9 @@ export class IssueFilterSuggestionPayload extends Request {
   }
 
   /** The json filter that is suggested. */
-  public filter?: L.Scalars["JSONObject"];
+  public filter?: L.Scalars["JSONObject"] | null;
   /** The log id of the prompt, that created this filter. */
-  public logId?: string;
+  public logId?: string | null;
 }
 /**
  * A record of changes to an issue.
@@ -8923,96 +8923,96 @@ export class IssueHistory extends Request {
   }
 
   /** The id of user who made these changes. If null, possibly means that the change made by an integration. */
-  public actorId?: string;
+  public actorId?: string | null;
   /** ID's of labels that were added. */
-  public addedLabelIds?: string[];
+  public addedLabelIds?: string[] | null;
   /** Whether the issue is archived at the time of this history entry. */
-  public archived?: boolean;
+  public archived?: boolean | null;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The id of linked attachment. */
-  public attachmentId?: string;
+  public attachmentId?: string | null;
   /** Whether the issue was auto-archived. */
-  public autoArchived?: boolean;
+  public autoArchived?: boolean | null;
   /** Whether the issue was auto-closed. */
-  public autoClosed?: boolean;
+  public autoClosed?: boolean | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The id of linked customer need. */
-  public customerNeedId?: string;
+  public customerNeedId?: string | null;
   /** The id of user from whom the issue was re-assigned from. */
-  public fromAssigneeId?: string;
+  public fromAssigneeId?: string | null;
   /** The id of previous cycle of the issue. */
-  public fromCycleId?: string;
+  public fromCycleId?: string | null;
   /** What the due date was changed from. */
-  public fromDueDate?: L.Scalars["TimelessDate"];
+  public fromDueDate?: L.Scalars["TimelessDate"] | null;
   /** What the estimate was changed from. */
-  public fromEstimate?: number;
+  public fromEstimate?: number | null;
   /** The id of previous parent of the issue. */
-  public fromParentId?: string;
+  public fromParentId?: string | null;
   /** What the priority was changed from. */
-  public fromPriority?: number;
+  public fromPriority?: number | null;
   /** The id of previous project of the issue. */
-  public fromProjectId?: string;
+  public fromProjectId?: string | null;
   /** The id of previous workflow state of the issue. */
-  public fromStateId?: string;
+  public fromStateId?: string | null;
   /** The id of team from which the issue was moved from. */
-  public fromTeamId?: string;
+  public fromTeamId?: string | null;
   /** What the title was changed from. */
-  public fromTitle?: string;
+  public fromTitle?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** ID's of labels that were removed. */
-  public removedLabelIds?: string[];
+  public removedLabelIds?: string[] | null;
   /** The id of user to whom the issue was assigned to. */
-  public toAssigneeId?: string;
+  public toAssigneeId?: string | null;
   /** The id of new project created from the issue. */
-  public toConvertedProjectId?: string;
+  public toConvertedProjectId?: string | null;
   /** The id of new cycle of the issue. */
-  public toCycleId?: string;
+  public toCycleId?: string | null;
   /** What the due date was changed to. */
-  public toDueDate?: L.Scalars["TimelessDate"];
+  public toDueDate?: L.Scalars["TimelessDate"] | null;
   /** What the estimate was changed to. */
-  public toEstimate?: number;
+  public toEstimate?: number | null;
   /** The id of new parent of the issue. */
-  public toParentId?: string;
+  public toParentId?: string | null;
   /** What the priority was changed to. */
-  public toPriority?: number;
+  public toPriority?: number | null;
   /** The id of new project of the issue. */
-  public toProjectId?: string;
+  public toProjectId?: string | null;
   /** The id of new workflow state of the issue. */
-  public toStateId?: string;
+  public toStateId?: string | null;
   /** The id of team to which the issue was moved to. */
-  public toTeamId?: string;
+  public toTeamId?: string | null;
   /** What the title was changed to. */
-  public toTitle?: string;
+  public toTitle?: string | null;
   /** Whether the issue was trashed or un-trashed. */
-  public trashed?: boolean;
+  public trashed?: boolean | null;
   /** Boolean indicating if the issue was auto-assigned using the triage responsibility feature. */
-  public triageResponsibilityAutoAssigned?: boolean;
+  public triageResponsibilityAutoAssigned?: boolean | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   public updatedAt: Date;
   /** Whether the issue's description was updated. */
-  public updatedDescription?: boolean;
+  public updatedDescription?: boolean | null;
   /** The actors that performed the actions. This field may be empty in the case of integrations or automations. */
-  public actors?: User[];
+  public actors?: User[] | null;
   /** The labels that were added to the issue. */
-  public addedLabels?: IssueLabel[];
+  public addedLabels?: IssueLabel[] | null;
   /** The actors that edited the description of the issue, if any. */
-  public descriptionUpdatedBy?: User[];
+  public descriptionUpdatedBy?: User[] | null;
   /** Changed issue relationships. */
-  public relationChanges?: IssueRelationHistoryPayload[];
+  public relationChanges?: IssueRelationHistoryPayload[] | null;
   /** The labels that were removed from the issue. */
-  public removedLabels?: IssueLabel[];
+  public removedLabels?: IssueLabel[] | null;
   /** The users that were notified of the issue. */
-  public triageResponsibilityNotifiedUsers?: User[];
+  public triageResponsibilityNotifiedUsers?: User[] | null;
   /** The bot that performed the action. */
-  public botActor?: ActorBot;
+  public botActor?: ActorBot | null;
   /** The import record. */
-  public issueImport?: IssueImport;
+  public issueImport?: IssueImport | null;
   /** The actor that performed the actions. This field may be empty in the case of integrations or automations. */
   public get actor(): LinearFetch<User> | undefined {
     return this._actor?.id ? new UserQuery(this._request).fetch(this._actor?.id) : undefined;
@@ -9148,33 +9148,33 @@ export class IssueImport extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The id for the user that started the job. */
-  public creatorId?: string;
+  public creatorId?: string | null;
   /** File URL for the uploaded CSV for the import, if there is one. */
-  public csvFileUrl?: string;
+  public csvFileUrl?: string | null;
   /** The display name of the import service. */
   public displayName: string;
   /** User readable error message, if one has occurred during the import. */
-  public error?: string;
+  public error?: string | null;
   /** Error code and metadata, if one has occurred during the import. */
-  public errorMetadata?: L.Scalars["JSONObject"];
+  public errorMetadata?: L.Scalars["JSONObject"] | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The data mapping configuration for the import job. */
-  public mapping?: L.Scalars["JSONObject"];
+  public mapping?: L.Scalars["JSONObject"] | null;
   /** Current step progress in % (0-100). */
-  public progress?: number;
+  public progress?: number | null;
   /** The service from which data will be imported. */
   public service: string;
   /** Metadata related to import service. */
-  public serviceMetadata?: L.Scalars["JSONObject"];
+  public serviceMetadata?: L.Scalars["JSONObject"] | null;
   /** The status for the import job. */
   public status: string;
   /** New team's name in cases when teamId not set. */
-  public teamName?: string;
+  public teamName?: string | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
@@ -9224,7 +9224,7 @@ export class IssueImportDeletePayload extends Request {
   /** Whether the operation was successful. */
   public success: boolean;
   /** The import job that was deleted. */
-  public issueImport?: IssueImport;
+  public issueImport?: IssueImport | null;
 }
 /**
  * Whether a custom JQL query is valid or not
@@ -9241,9 +9241,9 @@ export class IssueImportJqlCheckPayload extends Request {
   }
 
   /** Returns an approximate number of issues matching the JQL query, if available */
-  public count?: number;
+  public count?: number | null;
   /** An error message returned by Jira when validating the JQL query. */
-  public error?: string;
+  public error?: string | null;
   /** Returns true if the JQL query has been validated successfully, false otherwise */
   public success: boolean;
 }
@@ -9266,7 +9266,7 @@ export class IssueImportPayload extends Request {
   /** Whether the operation was successful. */
   public success: boolean;
   /** The import job that was created or updated. */
-  public issueImport?: IssueImport;
+  public issueImport?: IssueImport | null;
 }
 /**
  * Whether an issue import can be synced at the end of an import or not
@@ -9284,7 +9284,7 @@ export class IssueImportSyncCheckPayload extends Request {
   /** Returns true if the import can be synced, false otherwise */
   public canSync: boolean;
   /** An error message with a root cause of why the import cannot be synced */
-  public error?: string;
+  public error?: string | null;
 }
 /**
  * Labels that can be associated with issues.
@@ -9318,19 +9318,19 @@ export class IssueLabel extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The label's color as a HEX string. */
   public color: string;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The label's description. */
-  public description?: string;
+  public description?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Whether the label is a group. */
   public isGroup: boolean;
   /** The date when the label was last applied to an issue or project. */
-  public lastAppliedAt?: Date;
+  public lastAppliedAt?: Date | null;
   /** The label's name. */
   public name: string;
   /**
@@ -9422,7 +9422,7 @@ export class IssueLabelChildWebhookPayload {
   /** The name of the issue label. */
   public name: string;
   /** The parent ID of the issue label. */
-  public parentId?: string;
+  public parentId?: string | null;
 }
 /**
  * IssueLabelConnection model
@@ -9496,27 +9496,27 @@ export class IssueLabelWebhookPayload {
   }
 
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The color of the issue label. */
   public color: string;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The creator ID of the issue label. */
-  public creatorId?: string;
+  public creatorId?: string | null;
   /** The label's description. */
-  public description?: string;
+  public description?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The original label inherited from. */
-  public inheritedFromId?: string;
+  public inheritedFromId?: string | null;
   /** Whether the label is a group. */
   public isGroup: boolean;
   /** The name of the issue label. */
   public name: string;
   /** The parent ID of the issue label. */
-  public parentId?: string;
+  public parentId?: string | null;
   /** The team ID of the issue label. */
-  public teamId?: string;
+  public teamId?: string | null;
   /** The time at which the entity was updated. */
   public updatedAt: string;
 }
@@ -9541,13 +9541,13 @@ export class IssueMentionNotificationWebhookPayload {
   }
 
   /** The ID of the actor who caused the notification. */
-  public actorId?: string;
+  public actorId?: string | null;
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the external user who caused the notification. */
-  public externalUserActorId?: string;
+  public externalUserActorId?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The ID of the issue this notification belongs to. */
@@ -9559,7 +9559,7 @@ export class IssueMentionNotificationWebhookPayload {
   /** The ID of the user who received the notification. */
   public userId: string;
   /** The actor who caused the notification. */
-  public actor?: UserChildWebhookPayload;
+  public actor?: UserChildWebhookPayload | null;
   /** The issue this notification belongs to. */
   public issue: IssueWithDescriptionChildWebhookPayload;
 }
@@ -9588,21 +9588,21 @@ export class IssueNewCommentNotificationWebhookPayload {
   }
 
   /** The ID of the actor who caused the notification. */
-  public actorId?: string;
+  public actorId?: string | null;
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The ID of the comment this notification belongs to. */
   public commentId: string;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the external user who caused the notification. */
-  public externalUserActorId?: string;
+  public externalUserActorId?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The ID of the issue this notification belongs to. */
   public issueId: string;
   /** The ID of the parent comment for the comment this notification belongs to. */
-  public parentCommentId?: string;
+  public parentCommentId?: string | null;
   /** An issue new comment notification type. */
   public type: "issueNewComment";
   /** The time at which the entity was updated. */
@@ -9610,13 +9610,13 @@ export class IssueNewCommentNotificationWebhookPayload {
   /** The ID of the user who received the notification. */
   public userId: string;
   /** The actor who caused the notification. */
-  public actor?: UserChildWebhookPayload;
+  public actor?: UserChildWebhookPayload | null;
   /** The comment this notification belongs to. */
   public comment: CommentChildWebhookPayload;
   /** The issue this notification belongs to. */
   public issue: IssueWithDescriptionChildWebhookPayload;
   /** The parent comment for the comment this notification belongs to. */
-  public parentComment?: CommentChildWebhookPayload;
+  public parentComment?: CommentChildWebhookPayload | null;
 }
 /**
  * An issue related notification.
@@ -9663,41 +9663,41 @@ export class IssueNotification extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** Related comment ID. Null if the notification is not related to a comment. */
-  public commentId?: string;
+  public commentId?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /**
    * The time at when an email reminder for this notification was sent to the user. Null, if no email
    *     reminder has been sent.
    */
-  public emailedAt?: Date;
+  public emailedAt?: Date | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Related issue ID. */
   public issueId: string;
   /** Related parent comment ID. Null if the notification is not related to a comment. */
-  public parentCommentId?: string;
+  public parentCommentId?: string | null;
   /** Name of the reaction emoji related to the notification. */
-  public reactionEmoji?: string;
+  public reactionEmoji?: string | null;
   /** The time at when the user marked the notification as read. Null, if the the user hasn't read the notification */
-  public readAt?: Date;
+  public readAt?: Date | null;
   /** The time until a notification will be snoozed. After that it will appear in the inbox again. */
-  public snoozedUntilAt?: Date;
+  public snoozedUntilAt?: Date | null;
   /** Notification type. */
   public type: string;
   /** The time at which a notification was unsnoozed.. */
-  public unsnoozedAt?: Date;
+  public unsnoozedAt?: Date | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   public updatedAt: Date;
   /** The subscriptions related to the notification. */
-  public subscriptions?: NotificationSubscription[];
+  public subscriptions?: NotificationSubscription[] | null;
   /** The bot that caused the notification. */
-  public botActor?: ActorBot;
+  public botActor?: ActorBot | null;
   /** The category of the notification. */
   public category: L.NotificationCategory;
   /** The user that caused the notification. */
@@ -9816,7 +9816,7 @@ export class IssueRelation extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -10039,35 +10039,35 @@ export class IssueSearchResult extends Request {
   }
 
   /** The time at which the issue was added to a cycle. */
-  public addedToCycleAt?: Date;
+  public addedToCycleAt?: Date | null;
   /** The time at which the issue was added to a project. */
-  public addedToProjectAt?: Date;
+  public addedToProjectAt?: Date | null;
   /** The time at which the issue was added to a team. */
-  public addedToTeamAt?: Date;
+  public addedToTeamAt?: Date | null;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the issue was automatically archived by the auto pruning process. */
-  public autoArchivedAt?: Date;
+  public autoArchivedAt?: Date | null;
   /** The time at which the issue was automatically closed by the auto pruning process. */
-  public autoClosedAt?: Date;
+  public autoClosedAt?: Date | null;
   /** The order of the item in its column on the board. */
   public boardOrder: number;
   /** Suggested branch name for the issue. */
   public branchName: string;
   /** The time at which the issue was moved into canceled state. */
-  public canceledAt?: Date;
+  public canceledAt?: Date | null;
   /** The time at which the issue was moved into completed state. */
-  public completedAt?: Date;
+  public completedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Returns the number of Attachment resources which are created by customer support ticketing systems (e.g. Zendesk). */
   public customerTicketCount: number;
   /** The issue's description in markdown format. */
-  public description?: string;
+  public description?: string | null;
   /** The date at which the issue is due. */
-  public dueDate?: L.Scalars["TimelessDate"];
+  public dueDate?: L.Scalars["TimelessDate"] | null;
   /** The estimate of the complexity of the issue.. */
-  public estimate?: number;
+  public estimate?: number | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Issue's human readable identifier (e.g. ENG-123). */
@@ -10089,31 +10089,31 @@ export class IssueSearchResult extends Request {
   /** Emoji reaction summary, grouped by emoji type. */
   public reactionData: L.Scalars["JSONObject"];
   /** The time at which the issue's SLA will breach. */
-  public slaBreachesAt?: Date;
+  public slaBreachesAt?: Date | null;
   /** The time at which the issue's SLA will enter high risk state. */
-  public slaHighRiskAt?: Date;
+  public slaHighRiskAt?: Date | null;
   /** The time at which the issue's SLA will enter medium risk state. */
-  public slaMediumRiskAt?: Date;
+  public slaMediumRiskAt?: Date | null;
   /** The time at which the issue's SLA began. */
-  public slaStartedAt?: Date;
+  public slaStartedAt?: Date | null;
   /** The type of SLA set on the issue. Calendar days or business days. */
-  public slaType?: string;
+  public slaType?: string | null;
   /** The time until an issue will be snoozed in Triage view. */
-  public snoozedUntilAt?: Date;
+  public snoozedUntilAt?: Date | null;
   /** The order of the item in relation to other items in the organization. */
   public sortOrder: number;
   /** The time at which the issue was moved into started state. */
-  public startedAt?: Date;
+  public startedAt?: Date | null;
   /** The time at which the issue entered triage. */
-  public startedTriageAt?: Date;
+  public startedTriageAt?: Date | null;
   /** The order of the item in the sub-issue list. Only set if the issue has a parent. */
-  public subIssueSortOrder?: number;
+  public subIssueSortOrder?: number | null;
   /** The issue's title. */
   public title: string;
   /** A flag that indicates whether the issue is in the trash bin. */
-  public trashed?: boolean;
+  public trashed?: boolean | null;
   /** The time at which the issue left triage. */
-  public triagedAt?: Date;
+  public triagedAt?: Date | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
@@ -10124,11 +10124,11 @@ export class IssueSearchResult extends Request {
   /** Reactions associated with the issue. */
   public reactions: Reaction[];
   /** The external services the issue is synced with. */
-  public syncedWith?: ExternalEntityInfo[];
+  public syncedWith?: ExternalEntityInfo[] | null;
   /** The bot that created the issue, if applicable. */
-  public botActor?: ActorBot;
+  public botActor?: ActorBot | null;
   /** Integration type that created this issue, if applicable. */
-  public integrationSourceType?: L.IntegrationService;
+  public integrationSourceType?: L.IntegrationService | null;
   /** The external user who requested creation of the Asks issue on behalf of the creator. */
   public get asksExternalUserRequester(): LinearFetch<ExternalUser> | undefined {
     return this._asksExternalUserRequester?.id
@@ -10302,7 +10302,7 @@ export class IssueSlaWebhookPayload {
   /** The type of resource. */
   public type: string;
   /** URL for the issue. */
-  public url?: string;
+  public url?: string | null;
   /** The ID of the webhook that sent this event. */
   public webhookId: string;
   /** Unix timestamp in milliseconds when the webhook was sent. */
@@ -10329,7 +10329,7 @@ export class IssueStateSpan extends Request {
   }
 
   /** The timestamp when the issue left this state. Null if the issue is currently in this state. */
-  public endedAt?: Date;
+  public endedAt?: Date | null;
   /** The unique identifier of the state span. */
   public id: string;
   /** The timestamp when the issue entered this state. */
@@ -10383,13 +10383,13 @@ export class IssueStatusChangedNotificationWebhookPayload {
   }
 
   /** The ID of the actor who caused the notification. */
-  public actorId?: string;
+  public actorId?: string | null;
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the external user who caused the notification. */
-  public externalUserActorId?: string;
+  public externalUserActorId?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The ID of the issue this notification belongs to. */
@@ -10401,7 +10401,7 @@ export class IssueStatusChangedNotificationWebhookPayload {
   /** The ID of the user who received the notification. */
   public userId: string;
   /** The actor who caused the notification. */
-  public actor?: UserChildWebhookPayload;
+  public actor?: UserChildWebhookPayload | null;
   /** The issue this notification belongs to. */
   public issue: IssueWithDescriptionChildWebhookPayload;
 }
@@ -10443,23 +10443,23 @@ export class IssueSuggestion extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
-  public dismissalReason?: string;
+  public dismissalReason?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   public issueId: string;
   public stateChangedAt: Date;
-  public suggestedIssueId?: string;
-  public suggestedLabelId?: string;
-  public suggestedUserId?: string;
+  public suggestedIssueId?: string | null;
+  public suggestedLabelId?: string | null;
+  public suggestedUserId?: string | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   public updatedAt: Date;
-  public metadata?: IssueSuggestionMetadata;
+  public metadata?: IssueSuggestionMetadata | null;
   public state: L.IssueSuggestionState;
   public type: L.IssueSuggestionType;
   public get issue(): LinearFetch<Issue> | undefined {
@@ -10528,13 +10528,13 @@ export class IssueSuggestionMetadata extends Request {
     this.variant = data.variant ?? undefined;
   }
 
-  public appliedAutomationRuleId?: string;
-  public classification?: string;
-  public evalLogId?: string;
-  public rank?: number;
-  public reasons?: string[];
-  public score?: number;
-  public variant?: string;
+  public appliedAutomationRuleId?: string | null;
+  public classification?: string | null;
+  public evalLogId?: string | null;
+  public rank?: number | null;
+  public reasons?: string[] | null;
+  public score?: number | null;
+  public variant?: string | null;
 }
 /**
  * IssueTitleSuggestionFromCustomerRequestPayload model
@@ -10575,13 +10575,13 @@ export class IssueUnassignedFromYouNotificationWebhookPayload {
   }
 
   /** The ID of the actor who caused the notification. */
-  public actorId?: string;
+  public actorId?: string | null;
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the external user who caused the notification. */
-  public externalUserActorId?: string;
+  public externalUserActorId?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The ID of the issue this notification belongs to. */
@@ -10593,7 +10593,7 @@ export class IssueUnassignedFromYouNotificationWebhookPayload {
   /** The ID of the user who received the notification. */
   public userId: string;
   /** The actor who caused the notification. */
-  public actor?: UserChildWebhookPayload;
+  public actor?: UserChildWebhookPayload | null;
   /** The issue this notification belongs to. */
   public issue: IssueWithDescriptionChildWebhookPayload;
 }
@@ -10675,57 +10675,57 @@ export class IssueWebhookPayload {
   }
 
   /** The time at which the issue was added to a cycle. */
-  public addedToCycleAt?: string;
+  public addedToCycleAt?: string | null;
   /** The time at which the issue was added to a project. */
-  public addedToProjectAt?: string;
+  public addedToProjectAt?: string | null;
   /** The time at which the issue was added to a team. */
-  public addedToTeamAt?: string;
+  public addedToTeamAt?: string | null;
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The ID of the user that is assigned to the issue. */
-  public assigneeId?: string;
+  public assigneeId?: string | null;
   /** The time at which the issue was auto-archived. */
-  public autoArchivedAt?: string;
+  public autoArchivedAt?: string | null;
   /** The time at which the issue was auto-closed. */
-  public autoClosedAt?: string;
+  public autoClosedAt?: string | null;
   /** The bot actor data for this issue. */
-  public botActor?: string;
+  public botActor?: string | null;
   /** The time at which the issue was canceled. */
-  public canceledAt?: string;
+  public canceledAt?: string | null;
   /** The time at which the issue was completed. */
-  public completedAt?: string;
+  public completedAt?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the user that created the issue. */
-  public creatorId?: string;
+  public creatorId?: string | null;
   /** The ID of the cycle that the issue belongs to. */
-  public cycleId?: string;
+  public cycleId?: string | null;
   /** The ID of the agent user that the issue is delegated to. */
-  public delegateId?: string;
+  public delegateId?: string | null;
   /** The description of the issue. */
-  public description?: string;
+  public description?: string | null;
   /** The description data of the issue. */
-  public descriptionData?: string;
+  public descriptionData?: string | null;
   /** The due date of the issue. */
-  public dueDate?: string;
+  public dueDate?: string | null;
   /** The estimate of the complexity of the issue.. */
-  public estimate?: number;
+  public estimate?: number | null;
   /** The ID of the external user that created the issue. */
-  public externalUserCreatorId?: string;
+  public externalUserCreatorId?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The identifier of the issue. */
   public identifier: string;
   /** Integration type that created this issue, if applicable. */
-  public integrationSourceType?: string;
+  public integrationSourceType?: string | null;
   /** Id of the labels associated with this issue. */
   public labelIds: string[];
   /** The ID of the last template that was applied to the issue. */
-  public lastAppliedTemplateId?: string;
+  public lastAppliedTemplateId?: string | null;
   /** The issue's unique number. */
   public number: number;
   /** The ID of the parent issue. */
-  public parentId?: string;
+  public parentId?: string | null;
   /** Previous identifiers of the issue if it has been moved between teams. */
   public previousIdentifiers: string[];
   /** The priority of the issue. 0 = No priority, 1 = Urgent, 2 = High, 3 = Normal, 4 = Low. */
@@ -10735,49 +10735,49 @@ export class IssueWebhookPayload {
   /** The order of the item in relation to other items in the organization, when ordered by priority. */
   public prioritySortOrder: number;
   /** The ID of the project that the issue belongs to. */
-  public projectId?: string;
+  public projectId?: string | null;
   /** The ID of the project milestone that the issue belongs to. */
-  public projectMilestoneId?: string;
+  public projectMilestoneId?: string | null;
   /** The reaction data for this issue. */
   public reactionData: L.Scalars["JSONObject"];
   /** The ID of the recurring issue template that created the issue. */
-  public recurringIssueTemplateId?: string;
+  public recurringIssueTemplateId?: string | null;
   /** The time at which the issue would breach its SLA. */
-  public slaBreachesAt?: string;
+  public slaBreachesAt?: string | null;
   /** The time at which the issue would enter SLA high risk. */
-  public slaHighRiskAt?: string;
+  public slaHighRiskAt?: string | null;
   /** The time at which the issue would enter SLA medium risk. */
-  public slaMediumRiskAt?: string;
+  public slaMediumRiskAt?: string | null;
   /** The time at which the issue's SLA started. */
-  public slaStartedAt?: string;
+  public slaStartedAt?: string | null;
   /** The type of SLA the issue is under. */
-  public slaType?: string;
+  public slaType?: string | null;
   /** The time until an issue will be snoozed in Triage view. */
-  public snoozedUntilAt?: string;
+  public snoozedUntilAt?: string | null;
   /** The order of the item in relation to other items in the organization. */
   public sortOrder: number;
   /** The ID of the source comment that the issue was created from. */
-  public sourceCommentId?: string;
+  public sourceCommentId?: string | null;
   /** The time at which the issue was moved into started state. */
-  public startedAt?: string;
+  public startedAt?: string | null;
   /** The time at which the issue entered triage. */
-  public startedTriageAt?: string;
+  public startedTriageAt?: string | null;
   /** The ID of the issue's current workflow state. */
   public stateId: string;
   /** The order of the item in the sub-issue list. Only set if the issue has a parent. */
-  public subIssueSortOrder?: number;
+  public subIssueSortOrder?: number | null;
   /** The IDs of the users that are subscribed to the issue. */
   public subscriberIds: string[];
   /** The entity this issue is synced with. */
-  public syncedWith?: L.Scalars["JSONObject"];
+  public syncedWith?: L.Scalars["JSONObject"] | null;
   /** The ID of the team that the issue belongs to. */
   public teamId: string;
   /** The issue's title. */
   public title: string;
   /** A flag that indicates whether the issue is in the trash bin. */
-  public trashed?: boolean;
+  public trashed?: boolean | null;
   /** The time at which the issue was triaged. */
-  public triagedAt?: string;
+  public triagedAt?: string | null;
   /** The time at which the entity was updated. */
   public updatedAt: string;
   /** The URL of the issue. */
@@ -10785,23 +10785,23 @@ export class IssueWebhookPayload {
   /** The labels associated with this issue. */
   public labels: IssueLabelChildWebhookPayload[];
   /** The user that is assigned to the issue. */
-  public assignee?: UserChildWebhookPayload;
+  public assignee?: UserChildWebhookPayload | null;
   /** The user that created the issue. */
-  public creator?: UserChildWebhookPayload;
+  public creator?: UserChildWebhookPayload | null;
   /** The cycle that the issue belongs to. */
-  public cycle?: CycleChildWebhookPayload;
+  public cycle?: CycleChildWebhookPayload | null;
   /** The agent user that the issue is delegated to. */
-  public delegate?: UserChildWebhookPayload;
+  public delegate?: UserChildWebhookPayload | null;
   /** The external user that created the issue. */
-  public externalUserCreator?: ExternalUserChildWebhookPayload;
+  public externalUserCreator?: ExternalUserChildWebhookPayload | null;
   /** The project that the issue belongs to. */
-  public project?: ProjectChildWebhookPayload;
+  public project?: ProjectChildWebhookPayload | null;
   /** The project milestone that the issue belongs to. */
-  public projectMilestone?: ProjectMilestoneChildWebhookPayload;
+  public projectMilestone?: ProjectMilestoneChildWebhookPayload | null;
   /** The issue's current workflow state. */
   public state: WorkflowStateChildWebhookPayload;
   /** The team that the issue belongs to. */
-  public team?: TeamChildWebhookPayload;
+  public team?: TeamChildWebhookPayload | null;
 }
 /**
  * Certain properties of an issue, including its description.
@@ -10820,7 +10820,7 @@ export class IssueWithDescriptionChildWebhookPayload {
   }
 
   /** The description of the issue. */
-  public description?: string;
+  public description?: string | null;
   /** The ID of the issue. */
   public id: string;
   /** The identifier of the issue. */
@@ -10875,7 +10875,7 @@ export class LabelNotificationSubscription extends Request {
   /** Whether the subscription is active or not. */
   public active: boolean;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -10888,9 +10888,9 @@ export class LabelNotificationSubscription extends Request {
    */
   public updatedAt: Date;
   /** The type of view to which the notification subscription context is associated with. */
-  public contextViewType?: L.ContextViewType;
+  public contextViewType?: L.ContextViewType | null;
   /** The type of user view to which the notification subscription context is associated with. */
-  public userContextViewType?: L.UserContextViewType;
+  public userContextViewType?: L.UserContextViewType | null;
   /** The contextual custom view associated with the notification subscription. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return this._customView?.id ? new CustomViewQuery(this._request).fetch(this._customView?.id) : undefined;
@@ -11024,31 +11024,31 @@ export class Notification extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /**
    * The time at when an email reminder for this notification was sent to the user. Null, if no email
    *     reminder has been sent.
    */
-  public emailedAt?: Date;
+  public emailedAt?: Date | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The time at when the user marked the notification as read. Null, if the the user hasn't read the notification */
-  public readAt?: Date;
+  public readAt?: Date | null;
   /** The time until a notification will be snoozed. After that it will appear in the inbox again. */
-  public snoozedUntilAt?: Date;
+  public snoozedUntilAt?: Date | null;
   /** Notification type. */
   public type: string;
   /** The time at which a notification was unsnoozed.. */
-  public unsnoozedAt?: Date;
+  public unsnoozedAt?: Date | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   public updatedAt: Date;
   /** The bot that caused the notification. */
-  public botActor?: ActorBot;
+  public botActor?: ActorBot | null;
   /** The category of the notification. */
   public category: L.NotificationCategory;
   /** The user that caused the notification. */
@@ -11296,7 +11296,7 @@ export class NotificationDeliveryPreferences extends Request {
   }
 
   /** The delivery preferences for the mobile channel. */
-  public mobile?: NotificationDeliveryPreferencesChannel;
+  public mobile?: NotificationDeliveryPreferencesChannel | null;
 }
 /**
  * A user's notification delivery preferences.
@@ -11312,9 +11312,9 @@ export class NotificationDeliveryPreferencesChannel extends Request {
   }
 
   /** [DEPRECATED] Whether notifications are enabled for this channel. Use notificationChannelPreferences instead. */
-  public notificationsDisabled?: boolean;
+  public notificationsDisabled?: boolean | null;
   /** The schedule for notifications on this channel. */
-  public schedule?: NotificationDeliveryPreferencesSchedule;
+  public schedule?: NotificationDeliveryPreferencesSchedule | null;
 }
 /**
  * A user's notification delivery schedule for a particular day.
@@ -11330,9 +11330,9 @@ export class NotificationDeliveryPreferencesDay extends Request {
   }
 
   /** The time notifications end. */
-  public end?: string;
+  public end?: string | null;
   /** The time notifications start. */
-  public start?: string;
+  public start?: string | null;
 }
 /**
  * A user's notification delivery schedule for a particular day.
@@ -11354,7 +11354,7 @@ export class NotificationDeliveryPreferencesSchedule extends Request {
   }
 
   /** Whether the schedule is disabled. */
-  public disabled?: boolean;
+  public disabled?: boolean | null;
   /** Delivery preferences for Friday. */
   public friday: NotificationDeliveryPreferencesDay;
   /** Delivery preferences for Monday. */
@@ -11428,7 +11428,7 @@ export class NotificationSubscription extends Request {
   /** Whether the subscription is active or not. */
   public active: boolean;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -11439,9 +11439,9 @@ export class NotificationSubscription extends Request {
    */
   public updatedAt: Date;
   /** The type of view to which the notification subscription context is associated with. */
-  public contextViewType?: L.ContextViewType;
+  public contextViewType?: L.ContextViewType | null;
   /** The type of user view to which the notification subscription context is associated with. */
-  public userContextViewType?: L.UserContextViewType;
+  public userContextViewType?: L.UserContextViewType | null;
   /** The contextual custom view associated with the notification subscription. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return this._customView?.id ? new CustomViewQuery(this._request).fetch(this._customView?.id) : undefined;
@@ -11737,23 +11737,23 @@ export class OauthClientApproval extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The reason the request for the OAuth client approval was denied. */
-  public denyReason?: string;
+  public denyReason?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** New scopes that were requested for approval after the initial request. */
-  public newlyRequestedScopes?: string[];
+  public newlyRequestedScopes?: string[] | null;
   /** The uuid of the OAuth client being requested for installation. */
   public oauthClientId: string;
   /** The reason the person wants to install this OAuth client. */
-  public requestReason?: string;
+  public requestReason?: string | null;
   /** The person who requested installing the OAuth client. */
   public requesterId: string;
   /** The person who responded to the request to install the OAuth client. */
-  public responderId?: string;
+  public responderId?: string | null;
   /** The scopes the app has been approved for. */
   public scopes: string[];
   /**
@@ -11796,33 +11796,33 @@ export class OauthClientApprovalNotification extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /**
    * The time at when an email reminder for this notification was sent to the user. Null, if no email
    *     reminder has been sent.
    */
-  public emailedAt?: Date;
+  public emailedAt?: Date | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Related OAuth client approval request ID. */
   public oauthClientApprovalId: string;
   /** The time at when the user marked the notification as read. Null, if the the user hasn't read the notification */
-  public readAt?: Date;
+  public readAt?: Date | null;
   /** The time until a notification will be snoozed. After that it will appear in the inbox again. */
-  public snoozedUntilAt?: Date;
+  public snoozedUntilAt?: Date | null;
   /** Notification type. */
   public type: string;
   /** The time at which a notification was unsnoozed.. */
-  public unsnoozedAt?: Date;
+  public unsnoozedAt?: Date | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   public updatedAt: Date;
   /** The bot that caused the notification. */
-  public botActor?: ActorBot;
+  public botActor?: ActorBot | null;
   /** The OAuth client approval request related to the notification. */
   public oauthClientApproval: OauthClientApproval;
   /** The category of the notification. */
@@ -11936,13 +11936,13 @@ export class Organization extends Request {
   /** Whether the organization has enabled resolved thread AI summaries. */
   public aiThreadSummariesEnabled: boolean;
   /** [DEPRECATED] Whether member users are allowed to send invites. */
-  public allowMembersToInvite?: boolean;
+  public allowMembersToInvite?: boolean | null;
   /** Allowed authentication providers, empty array means all are allowed. */
   public allowedAuthServices: string[];
   /** Allowed file upload content types */
-  public allowedFileUploadContentTypes?: string[];
+  public allowedFileUploadContentTypes?: string[] | null;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Aproximate number of issues in the organization, including archived ones. */
@@ -11954,13 +11954,13 @@ export class Organization extends Request {
   /** Whether the organization is using Customers. */
   public customersEnabled: boolean;
   /** The time at which deletion of the organization was requested. */
-  public deletionRequestedAt?: Date;
+  public deletionRequestedAt?: Date | null;
   /** Whether the organization has enabled the feed feature. */
   public feedEnabled: boolean;
   /** The month at which the fiscal year starts. Defaults to January (0). */
   public fiscalYearStartMonth: number;
   /** How git branches are formatted. If null, default formatting will be used. */
-  public gitBranchFormat?: string;
+  public gitBranchFormat?: string | null;
   /** Whether issue descriptions should be included in Git integration linkback messages. */
   public gitLinkbackDescriptionsEnabled: boolean;
   /** Whether the Git integration linkback messages should be sent to private repositories. */
@@ -11972,11 +11972,11 @@ export class Organization extends Request {
   /** The unique identifier of the entity. */
   public id: string;
   /** The n-weekly frequency at which to prompt for initiative updates. When not set, reminders are off. */
-  public initiativeUpdateReminderFrequencyInWeeks?: number;
+  public initiativeUpdateReminderFrequencyInWeeks?: number | null;
   /** The hour at which to prompt for initiative updates. */
   public initiativeUpdateRemindersHour: number;
   /** The organization's logo URL. */
-  public logoUrl?: string;
+  public logoUrl?: string | null;
   /** The organization's name. */
   public name: string;
   /** Rolling 30-day total upload volume for the organization, in megabytes. */
@@ -11984,13 +11984,13 @@ export class Organization extends Request {
   /** Previously used URL keys for the organization (last 3 are kept and redirected). */
   public previousUrlKeys: string[];
   /** The n-weekly frequency at which to prompt for project updates. When not set, reminders are off. */
-  public projectUpdateReminderFrequencyInWeeks?: number;
+  public projectUpdateReminderFrequencyInWeeks?: number | null;
   /** The hour at which to prompt for project updates. */
   public projectUpdateRemindersHour: number;
   /** [DEPRECATED] Whether workspace label creation, update, and deletion is restricted to admins. */
-  public restrictLabelManagementToAdmins?: boolean;
+  public restrictLabelManagementToAdmins?: boolean | null;
   /** [DEPRECATED] Whether team creation is restricted to admins. */
-  public restrictTeamCreationToAdmins?: boolean;
+  public restrictTeamCreationToAdmins?: boolean | null;
   /** Whether the organization is using a roadmap. */
   public roadmapEnabled: boolean;
   /** Whether SAML authentication is enabled for organization. */
@@ -12000,9 +12000,9 @@ export class Organization extends Request {
   /** Security settings for the organization. */
   public securitySettings: L.Scalars["JSONObject"];
   /** The time at which the trial will end. */
-  public trialEndsAt?: Date;
+  public trialEndsAt?: Date | null;
   /** The time at which the trial started. */
-  public trialStartsAt?: Date;
+  public trialStartsAt?: Date | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
@@ -12013,13 +12013,13 @@ export class Organization extends Request {
   /** Number of active users in the organization. */
   public userCount: number;
   /** IP restriction configurations. */
-  public ipRestrictions?: OrganizationIpRestriction[];
+  public ipRestrictions?: OrganizationIpRestriction[] | null;
   /** The organization's project statuses. */
   public projectStatuses: ProjectStatus[];
   /** The organization's subscription to a paid plan. */
-  public subscription?: PaidSubscription;
+  public subscription?: PaidSubscription | null;
   /** Default schedule for how often feed summaries are generated. */
-  public defaultFeedSummarySchedule?: L.FeedSummarySchedule;
+  public defaultFeedSummarySchedule?: L.FeedSummarySchedule | null;
   /** The day at which to prompt for initiative updates. */
   public initiativeUpdateRemindersDay: L.Day;
   /** The day at which to prompt for project updates. */
@@ -12135,13 +12135,13 @@ export class OrganizationDomain extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** Whether the domains was claimed by the organization through DNS verification. */
-  public claimed?: boolean;
+  public claimed?: boolean | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Prevent users with this domain to create new workspaces. */
-  public disableOrganizationCreation?: boolean;
+  public disableOrganizationCreation?: boolean | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Domain name. */
@@ -12152,11 +12152,11 @@ export class OrganizationDomain extends Request {
    */
   public updatedAt: Date;
   /** E-mail used to verify this domain. */
-  public verificationEmail?: string;
+  public verificationEmail?: string | null;
   /** Is this domain verified. */
   public verified: boolean;
   /** The identity provider the domain belongs to. */
-  public identityProvider?: IdentityProvider;
+  public identityProvider?: IdentityProvider | null;
   /** What type of auth is the domain used for. */
   public authType: L.OrganizationDomainAuthType;
   /** The user who added the domain. */
@@ -12218,21 +12218,21 @@ export class OrganizationInvite extends Request {
   }
 
   /** The time at which the invite was accepted. Null, if the invite hasn't been accepted. */
-  public acceptedAt?: Date;
+  public acceptedAt?: Date | null;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The invitees email address. */
   public email: string;
   /** The time at which the invite will be expiring. Null, if the invite shouldn't expire. */
-  public expiresAt?: Date;
+  public expiresAt?: Date | null;
   /** The invite was sent to external address. */
   public external: boolean;
   /** The unique identifier of the entity. */
   public id: string;
   /** Extra metadata associated with the organization invite. */
-  public metadata?: L.Scalars["JSONObject"];
+  public metadata?: L.Scalars["JSONObject"] | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
@@ -12332,7 +12332,7 @@ export class OrganizationInviteFullDetailsPayload extends Request {
   /** ID of the workspace the invite is for. */
   public organizationId: string;
   /** URL of the workspace logo the invite is for. */
-  public organizationLogoUrl?: string;
+  public organizationLogoUrl?: string | null;
   /** Name of the workspace the invite is for. */
   public organizationName: string;
   /** What user role the invite should grant. */
@@ -12385,7 +12385,7 @@ export class OrganizationIpRestriction extends Request {
   }
 
   /** Optional restriction description. */
-  public description?: string;
+  public description?: string | null;
   /** Whether the restriction is enabled. */
   public enabled: boolean;
   /** IP range in CIDR format. */
@@ -12493,47 +12493,47 @@ export class OtherNotificationWebhookPayload {
   }
 
   /** The ID of the actor who caused the notification. */
-  public actorId?: string;
+  public actorId?: string | null;
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The ID of the comment this notification belongs to. */
-  public commentId?: string;
+  public commentId?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the document this notification belongs to. */
-  public documentId?: string;
+  public documentId?: string | null;
   /** The ID of the external user who caused the notification. */
-  public externalUserActorId?: string;
+  public externalUserActorId?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The ID of the issue this notification belongs to. */
-  public issueId?: string;
+  public issueId?: string | null;
   /** The ID of the parent comment this notification belongs to. */
-  public parentCommentId?: string;
+  public parentCommentId?: string | null;
   /** The ID of the project this notification belongs to. */
-  public projectId?: string;
+  public projectId?: string | null;
   /** The ID of the project update this notification belongs to. */
-  public projectUpdateId?: string;
+  public projectUpdateId?: string | null;
   /** The emoji of the reaction this notification is for. */
-  public reactionEmoji?: string;
+  public reactionEmoji?: string | null;
   /** The time at which the entity was updated. */
   public updatedAt: string;
   /** The ID of the user who received the notification. */
   public userId: string;
   /** The actor who caused the notification. */
-  public actor?: UserChildWebhookPayload;
+  public actor?: UserChildWebhookPayload | null;
   /** The comment this notification belongs to. */
-  public comment?: CommentChildWebhookPayload;
+  public comment?: CommentChildWebhookPayload | null;
   /** The document this notification belongs to. */
-  public document?: DocumentChildWebhookPayload;
+  public document?: DocumentChildWebhookPayload | null;
   /** The issue this notification belongs to. */
-  public issue?: IssueWithDescriptionChildWebhookPayload;
+  public issue?: IssueWithDescriptionChildWebhookPayload | null;
   /** The parent comment this notification belongs to. */
-  public parentComment?: CommentChildWebhookPayload;
+  public parentComment?: CommentChildWebhookPayload | null;
   /** The project this notification belongs to. */
-  public project?: ProjectChildWebhookPayload;
+  public project?: ProjectChildWebhookPayload | null;
   /** The project update this notification belongs to. */
-  public projectUpdate?: ProjectUpdateChildWebhookPayload;
+  public projectUpdate?: ProjectUpdateChildWebhookPayload | null;
   /** The type of the notification. */
   public type: L.OtherNotificationType;
 }
@@ -12553,13 +12553,13 @@ export class PageInfo extends Request {
   }
 
   /** Cursor representing the last result in the paginated results. */
-  public endCursor?: string;
+  public endCursor?: string | null;
   /** Indicates if there are more results when paginating forward. */
   public hasNextPage: boolean;
   /** Indicates if there are more results when paginating backward. */
   public hasPreviousPage: boolean;
   /** Cursor representing the first result in the paginated results. */
-  public startCursor?: string;
+  public startCursor?: string | null;
 }
 /**
  * The paid subscription of an organization.
@@ -12589,11 +12589,11 @@ export class PaidSubscription extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The date the subscription is scheduled to be canceled, if any. */
-  public cancelAt?: Date;
+  public cancelAt?: Date | null;
   /** The date the subscription was canceled, if any. */
-  public canceledAt?: Date;
+  public canceledAt?: Date | null;
   /** The collection method for this subscription, either automatically charged or invoiced. */
   public collectionMethod: string;
   /** The time at which the entity was created. */
@@ -12601,15 +12601,15 @@ export class PaidSubscription extends Request {
   /** The unique identifier of the entity. */
   public id: string;
   /** The date the subscription will be billed next. */
-  public nextBillingAt?: Date;
+  public nextBillingAt?: Date | null;
   /** The subscription type of a pending change. Null if no change pending. */
-  public pendingChangeType?: string;
+  public pendingChangeType?: string | null;
   /** The number of seats in the subscription. */
   public seats: number;
   /** The maximum number of seats that will be billed in the subscription. */
-  public seatsMaximum?: number;
+  public seatsMaximum?: number | null;
   /** The minimum number of seats that will be billed in the subscription. */
-  public seatsMinimum?: number;
+  public seatsMinimum?: number | null;
   /** The subscription type. */
   public type: string;
   /**
@@ -12680,39 +12680,39 @@ export class PostNotification extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** Related comment ID. Null if the notification is not related to a comment. */
-  public commentId?: string;
+  public commentId?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /**
    * The time at when an email reminder for this notification was sent to the user. Null, if no email
    *     reminder has been sent.
    */
-  public emailedAt?: Date;
+  public emailedAt?: Date | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Related parent comment ID. Null if the notification is not related to a comment. */
-  public parentCommentId?: string;
+  public parentCommentId?: string | null;
   /** Related post ID. */
   public postId: string;
   /** Name of the reaction emoji related to the notification. */
-  public reactionEmoji?: string;
+  public reactionEmoji?: string | null;
   /** The time at when the user marked the notification as read. Null, if the the user hasn't read the notification */
-  public readAt?: Date;
+  public readAt?: Date | null;
   /** The time until a notification will be snoozed. After that it will appear in the inbox again. */
-  public snoozedUntilAt?: Date;
+  public snoozedUntilAt?: Date | null;
   /** Notification type. */
   public type: string;
   /** The time at which a notification was unsnoozed.. */
-  public unsnoozedAt?: Date;
+  public unsnoozedAt?: Date | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   public updatedAt: Date;
   /** The bot that caused the notification. */
-  public botActor?: ActorBot;
+  public botActor?: ActorBot | null;
   /** The category of the notification. */
   public category: L.NotificationCategory;
   /** The user that caused the notification. */
@@ -12816,29 +12816,29 @@ export class Project extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the project was automatically archived by the auto pruning process. */
-  public autoArchivedAt?: Date;
+  public autoArchivedAt?: Date | null;
   /** The time at which the project was moved into canceled state. */
-  public canceledAt?: Date;
+  public canceledAt?: Date | null;
   /** The project's color. */
   public color: string;
   /** The time at which the project was moved into completed state. */
-  public completedAt?: Date;
+  public completedAt?: Date | null;
   /** The number of completed issues in the project after each week. */
   public completedIssueCountHistory: number[];
   /** The number of completed estimation points after each week. */
   public completedScopeHistory: number[];
   /** The project's content in markdown format. */
-  public content?: string;
+  public content?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The project's description. */
   public description: string;
   /** The time at which the project health was updated. */
-  public healthUpdatedAt?: Date;
+  public healthUpdatedAt?: Date | null;
   /** The icon of the project. */
-  public icon?: string;
+  public icon?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The number of in progress estimation points after each week. */
@@ -12858,7 +12858,7 @@ export class Project extends Request {
   /** The overall progress of the project. This is the (completed estimate points + 0.25 * in progress estimate points) / total estimate points. */
   public progress: number;
   /** The time until which project update reminders are paused. */
-  public projectUpdateRemindersPausedUntilAt?: Date;
+  public projectUpdateRemindersPausedUntilAt?: Date | null;
   /** The overall scope (total estimate points) of the project. */
   public scope: number;
   /** The total number of estimation points after each week. */
@@ -12874,21 +12874,21 @@ export class Project extends Request {
   /** The sort order for the project within the organization. */
   public sortOrder: number;
   /** The estimated start date of the project. */
-  public startDate?: L.Scalars["TimelessDate"];
+  public startDate?: L.Scalars["TimelessDate"] | null;
   /** The time at which the project was moved into started state. */
-  public startedAt?: Date;
+  public startedAt?: Date | null;
   /** [DEPRECATED] The type of the state. */
   public state: string;
   /** The estimated completion date of the project. */
-  public targetDate?: L.Scalars["TimelessDate"];
+  public targetDate?: L.Scalars["TimelessDate"] | null;
   /** A flag that indicates whether the project is in the trash bin. */
-  public trashed?: boolean;
+  public trashed?: boolean | null;
   /** The frequency at which to prompt for updates. When not set, reminders are inherited from workspace. */
-  public updateReminderFrequency?: number;
+  public updateReminderFrequency?: number | null;
   /** The n-weekly frequency at which to prompt for updates. When not set, reminders are inherited from workspace. */
-  public updateReminderFrequencyInWeeks?: number;
+  public updateReminderFrequencyInWeeks?: number | null;
   /** The hour at which to prompt for updates. */
-  public updateRemindersHour?: number;
+  public updateRemindersHour?: number | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
@@ -12897,17 +12897,17 @@ export class Project extends Request {
   /** Project URL. */
   public url: string;
   /** The content of the project description. */
-  public documentContent?: DocumentContent;
+  public documentContent?: DocumentContent | null;
   /** The resolution of the reminder frequency. */
   public frequencyResolution: L.FrequencyResolutionType;
   /** The health of the project. */
-  public health?: L.ProjectUpdateHealthType;
+  public health?: L.ProjectUpdateHealthType | null;
   /** The resolution of the project's start date. */
-  public startDateResolution?: L.DateResolutionType;
+  public startDateResolution?: L.DateResolutionType | null;
   /** The resolution of the project's estimated completion date. */
-  public targetDateResolution?: L.DateResolutionType;
+  public targetDateResolution?: L.DateResolutionType | null;
   /** The day at which to prompt for updates. */
-  public updateRemindersDay?: L.Day;
+  public updateRemindersDay?: L.Day | null;
   /** The project was created based on this issue. */
   public get convertedFromIssue(): LinearFetch<Issue> | undefined {
     return this._convertedFromIssue?.id ? new IssueQuery(this._request).fetch(this._convertedFromIssue?.id) : undefined;
@@ -13107,7 +13107,7 @@ export class ProjectAttachment extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -13115,11 +13115,11 @@ export class ProjectAttachment extends Request {
   /** Custom metadata related to the attachment. */
   public metadata: L.Scalars["JSONObject"];
   /** Information about the external source which created the attachment. */
-  public source?: L.Scalars["JSONObject"];
+  public source?: L.Scalars["JSONObject"] | null;
   /** An accessor helper to source.type, defines the source type of the attachment. */
-  public sourceType?: string;
+  public sourceType?: string | null;
   /** Optional subtitle of the attachment */
-  public subtitle?: string;
+  public subtitle?: string | null;
   /** Title of the attachment. */
   public title: string;
   /**
@@ -13192,9 +13192,9 @@ export class ProjectFilterSuggestionPayload extends Request {
   }
 
   /** The json filter that is suggested. */
-  public filter?: L.Scalars["JSONObject"];
+  public filter?: L.Scalars["JSONObject"] | null;
   /** The log id of the prompt, that created this filter. */
-  public logId?: string;
+  public logId?: string | null;
 }
 /**
  * An history associated with a project.
@@ -13216,7 +13216,7 @@ export class ProjectHistory extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The events that happened while recording that history. */
@@ -13286,19 +13286,19 @@ export class ProjectLabel extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The label's color as a HEX string. */
   public color: string;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The label's description. */
-  public description?: string;
+  public description?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Whether the label is a group. */
   public isGroup: boolean;
   /** The date when the label was last applied to an issue or project. */
-  public lastAppliedAt?: Date;
+  public lastAppliedAt?: Date | null;
   /** The label's name. */
   public name: string;
   /**
@@ -13374,7 +13374,7 @@ export class ProjectLabelChildWebhookPayload {
   /** The name of the project label. */
   public name: string;
   /** The parent ID of the project label. */
-  public parentId?: string;
+  public parentId?: string | null;
 }
 /**
  * ProjectLabelConnection model
@@ -13446,15 +13446,15 @@ export class ProjectLabelWebhookPayload {
   }
 
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The color of the project label. */
   public color: string;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The creator ID of the project label. */
-  public creatorId?: string;
+  public creatorId?: string | null;
   /** The label's description. */
-  public description?: string;
+  public description?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** Whether the label is a group. */
@@ -13462,7 +13462,7 @@ export class ProjectLabelWebhookPayload {
   /** The name of the project label. */
   public name: string;
   /** The parent ID of the project label. */
-  public parentId?: string;
+  public parentId?: string | null;
   /** The time at which the entity was updated. */
   public updatedAt: string;
 }
@@ -13492,11 +13492,11 @@ export class ProjectMilestone extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The project milestone's description in markdown format. */
-  public description?: string;
+  public description?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The name of the project milestone. */
@@ -13506,14 +13506,14 @@ export class ProjectMilestone extends Request {
   /** The order of the milestone in relation to other milestones within a project. */
   public sortOrder: number;
   /** The planned completion date of the milestone. */
-  public targetDate?: L.Scalars["TimelessDate"];
+  public targetDate?: L.Scalars["TimelessDate"] | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   public updatedAt: Date;
   /** The content of the project milestone description. */
-  public documentContent?: DocumentContent;
+  public documentContent?: DocumentContent | null;
   /** The status of the project milestone. */
   public status: L.ProjectMilestoneStatus;
   /** The project of the milestone. */
@@ -13626,9 +13626,9 @@ export class ProjectMilestoneMovePayload extends Request {
   /** Whether the operation was successful. */
   public success: boolean;
   /** A snapshot of the issues that were moved to new teams, if the user selected to do it, containing an array of mappings between an issue and its previous team. Store on the client to use for undoing a previous milestone move. */
-  public previousIssueTeamIds?: ProjectMilestoneMoveIssueToTeam[];
+  public previousIssueTeamIds?: ProjectMilestoneMoveIssueToTeam[] | null;
   /** A snapshot of the project that had new teams added to it, if the user selected to do it, containing an array of mappings between a project and its previous teams. Store on the client to use for undoing a previous milestone move. */
-  public previousProjectTeamIds?: ProjectMilestoneMoveProjectTeams;
+  public previousProjectTeamIds?: ProjectMilestoneMoveProjectTeams | null;
   /** The project milestone that was created or updated. */
   public get projectMilestone(): LinearFetch<ProjectMilestone> | undefined {
     return new ProjectMilestoneQuery(this._request).fetch(this._projectMilestone.id);
@@ -13731,43 +13731,43 @@ export class ProjectNotification extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** Related comment ID. Null if the notification is not related to a comment. */
-  public commentId?: string;
+  public commentId?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /**
    * The time at when an email reminder for this notification was sent to the user. Null, if no email
    *     reminder has been sent.
    */
-  public emailedAt?: Date;
+  public emailedAt?: Date | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Related parent comment ID. Null if the notification is not related to a comment. */
-  public parentCommentId?: string;
+  public parentCommentId?: string | null;
   /** Related project ID. */
   public projectId: string;
   /** Related project milestone ID. */
-  public projectMilestoneId?: string;
+  public projectMilestoneId?: string | null;
   /** Related project update ID. */
-  public projectUpdateId?: string;
+  public projectUpdateId?: string | null;
   /** Name of the reaction emoji related to the notification. */
-  public reactionEmoji?: string;
+  public reactionEmoji?: string | null;
   /** The time at when the user marked the notification as read. Null, if the the user hasn't read the notification */
-  public readAt?: Date;
+  public readAt?: Date | null;
   /** The time until a notification will be snoozed. After that it will appear in the inbox again. */
-  public snoozedUntilAt?: Date;
+  public snoozedUntilAt?: Date | null;
   /** Notification type. */
   public type: string;
   /** The time at which a notification was unsnoozed.. */
-  public unsnoozedAt?: Date;
+  public unsnoozedAt?: Date | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   public updatedAt: Date;
   /** The bot that caused the notification. */
-  public botActor?: ActorBot;
+  public botActor?: ActorBot | null;
   /** The category of the notification. */
   public category: L.NotificationCategory;
   /** The user that caused the notification. */
@@ -13862,7 +13862,7 @@ export class ProjectNotificationSubscription extends Request {
   /** Whether the subscription is active or not. */
   public active: boolean;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -13875,9 +13875,9 @@ export class ProjectNotificationSubscription extends Request {
    */
   public updatedAt: Date;
   /** The type of view to which the notification subscription context is associated with. */
-  public contextViewType?: L.ContextViewType;
+  public contextViewType?: L.ContextViewType | null;
   /** The type of user view to which the notification subscription context is associated with. */
-  public userContextViewType?: L.UserContextViewType;
+  public userContextViewType?: L.UserContextViewType | null;
   /** The contextual custom view associated with the notification subscription. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return this._customView?.id ? new CustomViewQuery(this._request).fetch(this._customView?.id) : undefined;
@@ -14012,7 +14012,7 @@ export class ProjectRelation extends Request {
   /** The type of anchor on the project end of the relation. */
   public anchorType: string;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -14231,29 +14231,29 @@ export class ProjectSearchResult extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the project was automatically archived by the auto pruning process. */
-  public autoArchivedAt?: Date;
+  public autoArchivedAt?: Date | null;
   /** The time at which the project was moved into canceled state. */
-  public canceledAt?: Date;
+  public canceledAt?: Date | null;
   /** The project's color. */
   public color: string;
   /** The time at which the project was moved into completed state. */
-  public completedAt?: Date;
+  public completedAt?: Date | null;
   /** The number of completed issues in the project after each week. */
   public completedIssueCountHistory: number[];
   /** The number of completed estimation points after each week. */
   public completedScopeHistory: number[];
   /** The project's content in markdown format. */
-  public content?: string;
+  public content?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The project's description. */
   public description: string;
   /** The time at which the project health was updated. */
-  public healthUpdatedAt?: Date;
+  public healthUpdatedAt?: Date | null;
   /** The icon of the project. */
-  public icon?: string;
+  public icon?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The number of in progress estimation points after each week. */
@@ -14275,7 +14275,7 @@ export class ProjectSearchResult extends Request {
   /** The overall progress of the project. This is the (completed estimate points + 0.25 * in progress estimate points) / total estimate points. */
   public progress: number;
   /** The time until which project update reminders are paused. */
-  public projectUpdateRemindersPausedUntilAt?: Date;
+  public projectUpdateRemindersPausedUntilAt?: Date | null;
   /** The overall scope (total estimate points) of the project. */
   public scope: number;
   /** The total number of estimation points after each week. */
@@ -14291,21 +14291,21 @@ export class ProjectSearchResult extends Request {
   /** The sort order for the project within the organization. */
   public sortOrder: number;
   /** The estimated start date of the project. */
-  public startDate?: L.Scalars["TimelessDate"];
+  public startDate?: L.Scalars["TimelessDate"] | null;
   /** The time at which the project was moved into started state. */
-  public startedAt?: Date;
+  public startedAt?: Date | null;
   /** [DEPRECATED] The type of the state. */
   public state: string;
   /** The estimated completion date of the project. */
-  public targetDate?: L.Scalars["TimelessDate"];
+  public targetDate?: L.Scalars["TimelessDate"] | null;
   /** A flag that indicates whether the project is in the trash bin. */
-  public trashed?: boolean;
+  public trashed?: boolean | null;
   /** The frequency at which to prompt for updates. When not set, reminders are inherited from workspace. */
-  public updateReminderFrequency?: number;
+  public updateReminderFrequency?: number | null;
   /** The n-weekly frequency at which to prompt for updates. When not set, reminders are inherited from workspace. */
-  public updateReminderFrequencyInWeeks?: number;
+  public updateReminderFrequencyInWeeks?: number | null;
   /** The hour at which to prompt for updates. */
-  public updateRemindersHour?: number;
+  public updateRemindersHour?: number | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
@@ -14314,17 +14314,17 @@ export class ProjectSearchResult extends Request {
   /** Project URL. */
   public url: string;
   /** The content of the project description. */
-  public documentContent?: DocumentContent;
+  public documentContent?: DocumentContent | null;
   /** The resolution of the reminder frequency. */
   public frequencyResolution: L.FrequencyResolutionType;
   /** The health of the project. */
-  public health?: L.ProjectUpdateHealthType;
+  public health?: L.ProjectUpdateHealthType | null;
   /** The resolution of the project's start date. */
-  public startDateResolution?: L.DateResolutionType;
+  public startDateResolution?: L.DateResolutionType | null;
   /** The resolution of the project's estimated completion date. */
-  public targetDateResolution?: L.DateResolutionType;
+  public targetDateResolution?: L.DateResolutionType | null;
   /** The day at which to prompt for updates. */
-  public updateRemindersDay?: L.Day;
+  public updateRemindersDay?: L.Day | null;
   /** The project was created based on this issue. */
   public get convertedFromIssue(): LinearFetch<Issue> | undefined {
     return this._convertedFromIssue?.id ? new IssueQuery(this._request).fetch(this._convertedFromIssue?.id) : undefined;
@@ -14416,13 +14416,13 @@ export class ProjectStatus extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The UI color of the status as a HEX string. */
   public color: string;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Description of the status. */
-  public description?: string;
+  public description?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Whether or not a project can be in this status indefinitely. */
@@ -14611,7 +14611,7 @@ export class ProjectUpdate extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The update content in markdown format. */
   public body: string;
   /** Number of comments associated with the project update. */
@@ -14619,11 +14619,11 @@ export class ProjectUpdate extends Request {
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The diff between the current update and the previous one. */
-  public diff?: L.Scalars["JSONObject"];
+  public diff?: L.Scalars["JSONObject"] | null;
   /** The diff between the current update and the previous one, formatted as markdown. */
-  public diffMarkdown?: string;
+  public diffMarkdown?: string | null;
   /** The time the update was edited. */
-  public editedAt?: Date;
+  public editedAt?: Date | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Whether project update diff should be hidden. */
@@ -14830,7 +14830,7 @@ export class ProjectUpdateWebhookPayload {
   }
 
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The body of the project update. */
   public body: string;
   /** The body data of the project update. */
@@ -14852,7 +14852,7 @@ export class ProjectUpdateWebhookPayload {
   /** The time at which the entity was updated. */
   public updatedAt: string;
   /** The URL of the project update. */
-  public url?: string;
+  public url?: string | null;
   /** The user id of the project update. */
   public userId: string;
   /** The project that the project update belongs to. */
@@ -14919,37 +14919,37 @@ export class ProjectWebhookPayload {
   }
 
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The auto archived at timestamp of the project. */
-  public autoArchivedAt?: string;
+  public autoArchivedAt?: string | null;
   /** The canceled at timestamp of the project. */
-  public canceledAt?: string;
+  public canceledAt?: string | null;
   /** The project's color. */
   public color: string;
   /** The completed at timestamp of the project. */
-  public completedAt?: string;
+  public completedAt?: string | null;
   /** The number of completed issues in the project after each week. */
   public completedIssueCountHistory: number[];
   /** The number of completed estimation points after each week. */
   public completedScopeHistory: number[];
   /** The content of the project. */
-  public content?: string;
+  public content?: string | null;
   /** The ID of the issue that was converted to the project. */
-  public convertedFromIssueId?: string;
+  public convertedFromIssueId?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The ID of the user who created the project. */
-  public creatorId?: string;
+  public creatorId?: string | null;
   /** The project's description. */
   public description: string;
   /** The document content ID of the project. */
-  public documentContentId?: string;
+  public documentContentId?: string | null;
   /** The health of the project. */
-  public health?: string;
+  public health?: string | null;
   /** The time at which the project health was updated. */
-  public healthUpdatedAt?: string;
+  public healthUpdatedAt?: string | null;
   /** The icon of the project. */
-  public icon?: string;
+  public icon?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The number of in progress estimation points after each week. */
@@ -14959,11 +14959,11 @@ export class ProjectWebhookPayload {
   /** IDs of the labels associated with this project. */
   public labelIds: string[];
   /** The ID of the last template that was applied to the project. */
-  public lastAppliedTemplateId?: string;
+  public lastAppliedTemplateId?: string | null;
   /** The ID of the last update posted for this project. */
-  public lastUpdateId?: string;
+  public lastUpdateId?: string | null;
   /** The ID of the project lead. */
-  public leadId?: string;
+  public leadId?: string | null;
   /** IDs of the members of the project. */
   public memberIds: string[];
   /** The project's name. */
@@ -14973,7 +14973,7 @@ export class ProjectWebhookPayload {
   /** The sort order for the project within the organization, when ordered by priority. */
   public prioritySortOrder: number;
   /** The time at which the project update reminders were paused until. */
-  public projectUpdateRemindersPausedUntilAt?: string;
+  public projectUpdateRemindersPausedUntilAt?: string | null;
   /** The total number of estimation points after each week. */
   public scopeHistory: number[];
   /** The project's unique URL slug. */
@@ -14981,33 +14981,33 @@ export class ProjectWebhookPayload {
   /** The sort order for the project within the organization. */
   public sortOrder: number;
   /** The estimated start date of the project. */
-  public startDate?: string;
+  public startDate?: string | null;
   /** The resolution of the project's estimated start date. */
-  public startDateResolution?: string;
+  public startDateResolution?: string | null;
   /** The time at which the project was moved into started state. */
-  public startedAt?: string;
+  public startedAt?: string | null;
   /** The ID of the project status. */
   public statusId: string;
   /** The target date of the project. */
-  public targetDate?: string;
+  public targetDate?: string | null;
   /** The resolution of the project's target date. */
-  public targetDateResolution?: string;
+  public targetDateResolution?: string | null;
   /** IDs of the teams associated with this project. */
   public teamIds: string[];
   /** The trashed status of the project. */
-  public trashed?: boolean;
+  public trashed?: boolean | null;
   /** The time at which the entity was updated. */
   public updatedAt: string;
   /** The URL of the project. */
   public url: string;
   /** The initiatives associated with the project. */
-  public initiatives?: InitiativeChildWebhookPayload[];
+  public initiatives?: InitiativeChildWebhookPayload[] | null;
   /** The milestones associated with the project. */
-  public milestones?: ProjectMilestoneChildWebhookPayload[];
+  public milestones?: ProjectMilestoneChildWebhookPayload[] | null;
   /** The project lead. */
-  public lead?: UserChildWebhookPayload;
+  public lead?: UserChildWebhookPayload | null;
   /** The project status. */
-  public status?: ProjectStatusChildWebhookPayload;
+  public status?: ProjectStatusChildWebhookPayload | null;
 }
 /**
  * A pull request related notification.
@@ -15041,35 +15041,35 @@ export class PullRequestNotification extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /**
    * The time at when an email reminder for this notification was sent to the user. Null, if no email
    *     reminder has been sent.
    */
-  public emailedAt?: Date;
+  public emailedAt?: Date | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Related pull request comment ID. Null if the notification is not related to a pull request comment. */
-  public pullRequestCommentId?: string;
+  public pullRequestCommentId?: string | null;
   /** Related pull request. */
   public pullRequestId: string;
   /** The time at when the user marked the notification as read. Null, if the the user hasn't read the notification */
-  public readAt?: Date;
+  public readAt?: Date | null;
   /** The time until a notification will be snoozed. After that it will appear in the inbox again. */
-  public snoozedUntilAt?: Date;
+  public snoozedUntilAt?: Date | null;
   /** Notification type. */
   public type: string;
   /** The time at which a notification was unsnoozed.. */
-  public unsnoozedAt?: Date;
+  public unsnoozedAt?: Date | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   public updatedAt: Date;
   /** The bot that caused the notification. */
-  public botActor?: ActorBot;
+  public botActor?: ActorBot | null;
   /** The category of the notification. */
   public category: L.NotificationCategory;
   /** The user that caused the notification. */
@@ -15115,7 +15115,7 @@ export class PushSubscription extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -15186,7 +15186,7 @@ export class RateLimitPayload extends Request {
   }
 
   /** The identifier we rate limit on. */
-  public identifier?: string;
+  public identifier?: string | null;
   /** The kind of rate limit selected for this request. */
   public kind: string;
   /** The state of the rate limit. */
@@ -15252,7 +15252,7 @@ export class Reaction extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Name of the reaction's emoji. */
@@ -15369,37 +15369,37 @@ export class ReactionWebhookPayload {
   }
 
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The ID of the comment that the reaction is associated with. */
-  public commentId?: string;
+  public commentId?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** Name of the reaction's emoji. */
   public emoji: string;
   /** The ID of the external user that created the reaction. */
-  public externalUserId?: string;
+  public externalUserId?: string | null;
   /** The ID of the entity. */
   public id: string;
   /** The ID of the initiative update that the reaction is associated with. */
-  public initiativeUpdateId?: string;
+  public initiativeUpdateId?: string | null;
   /** The ID of the issue that the reaction is associated with. */
-  public issueId?: string;
+  public issueId?: string | null;
   /** The ID of the post that the reaction is associated with. */
-  public postId?: string;
+  public postId?: string | null;
   /** The ID of the project update that the reaction is associated with. */
-  public projectUpdateId?: string;
+  public projectUpdateId?: string | null;
   /** The time at which the entity was updated. */
   public updatedAt: string;
   /** The ID of the user that created the reaction. */
-  public userId?: string;
+  public userId?: string | null;
   /** The comment the reaction is associated with. */
-  public comment?: CommentChildWebhookPayload;
+  public comment?: CommentChildWebhookPayload | null;
   /** The issue the reaction is associated with. */
-  public issue?: IssueChildWebhookPayload;
+  public issue?: IssueChildWebhookPayload | null;
   /** The project update the reaction is associated with. */
-  public projectUpdate?: ProjectUpdateChildWebhookPayload;
+  public projectUpdate?: ProjectUpdateChildWebhookPayload | null;
   /** The user that created the reaction. */
-  public user?: UserChildWebhookPayload;
+  public user?: UserChildWebhookPayload | null;
 }
 /**
  * A generic payload return from entity archive mutations.
@@ -15526,7 +15526,7 @@ export class RepositorySuggestion extends Request {
   /** Confidence score from 0.0 to 1.0. */
   public confidence: number;
   /** Hostname of the Git service (e.g., 'github.com', 'github.company.com'). */
-  public hostname?: string;
+  public hostname?: string | null;
   /** The full name of the repository in owner/name format (e.g., 'acme/backend'). */
   public repositoryFullName: string;
 }
@@ -15572,13 +15572,13 @@ export class Roadmap extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The roadmap's color. */
-  public color?: string;
+  public color?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The description of the roadmap. */
-  public description?: string;
+  public description?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The name of the roadmap. */
@@ -15740,7 +15740,7 @@ export class RoadmapToProject extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -15931,7 +15931,7 @@ export class SesDomainIdentity extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** Whether the domain is fully verified and can be used for sending emails. */
   public canSendFromCustomDomain: boolean;
   /** The time at which the entity was created. */
@@ -16028,9 +16028,9 @@ export class SlackChannelConnectPayload extends Request {
   /** The identifier of the last sync operation. */
   public lastSyncId: number;
   /** Whether it's recommended to connect main Slack integration. */
-  public nudgeToConnectMainSlackIntegration?: boolean;
+  public nudgeToConnectMainSlackIntegration?: boolean | null;
   /** Whether it's recommended to update main Slack integration. */
-  public nudgeToUpdateMainSlackIntegration?: boolean;
+  public nudgeToUpdateMainSlackIntegration?: boolean | null;
   /** Whether the operation was successful. */
   public success: boolean;
   /** The integration that was created or updated. */
@@ -16068,31 +16068,31 @@ export class SlackChannelNameMapping extends Request {
   }
 
   /** Whether or not to use AI to generate titles for Asks created in this channel. */
-  public aiTitles?: boolean;
+  public aiTitles?: boolean | null;
   /** Whether or not @-mentioning the bot should automatically create an Ask with the message. */
-  public autoCreateOnBotMention?: boolean;
+  public autoCreateOnBotMention?: boolean | null;
   /** Whether or not using the :ticket: emoji in this channel should automatically create Asks. */
-  public autoCreateOnEmoji?: boolean;
+  public autoCreateOnEmoji?: boolean | null;
   /** Whether or not top-level messages in this channel should automatically create Asks. */
-  public autoCreateOnMessage?: boolean;
+  public autoCreateOnMessage?: boolean | null;
   /** The optional template ID to use for Asks auto-created in this channel. If not set, auto-created Asks won't use any template. */
-  public autoCreateTemplateId?: string;
+  public autoCreateTemplateId?: string | null;
   /** Whether or not the Linear Asks bot has been added to this Slack channel. */
-  public botAdded?: boolean;
+  public botAdded?: boolean | null;
   /** The Slack channel ID. */
   public id: string;
   /** Whether or not the Slack channel is private. */
-  public isPrivate?: boolean;
+  public isPrivate?: boolean | null;
   /** Whether or not the Slack channel is shared with an external org. */
-  public isShared?: boolean;
+  public isShared?: boolean | null;
   /** The Slack channel name. */
   public name: string;
   /** Whether or not synced Slack threads should be updated with a message when their Ask is accepted from triage. */
-  public postAcceptedFromTriageUpdates?: boolean;
+  public postAcceptedFromTriageUpdates?: boolean | null;
   /** Whether or not synced Slack threads should be updated with a message and emoji when their Ask is canceled. */
-  public postCancellationUpdates?: boolean;
+  public postCancellationUpdates?: boolean | null;
   /** Whether or not synced Slack threads should be updated with a message and emoji when their Ask is completed. */
-  public postCompletionUpdates?: boolean;
+  public postCompletionUpdates?: boolean | null;
   /** Which teams are connected to the channel and settings for those teams. */
   public teams: SlackAsksTeamSettings[];
 }
@@ -16153,8 +16153,8 @@ export class SyncedExternalThread extends Request {
   }
 
   /** The display name of the thread. */
-  public displayName?: string;
-  public id?: string;
+  public displayName?: string | null;
+  public id?: string | null;
   /** Whether this thread is syncing with the external service. */
   public isConnected: boolean;
   /** Whether the current user has the corresponding personal integration connected for the external service. */
@@ -16162,13 +16162,13 @@ export class SyncedExternalThread extends Request {
   /** Whether a connected personal integration is required to comment in this thread. */
   public isPersonalIntegrationRequired: boolean;
   /** The display name of the source. */
-  public name?: string;
+  public name?: string | null;
   /** The sub type of the external source. */
-  public subType?: string;
+  public subType?: string | null;
   /** The type of the external source. */
   public type: string;
   /** The external url of the thread. */
-  public url?: string;
+  public url?: string | null;
 }
 /**
  * An organizational unit that contains issues.
@@ -16266,21 +16266,21 @@ export class Team extends Request {
   /** Whether to enable resolved thread AI summaries. */
   public aiThreadSummariesEnabled: boolean;
   /** Whether all members in the workspace can join the team. Only used for public teams. */
-  public allMembersCanJoin?: boolean;
+  public allMembersCanJoin?: boolean | null;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** Period after which automatically closed and completed issues are automatically archived in months. */
   public autoArchivePeriod: number;
   /** Whether child issues should automatically close when their parent issue is closed */
-  public autoCloseChildIssues?: boolean;
+  public autoCloseChildIssues?: boolean | null;
   /** Whether parent issues should automatically close when all child issues are closed */
-  public autoCloseParentIssues?: boolean;
+  public autoCloseParentIssues?: boolean | null;
   /** Period after which issues are automatically closed in months. Null/undefined means disabled. */
-  public autoClosePeriod?: number;
+  public autoClosePeriod?: number | null;
   /** The canceled workflow state which auto closed issues will be set to. Defaults to the first canceled state. */
-  public autoCloseStateId?: string;
+  public autoCloseStateId?: string | null;
   /** The team's color. */
-  public color?: string;
+  public color?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Calendar feed URL (iCal) for cycles. */
@@ -16302,17 +16302,17 @@ export class Team extends Request {
   /** What to use as a default estimate for unestimated issues. */
   public defaultIssueEstimate: number;
   /** The id of the default template to use for new issues created by members of the team. */
-  public defaultTemplateForMembersId?: string;
+  public defaultTemplateForMembersId?: string | null;
   /** The id of the default template to use for new issues created by non-members of the team. */
-  public defaultTemplateForNonMembersId?: string;
+  public defaultTemplateForNonMembersId?: string | null;
   /** The team's description. */
-  public description?: string;
+  public description?: string | null;
   /** The name of the team including its parent team name if it has one. */
   public displayName: string;
   /** Whether to group recent issue history entries. */
   public groupIssueHistory: boolean;
   /** The icon of the team. */
-  public icon?: string;
+  public icon?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Whether the team should inherit its estimation settings from its parent. Only applies to sub-teams. */
@@ -16342,7 +16342,7 @@ export class Team extends Request {
   /** Whether an issue needs to have a priority set before leaving triage. */
   public requirePriorityToLeaveTriage: boolean;
   /** The SCIM group name for the team. */
-  public scimGroupName?: string;
+  public scimGroupName?: string | null;
   /** Whether the team is managed by SCIM integration. */
   public scimManaged: boolean;
   /** Security settings for the team. */
@@ -16649,7 +16649,7 @@ export class TeamMembership extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -16786,7 +16786,7 @@ export class TeamNotificationSubscription extends Request {
   /** Whether the subscription is active or not. */
   public active: boolean;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -16799,9 +16799,9 @@ export class TeamNotificationSubscription extends Request {
    */
   public updatedAt: Date;
   /** The type of view to which the notification subscription context is associated with. */
-  public contextViewType?: L.ContextViewType;
+  public contextViewType?: L.ContextViewType | null;
   /** The type of user view to which the notification subscription context is associated with. */
-  public userContextViewType?: L.UserContextViewType;
+  public userContextViewType?: L.UserContextViewType | null;
   /** The contextual custom view associated with the notification subscription. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return this._customView?.id ? new CustomViewQuery(this._request).fetch(this._customView?.id) : undefined;
@@ -16943,7 +16943,7 @@ export class TeamWithParentWebhookPayload {
   /** The name of the team. */
   public name: string;
   /** The parent team's unique identifier, if any. */
-  public parentId?: string;
+  public parentId?: string | null;
 }
 /**
  * A template object used for creating entities faster.
@@ -16976,15 +16976,15 @@ export class Template extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Template description. */
-  public description?: string;
+  public description?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The date when the template was last applied. */
-  public lastAppliedAt?: Date;
+  public lastAppliedAt?: Date | null;
   /** The name of the template. */
   public name: string;
   /** The sort order of the template. */
@@ -17121,13 +17121,13 @@ export class TimeSchedule extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The identifier of the external schedule. */
-  public externalId?: string;
+  public externalId?: string | null;
   /** The URL to the external schedule. */
-  public externalUrl?: string;
+  public externalUrl?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The name of the schedule. */
@@ -17138,7 +17138,7 @@ export class TimeSchedule extends Request {
    */
   public updatedAt: Date;
   /** The schedule entries. */
-  public entries?: TimeScheduleEntry[];
+  public entries?: TimeScheduleEntry[] | null;
   /** The identifier of the Linear integration populating the schedule. */
   public get integration(): LinearFetch<Integration> | undefined {
     return this._integration?.id ? new IntegrationQuery(this._request).fetch(this._integration?.id) : undefined;
@@ -17206,9 +17206,9 @@ export class TimeScheduleEntry extends Request {
   /** The start date of the schedule in ISO 8601 date-time format. */
   public startsAt: Date;
   /** The email, name or reference to the user on schedule. This is used in case the external user could not be mapped to a Linear user id. */
-  public userEmail?: string;
+  public userEmail?: string | null;
   /** The Linear user id of the user on schedule. If the user cannot be mapped to a Linear user then `userEmail` can be used as a reference. */
-  public userId?: string;
+  public userId?: string | null;
 }
 /**
  * TimeSchedulePayload model
@@ -17265,7 +17265,7 @@ export class TriageResponsibility extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -17276,7 +17276,7 @@ export class TriageResponsibility extends Request {
    */
   public updatedAt: Date;
   /** Set of users used for triage responsibility. */
-  public manualSelection?: TriageResponsibilityManualSelection;
+  public manualSelection?: TriageResponsibilityManualSelection | null;
   /** The action to take when an issue is added to triage. */
   public action: L.TriageResponsibilityAction;
   /** The user currently responsible for triage. */
@@ -17405,7 +17405,7 @@ export class UploadFile extends Request {
   public contentType: string;
   /** The filename. */
   public filename: string;
-  public metaData?: L.Scalars["JSONObject"];
+  public metaData?: L.Scalars["JSONObject"] | null;
   /** The size of the uploaded file. */
   public size: number;
   /** The signed URL the for the uploaded file. (assigned automatically). */
@@ -17449,7 +17449,7 @@ export class UploadPayload extends Request {
   /** Whether the operation was successful. */
   public success: boolean;
   /** Object describing the file to be uploaded. */
-  public uploadFile?: UploadFile;
+  public uploadFile?: UploadFile | null;
 }
 /**
  * A user that has access to the the resources of an organization.
@@ -17501,13 +17501,13 @@ export class User extends Request {
   /** Whether the user is an app. */
   public app: boolean;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The background color of the avatar for users without set avatar. */
   public avatarBackgroundColor: string;
   /** An URL to the user's avatar image. */
-  public avatarUrl?: string;
+  public avatarUrl?: string | null;
   /** [DEPRECATED] Hash for the user to be used in calendar URLs. */
-  public calendarHash?: string;
+  public calendarHash?: string | null;
   /** Whether this user can access any public team in the organization. */
   public canAccessAnyPublicTeam: boolean;
   /** The time at which the entity was created. */
@@ -17515,15 +17515,15 @@ export class User extends Request {
   /** Number of issues created. */
   public createdIssueCount: number;
   /** A short description of the user, either its title or bio. */
-  public description?: string;
+  public description?: string | null;
   /** Reason why is the account disabled. */
-  public disableReason?: string;
+  public disableReason?: string | null;
   /** The user's display (nick) name. Unique within each organization. */
   public displayName: string;
   /** The user's email address. */
   public email: string;
   /** The user's GitHub user ID. */
-  public gitHubUserId?: string;
+  public gitHubUserId?: string | null;
   /** Whether the user is a guest in the workspace and limited to accessing a subset of teams. */
   public guest: boolean;
   /** The unique identifier of the entity. */
@@ -17539,21 +17539,21 @@ export class User extends Request {
   /** Whether the user is mentionable. */
   public isMentionable: boolean;
   /** The last time the user was seen online. */
-  public lastSeen?: Date;
+  public lastSeen?: Date | null;
   /** The user's full name. */
   public name: string;
   /** Whether the user is an organization owner. */
   public owner: boolean;
   /** The emoji to represent the user current status. */
-  public statusEmoji?: string;
+  public statusEmoji?: string | null;
   /** The label of the user current status. */
-  public statusLabel?: string;
+  public statusLabel?: string | null;
   /** A date at which the user current status should be cleared. */
-  public statusUntilAt?: Date;
+  public statusUntilAt?: Date | null;
   /** Whether this agent user supports agent sessions. */
   public supportsAgentSessions: boolean;
   /** The local timezone of the user. */
-  public timezone?: string;
+  public timezone?: string | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
@@ -17618,7 +17618,7 @@ export class UserActorWebhookPayload {
   }
 
   /** The avatar URL of the user. */
-  public avatarUrl?: string;
+  public avatarUrl?: string | null;
   /** The email of the user. */
   public email: string;
   /** The ID of the user. */
@@ -17660,7 +17660,7 @@ export class UserChildWebhookPayload {
   }
 
   /** The avatar URL of the user. */
-  public avatarUrl?: string;
+  public avatarUrl?: string | null;
   /** The email of the user. */
   public email: string;
   /** The ID of the user. */
@@ -17732,7 +17732,7 @@ export class UserNotificationSubscription extends Request {
   /** Whether the subscription is active or not. */
   public active: boolean;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -17745,9 +17745,9 @@ export class UserNotificationSubscription extends Request {
    */
   public updatedAt: Date;
   /** The type of view to which the notification subscription context is associated with. */
-  public contextViewType?: L.ContextViewType;
+  public contextViewType?: L.ContextViewType | null;
   /** The type of user view to which the notification subscription context is associated with. */
-  public userContextViewType?: L.UserContextViewType;
+  public userContextViewType?: L.UserContextViewType | null;
   /** The contextual custom view associated with the notification subscription. */
   public get customView(): LinearFetch<CustomView> | undefined {
     return this._customView?.id ? new CustomViewQuery(this._request).fetch(this._customView?.id) : undefined;
@@ -17892,15 +17892,15 @@ export class UserSettings extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** Whether to auto-assign newly created issues to the current user by default. */
   public autoAssignToSelf: boolean;
   /** Hash for the user to be used in calendar URLs. */
-  public calendarHash?: string;
+  public calendarHash?: string | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The user's last seen time for the pulse feed. */
-  public feedLastSeenTime?: Date;
+  public feedLastSeenTime?: Date | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** Whether to show full user names instead of display names. */
@@ -17927,9 +17927,9 @@ export class UserSettings extends Request {
   /** The notification delivery preferences for the user. Note: notificationDisabled field is deprecated in favor of notificationChannelPreferences. */
   public notificationDeliveryPreferences: NotificationDeliveryPreferences;
   /** The user's theme for a given mode and device type. */
-  public theme?: UserSettingsTheme;
+  public theme?: UserSettingsTheme | null;
   /** The user's feed summary schedule preference. */
-  public feedSummarySchedule?: L.FeedSummarySchedule;
+  public feedSummarySchedule?: L.FeedSummarySchedule | null;
   /** The user associated with these settings. */
   public get user(): LinearFetch<User> | undefined {
     return new UserQuery(this._request).fetch(this._user.id);
@@ -17987,7 +17987,7 @@ export class UserSettingsCustomTheme extends Request {
   /** The contrast value. */
   public contrast: number;
   /** Optional sidebar theme colors. */
-  public sidebar?: UserSettingsCustomSidebarTheme;
+  public sidebar?: UserSettingsCustomSidebarTheme | null;
 }
 /**
  * UserSettingsFlagPayload model
@@ -18005,13 +18005,13 @@ export class UserSettingsFlagPayload extends Request {
   }
 
   /** The flag key which was updated. */
-  public flag?: string;
+  public flag?: string | null;
   /** The identifier of the last sync operation. */
   public lastSyncId: number;
   /** Whether the operation was successful. */
   public success: boolean;
   /** The flag value after update. */
-  public value?: number;
+  public value?: number | null;
 }
 /**
  * UserSettingsFlagsResetPayload model
@@ -18067,7 +18067,7 @@ export class UserSettingsTheme extends Request {
   }
 
   /** The custom theme definition, only present when preset is 'custom'. */
-  public custom?: UserSettingsCustomTheme;
+  public custom?: UserSettingsCustomTheme | null;
   /** The theme preset. */
   public preset: L.UserSettingsThemePreset;
 }
@@ -18104,15 +18104,15 @@ export class UserWebhookPayload {
   /** Whether the user is an app. */
   public app: boolean;
   /** The time at which the entity was archived. */
-  public archivedAt?: string;
+  public archivedAt?: string | null;
   /** The avatar URL of the user. */
-  public avatarUrl?: string;
+  public avatarUrl?: string | null;
   /** The time at which the entity was created. */
   public createdAt: string;
   /** The description of the user. */
-  public description?: string;
+  public description?: string | null;
   /** The reason the user is disabled. */
-  public disableReason?: string;
+  public disableReason?: string | null;
   /** The display name of the user. */
   public displayName: string;
   /** The email of the user. */
@@ -18124,9 +18124,9 @@ export class UserWebhookPayload {
   /** The name of the user. */
   public name: string;
   /** Whether the user is an owner. */
-  public owner?: boolean;
+  public owner?: boolean | null;
   /** The local timezone of the user. */
-  public timezone?: string;
+  public timezone?: string | null;
   /** The time at which the entity was updated. */
   public updatedAt: string;
   /** The URL of the user. */
@@ -18151,7 +18151,7 @@ export class ViewPreferences extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** The unique identifier of the entity. */
@@ -18217,11 +18217,11 @@ export class ViewPreferencesValues extends Request {
   }
 
   /** The issue grouping. */
-  public issueGrouping?: string;
+  public issueGrouping?: string | null;
   /** Whether to show completed issues. */
-  public showCompletedIssues?: string;
+  public showCompletedIssues?: string | null;
   /** The issue ordering. */
-  public viewOrdering?: string;
+  public viewOrdering?: string | null;
 }
 /**
  * A webhook used to send HTTP notifications over data updates.
@@ -18252,7 +18252,7 @@ export class Webhook extends Request {
   /** Whether the Webhook is enabled for all public teams, including teams created after the webhook was created. */
   public allPublicTeams: boolean;
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Whether the Webhook is enabled. */
@@ -18260,18 +18260,18 @@ export class Webhook extends Request {
   /** The unique identifier of the entity. */
   public id: string;
   /** Webhook label. */
-  public label?: string;
+  public label?: string | null;
   /** The resource types this webhook is subscribed to. */
   public resourceTypes: string[];
   /** Secret token for verifying the origin on the recipient side. */
-  public secret?: string;
+  public secret?: string | null;
   /**
    * The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
    *     been updated after creation.
    */
   public updatedAt: Date;
   /** Webhook URL. */
-  public url?: string;
+  public url?: string | null;
   /** The user who created the webhook. */
   public get creator(): LinearFetch<User> | undefined {
     return this._creator?.id ? new UserQuery(this._request).fetch(this._creator?.id) : undefined;
@@ -18348,11 +18348,11 @@ export class WebhookFailureEvent extends Request {
   /** The unique execution ID of the webhook push. This is retained between retries of the same push. */
   public executionId: string;
   /** The HTTP status code returned by the recipient. */
-  public httpStatus?: number;
+  public httpStatus?: number | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The HTTP response body returned by the recipient or error occured. */
-  public responseOrError?: string;
+  public responseOrError?: string | null;
   /** The URL that the webhook was trying to push to. */
   public url: string;
   /** The webhook that this failure event is associated with. */
@@ -18419,13 +18419,13 @@ export class WorkflowState extends Request {
   }
 
   /** The time at which the entity was archived. Null if the entity has not been archived. */
-  public archivedAt?: Date;
+  public archivedAt?: Date | null;
   /** The state's UI color as a HEX string. */
   public color: string;
   /** The time at which the entity was created. */
   public createdAt: Date;
   /** Description of the state. */
-  public description?: string;
+  public description?: string | null;
   /** The unique identifier of the entity. */
   public id: string;
   /** The state's name. */

--- a/packages/sdk/src/_tests/_generated.test.ts
+++ b/packages/sdk/src/_tests/_generated.test.ts
@@ -22,12 +22,12 @@ describe("generated", () => {
 
   /** Test all Team queries */
   describe("AdministrableTeams", () => {
-    let _team: L.Team | undefined;
-    let _team_id: string | undefined;
+    let _team: L.Team | undefined | null;
+    let _team_id: string | undefined | null;
 
     /** Test the root connection query for the Team */
     it("administrableTeams", async () => {
-      const administrableTeams: L.TeamConnection | undefined = await client.administrableTeams();
+      const administrableTeams: L.TeamConnection | undefined | null = await client.administrableTeams();
       const team = administrableTeams?.nodes?.[0];
       _team_id = team?.id;
       expect(administrableTeams instanceof L.TeamConnection);
@@ -36,7 +36,7 @@ describe("generated", () => {
     /** Test the root query for a single Team */
     it("team", async () => {
       if (_team_id) {
-        const team: L.Team | undefined = await client.team(_team_id);
+        const team: L.Team | undefined | null = await client.team(_team_id);
         _team = team;
         expect(team instanceof L.Team);
       } else {
@@ -47,7 +47,7 @@ describe("generated", () => {
     /** Test the team connection query for the Cycle */
     it("team.cycles", async () => {
       if (_team) {
-        const cycles: L.CycleConnection | undefined = await _team.cycles();
+        const cycles: L.CycleConnection | undefined | null = await _team.cycles();
         expect(cycles instanceof L.CycleConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.cycles query");
@@ -57,7 +57,8 @@ describe("generated", () => {
     /** Test the team connection query for the GitAutomationState */
     it("team.gitAutomationStates", async () => {
       if (_team) {
-        const gitAutomationStates: L.GitAutomationStateConnection | undefined = await _team.gitAutomationStates();
+        const gitAutomationStates: L.GitAutomationStateConnection | undefined | null =
+          await _team.gitAutomationStates();
         expect(gitAutomationStates instanceof L.GitAutomationStateConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.gitAutomationStates query");
@@ -67,7 +68,7 @@ describe("generated", () => {
     /** Test the team connection query for the Issue */
     it("team.issues", async () => {
       if (_team) {
-        const issues: L.IssueConnection | undefined = await _team.issues();
+        const issues: L.IssueConnection | undefined | null = await _team.issues();
         expect(issues instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.issues query");
@@ -77,7 +78,7 @@ describe("generated", () => {
     /** Test the team connection query for the IssueLabel */
     it("team.labels", async () => {
       if (_team) {
-        const labels: L.IssueLabelConnection | undefined = await _team.labels();
+        const labels: L.IssueLabelConnection | undefined | null = await _team.labels();
         expect(labels instanceof L.IssueLabelConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.labels query");
@@ -87,7 +88,7 @@ describe("generated", () => {
     /** Test the team connection query for the User */
     it("team.members", async () => {
       if (_team) {
-        const members: L.UserConnection | undefined = await _team.members();
+        const members: L.UserConnection | undefined | null = await _team.members();
         expect(members instanceof L.UserConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.members query");
@@ -97,7 +98,7 @@ describe("generated", () => {
     /** Test the team connection query for the TeamMembership */
     it("team.memberships", async () => {
       if (_team) {
-        const memberships: L.TeamMembershipConnection | undefined = await _team.memberships();
+        const memberships: L.TeamMembershipConnection | undefined | null = await _team.memberships();
         expect(memberships instanceof L.TeamMembershipConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.memberships query");
@@ -107,7 +108,7 @@ describe("generated", () => {
     /** Test the team connection query for the Project */
     it("team.projects", async () => {
       if (_team) {
-        const projects: L.ProjectConnection | undefined = await _team.projects();
+        const projects: L.ProjectConnection | undefined | null = await _team.projects();
         expect(projects instanceof L.ProjectConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.projects query");
@@ -117,7 +118,7 @@ describe("generated", () => {
     /** Test the team connection query for the WorkflowState */
     it("team.states", async () => {
       if (_team) {
-        const states: L.WorkflowStateConnection | undefined = await _team.states();
+        const states: L.WorkflowStateConnection | undefined | null = await _team.states();
         expect(states instanceof L.WorkflowStateConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.states query");
@@ -127,7 +128,7 @@ describe("generated", () => {
     /** Test the team connection query for the Template */
     it("team.templates", async () => {
       if (_team) {
-        const templates: L.TemplateConnection | undefined = await _team.templates();
+        const templates: L.TemplateConnection | undefined | null = await _team.templates();
         expect(templates instanceof L.TemplateConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.templates query");
@@ -137,7 +138,7 @@ describe("generated", () => {
     /** Test the team connection query for the Webhook */
     it("team.webhooks", async () => {
       if (_team) {
-        const webhooks: L.WebhookConnection | undefined = await _team.webhooks();
+        const webhooks: L.WebhookConnection | undefined | null = await _team.webhooks();
         expect(webhooks instanceof L.WebhookConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.webhooks query");
@@ -147,7 +148,7 @@ describe("generated", () => {
     /** Test the team.activeCycle query for L.Cycle */
     it("team.activeCycle", async () => {
       if (_team) {
-        const team_activeCycle: L.Cycle | undefined = await _team.activeCycle;
+        const team_activeCycle: L.Cycle | undefined | null = await _team.activeCycle;
         expect(team_activeCycle instanceof L.Cycle);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.activeCycle query");
@@ -157,7 +158,7 @@ describe("generated", () => {
     /** Test the team.defaultIssueState query for L.WorkflowState */
     it("team.defaultIssueState", async () => {
       if (_team) {
-        const team_defaultIssueState: L.WorkflowState | undefined = await _team.defaultIssueState;
+        const team_defaultIssueState: L.WorkflowState | undefined | null = await _team.defaultIssueState;
         expect(team_defaultIssueState instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.defaultIssueState query");
@@ -167,7 +168,7 @@ describe("generated", () => {
     /** Test the team.defaultProjectTemplate query for L.Template */
     it("team.defaultProjectTemplate", async () => {
       if (_team) {
-        const team_defaultProjectTemplate: L.Template | undefined = await _team.defaultProjectTemplate;
+        const team_defaultProjectTemplate: L.Template | undefined | null = await _team.defaultProjectTemplate;
         expect(team_defaultProjectTemplate instanceof L.Template);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.defaultProjectTemplate query");
@@ -177,7 +178,7 @@ describe("generated", () => {
     /** Test the team.defaultTemplateForMembers query for L.Template */
     it("team.defaultTemplateForMembers", async () => {
       if (_team) {
-        const team_defaultTemplateForMembers: L.Template | undefined = await _team.defaultTemplateForMembers;
+        const team_defaultTemplateForMembers: L.Template | undefined | null = await _team.defaultTemplateForMembers;
         expect(team_defaultTemplateForMembers instanceof L.Template);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.defaultTemplateForMembers query");
@@ -187,7 +188,8 @@ describe("generated", () => {
     /** Test the team.defaultTemplateForNonMembers query for L.Template */
     it("team.defaultTemplateForNonMembers", async () => {
       if (_team) {
-        const team_defaultTemplateForNonMembers: L.Template | undefined = await _team.defaultTemplateForNonMembers;
+        const team_defaultTemplateForNonMembers: L.Template | undefined | null =
+          await _team.defaultTemplateForNonMembers;
         expect(team_defaultTemplateForNonMembers instanceof L.Template);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.defaultTemplateForNonMembers query");
@@ -197,7 +199,7 @@ describe("generated", () => {
     /** Test the team.draftWorkflowState query for L.WorkflowState */
     it("team.draftWorkflowState", async () => {
       if (_team) {
-        const team_draftWorkflowState: L.WorkflowState | undefined = await _team.draftWorkflowState;
+        const team_draftWorkflowState: L.WorkflowState | undefined | null = await _team.draftWorkflowState;
         expect(team_draftWorkflowState instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.draftWorkflowState query");
@@ -207,7 +209,7 @@ describe("generated", () => {
     /** Test the team.integrationsSettings query for L.IntegrationsSettings */
     it("team.integrationsSettings", async () => {
       if (_team) {
-        const team_integrationsSettings: L.IntegrationsSettings | undefined = await _team.integrationsSettings;
+        const team_integrationsSettings: L.IntegrationsSettings | undefined | null = await _team.integrationsSettings;
         expect(team_integrationsSettings instanceof L.IntegrationsSettings);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.integrationsSettings query");
@@ -217,7 +219,7 @@ describe("generated", () => {
     /** Test the team.markedAsDuplicateWorkflowState query for L.WorkflowState */
     it("team.markedAsDuplicateWorkflowState", async () => {
       if (_team) {
-        const team_markedAsDuplicateWorkflowState: L.WorkflowState | undefined =
+        const team_markedAsDuplicateWorkflowState: L.WorkflowState | undefined | null =
           await _team.markedAsDuplicateWorkflowState;
         expect(team_markedAsDuplicateWorkflowState instanceof L.WorkflowState);
       } else {
@@ -228,7 +230,7 @@ describe("generated", () => {
     /** Test the team.mergeWorkflowState query for L.WorkflowState */
     it("team.mergeWorkflowState", async () => {
       if (_team) {
-        const team_mergeWorkflowState: L.WorkflowState | undefined = await _team.mergeWorkflowState;
+        const team_mergeWorkflowState: L.WorkflowState | undefined | null = await _team.mergeWorkflowState;
         expect(team_mergeWorkflowState instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.mergeWorkflowState query");
@@ -238,7 +240,7 @@ describe("generated", () => {
     /** Test the team.mergeableWorkflowState query for L.WorkflowState */
     it("team.mergeableWorkflowState", async () => {
       if (_team) {
-        const team_mergeableWorkflowState: L.WorkflowState | undefined = await _team.mergeableWorkflowState;
+        const team_mergeableWorkflowState: L.WorkflowState | undefined | null = await _team.mergeableWorkflowState;
         expect(team_mergeableWorkflowState instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.mergeableWorkflowState query");
@@ -248,7 +250,7 @@ describe("generated", () => {
     /** Test the team.organization query for L.Organization */
     it("team.organization", async () => {
       if (_team) {
-        const team_organization: L.Organization | undefined = await _team.organization;
+        const team_organization: L.Organization | undefined | null = await _team.organization;
         expect(team_organization instanceof L.Organization);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.organization query");
@@ -258,7 +260,7 @@ describe("generated", () => {
     /** Test the team.reviewWorkflowState query for L.WorkflowState */
     it("team.reviewWorkflowState", async () => {
       if (_team) {
-        const team_reviewWorkflowState: L.WorkflowState | undefined = await _team.reviewWorkflowState;
+        const team_reviewWorkflowState: L.WorkflowState | undefined | null = await _team.reviewWorkflowState;
         expect(team_reviewWorkflowState instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.reviewWorkflowState query");
@@ -268,7 +270,7 @@ describe("generated", () => {
     /** Test the team.startWorkflowState query for L.WorkflowState */
     it("team.startWorkflowState", async () => {
       if (_team) {
-        const team_startWorkflowState: L.WorkflowState | undefined = await _team.startWorkflowState;
+        const team_startWorkflowState: L.WorkflowState | undefined | null = await _team.startWorkflowState;
         expect(team_startWorkflowState instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.startWorkflowState query");
@@ -278,7 +280,7 @@ describe("generated", () => {
     /** Test the team.triageIssueState query for L.WorkflowState */
     it("team.triageIssueState", async () => {
       if (_team) {
-        const team_triageIssueState: L.WorkflowState | undefined = await _team.triageIssueState;
+        const team_triageIssueState: L.WorkflowState | undefined | null = await _team.triageIssueState;
         expect(team_triageIssueState instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.triageIssueState query");
@@ -288,7 +290,7 @@ describe("generated", () => {
     /** Test the team.triageResponsibility query for L.TriageResponsibility */
     it("team.triageResponsibility", async () => {
       if (_team) {
-        const team_triageResponsibility: L.TriageResponsibility | undefined = await _team.triageResponsibility;
+        const team_triageResponsibility: L.TriageResponsibility | undefined | null = await _team.triageResponsibility;
         expect(team_triageResponsibility instanceof L.TriageResponsibility);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.triageResponsibility query");
@@ -298,12 +300,12 @@ describe("generated", () => {
 
   /** Test all AgentActivity queries */
   describe("AgentActivities", () => {
-    let _agentActivity: L.AgentActivity | undefined;
-    let _agentActivity_id: string | undefined;
+    let _agentActivity: L.AgentActivity | undefined | null;
+    let _agentActivity_id: string | undefined | null;
 
     /** Test the root connection query for the AgentActivity */
     it("agentActivities", async () => {
-      const agentActivities: L.AgentActivityConnection | undefined = await client.agentActivities();
+      const agentActivities: L.AgentActivityConnection | undefined | null = await client.agentActivities();
       const agentActivity = agentActivities?.nodes?.[0];
       _agentActivity_id = agentActivity?.id;
       expect(agentActivities instanceof L.AgentActivityConnection);
@@ -312,7 +314,7 @@ describe("generated", () => {
     /** Test the root query for a single AgentActivity */
     it("agentActivity", async () => {
       if (_agentActivity_id) {
-        const agentActivity: L.AgentActivity | undefined = await client.agentActivity(_agentActivity_id);
+        const agentActivity: L.AgentActivity | undefined | null = await client.agentActivity(_agentActivity_id);
         _agentActivity = agentActivity;
         expect(agentActivity instanceof L.AgentActivity);
       } else {
@@ -323,7 +325,7 @@ describe("generated", () => {
     /** Test the agentActivity.agentSession query for L.AgentSession */
     it("agentActivity.agentSession", async () => {
       if (_agentActivity) {
-        const agentActivity_agentSession: L.AgentSession | undefined = await _agentActivity.agentSession;
+        const agentActivity_agentSession: L.AgentSession | undefined | null = await _agentActivity.agentSession;
         expect(agentActivity_agentSession instanceof L.AgentSession);
       } else {
         console.warn("codegen-doc:print: No AgentActivity found - cannot test agentActivity.agentSession query");
@@ -333,7 +335,7 @@ describe("generated", () => {
     /** Test the agentActivity.sourceComment query for L.Comment */
     it("agentActivity.sourceComment", async () => {
       if (_agentActivity) {
-        const agentActivity_sourceComment: L.Comment | undefined = await _agentActivity.sourceComment;
+        const agentActivity_sourceComment: L.Comment | undefined | null = await _agentActivity.sourceComment;
         expect(agentActivity_sourceComment instanceof L.Comment);
       } else {
         console.warn("codegen-doc:print: No AgentActivity found - cannot test agentActivity.sourceComment query");
@@ -343,7 +345,7 @@ describe("generated", () => {
     /** Test the agentActivity.user query for L.User */
     it("agentActivity.user", async () => {
       if (_agentActivity) {
-        const agentActivity_user: L.User | undefined = await _agentActivity.user;
+        const agentActivity_user: L.User | undefined | null = await _agentActivity.user;
         expect(agentActivity_user instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No AgentActivity found - cannot test agentActivity.user query");
@@ -353,12 +355,12 @@ describe("generated", () => {
 
   /** Test all AgentSession queries */
   describe("AgentSessions", () => {
-    let _agentSession: L.AgentSession | undefined;
-    let _agentSession_id: string | undefined;
+    let _agentSession: L.AgentSession | undefined | null;
+    let _agentSession_id: string | undefined | null;
 
     /** Test the root connection query for the AgentSession */
     it("agentSessions", async () => {
-      const agentSessions: L.AgentSessionConnection | undefined = await client.agentSessions();
+      const agentSessions: L.AgentSessionConnection | undefined | null = await client.agentSessions();
       const agentSession = agentSessions?.nodes?.[0];
       _agentSession_id = agentSession?.id;
       expect(agentSessions instanceof L.AgentSessionConnection);
@@ -367,7 +369,7 @@ describe("generated", () => {
     /** Test the root query for a single AgentSession */
     it("agentSession", async () => {
       if (_agentSession_id) {
-        const agentSession: L.AgentSession | undefined = await client.agentSession(_agentSession_id);
+        const agentSession: L.AgentSession | undefined | null = await client.agentSession(_agentSession_id);
         _agentSession = agentSession;
         expect(agentSession instanceof L.AgentSession);
       } else {
@@ -378,7 +380,7 @@ describe("generated", () => {
     /** Test the agentSession connection query for the AgentActivity */
     it("agentSession.activities", async () => {
       if (_agentSession) {
-        const activities: L.AgentActivityConnection | undefined = await _agentSession.activities();
+        const activities: L.AgentActivityConnection | undefined | null = await _agentSession.activities();
         expect(activities instanceof L.AgentActivityConnection);
       } else {
         console.warn("codegen-doc:print: No agentSession found - cannot test _agentSession.activities query");
@@ -388,7 +390,7 @@ describe("generated", () => {
     /** Test the agentSession.appUser query for L.User */
     it("agentSession.appUser", async () => {
       if (_agentSession) {
-        const agentSession_appUser: L.User | undefined = await _agentSession.appUser;
+        const agentSession_appUser: L.User | undefined | null = await _agentSession.appUser;
         expect(agentSession_appUser instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No AgentSession found - cannot test agentSession.appUser query");
@@ -398,7 +400,7 @@ describe("generated", () => {
     /** Test the agentSession.comment query for L.Comment */
     it("agentSession.comment", async () => {
       if (_agentSession) {
-        const agentSession_comment: L.Comment | undefined = await _agentSession.comment;
+        const agentSession_comment: L.Comment | undefined | null = await _agentSession.comment;
         expect(agentSession_comment instanceof L.Comment);
       } else {
         console.warn("codegen-doc:print: No AgentSession found - cannot test agentSession.comment query");
@@ -408,7 +410,7 @@ describe("generated", () => {
     /** Test the agentSession.creator query for L.User */
     it("agentSession.creator", async () => {
       if (_agentSession) {
-        const agentSession_creator: L.User | undefined = await _agentSession.creator;
+        const agentSession_creator: L.User | undefined | null = await _agentSession.creator;
         expect(agentSession_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No AgentSession found - cannot test agentSession.creator query");
@@ -418,7 +420,7 @@ describe("generated", () => {
     /** Test the agentSession.dismissedBy query for L.User */
     it("agentSession.dismissedBy", async () => {
       if (_agentSession) {
-        const agentSession_dismissedBy: L.User | undefined = await _agentSession.dismissedBy;
+        const agentSession_dismissedBy: L.User | undefined | null = await _agentSession.dismissedBy;
         expect(agentSession_dismissedBy instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No AgentSession found - cannot test agentSession.dismissedBy query");
@@ -428,7 +430,7 @@ describe("generated", () => {
     /** Test the agentSession.issue query for L.Issue */
     it("agentSession.issue", async () => {
       if (_agentSession) {
-        const agentSession_issue: L.Issue | undefined = await _agentSession.issue;
+        const agentSession_issue: L.Issue | undefined | null = await _agentSession.issue;
         expect(agentSession_issue instanceof L.Issue);
       } else {
         console.warn("codegen-doc:print: No AgentSession found - cannot test agentSession.issue query");
@@ -438,7 +440,7 @@ describe("generated", () => {
     /** Test the agentSession.sourceComment query for L.Comment */
     it("agentSession.sourceComment", async () => {
       if (_agentSession) {
-        const agentSession_sourceComment: L.Comment | undefined = await _agentSession.sourceComment;
+        const agentSession_sourceComment: L.Comment | undefined | null = await _agentSession.sourceComment;
         expect(agentSession_sourceComment instanceof L.Comment);
       } else {
         console.warn("codegen-doc:print: No AgentSession found - cannot test agentSession.sourceComment query");
@@ -450,18 +452,18 @@ describe("generated", () => {
   describe("ApplicationInfo", () => {
     /** Test the root model query for ApplicationInfo */
     it("applicationInfo", async () => {
-      const applicationInfo: L.Application | undefined = await client.applicationInfo("mock-clientId");
+      const applicationInfo: L.Application | undefined | null = await client.applicationInfo("mock-clientId");
       expect(applicationInfo instanceof L.Application);
     });
   });
 
   /** Test AttachmentIssue query */
   describe("AttachmentIssue", () => {
-    let _attachmentIssue: L.Issue | undefined;
+    let _attachmentIssue: L.Issue | undefined | null;
 
     /** Test the root model query for AttachmentIssue */
     it("attachmentIssue", async () => {
-      const attachmentIssue: L.Issue | undefined = await client.attachmentIssue("mock-id");
+      const attachmentIssue: L.Issue | undefined | null = await client.attachmentIssue("mock-id");
       _attachmentIssue = attachmentIssue;
       expect(attachmentIssue instanceof L.Issue);
     });
@@ -469,7 +471,7 @@ describe("generated", () => {
     /** Test the attachmentIssue connection query for the Attachment */
     it("attachmentIssue.attachments", async () => {
       if (_attachmentIssue) {
-        const attachments: L.AttachmentConnection | undefined = await _attachmentIssue.attachments();
+        const attachments: L.AttachmentConnection | undefined | null = await _attachmentIssue.attachments();
         expect(attachments instanceof L.AttachmentConnection);
       } else {
         console.warn("codegen-doc:print: No attachmentIssue found - cannot test _attachmentIssue.attachments query");
@@ -479,7 +481,7 @@ describe("generated", () => {
     /** Test the attachmentIssue model query for AttachmentIssue_BotActor */
     it("attachmentIssue.botActor", async () => {
       if (_attachmentIssue) {
-        const botActor: L.ActorBot | undefined = _attachmentIssue.botActor;
+        const botActor: L.ActorBot | undefined | null = _attachmentIssue.botActor;
         expect(botActor instanceof L.ActorBot);
       } else {
         console.warn("codegen-doc:print: No attachmentIssue found - cannot test _attachmentIssue.botActor query");
@@ -489,7 +491,7 @@ describe("generated", () => {
     /** Test the attachmentIssue connection query for the Issue */
     it("attachmentIssue.children", async () => {
       if (_attachmentIssue) {
-        const children: L.IssueConnection | undefined = await _attachmentIssue.children();
+        const children: L.IssueConnection | undefined | null = await _attachmentIssue.children();
         expect(children instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No attachmentIssue found - cannot test _attachmentIssue.children query");
@@ -499,7 +501,7 @@ describe("generated", () => {
     /** Test the attachmentIssue connection query for the Comment */
     it("attachmentIssue.comments", async () => {
       if (_attachmentIssue) {
-        const comments: L.CommentConnection | undefined = await _attachmentIssue.comments();
+        const comments: L.CommentConnection | undefined | null = await _attachmentIssue.comments();
         expect(comments instanceof L.CommentConnection);
       } else {
         console.warn("codegen-doc:print: No attachmentIssue found - cannot test _attachmentIssue.comments query");
@@ -509,7 +511,7 @@ describe("generated", () => {
     /** Test the attachmentIssue connection query for the Document */
     it("attachmentIssue.documents", async () => {
       if (_attachmentIssue) {
-        const documents: L.DocumentConnection | undefined = await _attachmentIssue.documents();
+        const documents: L.DocumentConnection | undefined | null = await _attachmentIssue.documents();
         expect(documents instanceof L.DocumentConnection);
       } else {
         console.warn("codegen-doc:print: No attachmentIssue found - cannot test _attachmentIssue.documents query");
@@ -519,7 +521,7 @@ describe("generated", () => {
     /** Test the attachmentIssue connection query for the Attachment */
     it("attachmentIssue.formerAttachments", async () => {
       if (_attachmentIssue) {
-        const formerAttachments: L.AttachmentConnection | undefined = await _attachmentIssue.formerAttachments();
+        const formerAttachments: L.AttachmentConnection | undefined | null = await _attachmentIssue.formerAttachments();
         expect(formerAttachments instanceof L.AttachmentConnection);
       } else {
         console.warn(
@@ -531,7 +533,7 @@ describe("generated", () => {
     /** Test the attachmentIssue connection query for the CustomerNeed */
     it("attachmentIssue.formerNeeds", async () => {
       if (_attachmentIssue) {
-        const formerNeeds: L.CustomerNeedConnection | undefined = await _attachmentIssue.formerNeeds();
+        const formerNeeds: L.CustomerNeedConnection | undefined | null = await _attachmentIssue.formerNeeds();
         expect(formerNeeds instanceof L.CustomerNeedConnection);
       } else {
         console.warn("codegen-doc:print: No attachmentIssue found - cannot test _attachmentIssue.formerNeeds query");
@@ -541,7 +543,7 @@ describe("generated", () => {
     /** Test the attachmentIssue connection query for the IssueHistory */
     it("attachmentIssue.history", async () => {
       if (_attachmentIssue) {
-        const history: L.IssueHistoryConnection | undefined = await _attachmentIssue.history();
+        const history: L.IssueHistoryConnection | undefined | null = await _attachmentIssue.history();
         expect(history instanceof L.IssueHistoryConnection);
       } else {
         console.warn("codegen-doc:print: No attachmentIssue found - cannot test _attachmentIssue.history query");
@@ -551,7 +553,8 @@ describe("generated", () => {
     /** Test the attachmentIssue connection query for the IssueRelation */
     it("attachmentIssue.inverseRelations", async () => {
       if (_attachmentIssue) {
-        const inverseRelations: L.IssueRelationConnection | undefined = await _attachmentIssue.inverseRelations();
+        const inverseRelations: L.IssueRelationConnection | undefined | null =
+          await _attachmentIssue.inverseRelations();
         expect(inverseRelations instanceof L.IssueRelationConnection);
       } else {
         console.warn(
@@ -563,7 +566,7 @@ describe("generated", () => {
     /** Test the attachmentIssue connection query for the IssueLabel */
     it("attachmentIssue.labels", async () => {
       if (_attachmentIssue) {
-        const labels: L.IssueLabelConnection | undefined = await _attachmentIssue.labels();
+        const labels: L.IssueLabelConnection | undefined | null = await _attachmentIssue.labels();
         expect(labels instanceof L.IssueLabelConnection);
       } else {
         console.warn("codegen-doc:print: No attachmentIssue found - cannot test _attachmentIssue.labels query");
@@ -573,7 +576,7 @@ describe("generated", () => {
     /** Test the attachmentIssue connection query for the CustomerNeed */
     it("attachmentIssue.needs", async () => {
       if (_attachmentIssue) {
-        const needs: L.CustomerNeedConnection | undefined = await _attachmentIssue.needs();
+        const needs: L.CustomerNeedConnection | undefined | null = await _attachmentIssue.needs();
         expect(needs instanceof L.CustomerNeedConnection);
       } else {
         console.warn("codegen-doc:print: No attachmentIssue found - cannot test _attachmentIssue.needs query");
@@ -583,7 +586,7 @@ describe("generated", () => {
     /** Test the attachmentIssue connection query for the IssueRelation */
     it("attachmentIssue.relations", async () => {
       if (_attachmentIssue) {
-        const relations: L.IssueRelationConnection | undefined = await _attachmentIssue.relations();
+        const relations: L.IssueRelationConnection | undefined | null = await _attachmentIssue.relations();
         expect(relations instanceof L.IssueRelationConnection);
       } else {
         console.warn("codegen-doc:print: No attachmentIssue found - cannot test _attachmentIssue.relations query");
@@ -593,7 +596,7 @@ describe("generated", () => {
     /** Test the attachmentIssue connection query for the User */
     it("attachmentIssue.subscribers", async () => {
       if (_attachmentIssue) {
-        const subscribers: L.UserConnection | undefined = await _attachmentIssue.subscribers();
+        const subscribers: L.UserConnection | undefined | null = await _attachmentIssue.subscribers();
         expect(subscribers instanceof L.UserConnection);
       } else {
         console.warn("codegen-doc:print: No attachmentIssue found - cannot test _attachmentIssue.subscribers query");
@@ -603,12 +606,12 @@ describe("generated", () => {
 
   /** Test all Attachment queries */
   describe("Attachments", () => {
-    let _attachment: L.Attachment | undefined;
-    let _attachment_id: string | undefined;
+    let _attachment: L.Attachment | undefined | null;
+    let _attachment_id: string | undefined | null;
 
     /** Test the root connection query for the Attachment */
     it("attachments", async () => {
-      const attachments: L.AttachmentConnection | undefined = await client.attachments();
+      const attachments: L.AttachmentConnection | undefined | null = await client.attachments();
       const attachment = attachments?.nodes?.[0];
       _attachment_id = attachment?.id;
       expect(attachments instanceof L.AttachmentConnection);
@@ -617,7 +620,7 @@ describe("generated", () => {
     /** Test the root query for a single Attachment */
     it("attachment", async () => {
       if (_attachment_id) {
-        const attachment: L.Attachment | undefined = await client.attachment(_attachment_id);
+        const attachment: L.Attachment | undefined | null = await client.attachment(_attachment_id);
         _attachment = attachment;
         expect(attachment instanceof L.Attachment);
       } else {
@@ -628,7 +631,7 @@ describe("generated", () => {
     /** Test the attachment.creator query for L.User */
     it("attachment.creator", async () => {
       if (_attachment) {
-        const attachment_creator: L.User | undefined = await _attachment.creator;
+        const attachment_creator: L.User | undefined | null = await _attachment.creator;
         expect(attachment_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Attachment found - cannot test attachment.creator query");
@@ -638,7 +641,7 @@ describe("generated", () => {
     /** Test the attachment.externalUserCreator query for L.ExternalUser */
     it("attachment.externalUserCreator", async () => {
       if (_attachment) {
-        const attachment_externalUserCreator: L.ExternalUser | undefined = await _attachment.externalUserCreator;
+        const attachment_externalUserCreator: L.ExternalUser | undefined | null = await _attachment.externalUserCreator;
         expect(attachment_externalUserCreator instanceof L.ExternalUser);
       } else {
         console.warn("codegen-doc:print: No Attachment found - cannot test attachment.externalUserCreator query");
@@ -648,7 +651,7 @@ describe("generated", () => {
     /** Test the attachment.issue query for L.Issue */
     it("attachment.issue", async () => {
       if (_attachment) {
-        const attachment_issue: L.Issue | undefined = await _attachment.issue;
+        const attachment_issue: L.Issue | undefined | null = await _attachment.issue;
         expect(attachment_issue instanceof L.Issue);
       } else {
         console.warn("codegen-doc:print: No Attachment found - cannot test attachment.issue query");
@@ -658,7 +661,7 @@ describe("generated", () => {
     /** Test the attachment.originalIssue query for L.Issue */
     it("attachment.originalIssue", async () => {
       if (_attachment) {
-        const attachment_originalIssue: L.Issue | undefined = await _attachment.originalIssue;
+        const attachment_originalIssue: L.Issue | undefined | null = await _attachment.originalIssue;
         expect(attachment_originalIssue instanceof L.Issue);
       } else {
         console.warn("codegen-doc:print: No Attachment found - cannot test attachment.originalIssue query");
@@ -668,12 +671,12 @@ describe("generated", () => {
 
   /** Test all Attachment queries */
   describe("AttachmentsForUrl", () => {
-    let _attachment: L.Attachment | undefined;
-    let _attachment_id: string | undefined;
+    let _attachment: L.Attachment | undefined | null;
+    let _attachment_id: string | undefined | null;
 
     /** Test the root connection query for the Attachment */
     it("attachmentsForURL", async () => {
-      const attachmentsForURL: L.AttachmentConnection | undefined = await client.attachmentsForURL("mock-url");
+      const attachmentsForURL: L.AttachmentConnection | undefined | null = await client.attachmentsForURL("mock-url");
       const attachment = attachmentsForURL?.nodes?.[0];
       _attachment_id = attachment?.id;
       expect(attachmentsForURL instanceof L.AttachmentConnection);
@@ -682,7 +685,7 @@ describe("generated", () => {
     /** Test the root query for a single Attachment */
     it("attachment", async () => {
       if (_attachment_id) {
-        const attachment: L.Attachment | undefined = await client.attachment(_attachment_id);
+        const attachment: L.Attachment | undefined | null = await client.attachment(_attachment_id);
         _attachment = attachment;
         expect(attachment instanceof L.Attachment);
       } else {
@@ -693,7 +696,7 @@ describe("generated", () => {
     /** Test the attachment.creator query for L.User */
     it("attachment.creator", async () => {
       if (_attachment) {
-        const attachment_creator: L.User | undefined = await _attachment.creator;
+        const attachment_creator: L.User | undefined | null = await _attachment.creator;
         expect(attachment_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Attachment found - cannot test attachment.creator query");
@@ -703,7 +706,7 @@ describe("generated", () => {
     /** Test the attachment.externalUserCreator query for L.ExternalUser */
     it("attachment.externalUserCreator", async () => {
       if (_attachment) {
-        const attachment_externalUserCreator: L.ExternalUser | undefined = await _attachment.externalUserCreator;
+        const attachment_externalUserCreator: L.ExternalUser | undefined | null = await _attachment.externalUserCreator;
         expect(attachment_externalUserCreator instanceof L.ExternalUser);
       } else {
         console.warn("codegen-doc:print: No Attachment found - cannot test attachment.externalUserCreator query");
@@ -713,7 +716,7 @@ describe("generated", () => {
     /** Test the attachment.issue query for L.Issue */
     it("attachment.issue", async () => {
       if (_attachment) {
-        const attachment_issue: L.Issue | undefined = await _attachment.issue;
+        const attachment_issue: L.Issue | undefined | null = await _attachment.issue;
         expect(attachment_issue instanceof L.Issue);
       } else {
         console.warn("codegen-doc:print: No Attachment found - cannot test attachment.issue query");
@@ -723,7 +726,7 @@ describe("generated", () => {
     /** Test the attachment.originalIssue query for L.Issue */
     it("attachment.originalIssue", async () => {
       if (_attachment) {
-        const attachment_originalIssue: L.Issue | undefined = await _attachment.originalIssue;
+        const attachment_originalIssue: L.Issue | undefined | null = await _attachment.originalIssue;
         expect(attachment_originalIssue instanceof L.Issue);
       } else {
         console.warn("codegen-doc:print: No Attachment found - cannot test attachment.originalIssue query");
@@ -735,7 +738,7 @@ describe("generated", () => {
   describe("AuditEntries", () => {
     /** Test the root connection query for the AuditEntry */
     it("auditEntries", async () => {
-      const auditEntries: L.AuditEntryConnection | undefined = await client.auditEntries();
+      const auditEntries: L.AuditEntryConnection | undefined | null = await client.auditEntries();
       expect(auditEntries instanceof L.AuditEntryConnection);
     });
   });
@@ -744,7 +747,7 @@ describe("generated", () => {
   describe("AuditEntryTypes", () => {
     /** Test the root model query for AuditEntryTypes */
     it("auditEntryTypes", async () => {
-      const auditEntryTypes: L.AuditEntryType[] | undefined = await client.auditEntryTypes;
+      const auditEntryTypes: L.AuditEntryType[] | undefined | null = await client.auditEntryTypes;
       auditEntryTypes?.map(node => expect(node instanceof L.AuditEntryType));
     });
   });
@@ -753,7 +756,8 @@ describe("generated", () => {
   describe("AuthenticationSessions", () => {
     /** Test the root model query for AuthenticationSessions */
     it("authenticationSessions", async () => {
-      const authenticationSessions: L.AuthenticationSessionResponse[] | undefined = await client.authenticationSessions;
+      const authenticationSessions: L.AuthenticationSessionResponse[] | undefined | null =
+        await client.authenticationSessions;
       authenticationSessions?.map(node => expect(node instanceof L.AuthenticationSessionResponse));
     });
   });
@@ -762,19 +766,19 @@ describe("generated", () => {
   describe("AvailableUsers", () => {
     /** Test the root model query for AvailableUsers */
     it("availableUsers", async () => {
-      const availableUsers: L.AuthResolverResponse | undefined = await client.availableUsers;
+      const availableUsers: L.AuthResolverResponse | undefined | null = await client.availableUsers;
       expect(availableUsers instanceof L.AuthResolverResponse);
     });
   });
 
   /** Test all Comment queries */
   describe("Comments", () => {
-    let _comment: L.Comment | undefined;
-    let _comment_id: string | undefined;
+    let _comment: L.Comment | undefined | null;
+    let _comment_id: string | undefined | null;
 
     /** Test the root connection query for the Comment */
     it("comments", async () => {
-      const comments: L.CommentConnection | undefined = await client.comments();
+      const comments: L.CommentConnection | undefined | null = await client.comments();
       const comment = comments?.nodes?.[0];
       _comment_id = comment?.id;
       expect(comments instanceof L.CommentConnection);
@@ -783,7 +787,7 @@ describe("generated", () => {
     /** Test the root query for a single Comment */
     it("comment", async () => {
       if (_comment_id) {
-        const comment: L.Comment | undefined = await client.comment({ id: _comment_id });
+        const comment: L.Comment | undefined | null = await client.comment({ id: _comment_id });
         _comment = comment;
         expect(comment instanceof L.Comment);
       } else {
@@ -794,7 +798,7 @@ describe("generated", () => {
     /** Test the comment model query for Comment_BotActor */
     it("comment.botActor", async () => {
       if (_comment) {
-        const botActor: L.ActorBot | undefined = _comment.botActor;
+        const botActor: L.ActorBot | undefined | null = _comment.botActor;
         expect(botActor instanceof L.ActorBot);
       } else {
         console.warn("codegen-doc:print: No comment found - cannot test _comment.botActor query");
@@ -804,7 +808,7 @@ describe("generated", () => {
     /** Test the comment connection query for the Comment */
     it("comment.children", async () => {
       if (_comment) {
-        const children: L.CommentConnection | undefined = await _comment.children();
+        const children: L.CommentConnection | undefined | null = await _comment.children();
         expect(children instanceof L.CommentConnection);
       } else {
         console.warn("codegen-doc:print: No comment found - cannot test _comment.children query");
@@ -814,19 +818,19 @@ describe("generated", () => {
     /** Test the comment connection query for the Issue */
     it("comment.createdIssues", async () => {
       if (_comment) {
-        const createdIssues: L.IssueConnection | undefined = await _comment.createdIssues();
+        const createdIssues: L.IssueConnection | undefined | null = await _comment.createdIssues();
         expect(createdIssues instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No comment found - cannot test _comment.createdIssues query");
       }
     });
 
-    let _documentContent: L.DocumentContent | undefined;
+    let _documentContent: L.DocumentContent | undefined | null;
 
     /** Test the comment model query for Comment_DocumentContent */
     it("comment.documentContent", async () => {
       if (_comment) {
-        const documentContent: L.DocumentContent | undefined = _comment.documentContent;
+        const documentContent: L.DocumentContent | undefined | null = _comment.documentContent;
         _documentContent = documentContent;
         expect(documentContent instanceof L.DocumentContent);
       } else {
@@ -837,7 +841,7 @@ describe("generated", () => {
     /** Test the comment_documentContent model query for Comment_DocumentContent_AiPromptRules */
     it("comment_documentContent.aiPromptRules", async () => {
       if (_documentContent) {
-        const aiPromptRules: L.AiPromptRules | undefined = _documentContent.aiPromptRules;
+        const aiPromptRules: L.AiPromptRules | undefined | null = _documentContent.aiPromptRules;
         expect(aiPromptRules instanceof L.AiPromptRules);
       } else {
         console.warn("codegen-doc:print: No documentContent found - cannot test _documentContent.aiPromptRules query");
@@ -847,7 +851,7 @@ describe("generated", () => {
     /** Test the comment model query for Comment_ExternalThread */
     it("comment.externalThread", async () => {
       if (_comment) {
-        const externalThread: L.SyncedExternalThread | undefined = _comment.externalThread;
+        const externalThread: L.SyncedExternalThread | undefined | null = _comment.externalThread;
         expect(externalThread instanceof L.SyncedExternalThread);
       } else {
         console.warn("codegen-doc:print: No comment found - cannot test _comment.externalThread query");
@@ -857,7 +861,7 @@ describe("generated", () => {
     /** Test the comment.agentSession query for L.AgentSession */
     it("comment.agentSession", async () => {
       if (_comment) {
-        const comment_agentSession: L.AgentSession | undefined = await _comment.agentSession;
+        const comment_agentSession: L.AgentSession | undefined | null = await _comment.agentSession;
         expect(comment_agentSession instanceof L.AgentSession);
       } else {
         console.warn("codegen-doc:print: No Comment found - cannot test comment.agentSession query");
@@ -867,7 +871,7 @@ describe("generated", () => {
     /** Test the comment.externalUser query for L.ExternalUser */
     it("comment.externalUser", async () => {
       if (_comment) {
-        const comment_externalUser: L.ExternalUser | undefined = await _comment.externalUser;
+        const comment_externalUser: L.ExternalUser | undefined | null = await _comment.externalUser;
         expect(comment_externalUser instanceof L.ExternalUser);
       } else {
         console.warn("codegen-doc:print: No Comment found - cannot test comment.externalUser query");
@@ -877,7 +881,7 @@ describe("generated", () => {
     /** Test the comment.initiativeUpdate query for L.InitiativeUpdate */
     it("comment.initiativeUpdate", async () => {
       if (_comment) {
-        const comment_initiativeUpdate: L.InitiativeUpdate | undefined = await _comment.initiativeUpdate;
+        const comment_initiativeUpdate: L.InitiativeUpdate | undefined | null = await _comment.initiativeUpdate;
         expect(comment_initiativeUpdate instanceof L.InitiativeUpdate);
       } else {
         console.warn("codegen-doc:print: No Comment found - cannot test comment.initiativeUpdate query");
@@ -887,7 +891,7 @@ describe("generated", () => {
     /** Test the comment.issue query for L.Issue */
     it("comment.issue", async () => {
       if (_comment) {
-        const comment_issue: L.Issue | undefined = await _comment.issue;
+        const comment_issue: L.Issue | undefined | null = await _comment.issue;
         expect(comment_issue instanceof L.Issue);
       } else {
         console.warn("codegen-doc:print: No Comment found - cannot test comment.issue query");
@@ -897,7 +901,7 @@ describe("generated", () => {
     /** Test the comment.parent query for L.Comment */
     it("comment.parent", async () => {
       if (_comment) {
-        const comment_parent: L.Comment | undefined = await _comment.parent;
+        const comment_parent: L.Comment | undefined | null = await _comment.parent;
         expect(comment_parent instanceof L.Comment);
       } else {
         console.warn("codegen-doc:print: No Comment found - cannot test comment.parent query");
@@ -907,7 +911,7 @@ describe("generated", () => {
     /** Test the comment.projectUpdate query for L.ProjectUpdate */
     it("comment.projectUpdate", async () => {
       if (_comment) {
-        const comment_projectUpdate: L.ProjectUpdate | undefined = await _comment.projectUpdate;
+        const comment_projectUpdate: L.ProjectUpdate | undefined | null = await _comment.projectUpdate;
         expect(comment_projectUpdate instanceof L.ProjectUpdate);
       } else {
         console.warn("codegen-doc:print: No Comment found - cannot test comment.projectUpdate query");
@@ -917,7 +921,7 @@ describe("generated", () => {
     /** Test the comment.resolvingComment query for L.Comment */
     it("comment.resolvingComment", async () => {
       if (_comment) {
-        const comment_resolvingComment: L.Comment | undefined = await _comment.resolvingComment;
+        const comment_resolvingComment: L.Comment | undefined | null = await _comment.resolvingComment;
         expect(comment_resolvingComment instanceof L.Comment);
       } else {
         console.warn("codegen-doc:print: No Comment found - cannot test comment.resolvingComment query");
@@ -927,7 +931,7 @@ describe("generated", () => {
     /** Test the comment.resolvingUser query for L.User */
     it("comment.resolvingUser", async () => {
       if (_comment) {
-        const comment_resolvingUser: L.User | undefined = await _comment.resolvingUser;
+        const comment_resolvingUser: L.User | undefined | null = await _comment.resolvingUser;
         expect(comment_resolvingUser instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Comment found - cannot test comment.resolvingUser query");
@@ -937,7 +941,7 @@ describe("generated", () => {
     /** Test the comment.user query for L.User */
     it("comment.user", async () => {
       if (_comment) {
-        const comment_user: L.User | undefined = await _comment.user;
+        const comment_user: L.User | undefined | null = await _comment.user;
         expect(comment_user instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Comment found - cannot test comment.user query");
@@ -949,7 +953,7 @@ describe("generated", () => {
   describe("CustomViewHasSubscribers", () => {
     /** Test the root model query for CustomViewHasSubscribers */
     it("customViewHasSubscribers", async () => {
-      const customViewHasSubscribers: L.CustomViewHasSubscribersPayload | undefined =
+      const customViewHasSubscribers: L.CustomViewHasSubscribersPayload | undefined | null =
         await client.customViewHasSubscribers("mock-id");
       expect(customViewHasSubscribers instanceof L.CustomViewHasSubscribersPayload);
     });
@@ -957,12 +961,12 @@ describe("generated", () => {
 
   /** Test all CustomView queries */
   describe("CustomViews", () => {
-    let _customView: L.CustomView | undefined;
-    let _customView_id: string | undefined;
+    let _customView: L.CustomView | undefined | null;
+    let _customView_id: string | undefined | null;
 
     /** Test the root connection query for the CustomView */
     it("customViews", async () => {
-      const customViews: L.CustomViewConnection | undefined = await client.customViews();
+      const customViews: L.CustomViewConnection | undefined | null = await client.customViews();
       const customView = customViews?.nodes?.[0];
       _customView_id = customView?.id;
       expect(customViews instanceof L.CustomViewConnection);
@@ -971,7 +975,7 @@ describe("generated", () => {
     /** Test the root query for a single CustomView */
     it("customView", async () => {
       if (_customView_id) {
-        const customView: L.CustomView | undefined = await client.customView(_customView_id);
+        const customView: L.CustomView | undefined | null = await client.customView(_customView_id);
         _customView = customView;
         expect(customView instanceof L.CustomView);
       } else {
@@ -982,7 +986,7 @@ describe("generated", () => {
     /** Test the customView connection query for the Initiative */
     it("customView.initiatives", async () => {
       if (_customView) {
-        const initiatives: L.InitiativeConnection | undefined = await _customView.initiatives();
+        const initiatives: L.InitiativeConnection | undefined | null = await _customView.initiatives();
         expect(initiatives instanceof L.InitiativeConnection);
       } else {
         console.warn("codegen-doc:print: No customView found - cannot test _customView.initiatives query");
@@ -992,19 +996,20 @@ describe("generated", () => {
     /** Test the customView connection query for the Issue */
     it("customView.issues", async () => {
       if (_customView) {
-        const issues: L.IssueConnection | undefined = await _customView.issues();
+        const issues: L.IssueConnection | undefined | null = await _customView.issues();
         expect(issues instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No customView found - cannot test _customView.issues query");
       }
     });
 
-    let _organizationViewPreferences: L.ViewPreferences | undefined;
+    let _organizationViewPreferences: L.ViewPreferences | undefined | null;
 
     /** Test the customView model query for CustomView_OrganizationViewPreferences */
     it("customView.organizationViewPreferences", async () => {
       if (_customView) {
-        const organizationViewPreferences: L.ViewPreferences | undefined = _customView.organizationViewPreferences;
+        const organizationViewPreferences: L.ViewPreferences | undefined | null =
+          _customView.organizationViewPreferences;
         _organizationViewPreferences = organizationViewPreferences;
         expect(organizationViewPreferences instanceof L.ViewPreferences);
       } else {
@@ -1017,7 +1022,7 @@ describe("generated", () => {
     /** Test the customView_organizationViewPreferences model query for CustomView_OrganizationViewPreferences_Preferences */
     it("customView_organizationViewPreferences.preferences", async () => {
       if (_organizationViewPreferences) {
-        const preferences: L.ViewPreferencesValues | undefined = _organizationViewPreferences.preferences;
+        const preferences: L.ViewPreferencesValues | undefined | null = _organizationViewPreferences.preferences;
         expect(preferences instanceof L.ViewPreferencesValues);
       } else {
         console.warn(
@@ -1029,19 +1034,19 @@ describe("generated", () => {
     /** Test the customView connection query for the Project */
     it("customView.projects", async () => {
       if (_customView) {
-        const projects: L.ProjectConnection | undefined = await _customView.projects();
+        const projects: L.ProjectConnection | undefined | null = await _customView.projects();
         expect(projects instanceof L.ProjectConnection);
       } else {
         console.warn("codegen-doc:print: No customView found - cannot test _customView.projects query");
       }
     });
 
-    let _userViewPreferences: L.ViewPreferences | undefined;
+    let _userViewPreferences: L.ViewPreferences | undefined | null;
 
     /** Test the customView model query for CustomView_UserViewPreferences */
     it("customView.userViewPreferences", async () => {
       if (_customView) {
-        const userViewPreferences: L.ViewPreferences | undefined = _customView.userViewPreferences;
+        const userViewPreferences: L.ViewPreferences | undefined | null = _customView.userViewPreferences;
         _userViewPreferences = userViewPreferences;
         expect(userViewPreferences instanceof L.ViewPreferences);
       } else {
@@ -1052,7 +1057,7 @@ describe("generated", () => {
     /** Test the customView_userViewPreferences model query for CustomView_UserViewPreferences_Preferences */
     it("customView_userViewPreferences.preferences", async () => {
       if (_userViewPreferences) {
-        const preferences: L.ViewPreferencesValues | undefined = _userViewPreferences.preferences;
+        const preferences: L.ViewPreferencesValues | undefined | null = _userViewPreferences.preferences;
         expect(preferences instanceof L.ViewPreferencesValues);
       } else {
         console.warn(
@@ -1064,7 +1069,7 @@ describe("generated", () => {
     /** Test the customView model query for CustomView_ViewPreferencesValues */
     it("customView.viewPreferencesValues", async () => {
       if (_customView) {
-        const viewPreferencesValues: L.ViewPreferencesValues | undefined = _customView.viewPreferencesValues;
+        const viewPreferencesValues: L.ViewPreferencesValues | undefined | null = _customView.viewPreferencesValues;
         expect(viewPreferencesValues instanceof L.ViewPreferencesValues);
       } else {
         console.warn("codegen-doc:print: No customView found - cannot test _customView.viewPreferencesValues query");
@@ -1074,7 +1079,7 @@ describe("generated", () => {
     /** Test the customView.creator query for L.User */
     it("customView.creator", async () => {
       if (_customView) {
-        const customView_creator: L.User | undefined = await _customView.creator;
+        const customView_creator: L.User | undefined | null = await _customView.creator;
         expect(customView_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No CustomView found - cannot test customView.creator query");
@@ -1084,7 +1089,7 @@ describe("generated", () => {
     /** Test the customView.organization query for L.Organization */
     it("customView.organization", async () => {
       if (_customView) {
-        const customView_organization: L.Organization | undefined = await _customView.organization;
+        const customView_organization: L.Organization | undefined | null = await _customView.organization;
         expect(customView_organization instanceof L.Organization);
       } else {
         console.warn("codegen-doc:print: No CustomView found - cannot test customView.organization query");
@@ -1094,7 +1099,7 @@ describe("generated", () => {
     /** Test the customView.owner query for L.User */
     it("customView.owner", async () => {
       if (_customView) {
-        const customView_owner: L.User | undefined = await _customView.owner;
+        const customView_owner: L.User | undefined | null = await _customView.owner;
         expect(customView_owner instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No CustomView found - cannot test customView.owner query");
@@ -1104,7 +1109,7 @@ describe("generated", () => {
     /** Test the customView.team query for L.Team */
     it("customView.team", async () => {
       if (_customView) {
-        const customView_team: L.Team | undefined = await _customView.team;
+        const customView_team: L.Team | undefined | null = await _customView.team;
         expect(customView_team instanceof L.Team);
       } else {
         console.warn("codegen-doc:print: No CustomView found - cannot test customView.team query");
@@ -1114,7 +1119,7 @@ describe("generated", () => {
     /** Test the customView.updatedBy query for L.User */
     it("customView.updatedBy", async () => {
       if (_customView) {
-        const customView_updatedBy: L.User | undefined = await _customView.updatedBy;
+        const customView_updatedBy: L.User | undefined | null = await _customView.updatedBy;
         expect(customView_updatedBy instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No CustomView found - cannot test customView.updatedBy query");
@@ -1124,12 +1129,12 @@ describe("generated", () => {
 
   /** Test all CustomerNeed queries */
   describe("CustomerNeeds", () => {
-    let _customerNeed: L.CustomerNeed | undefined;
-    let _customerNeed_id: string | undefined;
+    let _customerNeed: L.CustomerNeed | undefined | null;
+    let _customerNeed_id: string | undefined | null;
 
     /** Test the root connection query for the CustomerNeed */
     it("customerNeeds", async () => {
-      const customerNeeds: L.CustomerNeedConnection | undefined = await client.customerNeeds();
+      const customerNeeds: L.CustomerNeedConnection | undefined | null = await client.customerNeeds();
       const customerNeed = customerNeeds?.nodes?.[0];
       _customerNeed_id = customerNeed?.id;
       expect(customerNeeds instanceof L.CustomerNeedConnection);
@@ -1138,7 +1143,7 @@ describe("generated", () => {
     /** Test the root query for a single CustomerNeed */
     it("customerNeed", async () => {
       if (_customerNeed_id) {
-        const customerNeed: L.CustomerNeed | undefined = await client.customerNeed({ id: _customerNeed_id });
+        const customerNeed: L.CustomerNeed | undefined | null = await client.customerNeed({ id: _customerNeed_id });
         _customerNeed = customerNeed;
         expect(customerNeed instanceof L.CustomerNeed);
       } else {
@@ -1149,7 +1154,7 @@ describe("generated", () => {
     /** Test the customerNeed model query for CustomerNeed_ProjectAttachment */
     it("customerNeed.projectAttachment", async () => {
       if (_customerNeed) {
-        const projectAttachment: L.ProjectAttachment | undefined = _customerNeed.projectAttachment;
+        const projectAttachment: L.ProjectAttachment | undefined | null = _customerNeed.projectAttachment;
         expect(projectAttachment instanceof L.ProjectAttachment);
       } else {
         console.warn("codegen-doc:print: No customerNeed found - cannot test _customerNeed.projectAttachment query");
@@ -1159,7 +1164,7 @@ describe("generated", () => {
     /** Test the customerNeed.attachment query for L.Attachment */
     it("customerNeed.attachment", async () => {
       if (_customerNeed) {
-        const customerNeed_attachment: L.Attachment | undefined = await _customerNeed.attachment;
+        const customerNeed_attachment: L.Attachment | undefined | null = await _customerNeed.attachment;
         expect(customerNeed_attachment instanceof L.Attachment);
       } else {
         console.warn("codegen-doc:print: No CustomerNeed found - cannot test customerNeed.attachment query");
@@ -1169,7 +1174,7 @@ describe("generated", () => {
     /** Test the customerNeed.comment query for L.Comment */
     it("customerNeed.comment", async () => {
       if (_customerNeed) {
-        const customerNeed_comment: L.Comment | undefined = await _customerNeed.comment;
+        const customerNeed_comment: L.Comment | undefined | null = await _customerNeed.comment;
         expect(customerNeed_comment instanceof L.Comment);
       } else {
         console.warn("codegen-doc:print: No CustomerNeed found - cannot test customerNeed.comment query");
@@ -1179,7 +1184,7 @@ describe("generated", () => {
     /** Test the customerNeed.creator query for L.User */
     it("customerNeed.creator", async () => {
       if (_customerNeed) {
-        const customerNeed_creator: L.User | undefined = await _customerNeed.creator;
+        const customerNeed_creator: L.User | undefined | null = await _customerNeed.creator;
         expect(customerNeed_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No CustomerNeed found - cannot test customerNeed.creator query");
@@ -1189,7 +1194,7 @@ describe("generated", () => {
     /** Test the customerNeed.customer query for L.Customer */
     it("customerNeed.customer", async () => {
       if (_customerNeed) {
-        const customerNeed_customer: L.Customer | undefined = await _customerNeed.customer;
+        const customerNeed_customer: L.Customer | undefined | null = await _customerNeed.customer;
         expect(customerNeed_customer instanceof L.Customer);
       } else {
         console.warn("codegen-doc:print: No CustomerNeed found - cannot test customerNeed.customer query");
@@ -1199,7 +1204,7 @@ describe("generated", () => {
     /** Test the customerNeed.issue query for L.Issue */
     it("customerNeed.issue", async () => {
       if (_customerNeed) {
-        const customerNeed_issue: L.Issue | undefined = await _customerNeed.issue;
+        const customerNeed_issue: L.Issue | undefined | null = await _customerNeed.issue;
         expect(customerNeed_issue instanceof L.Issue);
       } else {
         console.warn("codegen-doc:print: No CustomerNeed found - cannot test customerNeed.issue query");
@@ -1209,7 +1214,7 @@ describe("generated", () => {
     /** Test the customerNeed.originalIssue query for L.Issue */
     it("customerNeed.originalIssue", async () => {
       if (_customerNeed) {
-        const customerNeed_originalIssue: L.Issue | undefined = await _customerNeed.originalIssue;
+        const customerNeed_originalIssue: L.Issue | undefined | null = await _customerNeed.originalIssue;
         expect(customerNeed_originalIssue instanceof L.Issue);
       } else {
         console.warn("codegen-doc:print: No CustomerNeed found - cannot test customerNeed.originalIssue query");
@@ -1219,7 +1224,7 @@ describe("generated", () => {
     /** Test the customerNeed.project query for L.Project */
     it("customerNeed.project", async () => {
       if (_customerNeed) {
-        const customerNeed_project: L.Project | undefined = await _customerNeed.project;
+        const customerNeed_project: L.Project | undefined | null = await _customerNeed.project;
         expect(customerNeed_project instanceof L.Project);
       } else {
         console.warn("codegen-doc:print: No CustomerNeed found - cannot test customerNeed.project query");
@@ -1229,12 +1234,12 @@ describe("generated", () => {
 
   /** Test all CustomerStatus queries */
   describe("CustomerStatuses", () => {
-    let _customerStatus: L.CustomerStatus | undefined;
-    let _customerStatus_id: string | undefined;
+    let _customerStatus: L.CustomerStatus | undefined | null;
+    let _customerStatus_id: string | undefined | null;
 
     /** Test the root connection query for the CustomerStatus */
     it("customerStatuses", async () => {
-      const customerStatuses: L.CustomerStatusConnection | undefined = await client.customerStatuses();
+      const customerStatuses: L.CustomerStatusConnection | undefined | null = await client.customerStatuses();
       const customerStatus = customerStatuses?.nodes?.[0];
       _customerStatus_id = customerStatus?.id;
       expect(customerStatuses instanceof L.CustomerStatusConnection);
@@ -1243,7 +1248,7 @@ describe("generated", () => {
     /** Test the root query for a single CustomerStatus */
     it("customerStatus", async () => {
       if (_customerStatus_id) {
-        const customerStatus: L.CustomerStatus | undefined = await client.customerStatus(_customerStatus_id);
+        const customerStatus: L.CustomerStatus | undefined | null = await client.customerStatus(_customerStatus_id);
         expect(customerStatus instanceof L.CustomerStatus);
       } else {
         console.warn(
@@ -1255,12 +1260,12 @@ describe("generated", () => {
 
   /** Test all CustomerTier queries */
   describe("CustomerTiers", () => {
-    let _customerTier: L.CustomerTier | undefined;
-    let _customerTier_id: string | undefined;
+    let _customerTier: L.CustomerTier | undefined | null;
+    let _customerTier_id: string | undefined | null;
 
     /** Test the root connection query for the CustomerTier */
     it("customerTiers", async () => {
-      const customerTiers: L.CustomerTierConnection | undefined = await client.customerTiers();
+      const customerTiers: L.CustomerTierConnection | undefined | null = await client.customerTiers();
       const customerTier = customerTiers?.nodes?.[0];
       _customerTier_id = customerTier?.id;
       expect(customerTiers instanceof L.CustomerTierConnection);
@@ -1269,7 +1274,7 @@ describe("generated", () => {
     /** Test the root query for a single CustomerTier */
     it("customerTier", async () => {
       if (_customerTier_id) {
-        const customerTier: L.CustomerTier | undefined = await client.customerTier(_customerTier_id);
+        const customerTier: L.CustomerTier | undefined | null = await client.customerTier(_customerTier_id);
         expect(customerTier instanceof L.CustomerTier);
       } else {
         console.warn("codegen-doc:print: No first CustomerTier found in connection - cannot test customerTier query");
@@ -1279,12 +1284,12 @@ describe("generated", () => {
 
   /** Test all Customer queries */
   describe("Customers", () => {
-    let _customer: L.Customer | undefined;
-    let _customer_id: string | undefined;
+    let _customer: L.Customer | undefined | null;
+    let _customer_id: string | undefined | null;
 
     /** Test the root connection query for the Customer */
     it("customers", async () => {
-      const customers: L.CustomerConnection | undefined = await client.customers();
+      const customers: L.CustomerConnection | undefined | null = await client.customers();
       const customer = customers?.nodes?.[0];
       _customer_id = customer?.id;
       expect(customers instanceof L.CustomerConnection);
@@ -1293,7 +1298,7 @@ describe("generated", () => {
     /** Test the root query for a single Customer */
     it("customer", async () => {
       if (_customer_id) {
-        const customer: L.Customer | undefined = await client.customer(_customer_id);
+        const customer: L.Customer | undefined | null = await client.customer(_customer_id);
         _customer = customer;
         expect(customer instanceof L.Customer);
       } else {
@@ -1304,7 +1309,7 @@ describe("generated", () => {
     /** Test the customer.integration query for L.Integration */
     it("customer.integration", async () => {
       if (_customer) {
-        const customer_integration: L.Integration | undefined = await _customer.integration;
+        const customer_integration: L.Integration | undefined | null = await _customer.integration;
         expect(customer_integration instanceof L.Integration);
       } else {
         console.warn("codegen-doc:print: No Customer found - cannot test customer.integration query");
@@ -1314,7 +1319,7 @@ describe("generated", () => {
     /** Test the customer.owner query for L.User */
     it("customer.owner", async () => {
       if (_customer) {
-        const customer_owner: L.User | undefined = await _customer.owner;
+        const customer_owner: L.User | undefined | null = await _customer.owner;
         expect(customer_owner instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Customer found - cannot test customer.owner query");
@@ -1324,7 +1329,7 @@ describe("generated", () => {
     /** Test the customer.status query for L.CustomerStatus */
     it("customer.status", async () => {
       if (_customer) {
-        const customer_status: L.CustomerStatus | undefined = await _customer.status;
+        const customer_status: L.CustomerStatus | undefined | null = await _customer.status;
         expect(customer_status instanceof L.CustomerStatus);
       } else {
         console.warn("codegen-doc:print: No Customer found - cannot test customer.status query");
@@ -1334,7 +1339,7 @@ describe("generated", () => {
     /** Test the customer.tier query for L.CustomerTier */
     it("customer.tier", async () => {
       if (_customer) {
-        const customer_tier: L.CustomerTier | undefined = await _customer.tier;
+        const customer_tier: L.CustomerTier | undefined | null = await _customer.tier;
         expect(customer_tier instanceof L.CustomerTier);
       } else {
         console.warn("codegen-doc:print: No Customer found - cannot test customer.tier query");
@@ -1344,12 +1349,12 @@ describe("generated", () => {
 
   /** Test all Cycle queries */
   describe("Cycles", () => {
-    let _cycle: L.Cycle | undefined;
-    let _cycle_id: string | undefined;
+    let _cycle: L.Cycle | undefined | null;
+    let _cycle_id: string | undefined | null;
 
     /** Test the root connection query for the Cycle */
     it("cycles", async () => {
-      const cycles: L.CycleConnection | undefined = await client.cycles();
+      const cycles: L.CycleConnection | undefined | null = await client.cycles();
       const cycle = cycles?.nodes?.[0];
       _cycle_id = cycle?.id;
       expect(cycles instanceof L.CycleConnection);
@@ -1358,7 +1363,7 @@ describe("generated", () => {
     /** Test the root query for a single Cycle */
     it("cycle", async () => {
       if (_cycle_id) {
-        const cycle: L.Cycle | undefined = await client.cycle(_cycle_id);
+        const cycle: L.Cycle | undefined | null = await client.cycle(_cycle_id);
         _cycle = cycle;
         expect(cycle instanceof L.Cycle);
       } else {
@@ -1369,7 +1374,7 @@ describe("generated", () => {
     /** Test the cycle connection query for the Issue */
     it("cycle.issues", async () => {
       if (_cycle) {
-        const issues: L.IssueConnection | undefined = await _cycle.issues();
+        const issues: L.IssueConnection | undefined | null = await _cycle.issues();
         expect(issues instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No cycle found - cannot test _cycle.issues query");
@@ -1379,7 +1384,8 @@ describe("generated", () => {
     /** Test the cycle connection query for the Issue */
     it("cycle.uncompletedIssuesUponClose", async () => {
       if (_cycle) {
-        const uncompletedIssuesUponClose: L.IssueConnection | undefined = await _cycle.uncompletedIssuesUponClose();
+        const uncompletedIssuesUponClose: L.IssueConnection | undefined | null =
+          await _cycle.uncompletedIssuesUponClose();
         expect(uncompletedIssuesUponClose instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No cycle found - cannot test _cycle.uncompletedIssuesUponClose query");
@@ -1389,7 +1395,7 @@ describe("generated", () => {
     /** Test the cycle.inheritedFrom query for L.Cycle */
     it("cycle.inheritedFrom", async () => {
       if (_cycle) {
-        const cycle_inheritedFrom: L.Cycle | undefined = await _cycle.inheritedFrom;
+        const cycle_inheritedFrom: L.Cycle | undefined | null = await _cycle.inheritedFrom;
         expect(cycle_inheritedFrom instanceof L.Cycle);
       } else {
         console.warn("codegen-doc:print: No Cycle found - cannot test cycle.inheritedFrom query");
@@ -1399,7 +1405,7 @@ describe("generated", () => {
     /** Test the cycle.team query for L.Team */
     it("cycle.team", async () => {
       if (_cycle) {
-        const cycle_team: L.Team | undefined = await _cycle.team;
+        const cycle_team: L.Team | undefined | null = await _cycle.team;
         expect(cycle_team instanceof L.Team);
       } else {
         console.warn("codegen-doc:print: No Cycle found - cannot test cycle.team query");
@@ -1411,7 +1417,7 @@ describe("generated", () => {
   describe("DocumentContentHistory", () => {
     /** Test the root model query for DocumentContentHistory */
     it("documentContentHistory", async () => {
-      const documentContentHistory: L.DocumentContentHistoryPayload | undefined =
+      const documentContentHistory: L.DocumentContentHistoryPayload | undefined | null =
         await client.documentContentHistory("mock-id");
       expect(documentContentHistory instanceof L.DocumentContentHistoryPayload);
     });
@@ -1419,12 +1425,12 @@ describe("generated", () => {
 
   /** Test all Document queries */
   describe("Documents", () => {
-    let _document: L.Document | undefined;
-    let _document_id: string | undefined;
+    let _document: L.Document | undefined | null;
+    let _document_id: string | undefined | null;
 
     /** Test the root connection query for the Document */
     it("documents", async () => {
-      const documents: L.DocumentConnection | undefined = await client.documents();
+      const documents: L.DocumentConnection | undefined | null = await client.documents();
       const document = documents?.nodes?.[0];
       _document_id = document?.id;
       expect(documents instanceof L.DocumentConnection);
@@ -1433,7 +1439,7 @@ describe("generated", () => {
     /** Test the root query for a single Document */
     it("document", async () => {
       if (_document_id) {
-        const document: L.Document | undefined = await client.document(_document_id);
+        const document: L.Document | undefined | null = await client.document(_document_id);
         _document = document;
         expect(document instanceof L.Document);
       } else {
@@ -1444,7 +1450,7 @@ describe("generated", () => {
     /** Test the document connection query for the Comment */
     it("document.comments", async () => {
       if (_document) {
-        const comments: L.CommentConnection | undefined = await _document.comments();
+        const comments: L.CommentConnection | undefined | null = await _document.comments();
         expect(comments instanceof L.CommentConnection);
       } else {
         console.warn("codegen-doc:print: No document found - cannot test _document.comments query");
@@ -1454,7 +1460,7 @@ describe("generated", () => {
     /** Test the document.creator query for L.User */
     it("document.creator", async () => {
       if (_document) {
-        const document_creator: L.User | undefined = await _document.creator;
+        const document_creator: L.User | undefined | null = await _document.creator;
         expect(document_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Document found - cannot test document.creator query");
@@ -1464,7 +1470,7 @@ describe("generated", () => {
     /** Test the document.initiative query for L.Initiative */
     it("document.initiative", async () => {
       if (_document) {
-        const document_initiative: L.Initiative | undefined = await _document.initiative;
+        const document_initiative: L.Initiative | undefined | null = await _document.initiative;
         expect(document_initiative instanceof L.Initiative);
       } else {
         console.warn("codegen-doc:print: No Document found - cannot test document.initiative query");
@@ -1474,7 +1480,7 @@ describe("generated", () => {
     /** Test the document.issue query for L.Issue */
     it("document.issue", async () => {
       if (_document) {
-        const document_issue: L.Issue | undefined = await _document.issue;
+        const document_issue: L.Issue | undefined | null = await _document.issue;
         expect(document_issue instanceof L.Issue);
       } else {
         console.warn("codegen-doc:print: No Document found - cannot test document.issue query");
@@ -1484,7 +1490,7 @@ describe("generated", () => {
     /** Test the document.lastAppliedTemplate query for L.Template */
     it("document.lastAppliedTemplate", async () => {
       if (_document) {
-        const document_lastAppliedTemplate: L.Template | undefined = await _document.lastAppliedTemplate;
+        const document_lastAppliedTemplate: L.Template | undefined | null = await _document.lastAppliedTemplate;
         expect(document_lastAppliedTemplate instanceof L.Template);
       } else {
         console.warn("codegen-doc:print: No Document found - cannot test document.lastAppliedTemplate query");
@@ -1494,7 +1500,7 @@ describe("generated", () => {
     /** Test the document.project query for L.Project */
     it("document.project", async () => {
       if (_document) {
-        const document_project: L.Project | undefined = await _document.project;
+        const document_project: L.Project | undefined | null = await _document.project;
         expect(document_project instanceof L.Project);
       } else {
         console.warn("codegen-doc:print: No Document found - cannot test document.project query");
@@ -1504,7 +1510,7 @@ describe("generated", () => {
     /** Test the document.updatedBy query for L.User */
     it("document.updatedBy", async () => {
       if (_document) {
-        const document_updatedBy: L.User | undefined = await _document.updatedBy;
+        const document_updatedBy: L.User | undefined | null = await _document.updatedBy;
         expect(document_updatedBy instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Document found - cannot test document.updatedBy query");
@@ -1514,11 +1520,11 @@ describe("generated", () => {
 
   /** Test EmailIntakeAddress query */
   describe("EmailIntakeAddress", () => {
-    let _emailIntakeAddress: L.EmailIntakeAddress | undefined;
+    let _emailIntakeAddress: L.EmailIntakeAddress | undefined | null;
 
     /** Test the root model query for EmailIntakeAddress */
     it("emailIntakeAddress", async () => {
-      const emailIntakeAddress: L.EmailIntakeAddress | undefined = await client.emailIntakeAddress("mock-id");
+      const emailIntakeAddress: L.EmailIntakeAddress | undefined | null = await client.emailIntakeAddress("mock-id");
       _emailIntakeAddress = emailIntakeAddress;
       expect(emailIntakeAddress instanceof L.EmailIntakeAddress);
     });
@@ -1526,7 +1532,7 @@ describe("generated", () => {
     /** Test the emailIntakeAddress model query for EmailIntakeAddress_SesDomainIdentity */
     it("emailIntakeAddress.sesDomainIdentity", async () => {
       if (_emailIntakeAddress) {
-        const sesDomainIdentity: L.SesDomainIdentity | undefined = _emailIntakeAddress.sesDomainIdentity;
+        const sesDomainIdentity: L.SesDomainIdentity | undefined | null = _emailIntakeAddress.sesDomainIdentity;
         expect(sesDomainIdentity instanceof L.SesDomainIdentity);
       } else {
         console.warn(
@@ -1538,12 +1544,12 @@ describe("generated", () => {
 
   /** Test all Emoji queries */
   describe("Emojis", () => {
-    let _emoji: L.Emoji | undefined;
-    let _emoji_id: string | undefined;
+    let _emoji: L.Emoji | undefined | null;
+    let _emoji_id: string | undefined | null;
 
     /** Test the root connection query for the Emoji */
     it("emojis", async () => {
-      const emojis: L.EmojiConnection | undefined = await client.emojis();
+      const emojis: L.EmojiConnection | undefined | null = await client.emojis();
       const emoji = emojis?.nodes?.[0];
       _emoji_id = emoji?.id;
       expect(emojis instanceof L.EmojiConnection);
@@ -1552,7 +1558,7 @@ describe("generated", () => {
     /** Test the root query for a single Emoji */
     it("emoji", async () => {
       if (_emoji_id) {
-        const emoji: L.Emoji | undefined = await client.emoji(_emoji_id);
+        const emoji: L.Emoji | undefined | null = await client.emoji(_emoji_id);
         _emoji = emoji;
         expect(emoji instanceof L.Emoji);
       } else {
@@ -1563,7 +1569,7 @@ describe("generated", () => {
     /** Test the emoji.creator query for L.User */
     it("emoji.creator", async () => {
       if (_emoji) {
-        const emoji_creator: L.User | undefined = await _emoji.creator;
+        const emoji_creator: L.User | undefined | null = await _emoji.creator;
         expect(emoji_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Emoji found - cannot test emoji.creator query");
@@ -1573,7 +1579,7 @@ describe("generated", () => {
     /** Test the emoji.organization query for L.Organization */
     it("emoji.organization", async () => {
       if (_emoji) {
-        const emoji_organization: L.Organization | undefined = await _emoji.organization;
+        const emoji_organization: L.Organization | undefined | null = await _emoji.organization;
         expect(emoji_organization instanceof L.Organization);
       } else {
         console.warn("codegen-doc:print: No Emoji found - cannot test emoji.organization query");
@@ -1585,19 +1591,19 @@ describe("generated", () => {
   describe("EntityExternalLink", () => {
     /** Test the root model query for EntityExternalLink */
     it("entityExternalLink", async () => {
-      const entityExternalLink: L.EntityExternalLink | undefined = await client.entityExternalLink("mock-id");
+      const entityExternalLink: L.EntityExternalLink | undefined | null = await client.entityExternalLink("mock-id");
       expect(entityExternalLink instanceof L.EntityExternalLink);
     });
   });
 
   /** Test all ExternalUser queries */
   describe("ExternalUsers", () => {
-    let _externalUser: L.ExternalUser | undefined;
-    let _externalUser_id: string | undefined;
+    let _externalUser: L.ExternalUser | undefined | null;
+    let _externalUser_id: string | undefined | null;
 
     /** Test the root connection query for the ExternalUser */
     it("externalUsers", async () => {
-      const externalUsers: L.ExternalUserConnection | undefined = await client.externalUsers();
+      const externalUsers: L.ExternalUserConnection | undefined | null = await client.externalUsers();
       const externalUser = externalUsers?.nodes?.[0];
       _externalUser_id = externalUser?.id;
       expect(externalUsers instanceof L.ExternalUserConnection);
@@ -1606,7 +1612,7 @@ describe("generated", () => {
     /** Test the root query for a single ExternalUser */
     it("externalUser", async () => {
       if (_externalUser_id) {
-        const externalUser: L.ExternalUser | undefined = await client.externalUser(_externalUser_id);
+        const externalUser: L.ExternalUser | undefined | null = await client.externalUser(_externalUser_id);
         _externalUser = externalUser;
         expect(externalUser instanceof L.ExternalUser);
       } else {
@@ -1617,7 +1623,7 @@ describe("generated", () => {
     /** Test the externalUser.organization query for L.Organization */
     it("externalUser.organization", async () => {
       if (_externalUser) {
-        const externalUser_organization: L.Organization | undefined = await _externalUser.organization;
+        const externalUser_organization: L.Organization | undefined | null = await _externalUser.organization;
         expect(externalUser_organization instanceof L.Organization);
       } else {
         console.warn("codegen-doc:print: No ExternalUser found - cannot test externalUser.organization query");
@@ -1627,12 +1633,12 @@ describe("generated", () => {
 
   /** Test all Favorite queries */
   describe("Favorites", () => {
-    let _favorite: L.Favorite | undefined;
-    let _favorite_id: string | undefined;
+    let _favorite: L.Favorite | undefined | null;
+    let _favorite_id: string | undefined | null;
 
     /** Test the root connection query for the Favorite */
     it("favorites", async () => {
-      const favorites: L.FavoriteConnection | undefined = await client.favorites();
+      const favorites: L.FavoriteConnection | undefined | null = await client.favorites();
       const favorite = favorites?.nodes?.[0];
       _favorite_id = favorite?.id;
       expect(favorites instanceof L.FavoriteConnection);
@@ -1641,7 +1647,7 @@ describe("generated", () => {
     /** Test the root query for a single Favorite */
     it("favorite", async () => {
       if (_favorite_id) {
-        const favorite: L.Favorite | undefined = await client.favorite(_favorite_id);
+        const favorite: L.Favorite | undefined | null = await client.favorite(_favorite_id);
         _favorite = favorite;
         expect(favorite instanceof L.Favorite);
       } else {
@@ -1652,7 +1658,7 @@ describe("generated", () => {
     /** Test the favorite connection query for the Favorite */
     it("favorite.children", async () => {
       if (_favorite) {
-        const children: L.FavoriteConnection | undefined = await _favorite.children();
+        const children: L.FavoriteConnection | undefined | null = await _favorite.children();
         expect(children instanceof L.FavoriteConnection);
       } else {
         console.warn("codegen-doc:print: No favorite found - cannot test _favorite.children query");
@@ -1662,7 +1668,7 @@ describe("generated", () => {
     /** Test the favorite.customView query for L.CustomView */
     it("favorite.customView", async () => {
       if (_favorite) {
-        const favorite_customView: L.CustomView | undefined = await _favorite.customView;
+        const favorite_customView: L.CustomView | undefined | null = await _favorite.customView;
         expect(favorite_customView instanceof L.CustomView);
       } else {
         console.warn("codegen-doc:print: No Favorite found - cannot test favorite.customView query");
@@ -1672,7 +1678,7 @@ describe("generated", () => {
     /** Test the favorite.customer query for L.Customer */
     it("favorite.customer", async () => {
       if (_favorite) {
-        const favorite_customer: L.Customer | undefined = await _favorite.customer;
+        const favorite_customer: L.Customer | undefined | null = await _favorite.customer;
         expect(favorite_customer instanceof L.Customer);
       } else {
         console.warn("codegen-doc:print: No Favorite found - cannot test favorite.customer query");
@@ -1682,7 +1688,7 @@ describe("generated", () => {
     /** Test the favorite.cycle query for L.Cycle */
     it("favorite.cycle", async () => {
       if (_favorite) {
-        const favorite_cycle: L.Cycle | undefined = await _favorite.cycle;
+        const favorite_cycle: L.Cycle | undefined | null = await _favorite.cycle;
         expect(favorite_cycle instanceof L.Cycle);
       } else {
         console.warn("codegen-doc:print: No Favorite found - cannot test favorite.cycle query");
@@ -1692,7 +1698,7 @@ describe("generated", () => {
     /** Test the favorite.document query for L.Document */
     it("favorite.document", async () => {
       if (_favorite) {
-        const favorite_document: L.Document | undefined = await _favorite.document;
+        const favorite_document: L.Document | undefined | null = await _favorite.document;
         expect(favorite_document instanceof L.Document);
       } else {
         console.warn("codegen-doc:print: No Favorite found - cannot test favorite.document query");
@@ -1702,7 +1708,7 @@ describe("generated", () => {
     /** Test the favorite.initiative query for L.Initiative */
     it("favorite.initiative", async () => {
       if (_favorite) {
-        const favorite_initiative: L.Initiative | undefined = await _favorite.initiative;
+        const favorite_initiative: L.Initiative | undefined | null = await _favorite.initiative;
         expect(favorite_initiative instanceof L.Initiative);
       } else {
         console.warn("codegen-doc:print: No Favorite found - cannot test favorite.initiative query");
@@ -1712,7 +1718,7 @@ describe("generated", () => {
     /** Test the favorite.issue query for L.Issue */
     it("favorite.issue", async () => {
       if (_favorite) {
-        const favorite_issue: L.Issue | undefined = await _favorite.issue;
+        const favorite_issue: L.Issue | undefined | null = await _favorite.issue;
         expect(favorite_issue instanceof L.Issue);
       } else {
         console.warn("codegen-doc:print: No Favorite found - cannot test favorite.issue query");
@@ -1722,7 +1728,7 @@ describe("generated", () => {
     /** Test the favorite.label query for L.IssueLabel */
     it("favorite.label", async () => {
       if (_favorite) {
-        const favorite_label: L.IssueLabel | undefined = await _favorite.label;
+        const favorite_label: L.IssueLabel | undefined | null = await _favorite.label;
         expect(favorite_label instanceof L.IssueLabel);
       } else {
         console.warn("codegen-doc:print: No Favorite found - cannot test favorite.label query");
@@ -1732,7 +1738,7 @@ describe("generated", () => {
     /** Test the favorite.owner query for L.User */
     it("favorite.owner", async () => {
       if (_favorite) {
-        const favorite_owner: L.User | undefined = await _favorite.owner;
+        const favorite_owner: L.User | undefined | null = await _favorite.owner;
         expect(favorite_owner instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Favorite found - cannot test favorite.owner query");
@@ -1742,7 +1748,7 @@ describe("generated", () => {
     /** Test the favorite.parent query for L.Favorite */
     it("favorite.parent", async () => {
       if (_favorite) {
-        const favorite_parent: L.Favorite | undefined = await _favorite.parent;
+        const favorite_parent: L.Favorite | undefined | null = await _favorite.parent;
         expect(favorite_parent instanceof L.Favorite);
       } else {
         console.warn("codegen-doc:print: No Favorite found - cannot test favorite.parent query");
@@ -1752,7 +1758,7 @@ describe("generated", () => {
     /** Test the favorite.predefinedViewTeam query for L.Team */
     it("favorite.predefinedViewTeam", async () => {
       if (_favorite) {
-        const favorite_predefinedViewTeam: L.Team | undefined = await _favorite.predefinedViewTeam;
+        const favorite_predefinedViewTeam: L.Team | undefined | null = await _favorite.predefinedViewTeam;
         expect(favorite_predefinedViewTeam instanceof L.Team);
       } else {
         console.warn("codegen-doc:print: No Favorite found - cannot test favorite.predefinedViewTeam query");
@@ -1762,7 +1768,7 @@ describe("generated", () => {
     /** Test the favorite.project query for L.Project */
     it("favorite.project", async () => {
       if (_favorite) {
-        const favorite_project: L.Project | undefined = await _favorite.project;
+        const favorite_project: L.Project | undefined | null = await _favorite.project;
         expect(favorite_project instanceof L.Project);
       } else {
         console.warn("codegen-doc:print: No Favorite found - cannot test favorite.project query");
@@ -1772,7 +1778,7 @@ describe("generated", () => {
     /** Test the favorite.projectLabel query for L.ProjectLabel */
     it("favorite.projectLabel", async () => {
       if (_favorite) {
-        const favorite_projectLabel: L.ProjectLabel | undefined = await _favorite.projectLabel;
+        const favorite_projectLabel: L.ProjectLabel | undefined | null = await _favorite.projectLabel;
         expect(favorite_projectLabel instanceof L.ProjectLabel);
       } else {
         console.warn("codegen-doc:print: No Favorite found - cannot test favorite.projectLabel query");
@@ -1782,7 +1788,7 @@ describe("generated", () => {
     /** Test the favorite.projectTeam query for L.Team */
     it("favorite.projectTeam", async () => {
       if (_favorite) {
-        const favorite_projectTeam: L.Team | undefined = await _favorite.projectTeam;
+        const favorite_projectTeam: L.Team | undefined | null = await _favorite.projectTeam;
         expect(favorite_projectTeam instanceof L.Team);
       } else {
         console.warn("codegen-doc:print: No Favorite found - cannot test favorite.projectTeam query");
@@ -1792,7 +1798,7 @@ describe("generated", () => {
     /** Test the favorite.user query for L.User */
     it("favorite.user", async () => {
       if (_favorite) {
-        const favorite_user: L.User | undefined = await _favorite.user;
+        const favorite_user: L.User | undefined | null = await _favorite.user;
         expect(favorite_user instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Favorite found - cannot test favorite.user query");
@@ -1804,19 +1810,20 @@ describe("generated", () => {
   describe("InitiativeRelations", () => {
     /** Test the root connection query for the InitiativeRelation */
     it("initiativeRelations", async () => {
-      const initiativeRelations: L.InitiativeRelationConnection | undefined = await client.initiativeRelations();
+      const initiativeRelations: L.InitiativeRelationConnection | undefined | null = await client.initiativeRelations();
       expect(initiativeRelations instanceof L.InitiativeRelationConnection);
     });
   });
 
   /** Test all InitiativeToProject queries */
   describe("InitiativeToProjects", () => {
-    let _initiativeToProject: L.InitiativeToProject | undefined;
-    let _initiativeToProject_id: string | undefined;
+    let _initiativeToProject: L.InitiativeToProject | undefined | null;
+    let _initiativeToProject_id: string | undefined | null;
 
     /** Test the root connection query for the InitiativeToProject */
     it("initiativeToProjects", async () => {
-      const initiativeToProjects: L.InitiativeToProjectConnection | undefined = await client.initiativeToProjects();
+      const initiativeToProjects: L.InitiativeToProjectConnection | undefined | null =
+        await client.initiativeToProjects();
       const initiativeToProject = initiativeToProjects?.nodes?.[0];
       _initiativeToProject_id = initiativeToProject?.id;
       expect(initiativeToProjects instanceof L.InitiativeToProjectConnection);
@@ -1825,7 +1832,7 @@ describe("generated", () => {
     /** Test the root query for a single InitiativeToProject */
     it("initiativeToProject", async () => {
       if (_initiativeToProject_id) {
-        const initiativeToProject: L.InitiativeToProject | undefined =
+        const initiativeToProject: L.InitiativeToProject | undefined | null =
           await client.initiativeToProject(_initiativeToProject_id);
         _initiativeToProject = initiativeToProject;
         expect(initiativeToProject instanceof L.InitiativeToProject);
@@ -1839,7 +1846,7 @@ describe("generated", () => {
     /** Test the initiativeToProject.initiative query for L.Initiative */
     it("initiativeToProject.initiative", async () => {
       if (_initiativeToProject) {
-        const initiativeToProject_initiative: L.Initiative | undefined = await _initiativeToProject.initiative;
+        const initiativeToProject_initiative: L.Initiative | undefined | null = await _initiativeToProject.initiative;
         expect(initiativeToProject_initiative instanceof L.Initiative);
       } else {
         console.warn(
@@ -1851,7 +1858,7 @@ describe("generated", () => {
     /** Test the initiativeToProject.project query for L.Project */
     it("initiativeToProject.project", async () => {
       if (_initiativeToProject) {
-        const initiativeToProject_project: L.Project | undefined = await _initiativeToProject.project;
+        const initiativeToProject_project: L.Project | undefined | null = await _initiativeToProject.project;
         expect(initiativeToProject_project instanceof L.Project);
       } else {
         console.warn("codegen-doc:print: No InitiativeToProject found - cannot test initiativeToProject.project query");
@@ -1861,12 +1868,12 @@ describe("generated", () => {
 
   /** Test all InitiativeUpdate queries */
   describe("InitiativeUpdates", () => {
-    let _initiativeUpdate: L.InitiativeUpdate | undefined;
-    let _initiativeUpdate_id: string | undefined;
+    let _initiativeUpdate: L.InitiativeUpdate | undefined | null;
+    let _initiativeUpdate_id: string | undefined | null;
 
     /** Test the root connection query for the InitiativeUpdate */
     it("initiativeUpdates", async () => {
-      const initiativeUpdates: L.InitiativeUpdateConnection | undefined = await client.initiativeUpdates();
+      const initiativeUpdates: L.InitiativeUpdateConnection | undefined | null = await client.initiativeUpdates();
       const initiativeUpdate = initiativeUpdates?.nodes?.[0];
       _initiativeUpdate_id = initiativeUpdate?.id;
       expect(initiativeUpdates instanceof L.InitiativeUpdateConnection);
@@ -1875,7 +1882,8 @@ describe("generated", () => {
     /** Test the root query for a single InitiativeUpdate */
     it("initiativeUpdate", async () => {
       if (_initiativeUpdate_id) {
-        const initiativeUpdate: L.InitiativeUpdate | undefined = await client.initiativeUpdate(_initiativeUpdate_id);
+        const initiativeUpdate: L.InitiativeUpdate | undefined | null =
+          await client.initiativeUpdate(_initiativeUpdate_id);
         _initiativeUpdate = initiativeUpdate;
         expect(initiativeUpdate instanceof L.InitiativeUpdate);
       } else {
@@ -1888,7 +1896,7 @@ describe("generated", () => {
     /** Test the initiativeUpdate connection query for the Comment */
     it("initiativeUpdate.comments", async () => {
       if (_initiativeUpdate) {
-        const comments: L.CommentConnection | undefined = await _initiativeUpdate.comments();
+        const comments: L.CommentConnection | undefined | null = await _initiativeUpdate.comments();
         expect(comments instanceof L.CommentConnection);
       } else {
         console.warn("codegen-doc:print: No initiativeUpdate found - cannot test _initiativeUpdate.comments query");
@@ -1898,7 +1906,7 @@ describe("generated", () => {
     /** Test the initiativeUpdate.initiative query for L.Initiative */
     it("initiativeUpdate.initiative", async () => {
       if (_initiativeUpdate) {
-        const initiativeUpdate_initiative: L.Initiative | undefined = await _initiativeUpdate.initiative;
+        const initiativeUpdate_initiative: L.Initiative | undefined | null = await _initiativeUpdate.initiative;
         expect(initiativeUpdate_initiative instanceof L.Initiative);
       } else {
         console.warn("codegen-doc:print: No InitiativeUpdate found - cannot test initiativeUpdate.initiative query");
@@ -1908,7 +1916,7 @@ describe("generated", () => {
     /** Test the initiativeUpdate.user query for L.User */
     it("initiativeUpdate.user", async () => {
       if (_initiativeUpdate) {
-        const initiativeUpdate_user: L.User | undefined = await _initiativeUpdate.user;
+        const initiativeUpdate_user: L.User | undefined | null = await _initiativeUpdate.user;
         expect(initiativeUpdate_user instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No InitiativeUpdate found - cannot test initiativeUpdate.user query");
@@ -1918,12 +1926,12 @@ describe("generated", () => {
 
   /** Test all Initiative queries */
   describe("Initiatives", () => {
-    let _initiative: L.Initiative | undefined;
-    let _initiative_id: string | undefined;
+    let _initiative: L.Initiative | undefined | null;
+    let _initiative_id: string | undefined | null;
 
     /** Test the root connection query for the Initiative */
     it("initiatives", async () => {
-      const initiatives: L.InitiativeConnection | undefined = await client.initiatives();
+      const initiatives: L.InitiativeConnection | undefined | null = await client.initiatives();
       const initiative = initiatives?.nodes?.[0];
       _initiative_id = initiative?.id;
       expect(initiatives instanceof L.InitiativeConnection);
@@ -1932,7 +1940,7 @@ describe("generated", () => {
     /** Test the root query for a single Initiative */
     it("initiative", async () => {
       if (_initiative_id) {
-        const initiative: L.Initiative | undefined = await client.initiative(_initiative_id);
+        const initiative: L.Initiative | undefined | null = await client.initiative(_initiative_id);
         _initiative = initiative;
         expect(initiative instanceof L.Initiative);
       } else {
@@ -1940,12 +1948,12 @@ describe("generated", () => {
       }
     });
 
-    let _documentContent: L.DocumentContent | undefined;
+    let _documentContent: L.DocumentContent | undefined | null;
 
     /** Test the initiative model query for Initiative_DocumentContent */
     it("initiative.documentContent", async () => {
       if (_initiative) {
-        const documentContent: L.DocumentContent | undefined = _initiative.documentContent;
+        const documentContent: L.DocumentContent | undefined | null = _initiative.documentContent;
         _documentContent = documentContent;
         expect(documentContent instanceof L.DocumentContent);
       } else {
@@ -1956,7 +1964,7 @@ describe("generated", () => {
     /** Test the initiative_documentContent model query for Initiative_DocumentContent_AiPromptRules */
     it("initiative_documentContent.aiPromptRules", async () => {
       if (_documentContent) {
-        const aiPromptRules: L.AiPromptRules | undefined = _documentContent.aiPromptRules;
+        const aiPromptRules: L.AiPromptRules | undefined | null = _documentContent.aiPromptRules;
         expect(aiPromptRules instanceof L.AiPromptRules);
       } else {
         console.warn("codegen-doc:print: No documentContent found - cannot test _documentContent.aiPromptRules query");
@@ -1966,7 +1974,7 @@ describe("generated", () => {
     /** Test the initiative connection query for the Document */
     it("initiative.documents", async () => {
       if (_initiative) {
-        const documents: L.DocumentConnection | undefined = await _initiative.documents();
+        const documents: L.DocumentConnection | undefined | null = await _initiative.documents();
         expect(documents instanceof L.DocumentConnection);
       } else {
         console.warn("codegen-doc:print: No initiative found - cannot test _initiative.documents query");
@@ -1976,7 +1984,7 @@ describe("generated", () => {
     /** Test the initiative connection query for the InitiativeHistory */
     it("initiative.history", async () => {
       if (_initiative) {
-        const history: L.InitiativeHistoryConnection | undefined = await _initiative.history();
+        const history: L.InitiativeHistoryConnection | undefined | null = await _initiative.history();
         expect(history instanceof L.InitiativeHistoryConnection);
       } else {
         console.warn("codegen-doc:print: No initiative found - cannot test _initiative.history query");
@@ -1986,7 +1994,8 @@ describe("generated", () => {
     /** Test the initiative connection query for the InitiativeUpdate */
     it("initiative.initiativeUpdates", async () => {
       if (_initiative) {
-        const initiativeUpdates: L.InitiativeUpdateConnection | undefined = await _initiative.initiativeUpdates();
+        const initiativeUpdates: L.InitiativeUpdateConnection | undefined | null =
+          await _initiative.initiativeUpdates();
         expect(initiativeUpdates instanceof L.InitiativeUpdateConnection);
       } else {
         console.warn("codegen-doc:print: No initiative found - cannot test _initiative.initiativeUpdates query");
@@ -1996,7 +2005,7 @@ describe("generated", () => {
     /** Test the initiative connection query for the EntityExternalLink */
     it("initiative.links", async () => {
       if (_initiative) {
-        const links: L.EntityExternalLinkConnection | undefined = await _initiative.links();
+        const links: L.EntityExternalLinkConnection | undefined | null = await _initiative.links();
         expect(links instanceof L.EntityExternalLinkConnection);
       } else {
         console.warn("codegen-doc:print: No initiative found - cannot test _initiative.links query");
@@ -2006,7 +2015,7 @@ describe("generated", () => {
     /** Test the initiative connection query for the Project */
     it("initiative.projects", async () => {
       if (_initiative) {
-        const projects: L.ProjectConnection | undefined = await _initiative.projects();
+        const projects: L.ProjectConnection | undefined | null = await _initiative.projects();
         expect(projects instanceof L.ProjectConnection);
       } else {
         console.warn("codegen-doc:print: No initiative found - cannot test _initiative.projects query");
@@ -2016,7 +2025,7 @@ describe("generated", () => {
     /** Test the initiative connection query for the Initiative */
     it("initiative.subInitiatives", async () => {
       if (_initiative) {
-        const subInitiatives: L.InitiativeConnection | undefined = await _initiative.subInitiatives();
+        const subInitiatives: L.InitiativeConnection | undefined | null = await _initiative.subInitiatives();
         expect(subInitiatives instanceof L.InitiativeConnection);
       } else {
         console.warn("codegen-doc:print: No initiative found - cannot test _initiative.subInitiatives query");
@@ -2026,7 +2035,7 @@ describe("generated", () => {
     /** Test the initiative.creator query for L.User */
     it("initiative.creator", async () => {
       if (_initiative) {
-        const initiative_creator: L.User | undefined = await _initiative.creator;
+        const initiative_creator: L.User | undefined | null = await _initiative.creator;
         expect(initiative_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Initiative found - cannot test initiative.creator query");
@@ -2036,7 +2045,7 @@ describe("generated", () => {
     /** Test the initiative.integrationsSettings query for L.IntegrationsSettings */
     it("initiative.integrationsSettings", async () => {
       if (_initiative) {
-        const initiative_integrationsSettings: L.IntegrationsSettings | undefined =
+        const initiative_integrationsSettings: L.IntegrationsSettings | undefined | null =
           await _initiative.integrationsSettings;
         expect(initiative_integrationsSettings instanceof L.IntegrationsSettings);
       } else {
@@ -2047,7 +2056,7 @@ describe("generated", () => {
     /** Test the initiative.lastUpdate query for L.InitiativeUpdate */
     it("initiative.lastUpdate", async () => {
       if (_initiative) {
-        const initiative_lastUpdate: L.InitiativeUpdate | undefined = await _initiative.lastUpdate;
+        const initiative_lastUpdate: L.InitiativeUpdate | undefined | null = await _initiative.lastUpdate;
         expect(initiative_lastUpdate instanceof L.InitiativeUpdate);
       } else {
         console.warn("codegen-doc:print: No Initiative found - cannot test initiative.lastUpdate query");
@@ -2057,7 +2066,7 @@ describe("generated", () => {
     /** Test the initiative.organization query for L.Organization */
     it("initiative.organization", async () => {
       if (_initiative) {
-        const initiative_organization: L.Organization | undefined = await _initiative.organization;
+        const initiative_organization: L.Organization | undefined | null = await _initiative.organization;
         expect(initiative_organization instanceof L.Organization);
       } else {
         console.warn("codegen-doc:print: No Initiative found - cannot test initiative.organization query");
@@ -2067,7 +2076,7 @@ describe("generated", () => {
     /** Test the initiative.owner query for L.User */
     it("initiative.owner", async () => {
       if (_initiative) {
-        const initiative_owner: L.User | undefined = await _initiative.owner;
+        const initiative_owner: L.User | undefined | null = await _initiative.owner;
         expect(initiative_owner instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Initiative found - cannot test initiative.owner query");
@@ -2077,7 +2086,7 @@ describe("generated", () => {
     /** Test the initiative.parentInitiative query for L.Initiative */
     it("initiative.parentInitiative", async () => {
       if (_initiative) {
-        const initiative_parentInitiative: L.Initiative | undefined = await _initiative.parentInitiative;
+        const initiative_parentInitiative: L.Initiative | undefined | null = await _initiative.parentInitiative;
         expect(initiative_parentInitiative instanceof L.Initiative);
       } else {
         console.warn("codegen-doc:print: No Initiative found - cannot test initiative.parentInitiative query");
@@ -2089,7 +2098,7 @@ describe("generated", () => {
   describe("IntegrationHasScopes", () => {
     /** Test the root model query for IntegrationHasScopes */
     it("integrationHasScopes", async () => {
-      const integrationHasScopes: L.IntegrationHasScopesPayload | undefined = await client.integrationHasScopes(
+      const integrationHasScopes: L.IntegrationHasScopesPayload | undefined | null = await client.integrationHasScopes(
         "mock-integrationId",
         ["mock-scopes"]
       );
@@ -2099,12 +2108,13 @@ describe("generated", () => {
 
   /** Test all IntegrationTemplate queries */
   describe("IntegrationTemplates", () => {
-    let _integrationTemplate: L.IntegrationTemplate | undefined;
-    let _integrationTemplate_id: string | undefined;
+    let _integrationTemplate: L.IntegrationTemplate | undefined | null;
+    let _integrationTemplate_id: string | undefined | null;
 
     /** Test the root connection query for the IntegrationTemplate */
     it("integrationTemplates", async () => {
-      const integrationTemplates: L.IntegrationTemplateConnection | undefined = await client.integrationTemplates();
+      const integrationTemplates: L.IntegrationTemplateConnection | undefined | null =
+        await client.integrationTemplates();
       const integrationTemplate = integrationTemplates?.nodes?.[0];
       _integrationTemplate_id = integrationTemplate?.id;
       expect(integrationTemplates instanceof L.IntegrationTemplateConnection);
@@ -2113,7 +2123,7 @@ describe("generated", () => {
     /** Test the root query for a single IntegrationTemplate */
     it("integrationTemplate", async () => {
       if (_integrationTemplate_id) {
-        const integrationTemplate: L.IntegrationTemplate | undefined =
+        const integrationTemplate: L.IntegrationTemplate | undefined | null =
           await client.integrationTemplate(_integrationTemplate_id);
         _integrationTemplate = integrationTemplate;
         expect(integrationTemplate instanceof L.IntegrationTemplate);
@@ -2127,7 +2137,8 @@ describe("generated", () => {
     /** Test the integrationTemplate.integration query for L.Integration */
     it("integrationTemplate.integration", async () => {
       if (_integrationTemplate) {
-        const integrationTemplate_integration: L.Integration | undefined = await _integrationTemplate.integration;
+        const integrationTemplate_integration: L.Integration | undefined | null =
+          await _integrationTemplate.integration;
         expect(integrationTemplate_integration instanceof L.Integration);
       } else {
         console.warn(
@@ -2139,7 +2150,7 @@ describe("generated", () => {
     /** Test the integrationTemplate.template query for L.Template */
     it("integrationTemplate.template", async () => {
       if (_integrationTemplate) {
-        const integrationTemplate_template: L.Template | undefined = await _integrationTemplate.template;
+        const integrationTemplate_template: L.Template | undefined | null = await _integrationTemplate.template;
         expect(integrationTemplate_template instanceof L.Template);
       } else {
         console.warn(
@@ -2151,12 +2162,12 @@ describe("generated", () => {
 
   /** Test all Integration queries */
   describe("Integrations", () => {
-    let _integration: L.Integration | undefined;
-    let _integration_id: string | undefined;
+    let _integration: L.Integration | undefined | null;
+    let _integration_id: string | undefined | null;
 
     /** Test the root connection query for the Integration */
     it("integrations", async () => {
-      const integrations: L.IntegrationConnection | undefined = await client.integrations();
+      const integrations: L.IntegrationConnection | undefined | null = await client.integrations();
       const integration = integrations?.nodes?.[0];
       _integration_id = integration?.id;
       expect(integrations instanceof L.IntegrationConnection);
@@ -2165,7 +2176,7 @@ describe("generated", () => {
     /** Test the root query for a single Integration */
     it("integration", async () => {
       if (_integration_id) {
-        const integration: L.Integration | undefined = await client.integration(_integration_id);
+        const integration: L.Integration | undefined | null = await client.integration(_integration_id);
         _integration = integration;
         expect(integration instanceof L.Integration);
       } else {
@@ -2176,7 +2187,7 @@ describe("generated", () => {
     /** Test the integration.creator query for L.User */
     it("integration.creator", async () => {
       if (_integration) {
-        const integration_creator: L.User | undefined = await _integration.creator;
+        const integration_creator: L.User | undefined | null = await _integration.creator;
         expect(integration_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Integration found - cannot test integration.creator query");
@@ -2186,7 +2197,7 @@ describe("generated", () => {
     /** Test the integration.organization query for L.Organization */
     it("integration.organization", async () => {
       if (_integration) {
-        const integration_organization: L.Organization | undefined = await _integration.organization;
+        const integration_organization: L.Organization | undefined | null = await _integration.organization;
         expect(integration_organization instanceof L.Organization);
       } else {
         console.warn("codegen-doc:print: No Integration found - cannot test integration.organization query");
@@ -2196,7 +2207,7 @@ describe("generated", () => {
     /** Test the integration.team query for L.Team */
     it("integration.team", async () => {
       if (_integration) {
-        const integration_team: L.Team | undefined = await _integration.team;
+        const integration_team: L.Team | undefined | null = await _integration.team;
         expect(integration_team instanceof L.Team);
       } else {
         console.warn("codegen-doc:print: No Integration found - cannot test integration.team query");
@@ -2208,19 +2219,20 @@ describe("generated", () => {
   describe("IntegrationsSettings", () => {
     /** Test the root model query for IntegrationsSettings */
     it("integrationsSettings", async () => {
-      const integrationsSettings: L.IntegrationsSettings | undefined = await client.integrationsSettings("mock-id");
+      const integrationsSettings: L.IntegrationsSettings | undefined | null =
+        await client.integrationsSettings("mock-id");
       expect(integrationsSettings instanceof L.IntegrationsSettings);
     });
   });
 
   /** Test all Issue queries */
   describe("IssueFigmaFileKeySearch", () => {
-    let _issue: L.Issue | undefined;
-    let _issue_id: string | undefined;
+    let _issue: L.Issue | undefined | null;
+    let _issue_id: string | undefined | null;
 
     /** Test the root connection query for the Issue */
     it("issueFigmaFileKeySearch", async () => {
-      const issueFigmaFileKeySearch: L.IssueConnection | undefined =
+      const issueFigmaFileKeySearch: L.IssueConnection | undefined | null =
         await client.issueFigmaFileKeySearch("mock-fileKey");
       const issue = issueFigmaFileKeySearch?.nodes?.[0];
       _issue_id = issue?.id;
@@ -2230,7 +2242,7 @@ describe("generated", () => {
     /** Test the root query for a single Issue */
     it("issue", async () => {
       if (_issue_id) {
-        const issue: L.Issue | undefined = await client.issue(_issue_id);
+        const issue: L.Issue | undefined | null = await client.issue(_issue_id);
         _issue = issue;
         expect(issue instanceof L.Issue);
       } else {
@@ -2241,7 +2253,7 @@ describe("generated", () => {
     /** Test the issue connection query for the Attachment */
     it("issue.attachments", async () => {
       if (_issue) {
-        const attachments: L.AttachmentConnection | undefined = await _issue.attachments();
+        const attachments: L.AttachmentConnection | undefined | null = await _issue.attachments();
         expect(attachments instanceof L.AttachmentConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.attachments query");
@@ -2251,7 +2263,7 @@ describe("generated", () => {
     /** Test the issue model query for Issue_BotActor */
     it("issue.botActor", async () => {
       if (_issue) {
-        const botActor: L.ActorBot | undefined = _issue.botActor;
+        const botActor: L.ActorBot | undefined | null = _issue.botActor;
         expect(botActor instanceof L.ActorBot);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.botActor query");
@@ -2261,7 +2273,7 @@ describe("generated", () => {
     /** Test the issue connection query for the Issue */
     it("issue.children", async () => {
       if (_issue) {
-        const children: L.IssueConnection | undefined = await _issue.children();
+        const children: L.IssueConnection | undefined | null = await _issue.children();
         expect(children instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.children query");
@@ -2271,7 +2283,7 @@ describe("generated", () => {
     /** Test the issue connection query for the Comment */
     it("issue.comments", async () => {
       if (_issue) {
-        const comments: L.CommentConnection | undefined = await _issue.comments();
+        const comments: L.CommentConnection | undefined | null = await _issue.comments();
         expect(comments instanceof L.CommentConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.comments query");
@@ -2281,7 +2293,7 @@ describe("generated", () => {
     /** Test the issue connection query for the Document */
     it("issue.documents", async () => {
       if (_issue) {
-        const documents: L.DocumentConnection | undefined = await _issue.documents();
+        const documents: L.DocumentConnection | undefined | null = await _issue.documents();
         expect(documents instanceof L.DocumentConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.documents query");
@@ -2291,7 +2303,7 @@ describe("generated", () => {
     /** Test the issue connection query for the Attachment */
     it("issue.formerAttachments", async () => {
       if (_issue) {
-        const formerAttachments: L.AttachmentConnection | undefined = await _issue.formerAttachments();
+        const formerAttachments: L.AttachmentConnection | undefined | null = await _issue.formerAttachments();
         expect(formerAttachments instanceof L.AttachmentConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.formerAttachments query");
@@ -2301,7 +2313,7 @@ describe("generated", () => {
     /** Test the issue connection query for the CustomerNeed */
     it("issue.formerNeeds", async () => {
       if (_issue) {
-        const formerNeeds: L.CustomerNeedConnection | undefined = await _issue.formerNeeds();
+        const formerNeeds: L.CustomerNeedConnection | undefined | null = await _issue.formerNeeds();
         expect(formerNeeds instanceof L.CustomerNeedConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.formerNeeds query");
@@ -2311,7 +2323,7 @@ describe("generated", () => {
     /** Test the issue connection query for the IssueHistory */
     it("issue.history", async () => {
       if (_issue) {
-        const history: L.IssueHistoryConnection | undefined = await _issue.history();
+        const history: L.IssueHistoryConnection | undefined | null = await _issue.history();
         expect(history instanceof L.IssueHistoryConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.history query");
@@ -2321,7 +2333,7 @@ describe("generated", () => {
     /** Test the issue connection query for the IssueRelation */
     it("issue.inverseRelations", async () => {
       if (_issue) {
-        const inverseRelations: L.IssueRelationConnection | undefined = await _issue.inverseRelations();
+        const inverseRelations: L.IssueRelationConnection | undefined | null = await _issue.inverseRelations();
         expect(inverseRelations instanceof L.IssueRelationConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.inverseRelations query");
@@ -2331,7 +2343,7 @@ describe("generated", () => {
     /** Test the issue connection query for the IssueLabel */
     it("issue.labels", async () => {
       if (_issue) {
-        const labels: L.IssueLabelConnection | undefined = await _issue.labels();
+        const labels: L.IssueLabelConnection | undefined | null = await _issue.labels();
         expect(labels instanceof L.IssueLabelConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.labels query");
@@ -2341,7 +2353,7 @@ describe("generated", () => {
     /** Test the issue connection query for the CustomerNeed */
     it("issue.needs", async () => {
       if (_issue) {
-        const needs: L.CustomerNeedConnection | undefined = await _issue.needs();
+        const needs: L.CustomerNeedConnection | undefined | null = await _issue.needs();
         expect(needs instanceof L.CustomerNeedConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.needs query");
@@ -2351,7 +2363,7 @@ describe("generated", () => {
     /** Test the issue connection query for the IssueRelation */
     it("issue.relations", async () => {
       if (_issue) {
-        const relations: L.IssueRelationConnection | undefined = await _issue.relations();
+        const relations: L.IssueRelationConnection | undefined | null = await _issue.relations();
         expect(relations instanceof L.IssueRelationConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.relations query");
@@ -2361,7 +2373,7 @@ describe("generated", () => {
     /** Test the issue connection query for the User */
     it("issue.subscribers", async () => {
       if (_issue) {
-        const subscribers: L.UserConnection | undefined = await _issue.subscribers();
+        const subscribers: L.UserConnection | undefined | null = await _issue.subscribers();
         expect(subscribers instanceof L.UserConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.subscribers query");
@@ -2371,7 +2383,8 @@ describe("generated", () => {
     /** Test the issue.asksExternalUserRequester query for L.ExternalUser */
     it("issue.asksExternalUserRequester", async () => {
       if (_issue) {
-        const issue_asksExternalUserRequester: L.ExternalUser | undefined = await _issue.asksExternalUserRequester;
+        const issue_asksExternalUserRequester: L.ExternalUser | undefined | null =
+          await _issue.asksExternalUserRequester;
         expect(issue_asksExternalUserRequester instanceof L.ExternalUser);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.asksExternalUserRequester query");
@@ -2381,7 +2394,7 @@ describe("generated", () => {
     /** Test the issue.asksRequester query for L.User */
     it("issue.asksRequester", async () => {
       if (_issue) {
-        const issue_asksRequester: L.User | undefined = await _issue.asksRequester;
+        const issue_asksRequester: L.User | undefined | null = await _issue.asksRequester;
         expect(issue_asksRequester instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.asksRequester query");
@@ -2391,7 +2404,7 @@ describe("generated", () => {
     /** Test the issue.assignee query for L.User */
     it("issue.assignee", async () => {
       if (_issue) {
-        const issue_assignee: L.User | undefined = await _issue.assignee;
+        const issue_assignee: L.User | undefined | null = await _issue.assignee;
         expect(issue_assignee instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.assignee query");
@@ -2401,7 +2414,7 @@ describe("generated", () => {
     /** Test the issue.creator query for L.User */
     it("issue.creator", async () => {
       if (_issue) {
-        const issue_creator: L.User | undefined = await _issue.creator;
+        const issue_creator: L.User | undefined | null = await _issue.creator;
         expect(issue_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.creator query");
@@ -2411,7 +2424,7 @@ describe("generated", () => {
     /** Test the issue.cycle query for L.Cycle */
     it("issue.cycle", async () => {
       if (_issue) {
-        const issue_cycle: L.Cycle | undefined = await _issue.cycle;
+        const issue_cycle: L.Cycle | undefined | null = await _issue.cycle;
         expect(issue_cycle instanceof L.Cycle);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.cycle query");
@@ -2421,7 +2434,7 @@ describe("generated", () => {
     /** Test the issue.delegate query for L.User */
     it("issue.delegate", async () => {
       if (_issue) {
-        const issue_delegate: L.User | undefined = await _issue.delegate;
+        const issue_delegate: L.User | undefined | null = await _issue.delegate;
         expect(issue_delegate instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.delegate query");
@@ -2431,7 +2444,7 @@ describe("generated", () => {
     /** Test the issue.externalUserCreator query for L.ExternalUser */
     it("issue.externalUserCreator", async () => {
       if (_issue) {
-        const issue_externalUserCreator: L.ExternalUser | undefined = await _issue.externalUserCreator;
+        const issue_externalUserCreator: L.ExternalUser | undefined | null = await _issue.externalUserCreator;
         expect(issue_externalUserCreator instanceof L.ExternalUser);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.externalUserCreator query");
@@ -2441,7 +2454,7 @@ describe("generated", () => {
     /** Test the issue.favorite query for L.Favorite */
     it("issue.favorite", async () => {
       if (_issue) {
-        const issue_favorite: L.Favorite | undefined = await _issue.favorite;
+        const issue_favorite: L.Favorite | undefined | null = await _issue.favorite;
         expect(issue_favorite instanceof L.Favorite);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.favorite query");
@@ -2451,7 +2464,7 @@ describe("generated", () => {
     /** Test the issue.lastAppliedTemplate query for L.Template */
     it("issue.lastAppliedTemplate", async () => {
       if (_issue) {
-        const issue_lastAppliedTemplate: L.Template | undefined = await _issue.lastAppliedTemplate;
+        const issue_lastAppliedTemplate: L.Template | undefined | null = await _issue.lastAppliedTemplate;
         expect(issue_lastAppliedTemplate instanceof L.Template);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.lastAppliedTemplate query");
@@ -2461,7 +2474,7 @@ describe("generated", () => {
     /** Test the issue.parent query for L.Issue */
     it("issue.parent", async () => {
       if (_issue) {
-        const issue_parent: L.Issue | undefined = await _issue.parent;
+        const issue_parent: L.Issue | undefined | null = await _issue.parent;
         expect(issue_parent instanceof L.Issue);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.parent query");
@@ -2471,7 +2484,7 @@ describe("generated", () => {
     /** Test the issue.project query for L.Project */
     it("issue.project", async () => {
       if (_issue) {
-        const issue_project: L.Project | undefined = await _issue.project;
+        const issue_project: L.Project | undefined | null = await _issue.project;
         expect(issue_project instanceof L.Project);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.project query");
@@ -2481,7 +2494,7 @@ describe("generated", () => {
     /** Test the issue.projectMilestone query for L.ProjectMilestone */
     it("issue.projectMilestone", async () => {
       if (_issue) {
-        const issue_projectMilestone: L.ProjectMilestone | undefined = await _issue.projectMilestone;
+        const issue_projectMilestone: L.ProjectMilestone | undefined | null = await _issue.projectMilestone;
         expect(issue_projectMilestone instanceof L.ProjectMilestone);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.projectMilestone query");
@@ -2491,7 +2504,7 @@ describe("generated", () => {
     /** Test the issue.recurringIssueTemplate query for L.Template */
     it("issue.recurringIssueTemplate", async () => {
       if (_issue) {
-        const issue_recurringIssueTemplate: L.Template | undefined = await _issue.recurringIssueTemplate;
+        const issue_recurringIssueTemplate: L.Template | undefined | null = await _issue.recurringIssueTemplate;
         expect(issue_recurringIssueTemplate instanceof L.Template);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.recurringIssueTemplate query");
@@ -2501,7 +2514,7 @@ describe("generated", () => {
     /** Test the issue.snoozedBy query for L.User */
     it("issue.snoozedBy", async () => {
       if (_issue) {
-        const issue_snoozedBy: L.User | undefined = await _issue.snoozedBy;
+        const issue_snoozedBy: L.User | undefined | null = await _issue.snoozedBy;
         expect(issue_snoozedBy instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.snoozedBy query");
@@ -2511,7 +2524,7 @@ describe("generated", () => {
     /** Test the issue.sourceComment query for L.Comment */
     it("issue.sourceComment", async () => {
       if (_issue) {
-        const issue_sourceComment: L.Comment | undefined = await _issue.sourceComment;
+        const issue_sourceComment: L.Comment | undefined | null = await _issue.sourceComment;
         expect(issue_sourceComment instanceof L.Comment);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.sourceComment query");
@@ -2521,7 +2534,7 @@ describe("generated", () => {
     /** Test the issue.state query for L.WorkflowState */
     it("issue.state", async () => {
       if (_issue) {
-        const issue_state: L.WorkflowState | undefined = await _issue.state;
+        const issue_state: L.WorkflowState | undefined | null = await _issue.state;
         expect(issue_state instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.state query");
@@ -2531,7 +2544,7 @@ describe("generated", () => {
     /** Test the issue.team query for L.Team */
     it("issue.team", async () => {
       if (_issue) {
-        const issue_team: L.Team | undefined = await _issue.team;
+        const issue_team: L.Team | undefined | null = await _issue.team;
         expect(issue_team instanceof L.Team);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.team query");
@@ -2543,7 +2556,7 @@ describe("generated", () => {
   describe("IssueFilterSuggestion", () => {
     /** Test the root model query for IssueFilterSuggestion */
     it("issueFilterSuggestion", async () => {
-      const issueFilterSuggestion: L.IssueFilterSuggestionPayload | undefined =
+      const issueFilterSuggestion: L.IssueFilterSuggestionPayload | undefined | null =
         await client.issueFilterSuggestion("mock-prompt");
       expect(issueFilterSuggestion instanceof L.IssueFilterSuggestionPayload);
     });
@@ -2553,7 +2566,7 @@ describe("generated", () => {
   describe("IssueImportCheckCsv", () => {
     /** Test the root model query for IssueImportCheckCsv */
     it("issueImportCheckCSV", async () => {
-      const issueImportCheckCSV: L.IssueImportCheckPayload | undefined = await client.issueImportCheckCSV(
+      const issueImportCheckCSV: L.IssueImportCheckPayload | undefined | null = await client.issueImportCheckCSV(
         "mock-csvUrl",
         "mock-service"
       );
@@ -2565,7 +2578,7 @@ describe("generated", () => {
   describe("IssueImportCheckSync", () => {
     /** Test the root model query for IssueImportCheckSync */
     it("issueImportCheckSync", async () => {
-      const issueImportCheckSync: L.IssueImportSyncCheckPayload | undefined =
+      const issueImportCheckSync: L.IssueImportSyncCheckPayload | undefined | null =
         await client.issueImportCheckSync("mock-issueImportId");
       expect(issueImportCheckSync instanceof L.IssueImportSyncCheckPayload);
     });
@@ -2575,7 +2588,7 @@ describe("generated", () => {
   describe("IssueImportJqlCheck", () => {
     /** Test the root model query for IssueImportJqlCheck */
     it("issueImportJqlCheck", async () => {
-      const issueImportJqlCheck: L.IssueImportJqlCheckPayload | undefined = await client.issueImportJqlCheck(
+      const issueImportJqlCheck: L.IssueImportJqlCheckPayload | undefined | null = await client.issueImportJqlCheck(
         "mock-jiraEmail",
         "mock-jiraHostname",
         "mock-jiraProject",
@@ -2588,12 +2601,12 @@ describe("generated", () => {
 
   /** Test all IssueLabel queries */
   describe("IssueLabels", () => {
-    let _issueLabel: L.IssueLabel | undefined;
-    let _issueLabel_id: string | undefined;
+    let _issueLabel: L.IssueLabel | undefined | null;
+    let _issueLabel_id: string | undefined | null;
 
     /** Test the root connection query for the IssueLabel */
     it("issueLabels", async () => {
-      const issueLabels: L.IssueLabelConnection | undefined = await client.issueLabels();
+      const issueLabels: L.IssueLabelConnection | undefined | null = await client.issueLabels();
       const issueLabel = issueLabels?.nodes?.[0];
       _issueLabel_id = issueLabel?.id;
       expect(issueLabels instanceof L.IssueLabelConnection);
@@ -2602,7 +2615,7 @@ describe("generated", () => {
     /** Test the root query for a single IssueLabel */
     it("issueLabel", async () => {
       if (_issueLabel_id) {
-        const issueLabel: L.IssueLabel | undefined = await client.issueLabel(_issueLabel_id);
+        const issueLabel: L.IssueLabel | undefined | null = await client.issueLabel(_issueLabel_id);
         _issueLabel = issueLabel;
         expect(issueLabel instanceof L.IssueLabel);
       } else {
@@ -2613,7 +2626,7 @@ describe("generated", () => {
     /** Test the issueLabel connection query for the IssueLabel */
     it("issueLabel.children", async () => {
       if (_issueLabel) {
-        const children: L.IssueLabelConnection | undefined = await _issueLabel.children();
+        const children: L.IssueLabelConnection | undefined | null = await _issueLabel.children();
         expect(children instanceof L.IssueLabelConnection);
       } else {
         console.warn("codegen-doc:print: No issueLabel found - cannot test _issueLabel.children query");
@@ -2623,7 +2636,7 @@ describe("generated", () => {
     /** Test the issueLabel connection query for the Issue */
     it("issueLabel.issues", async () => {
       if (_issueLabel) {
-        const issues: L.IssueConnection | undefined = await _issueLabel.issues();
+        const issues: L.IssueConnection | undefined | null = await _issueLabel.issues();
         expect(issues instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No issueLabel found - cannot test _issueLabel.issues query");
@@ -2633,7 +2646,7 @@ describe("generated", () => {
     /** Test the issueLabel.creator query for L.User */
     it("issueLabel.creator", async () => {
       if (_issueLabel) {
-        const issueLabel_creator: L.User | undefined = await _issueLabel.creator;
+        const issueLabel_creator: L.User | undefined | null = await _issueLabel.creator;
         expect(issueLabel_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No IssueLabel found - cannot test issueLabel.creator query");
@@ -2643,7 +2656,7 @@ describe("generated", () => {
     /** Test the issueLabel.inheritedFrom query for L.IssueLabel */
     it("issueLabel.inheritedFrom", async () => {
       if (_issueLabel) {
-        const issueLabel_inheritedFrom: L.IssueLabel | undefined = await _issueLabel.inheritedFrom;
+        const issueLabel_inheritedFrom: L.IssueLabel | undefined | null = await _issueLabel.inheritedFrom;
         expect(issueLabel_inheritedFrom instanceof L.IssueLabel);
       } else {
         console.warn("codegen-doc:print: No IssueLabel found - cannot test issueLabel.inheritedFrom query");
@@ -2653,7 +2666,7 @@ describe("generated", () => {
     /** Test the issueLabel.organization query for L.Organization */
     it("issueLabel.organization", async () => {
       if (_issueLabel) {
-        const issueLabel_organization: L.Organization | undefined = await _issueLabel.organization;
+        const issueLabel_organization: L.Organization | undefined | null = await _issueLabel.organization;
         expect(issueLabel_organization instanceof L.Organization);
       } else {
         console.warn("codegen-doc:print: No IssueLabel found - cannot test issueLabel.organization query");
@@ -2663,7 +2676,7 @@ describe("generated", () => {
     /** Test the issueLabel.parent query for L.IssueLabel */
     it("issueLabel.parent", async () => {
       if (_issueLabel) {
-        const issueLabel_parent: L.IssueLabel | undefined = await _issueLabel.parent;
+        const issueLabel_parent: L.IssueLabel | undefined | null = await _issueLabel.parent;
         expect(issueLabel_parent instanceof L.IssueLabel);
       } else {
         console.warn("codegen-doc:print: No IssueLabel found - cannot test issueLabel.parent query");
@@ -2673,7 +2686,7 @@ describe("generated", () => {
     /** Test the issueLabel.retiredBy query for L.User */
     it("issueLabel.retiredBy", async () => {
       if (_issueLabel) {
-        const issueLabel_retiredBy: L.User | undefined = await _issueLabel.retiredBy;
+        const issueLabel_retiredBy: L.User | undefined | null = await _issueLabel.retiredBy;
         expect(issueLabel_retiredBy instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No IssueLabel found - cannot test issueLabel.retiredBy query");
@@ -2683,7 +2696,7 @@ describe("generated", () => {
     /** Test the issueLabel.team query for L.Team */
     it("issueLabel.team", async () => {
       if (_issueLabel) {
-        const issueLabel_team: L.Team | undefined = await _issueLabel.team;
+        const issueLabel_team: L.Team | undefined | null = await _issueLabel.team;
         expect(issueLabel_team instanceof L.Team);
       } else {
         console.warn("codegen-doc:print: No IssueLabel found - cannot test issueLabel.team query");
@@ -2695,19 +2708,19 @@ describe("generated", () => {
   describe("IssuePriorityValues", () => {
     /** Test the root model query for IssuePriorityValues */
     it("issuePriorityValues", async () => {
-      const issuePriorityValues: L.IssuePriorityValue[] | undefined = await client.issuePriorityValues;
+      const issuePriorityValues: L.IssuePriorityValue[] | undefined | null = await client.issuePriorityValues;
       issuePriorityValues?.map(node => expect(node instanceof L.IssuePriorityValue));
     });
   });
 
   /** Test all IssueRelation queries */
   describe("IssueRelations", () => {
-    let _issueRelation: L.IssueRelation | undefined;
-    let _issueRelation_id: string | undefined;
+    let _issueRelation: L.IssueRelation | undefined | null;
+    let _issueRelation_id: string | undefined | null;
 
     /** Test the root connection query for the IssueRelation */
     it("issueRelations", async () => {
-      const issueRelations: L.IssueRelationConnection | undefined = await client.issueRelations();
+      const issueRelations: L.IssueRelationConnection | undefined | null = await client.issueRelations();
       const issueRelation = issueRelations?.nodes?.[0];
       _issueRelation_id = issueRelation?.id;
       expect(issueRelations instanceof L.IssueRelationConnection);
@@ -2716,7 +2729,7 @@ describe("generated", () => {
     /** Test the root query for a single IssueRelation */
     it("issueRelation", async () => {
       if (_issueRelation_id) {
-        const issueRelation: L.IssueRelation | undefined = await client.issueRelation(_issueRelation_id);
+        const issueRelation: L.IssueRelation | undefined | null = await client.issueRelation(_issueRelation_id);
         _issueRelation = issueRelation;
         expect(issueRelation instanceof L.IssueRelation);
       } else {
@@ -2727,7 +2740,7 @@ describe("generated", () => {
     /** Test the issueRelation.issue query for L.Issue */
     it("issueRelation.issue", async () => {
       if (_issueRelation) {
-        const issueRelation_issue: L.Issue | undefined = await _issueRelation.issue;
+        const issueRelation_issue: L.Issue | undefined | null = await _issueRelation.issue;
         expect(issueRelation_issue instanceof L.Issue);
       } else {
         console.warn("codegen-doc:print: No IssueRelation found - cannot test issueRelation.issue query");
@@ -2737,7 +2750,7 @@ describe("generated", () => {
     /** Test the issueRelation.relatedIssue query for L.Issue */
     it("issueRelation.relatedIssue", async () => {
       if (_issueRelation) {
-        const issueRelation_relatedIssue: L.Issue | undefined = await _issueRelation.relatedIssue;
+        const issueRelation_relatedIssue: L.Issue | undefined | null = await _issueRelation.relatedIssue;
         expect(issueRelation_relatedIssue instanceof L.Issue);
       } else {
         console.warn("codegen-doc:print: No IssueRelation found - cannot test issueRelation.relatedIssue query");
@@ -2747,12 +2760,12 @@ describe("generated", () => {
 
   /** Test all Issue queries */
   describe("IssueSearch", () => {
-    let _issue: L.Issue | undefined;
-    let _issue_id: string | undefined;
+    let _issue: L.Issue | undefined | null;
+    let _issue_id: string | undefined | null;
 
     /** Test the root connection query for the Issue */
     it("issueSearch", async () => {
-      const issueSearch: L.IssueConnection | undefined = await client.issueSearch();
+      const issueSearch: L.IssueConnection | undefined | null = await client.issueSearch();
       const issue = issueSearch?.nodes?.[0];
       _issue_id = issue?.id;
       expect(issueSearch instanceof L.IssueConnection);
@@ -2761,7 +2774,7 @@ describe("generated", () => {
     /** Test the root query for a single Issue */
     it("issue", async () => {
       if (_issue_id) {
-        const issue: L.Issue | undefined = await client.issue(_issue_id);
+        const issue: L.Issue | undefined | null = await client.issue(_issue_id);
         _issue = issue;
         expect(issue instanceof L.Issue);
       } else {
@@ -2772,7 +2785,7 @@ describe("generated", () => {
     /** Test the issue connection query for the Attachment */
     it("issue.attachments", async () => {
       if (_issue) {
-        const attachments: L.AttachmentConnection | undefined = await _issue.attachments();
+        const attachments: L.AttachmentConnection | undefined | null = await _issue.attachments();
         expect(attachments instanceof L.AttachmentConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.attachments query");
@@ -2782,7 +2795,7 @@ describe("generated", () => {
     /** Test the issue model query for Issue_BotActor */
     it("issue.botActor", async () => {
       if (_issue) {
-        const botActor: L.ActorBot | undefined = _issue.botActor;
+        const botActor: L.ActorBot | undefined | null = _issue.botActor;
         expect(botActor instanceof L.ActorBot);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.botActor query");
@@ -2792,7 +2805,7 @@ describe("generated", () => {
     /** Test the issue connection query for the Issue */
     it("issue.children", async () => {
       if (_issue) {
-        const children: L.IssueConnection | undefined = await _issue.children();
+        const children: L.IssueConnection | undefined | null = await _issue.children();
         expect(children instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.children query");
@@ -2802,7 +2815,7 @@ describe("generated", () => {
     /** Test the issue connection query for the Comment */
     it("issue.comments", async () => {
       if (_issue) {
-        const comments: L.CommentConnection | undefined = await _issue.comments();
+        const comments: L.CommentConnection | undefined | null = await _issue.comments();
         expect(comments instanceof L.CommentConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.comments query");
@@ -2812,7 +2825,7 @@ describe("generated", () => {
     /** Test the issue connection query for the Document */
     it("issue.documents", async () => {
       if (_issue) {
-        const documents: L.DocumentConnection | undefined = await _issue.documents();
+        const documents: L.DocumentConnection | undefined | null = await _issue.documents();
         expect(documents instanceof L.DocumentConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.documents query");
@@ -2822,7 +2835,7 @@ describe("generated", () => {
     /** Test the issue connection query for the Attachment */
     it("issue.formerAttachments", async () => {
       if (_issue) {
-        const formerAttachments: L.AttachmentConnection | undefined = await _issue.formerAttachments();
+        const formerAttachments: L.AttachmentConnection | undefined | null = await _issue.formerAttachments();
         expect(formerAttachments instanceof L.AttachmentConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.formerAttachments query");
@@ -2832,7 +2845,7 @@ describe("generated", () => {
     /** Test the issue connection query for the CustomerNeed */
     it("issue.formerNeeds", async () => {
       if (_issue) {
-        const formerNeeds: L.CustomerNeedConnection | undefined = await _issue.formerNeeds();
+        const formerNeeds: L.CustomerNeedConnection | undefined | null = await _issue.formerNeeds();
         expect(formerNeeds instanceof L.CustomerNeedConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.formerNeeds query");
@@ -2842,7 +2855,7 @@ describe("generated", () => {
     /** Test the issue connection query for the IssueHistory */
     it("issue.history", async () => {
       if (_issue) {
-        const history: L.IssueHistoryConnection | undefined = await _issue.history();
+        const history: L.IssueHistoryConnection | undefined | null = await _issue.history();
         expect(history instanceof L.IssueHistoryConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.history query");
@@ -2852,7 +2865,7 @@ describe("generated", () => {
     /** Test the issue connection query for the IssueRelation */
     it("issue.inverseRelations", async () => {
       if (_issue) {
-        const inverseRelations: L.IssueRelationConnection | undefined = await _issue.inverseRelations();
+        const inverseRelations: L.IssueRelationConnection | undefined | null = await _issue.inverseRelations();
         expect(inverseRelations instanceof L.IssueRelationConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.inverseRelations query");
@@ -2862,7 +2875,7 @@ describe("generated", () => {
     /** Test the issue connection query for the IssueLabel */
     it("issue.labels", async () => {
       if (_issue) {
-        const labels: L.IssueLabelConnection | undefined = await _issue.labels();
+        const labels: L.IssueLabelConnection | undefined | null = await _issue.labels();
         expect(labels instanceof L.IssueLabelConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.labels query");
@@ -2872,7 +2885,7 @@ describe("generated", () => {
     /** Test the issue connection query for the CustomerNeed */
     it("issue.needs", async () => {
       if (_issue) {
-        const needs: L.CustomerNeedConnection | undefined = await _issue.needs();
+        const needs: L.CustomerNeedConnection | undefined | null = await _issue.needs();
         expect(needs instanceof L.CustomerNeedConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.needs query");
@@ -2882,7 +2895,7 @@ describe("generated", () => {
     /** Test the issue connection query for the IssueRelation */
     it("issue.relations", async () => {
       if (_issue) {
-        const relations: L.IssueRelationConnection | undefined = await _issue.relations();
+        const relations: L.IssueRelationConnection | undefined | null = await _issue.relations();
         expect(relations instanceof L.IssueRelationConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.relations query");
@@ -2892,7 +2905,7 @@ describe("generated", () => {
     /** Test the issue connection query for the User */
     it("issue.subscribers", async () => {
       if (_issue) {
-        const subscribers: L.UserConnection | undefined = await _issue.subscribers();
+        const subscribers: L.UserConnection | undefined | null = await _issue.subscribers();
         expect(subscribers instanceof L.UserConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.subscribers query");
@@ -2902,7 +2915,8 @@ describe("generated", () => {
     /** Test the issue.asksExternalUserRequester query for L.ExternalUser */
     it("issue.asksExternalUserRequester", async () => {
       if (_issue) {
-        const issue_asksExternalUserRequester: L.ExternalUser | undefined = await _issue.asksExternalUserRequester;
+        const issue_asksExternalUserRequester: L.ExternalUser | undefined | null =
+          await _issue.asksExternalUserRequester;
         expect(issue_asksExternalUserRequester instanceof L.ExternalUser);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.asksExternalUserRequester query");
@@ -2912,7 +2926,7 @@ describe("generated", () => {
     /** Test the issue.asksRequester query for L.User */
     it("issue.asksRequester", async () => {
       if (_issue) {
-        const issue_asksRequester: L.User | undefined = await _issue.asksRequester;
+        const issue_asksRequester: L.User | undefined | null = await _issue.asksRequester;
         expect(issue_asksRequester instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.asksRequester query");
@@ -2922,7 +2936,7 @@ describe("generated", () => {
     /** Test the issue.assignee query for L.User */
     it("issue.assignee", async () => {
       if (_issue) {
-        const issue_assignee: L.User | undefined = await _issue.assignee;
+        const issue_assignee: L.User | undefined | null = await _issue.assignee;
         expect(issue_assignee instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.assignee query");
@@ -2932,7 +2946,7 @@ describe("generated", () => {
     /** Test the issue.creator query for L.User */
     it("issue.creator", async () => {
       if (_issue) {
-        const issue_creator: L.User | undefined = await _issue.creator;
+        const issue_creator: L.User | undefined | null = await _issue.creator;
         expect(issue_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.creator query");
@@ -2942,7 +2956,7 @@ describe("generated", () => {
     /** Test the issue.cycle query for L.Cycle */
     it("issue.cycle", async () => {
       if (_issue) {
-        const issue_cycle: L.Cycle | undefined = await _issue.cycle;
+        const issue_cycle: L.Cycle | undefined | null = await _issue.cycle;
         expect(issue_cycle instanceof L.Cycle);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.cycle query");
@@ -2952,7 +2966,7 @@ describe("generated", () => {
     /** Test the issue.delegate query for L.User */
     it("issue.delegate", async () => {
       if (_issue) {
-        const issue_delegate: L.User | undefined = await _issue.delegate;
+        const issue_delegate: L.User | undefined | null = await _issue.delegate;
         expect(issue_delegate instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.delegate query");
@@ -2962,7 +2976,7 @@ describe("generated", () => {
     /** Test the issue.externalUserCreator query for L.ExternalUser */
     it("issue.externalUserCreator", async () => {
       if (_issue) {
-        const issue_externalUserCreator: L.ExternalUser | undefined = await _issue.externalUserCreator;
+        const issue_externalUserCreator: L.ExternalUser | undefined | null = await _issue.externalUserCreator;
         expect(issue_externalUserCreator instanceof L.ExternalUser);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.externalUserCreator query");
@@ -2972,7 +2986,7 @@ describe("generated", () => {
     /** Test the issue.favorite query for L.Favorite */
     it("issue.favorite", async () => {
       if (_issue) {
-        const issue_favorite: L.Favorite | undefined = await _issue.favorite;
+        const issue_favorite: L.Favorite | undefined | null = await _issue.favorite;
         expect(issue_favorite instanceof L.Favorite);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.favorite query");
@@ -2982,7 +2996,7 @@ describe("generated", () => {
     /** Test the issue.lastAppliedTemplate query for L.Template */
     it("issue.lastAppliedTemplate", async () => {
       if (_issue) {
-        const issue_lastAppliedTemplate: L.Template | undefined = await _issue.lastAppliedTemplate;
+        const issue_lastAppliedTemplate: L.Template | undefined | null = await _issue.lastAppliedTemplate;
         expect(issue_lastAppliedTemplate instanceof L.Template);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.lastAppliedTemplate query");
@@ -2992,7 +3006,7 @@ describe("generated", () => {
     /** Test the issue.parent query for L.Issue */
     it("issue.parent", async () => {
       if (_issue) {
-        const issue_parent: L.Issue | undefined = await _issue.parent;
+        const issue_parent: L.Issue | undefined | null = await _issue.parent;
         expect(issue_parent instanceof L.Issue);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.parent query");
@@ -3002,7 +3016,7 @@ describe("generated", () => {
     /** Test the issue.project query for L.Project */
     it("issue.project", async () => {
       if (_issue) {
-        const issue_project: L.Project | undefined = await _issue.project;
+        const issue_project: L.Project | undefined | null = await _issue.project;
         expect(issue_project instanceof L.Project);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.project query");
@@ -3012,7 +3026,7 @@ describe("generated", () => {
     /** Test the issue.projectMilestone query for L.ProjectMilestone */
     it("issue.projectMilestone", async () => {
       if (_issue) {
-        const issue_projectMilestone: L.ProjectMilestone | undefined = await _issue.projectMilestone;
+        const issue_projectMilestone: L.ProjectMilestone | undefined | null = await _issue.projectMilestone;
         expect(issue_projectMilestone instanceof L.ProjectMilestone);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.projectMilestone query");
@@ -3022,7 +3036,7 @@ describe("generated", () => {
     /** Test the issue.recurringIssueTemplate query for L.Template */
     it("issue.recurringIssueTemplate", async () => {
       if (_issue) {
-        const issue_recurringIssueTemplate: L.Template | undefined = await _issue.recurringIssueTemplate;
+        const issue_recurringIssueTemplate: L.Template | undefined | null = await _issue.recurringIssueTemplate;
         expect(issue_recurringIssueTemplate instanceof L.Template);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.recurringIssueTemplate query");
@@ -3032,7 +3046,7 @@ describe("generated", () => {
     /** Test the issue.snoozedBy query for L.User */
     it("issue.snoozedBy", async () => {
       if (_issue) {
-        const issue_snoozedBy: L.User | undefined = await _issue.snoozedBy;
+        const issue_snoozedBy: L.User | undefined | null = await _issue.snoozedBy;
         expect(issue_snoozedBy instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.snoozedBy query");
@@ -3042,7 +3056,7 @@ describe("generated", () => {
     /** Test the issue.sourceComment query for L.Comment */
     it("issue.sourceComment", async () => {
       if (_issue) {
-        const issue_sourceComment: L.Comment | undefined = await _issue.sourceComment;
+        const issue_sourceComment: L.Comment | undefined | null = await _issue.sourceComment;
         expect(issue_sourceComment instanceof L.Comment);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.sourceComment query");
@@ -3052,7 +3066,7 @@ describe("generated", () => {
     /** Test the issue.state query for L.WorkflowState */
     it("issue.state", async () => {
       if (_issue) {
-        const issue_state: L.WorkflowState | undefined = await _issue.state;
+        const issue_state: L.WorkflowState | undefined | null = await _issue.state;
         expect(issue_state instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.state query");
@@ -3062,7 +3076,7 @@ describe("generated", () => {
     /** Test the issue.team query for L.Team */
     it("issue.team", async () => {
       if (_issue) {
-        const issue_team: L.Team | undefined = await _issue.team;
+        const issue_team: L.Team | undefined | null = await _issue.team;
         expect(issue_team instanceof L.Team);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.team query");
@@ -3074,19 +3088,21 @@ describe("generated", () => {
   describe("IssueTitleSuggestionFromCustomerRequest", () => {
     /** Test the root model query for IssueTitleSuggestionFromCustomerRequest */
     it("issueTitleSuggestionFromCustomerRequest", async () => {
-      const issueTitleSuggestionFromCustomerRequest: L.IssueTitleSuggestionFromCustomerRequestPayload | undefined =
-        await client.issueTitleSuggestionFromCustomerRequest("mock-request");
+      const issueTitleSuggestionFromCustomerRequest:
+        | L.IssueTitleSuggestionFromCustomerRequestPayload
+        | undefined
+        | null = await client.issueTitleSuggestionFromCustomerRequest("mock-request");
       expect(issueTitleSuggestionFromCustomerRequest instanceof L.IssueTitleSuggestionFromCustomerRequestPayload);
     });
   });
 
   /** Test IssueVcsBranchSearch query */
   describe("IssueVcsBranchSearch", () => {
-    let _issueVcsBranchSearch: L.Issue | undefined;
+    let _issueVcsBranchSearch: L.Issue | undefined | null;
 
     /** Test the root model query for IssueVcsBranchSearch */
     it("issueVcsBranchSearch", async () => {
-      const issueVcsBranchSearch: L.Issue | undefined = await client.issueVcsBranchSearch("mock-branchName");
+      const issueVcsBranchSearch: L.Issue | undefined | null = await client.issueVcsBranchSearch("mock-branchName");
       _issueVcsBranchSearch = issueVcsBranchSearch;
       expect(issueVcsBranchSearch instanceof L.Issue);
     });
@@ -3094,7 +3110,7 @@ describe("generated", () => {
     /** Test the issueVcsBranchSearch connection query for the Attachment */
     it("issueVcsBranchSearch.attachments", async () => {
       if (_issueVcsBranchSearch) {
-        const attachments: L.AttachmentConnection | undefined = await _issueVcsBranchSearch.attachments();
+        const attachments: L.AttachmentConnection | undefined | null = await _issueVcsBranchSearch.attachments();
         expect(attachments instanceof L.AttachmentConnection);
       } else {
         console.warn(
@@ -3106,7 +3122,7 @@ describe("generated", () => {
     /** Test the issueVcsBranchSearch model query for IssueVcsBranchSearch_BotActor */
     it("issueVcsBranchSearch.botActor", async () => {
       if (_issueVcsBranchSearch) {
-        const botActor: L.ActorBot | undefined = _issueVcsBranchSearch.botActor;
+        const botActor: L.ActorBot | undefined | null = _issueVcsBranchSearch.botActor;
         expect(botActor instanceof L.ActorBot);
       } else {
         console.warn(
@@ -3118,7 +3134,7 @@ describe("generated", () => {
     /** Test the issueVcsBranchSearch connection query for the Issue */
     it("issueVcsBranchSearch.children", async () => {
       if (_issueVcsBranchSearch) {
-        const children: L.IssueConnection | undefined = await _issueVcsBranchSearch.children();
+        const children: L.IssueConnection | undefined | null = await _issueVcsBranchSearch.children();
         expect(children instanceof L.IssueConnection);
       } else {
         console.warn(
@@ -3130,7 +3146,7 @@ describe("generated", () => {
     /** Test the issueVcsBranchSearch connection query for the Comment */
     it("issueVcsBranchSearch.comments", async () => {
       if (_issueVcsBranchSearch) {
-        const comments: L.CommentConnection | undefined = await _issueVcsBranchSearch.comments();
+        const comments: L.CommentConnection | undefined | null = await _issueVcsBranchSearch.comments();
         expect(comments instanceof L.CommentConnection);
       } else {
         console.warn(
@@ -3142,7 +3158,7 @@ describe("generated", () => {
     /** Test the issueVcsBranchSearch connection query for the Document */
     it("issueVcsBranchSearch.documents", async () => {
       if (_issueVcsBranchSearch) {
-        const documents: L.DocumentConnection | undefined = await _issueVcsBranchSearch.documents();
+        const documents: L.DocumentConnection | undefined | null = await _issueVcsBranchSearch.documents();
         expect(documents instanceof L.DocumentConnection);
       } else {
         console.warn(
@@ -3154,7 +3170,8 @@ describe("generated", () => {
     /** Test the issueVcsBranchSearch connection query for the Attachment */
     it("issueVcsBranchSearch.formerAttachments", async () => {
       if (_issueVcsBranchSearch) {
-        const formerAttachments: L.AttachmentConnection | undefined = await _issueVcsBranchSearch.formerAttachments();
+        const formerAttachments: L.AttachmentConnection | undefined | null =
+          await _issueVcsBranchSearch.formerAttachments();
         expect(formerAttachments instanceof L.AttachmentConnection);
       } else {
         console.warn(
@@ -3166,7 +3183,7 @@ describe("generated", () => {
     /** Test the issueVcsBranchSearch connection query for the CustomerNeed */
     it("issueVcsBranchSearch.formerNeeds", async () => {
       if (_issueVcsBranchSearch) {
-        const formerNeeds: L.CustomerNeedConnection | undefined = await _issueVcsBranchSearch.formerNeeds();
+        const formerNeeds: L.CustomerNeedConnection | undefined | null = await _issueVcsBranchSearch.formerNeeds();
         expect(formerNeeds instanceof L.CustomerNeedConnection);
       } else {
         console.warn(
@@ -3178,7 +3195,7 @@ describe("generated", () => {
     /** Test the issueVcsBranchSearch connection query for the IssueHistory */
     it("issueVcsBranchSearch.history", async () => {
       if (_issueVcsBranchSearch) {
-        const history: L.IssueHistoryConnection | undefined = await _issueVcsBranchSearch.history();
+        const history: L.IssueHistoryConnection | undefined | null = await _issueVcsBranchSearch.history();
         expect(history instanceof L.IssueHistoryConnection);
       } else {
         console.warn(
@@ -3190,7 +3207,8 @@ describe("generated", () => {
     /** Test the issueVcsBranchSearch connection query for the IssueRelation */
     it("issueVcsBranchSearch.inverseRelations", async () => {
       if (_issueVcsBranchSearch) {
-        const inverseRelations: L.IssueRelationConnection | undefined = await _issueVcsBranchSearch.inverseRelations();
+        const inverseRelations: L.IssueRelationConnection | undefined | null =
+          await _issueVcsBranchSearch.inverseRelations();
         expect(inverseRelations instanceof L.IssueRelationConnection);
       } else {
         console.warn(
@@ -3202,7 +3220,7 @@ describe("generated", () => {
     /** Test the issueVcsBranchSearch connection query for the IssueLabel */
     it("issueVcsBranchSearch.labels", async () => {
       if (_issueVcsBranchSearch) {
-        const labels: L.IssueLabelConnection | undefined = await _issueVcsBranchSearch.labels();
+        const labels: L.IssueLabelConnection | undefined | null = await _issueVcsBranchSearch.labels();
         expect(labels instanceof L.IssueLabelConnection);
       } else {
         console.warn(
@@ -3214,7 +3232,7 @@ describe("generated", () => {
     /** Test the issueVcsBranchSearch connection query for the CustomerNeed */
     it("issueVcsBranchSearch.needs", async () => {
       if (_issueVcsBranchSearch) {
-        const needs: L.CustomerNeedConnection | undefined = await _issueVcsBranchSearch.needs();
+        const needs: L.CustomerNeedConnection | undefined | null = await _issueVcsBranchSearch.needs();
         expect(needs instanceof L.CustomerNeedConnection);
       } else {
         console.warn(
@@ -3226,7 +3244,7 @@ describe("generated", () => {
     /** Test the issueVcsBranchSearch connection query for the IssueRelation */
     it("issueVcsBranchSearch.relations", async () => {
       if (_issueVcsBranchSearch) {
-        const relations: L.IssueRelationConnection | undefined = await _issueVcsBranchSearch.relations();
+        const relations: L.IssueRelationConnection | undefined | null = await _issueVcsBranchSearch.relations();
         expect(relations instanceof L.IssueRelationConnection);
       } else {
         console.warn(
@@ -3238,7 +3256,7 @@ describe("generated", () => {
     /** Test the issueVcsBranchSearch connection query for the User */
     it("issueVcsBranchSearch.subscribers", async () => {
       if (_issueVcsBranchSearch) {
-        const subscribers: L.UserConnection | undefined = await _issueVcsBranchSearch.subscribers();
+        const subscribers: L.UserConnection | undefined | null = await _issueVcsBranchSearch.subscribers();
         expect(subscribers instanceof L.UserConnection);
       } else {
         console.warn(
@@ -3250,12 +3268,12 @@ describe("generated", () => {
 
   /** Test all Issue queries */
   describe("Issues", () => {
-    let _issue: L.Issue | undefined;
-    let _issue_id: string | undefined;
+    let _issue: L.Issue | undefined | null;
+    let _issue_id: string | undefined | null;
 
     /** Test the root connection query for the Issue */
     it("issues", async () => {
-      const issues: L.IssueConnection | undefined = await client.issues();
+      const issues: L.IssueConnection | undefined | null = await client.issues();
       const issue = issues?.nodes?.[0];
       _issue_id = issue?.id;
       expect(issues instanceof L.IssueConnection);
@@ -3264,7 +3282,7 @@ describe("generated", () => {
     /** Test the root query for a single Issue */
     it("issue", async () => {
       if (_issue_id) {
-        const issue: L.Issue | undefined = await client.issue(_issue_id);
+        const issue: L.Issue | undefined | null = await client.issue(_issue_id);
         _issue = issue;
         expect(issue instanceof L.Issue);
       } else {
@@ -3275,7 +3293,7 @@ describe("generated", () => {
     /** Test the issue connection query for the Attachment */
     it("issue.attachments", async () => {
       if (_issue) {
-        const attachments: L.AttachmentConnection | undefined = await _issue.attachments();
+        const attachments: L.AttachmentConnection | undefined | null = await _issue.attachments();
         expect(attachments instanceof L.AttachmentConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.attachments query");
@@ -3285,7 +3303,7 @@ describe("generated", () => {
     /** Test the issue model query for Issue_BotActor */
     it("issue.botActor", async () => {
       if (_issue) {
-        const botActor: L.ActorBot | undefined = _issue.botActor;
+        const botActor: L.ActorBot | undefined | null = _issue.botActor;
         expect(botActor instanceof L.ActorBot);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.botActor query");
@@ -3295,7 +3313,7 @@ describe("generated", () => {
     /** Test the issue connection query for the Issue */
     it("issue.children", async () => {
       if (_issue) {
-        const children: L.IssueConnection | undefined = await _issue.children();
+        const children: L.IssueConnection | undefined | null = await _issue.children();
         expect(children instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.children query");
@@ -3305,7 +3323,7 @@ describe("generated", () => {
     /** Test the issue connection query for the Comment */
     it("issue.comments", async () => {
       if (_issue) {
-        const comments: L.CommentConnection | undefined = await _issue.comments();
+        const comments: L.CommentConnection | undefined | null = await _issue.comments();
         expect(comments instanceof L.CommentConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.comments query");
@@ -3315,7 +3333,7 @@ describe("generated", () => {
     /** Test the issue connection query for the Document */
     it("issue.documents", async () => {
       if (_issue) {
-        const documents: L.DocumentConnection | undefined = await _issue.documents();
+        const documents: L.DocumentConnection | undefined | null = await _issue.documents();
         expect(documents instanceof L.DocumentConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.documents query");
@@ -3325,7 +3343,7 @@ describe("generated", () => {
     /** Test the issue connection query for the Attachment */
     it("issue.formerAttachments", async () => {
       if (_issue) {
-        const formerAttachments: L.AttachmentConnection | undefined = await _issue.formerAttachments();
+        const formerAttachments: L.AttachmentConnection | undefined | null = await _issue.formerAttachments();
         expect(formerAttachments instanceof L.AttachmentConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.formerAttachments query");
@@ -3335,7 +3353,7 @@ describe("generated", () => {
     /** Test the issue connection query for the CustomerNeed */
     it("issue.formerNeeds", async () => {
       if (_issue) {
-        const formerNeeds: L.CustomerNeedConnection | undefined = await _issue.formerNeeds();
+        const formerNeeds: L.CustomerNeedConnection | undefined | null = await _issue.formerNeeds();
         expect(formerNeeds instanceof L.CustomerNeedConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.formerNeeds query");
@@ -3345,7 +3363,7 @@ describe("generated", () => {
     /** Test the issue connection query for the IssueHistory */
     it("issue.history", async () => {
       if (_issue) {
-        const history: L.IssueHistoryConnection | undefined = await _issue.history();
+        const history: L.IssueHistoryConnection | undefined | null = await _issue.history();
         expect(history instanceof L.IssueHistoryConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.history query");
@@ -3355,7 +3373,7 @@ describe("generated", () => {
     /** Test the issue connection query for the IssueRelation */
     it("issue.inverseRelations", async () => {
       if (_issue) {
-        const inverseRelations: L.IssueRelationConnection | undefined = await _issue.inverseRelations();
+        const inverseRelations: L.IssueRelationConnection | undefined | null = await _issue.inverseRelations();
         expect(inverseRelations instanceof L.IssueRelationConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.inverseRelations query");
@@ -3365,7 +3383,7 @@ describe("generated", () => {
     /** Test the issue connection query for the IssueLabel */
     it("issue.labels", async () => {
       if (_issue) {
-        const labels: L.IssueLabelConnection | undefined = await _issue.labels();
+        const labels: L.IssueLabelConnection | undefined | null = await _issue.labels();
         expect(labels instanceof L.IssueLabelConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.labels query");
@@ -3375,7 +3393,7 @@ describe("generated", () => {
     /** Test the issue connection query for the CustomerNeed */
     it("issue.needs", async () => {
       if (_issue) {
-        const needs: L.CustomerNeedConnection | undefined = await _issue.needs();
+        const needs: L.CustomerNeedConnection | undefined | null = await _issue.needs();
         expect(needs instanceof L.CustomerNeedConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.needs query");
@@ -3385,7 +3403,7 @@ describe("generated", () => {
     /** Test the issue connection query for the IssueRelation */
     it("issue.relations", async () => {
       if (_issue) {
-        const relations: L.IssueRelationConnection | undefined = await _issue.relations();
+        const relations: L.IssueRelationConnection | undefined | null = await _issue.relations();
         expect(relations instanceof L.IssueRelationConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.relations query");
@@ -3395,7 +3413,7 @@ describe("generated", () => {
     /** Test the issue connection query for the User */
     it("issue.subscribers", async () => {
       if (_issue) {
-        const subscribers: L.UserConnection | undefined = await _issue.subscribers();
+        const subscribers: L.UserConnection | undefined | null = await _issue.subscribers();
         expect(subscribers instanceof L.UserConnection);
       } else {
         console.warn("codegen-doc:print: No issue found - cannot test _issue.subscribers query");
@@ -3405,7 +3423,8 @@ describe("generated", () => {
     /** Test the issue.asksExternalUserRequester query for L.ExternalUser */
     it("issue.asksExternalUserRequester", async () => {
       if (_issue) {
-        const issue_asksExternalUserRequester: L.ExternalUser | undefined = await _issue.asksExternalUserRequester;
+        const issue_asksExternalUserRequester: L.ExternalUser | undefined | null =
+          await _issue.asksExternalUserRequester;
         expect(issue_asksExternalUserRequester instanceof L.ExternalUser);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.asksExternalUserRequester query");
@@ -3415,7 +3434,7 @@ describe("generated", () => {
     /** Test the issue.asksRequester query for L.User */
     it("issue.asksRequester", async () => {
       if (_issue) {
-        const issue_asksRequester: L.User | undefined = await _issue.asksRequester;
+        const issue_asksRequester: L.User | undefined | null = await _issue.asksRequester;
         expect(issue_asksRequester instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.asksRequester query");
@@ -3425,7 +3444,7 @@ describe("generated", () => {
     /** Test the issue.assignee query for L.User */
     it("issue.assignee", async () => {
       if (_issue) {
-        const issue_assignee: L.User | undefined = await _issue.assignee;
+        const issue_assignee: L.User | undefined | null = await _issue.assignee;
         expect(issue_assignee instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.assignee query");
@@ -3435,7 +3454,7 @@ describe("generated", () => {
     /** Test the issue.creator query for L.User */
     it("issue.creator", async () => {
       if (_issue) {
-        const issue_creator: L.User | undefined = await _issue.creator;
+        const issue_creator: L.User | undefined | null = await _issue.creator;
         expect(issue_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.creator query");
@@ -3445,7 +3464,7 @@ describe("generated", () => {
     /** Test the issue.cycle query for L.Cycle */
     it("issue.cycle", async () => {
       if (_issue) {
-        const issue_cycle: L.Cycle | undefined = await _issue.cycle;
+        const issue_cycle: L.Cycle | undefined | null = await _issue.cycle;
         expect(issue_cycle instanceof L.Cycle);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.cycle query");
@@ -3455,7 +3474,7 @@ describe("generated", () => {
     /** Test the issue.delegate query for L.User */
     it("issue.delegate", async () => {
       if (_issue) {
-        const issue_delegate: L.User | undefined = await _issue.delegate;
+        const issue_delegate: L.User | undefined | null = await _issue.delegate;
         expect(issue_delegate instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.delegate query");
@@ -3465,7 +3484,7 @@ describe("generated", () => {
     /** Test the issue.externalUserCreator query for L.ExternalUser */
     it("issue.externalUserCreator", async () => {
       if (_issue) {
-        const issue_externalUserCreator: L.ExternalUser | undefined = await _issue.externalUserCreator;
+        const issue_externalUserCreator: L.ExternalUser | undefined | null = await _issue.externalUserCreator;
         expect(issue_externalUserCreator instanceof L.ExternalUser);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.externalUserCreator query");
@@ -3475,7 +3494,7 @@ describe("generated", () => {
     /** Test the issue.favorite query for L.Favorite */
     it("issue.favorite", async () => {
       if (_issue) {
-        const issue_favorite: L.Favorite | undefined = await _issue.favorite;
+        const issue_favorite: L.Favorite | undefined | null = await _issue.favorite;
         expect(issue_favorite instanceof L.Favorite);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.favorite query");
@@ -3485,7 +3504,7 @@ describe("generated", () => {
     /** Test the issue.lastAppliedTemplate query for L.Template */
     it("issue.lastAppliedTemplate", async () => {
       if (_issue) {
-        const issue_lastAppliedTemplate: L.Template | undefined = await _issue.lastAppliedTemplate;
+        const issue_lastAppliedTemplate: L.Template | undefined | null = await _issue.lastAppliedTemplate;
         expect(issue_lastAppliedTemplate instanceof L.Template);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.lastAppliedTemplate query");
@@ -3495,7 +3514,7 @@ describe("generated", () => {
     /** Test the issue.parent query for L.Issue */
     it("issue.parent", async () => {
       if (_issue) {
-        const issue_parent: L.Issue | undefined = await _issue.parent;
+        const issue_parent: L.Issue | undefined | null = await _issue.parent;
         expect(issue_parent instanceof L.Issue);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.parent query");
@@ -3505,7 +3524,7 @@ describe("generated", () => {
     /** Test the issue.project query for L.Project */
     it("issue.project", async () => {
       if (_issue) {
-        const issue_project: L.Project | undefined = await _issue.project;
+        const issue_project: L.Project | undefined | null = await _issue.project;
         expect(issue_project instanceof L.Project);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.project query");
@@ -3515,7 +3534,7 @@ describe("generated", () => {
     /** Test the issue.projectMilestone query for L.ProjectMilestone */
     it("issue.projectMilestone", async () => {
       if (_issue) {
-        const issue_projectMilestone: L.ProjectMilestone | undefined = await _issue.projectMilestone;
+        const issue_projectMilestone: L.ProjectMilestone | undefined | null = await _issue.projectMilestone;
         expect(issue_projectMilestone instanceof L.ProjectMilestone);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.projectMilestone query");
@@ -3525,7 +3544,7 @@ describe("generated", () => {
     /** Test the issue.recurringIssueTemplate query for L.Template */
     it("issue.recurringIssueTemplate", async () => {
       if (_issue) {
-        const issue_recurringIssueTemplate: L.Template | undefined = await _issue.recurringIssueTemplate;
+        const issue_recurringIssueTemplate: L.Template | undefined | null = await _issue.recurringIssueTemplate;
         expect(issue_recurringIssueTemplate instanceof L.Template);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.recurringIssueTemplate query");
@@ -3535,7 +3554,7 @@ describe("generated", () => {
     /** Test the issue.snoozedBy query for L.User */
     it("issue.snoozedBy", async () => {
       if (_issue) {
-        const issue_snoozedBy: L.User | undefined = await _issue.snoozedBy;
+        const issue_snoozedBy: L.User | undefined | null = await _issue.snoozedBy;
         expect(issue_snoozedBy instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.snoozedBy query");
@@ -3545,7 +3564,7 @@ describe("generated", () => {
     /** Test the issue.sourceComment query for L.Comment */
     it("issue.sourceComment", async () => {
       if (_issue) {
-        const issue_sourceComment: L.Comment | undefined = await _issue.sourceComment;
+        const issue_sourceComment: L.Comment | undefined | null = await _issue.sourceComment;
         expect(issue_sourceComment instanceof L.Comment);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.sourceComment query");
@@ -3555,7 +3574,7 @@ describe("generated", () => {
     /** Test the issue.state query for L.WorkflowState */
     it("issue.state", async () => {
       if (_issue) {
-        const issue_state: L.WorkflowState | undefined = await _issue.state;
+        const issue_state: L.WorkflowState | undefined | null = await _issue.state;
         expect(issue_state instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.state query");
@@ -3565,7 +3584,7 @@ describe("generated", () => {
     /** Test the issue.team query for L.Team */
     it("issue.team", async () => {
       if (_issue) {
-        const issue_team: L.Team | undefined = await _issue.team;
+        const issue_team: L.Team | undefined | null = await _issue.team;
         expect(issue_team instanceof L.Team);
       } else {
         console.warn("codegen-doc:print: No Issue found - cannot test issue.team query");
@@ -3585,12 +3604,13 @@ describe("generated", () => {
       | L.ProjectNotificationSubscription
       | L.TeamNotificationSubscription
       | L.UserNotificationSubscription
-      | undefined;
-    let _notificationSubscription_id: string | undefined;
+      | undefined
+      | null;
+    let _notificationSubscription_id: string | undefined | null;
 
     /** Test the root connection query for the NotificationSubscription */
     it("notificationSubscriptions", async () => {
-      const notificationSubscriptions: L.NotificationSubscriptionConnection | undefined =
+      const notificationSubscriptions: L.NotificationSubscriptionConnection | undefined | null =
         await client.notificationSubscriptions();
       const notificationSubscription = notificationSubscriptions?.nodes?.[0];
       _notificationSubscription_id = notificationSubscription?.id;
@@ -3610,7 +3630,8 @@ describe("generated", () => {
           | L.ProjectNotificationSubscription
           | L.TeamNotificationSubscription
           | L.UserNotificationSubscription
-          | undefined = await client.notificationSubscription(_notificationSubscription_id);
+          | undefined
+          | null = await client.notificationSubscription(_notificationSubscription_id);
         _notificationSubscription = notificationSubscription;
         expect(notificationSubscription instanceof L.NotificationSubscription);
       } else {
@@ -3623,7 +3644,7 @@ describe("generated", () => {
     /** Test the notificationSubscription.customView query for L.CustomView */
     it("notificationSubscription.customView", async () => {
       if (_notificationSubscription) {
-        const notificationSubscription_customView: L.CustomView | undefined =
+        const notificationSubscription_customView: L.CustomView | undefined | null =
           await _notificationSubscription.customView;
         expect(notificationSubscription_customView instanceof L.CustomView);
       } else {
@@ -3636,7 +3657,8 @@ describe("generated", () => {
     /** Test the notificationSubscription.customer query for L.Customer */
     it("notificationSubscription.customer", async () => {
       if (_notificationSubscription) {
-        const notificationSubscription_customer: L.Customer | undefined = await _notificationSubscription.customer;
+        const notificationSubscription_customer: L.Customer | undefined | null =
+          await _notificationSubscription.customer;
         expect(notificationSubscription_customer instanceof L.Customer);
       } else {
         console.warn(
@@ -3648,7 +3670,7 @@ describe("generated", () => {
     /** Test the notificationSubscription.cycle query for L.Cycle */
     it("notificationSubscription.cycle", async () => {
       if (_notificationSubscription) {
-        const notificationSubscription_cycle: L.Cycle | undefined = await _notificationSubscription.cycle;
+        const notificationSubscription_cycle: L.Cycle | undefined | null = await _notificationSubscription.cycle;
         expect(notificationSubscription_cycle instanceof L.Cycle);
       } else {
         console.warn(
@@ -3660,7 +3682,7 @@ describe("generated", () => {
     /** Test the notificationSubscription.initiative query for L.Initiative */
     it("notificationSubscription.initiative", async () => {
       if (_notificationSubscription) {
-        const notificationSubscription_initiative: L.Initiative | undefined =
+        const notificationSubscription_initiative: L.Initiative | undefined | null =
           await _notificationSubscription.initiative;
         expect(notificationSubscription_initiative instanceof L.Initiative);
       } else {
@@ -3673,7 +3695,7 @@ describe("generated", () => {
     /** Test the notificationSubscription.label query for L.IssueLabel */
     it("notificationSubscription.label", async () => {
       if (_notificationSubscription) {
-        const notificationSubscription_label: L.IssueLabel | undefined = await _notificationSubscription.label;
+        const notificationSubscription_label: L.IssueLabel | undefined | null = await _notificationSubscription.label;
         expect(notificationSubscription_label instanceof L.IssueLabel);
       } else {
         console.warn(
@@ -3685,7 +3707,7 @@ describe("generated", () => {
     /** Test the notificationSubscription.project query for L.Project */
     it("notificationSubscription.project", async () => {
       if (_notificationSubscription) {
-        const notificationSubscription_project: L.Project | undefined = await _notificationSubscription.project;
+        const notificationSubscription_project: L.Project | undefined | null = await _notificationSubscription.project;
         expect(notificationSubscription_project instanceof L.Project);
       } else {
         console.warn(
@@ -3697,7 +3719,8 @@ describe("generated", () => {
     /** Test the notificationSubscription.subscriber query for L.User */
     it("notificationSubscription.subscriber", async () => {
       if (_notificationSubscription) {
-        const notificationSubscription_subscriber: L.User | undefined = await _notificationSubscription.subscriber;
+        const notificationSubscription_subscriber: L.User | undefined | null =
+          await _notificationSubscription.subscriber;
         expect(notificationSubscription_subscriber instanceof L.User);
       } else {
         console.warn(
@@ -3709,7 +3732,7 @@ describe("generated", () => {
     /** Test the notificationSubscription.team query for L.Team */
     it("notificationSubscription.team", async () => {
       if (_notificationSubscription) {
-        const notificationSubscription_team: L.Team | undefined = await _notificationSubscription.team;
+        const notificationSubscription_team: L.Team | undefined | null = await _notificationSubscription.team;
         expect(notificationSubscription_team instanceof L.Team);
       } else {
         console.warn(
@@ -3721,7 +3744,7 @@ describe("generated", () => {
     /** Test the notificationSubscription.user query for L.User */
     it("notificationSubscription.user", async () => {
       if (_notificationSubscription) {
-        const notificationSubscription_user: L.User | undefined = await _notificationSubscription.user;
+        const notificationSubscription_user: L.User | undefined | null = await _notificationSubscription.user;
         expect(notificationSubscription_user instanceof L.User);
       } else {
         console.warn(
@@ -3744,12 +3767,13 @@ describe("generated", () => {
       | L.PostNotification
       | L.ProjectNotification
       | L.PullRequestNotification
-      | undefined;
-    let _notification_id: string | undefined;
+      | undefined
+      | null;
+    let _notification_id: string | undefined | null;
 
     /** Test the root connection query for the Notification */
     it("notifications", async () => {
-      const notifications: L.NotificationConnection | undefined = await client.notifications();
+      const notifications: L.NotificationConnection | undefined | null = await client.notifications();
       const notification = notifications?.nodes?.[0];
       _notification_id = notification?.id;
       expect(notifications instanceof L.NotificationConnection);
@@ -3769,7 +3793,8 @@ describe("generated", () => {
           | L.PostNotification
           | L.ProjectNotification
           | L.PullRequestNotification
-          | undefined = await client.notification(_notification_id);
+          | undefined
+          | null = await client.notification(_notification_id);
         _notification = notification;
         expect(notification instanceof L.Notification);
       } else {
@@ -3780,7 +3805,7 @@ describe("generated", () => {
     /** Test the notification.actor query for L.User */
     it("notification.actor", async () => {
       if (_notification) {
-        const notification_actor: L.User | undefined = await _notification.actor;
+        const notification_actor: L.User | undefined | null = await _notification.actor;
         expect(notification_actor instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Notification found - cannot test notification.actor query");
@@ -3790,7 +3815,7 @@ describe("generated", () => {
     /** Test the notification.externalUserActor query for L.ExternalUser */
     it("notification.externalUserActor", async () => {
       if (_notification) {
-        const notification_externalUserActor: L.ExternalUser | undefined = await _notification.externalUserActor;
+        const notification_externalUserActor: L.ExternalUser | undefined | null = await _notification.externalUserActor;
         expect(notification_externalUserActor instanceof L.ExternalUser);
       } else {
         console.warn("codegen-doc:print: No Notification found - cannot test notification.externalUserActor query");
@@ -3800,7 +3825,7 @@ describe("generated", () => {
     /** Test the notification.user query for L.User */
     it("notification.user", async () => {
       if (_notification) {
-        const notification_user: L.User | undefined = await _notification.user;
+        const notification_user: L.User | undefined | null = await _notification.user;
         expect(notification_user instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Notification found - cannot test notification.user query");
@@ -3810,11 +3835,11 @@ describe("generated", () => {
 
   /** Test Organization query */
   describe("Organization", () => {
-    let _organization: L.Organization | undefined;
+    let _organization: L.Organization | undefined | null;
 
     /** Test the root model query for Organization */
     it("organization", async () => {
-      const organization: L.Organization | undefined = await client.organization;
+      const organization: L.Organization | undefined | null = await client.organization;
       _organization = organization;
       expect(organization instanceof L.Organization);
     });
@@ -3822,7 +3847,7 @@ describe("generated", () => {
     /** Test the organization connection query for the Integration */
     it("organization.integrations", async () => {
       if (_organization) {
-        const integrations: L.IntegrationConnection | undefined = await _organization.integrations();
+        const integrations: L.IntegrationConnection | undefined | null = await _organization.integrations();
         expect(integrations instanceof L.IntegrationConnection);
       } else {
         console.warn("codegen-doc:print: No organization found - cannot test _organization.integrations query");
@@ -3832,7 +3857,7 @@ describe("generated", () => {
     /** Test the organization connection query for the IssueLabel */
     it("organization.labels", async () => {
       if (_organization) {
-        const labels: L.IssueLabelConnection | undefined = await _organization.labels();
+        const labels: L.IssueLabelConnection | undefined | null = await _organization.labels();
         expect(labels instanceof L.IssueLabelConnection);
       } else {
         console.warn("codegen-doc:print: No organization found - cannot test _organization.labels query");
@@ -3842,7 +3867,7 @@ describe("generated", () => {
     /** Test the organization connection query for the ProjectLabel */
     it("organization.projectLabels", async () => {
       if (_organization) {
-        const projectLabels: L.ProjectLabelConnection | undefined = await _organization.projectLabels();
+        const projectLabels: L.ProjectLabelConnection | undefined | null = await _organization.projectLabels();
         expect(projectLabels instanceof L.ProjectLabelConnection);
       } else {
         console.warn("codegen-doc:print: No organization found - cannot test _organization.projectLabels query");
@@ -3852,7 +3877,7 @@ describe("generated", () => {
     /** Test the organization model query for Organization_Subscription */
     it("organization.subscription", async () => {
       if (_organization) {
-        const subscription: L.PaidSubscription | undefined = _organization.subscription;
+        const subscription: L.PaidSubscription | undefined | null = _organization.subscription;
         expect(subscription instanceof L.PaidSubscription);
       } else {
         console.warn("codegen-doc:print: No organization found - cannot test _organization.subscription query");
@@ -3862,7 +3887,7 @@ describe("generated", () => {
     /** Test the organization connection query for the Team */
     it("organization.teams", async () => {
       if (_organization) {
-        const teams: L.TeamConnection | undefined = await _organization.teams();
+        const teams: L.TeamConnection | undefined | null = await _organization.teams();
         expect(teams instanceof L.TeamConnection);
       } else {
         console.warn("codegen-doc:print: No organization found - cannot test _organization.teams query");
@@ -3872,7 +3897,7 @@ describe("generated", () => {
     /** Test the organization connection query for the Template */
     it("organization.templates", async () => {
       if (_organization) {
-        const templates: L.TemplateConnection | undefined = await _organization.templates();
+        const templates: L.TemplateConnection | undefined | null = await _organization.templates();
         expect(templates instanceof L.TemplateConnection);
       } else {
         console.warn("codegen-doc:print: No organization found - cannot test _organization.templates query");
@@ -3882,7 +3907,7 @@ describe("generated", () => {
     /** Test the organization connection query for the User */
     it("organization.users", async () => {
       if (_organization) {
-        const users: L.UserConnection | undefined = await _organization.users();
+        const users: L.UserConnection | undefined | null = await _organization.users();
         expect(users instanceof L.UserConnection);
       } else {
         console.warn("codegen-doc:print: No organization found - cannot test _organization.users query");
@@ -3894,7 +3919,7 @@ describe("generated", () => {
   describe("OrganizationExists", () => {
     /** Test the root model query for OrganizationExists */
     it("organizationExists", async () => {
-      const organizationExists: L.OrganizationExistsPayload | undefined =
+      const organizationExists: L.OrganizationExistsPayload | undefined | null =
         await client.organizationExists("mock-urlKey");
       expect(organizationExists instanceof L.OrganizationExistsPayload);
     });
@@ -3902,12 +3927,12 @@ describe("generated", () => {
 
   /** Test all OrganizationInvite queries */
   describe("OrganizationInvites", () => {
-    let _organizationInvite: L.OrganizationInvite | undefined;
-    let _organizationInvite_id: string | undefined;
+    let _organizationInvite: L.OrganizationInvite | undefined | null;
+    let _organizationInvite_id: string | undefined | null;
 
     /** Test the root connection query for the OrganizationInvite */
     it("organizationInvites", async () => {
-      const organizationInvites: L.OrganizationInviteConnection | undefined = await client.organizationInvites();
+      const organizationInvites: L.OrganizationInviteConnection | undefined | null = await client.organizationInvites();
       const organizationInvite = organizationInvites?.nodes?.[0];
       _organizationInvite_id = organizationInvite?.id;
       expect(organizationInvites instanceof L.OrganizationInviteConnection);
@@ -3916,7 +3941,7 @@ describe("generated", () => {
     /** Test the root query for a single OrganizationInvite */
     it("organizationInvite", async () => {
       if (_organizationInvite_id) {
-        const organizationInvite: L.OrganizationInvite | undefined =
+        const organizationInvite: L.OrganizationInvite | undefined | null =
           await client.organizationInvite(_organizationInvite_id);
         _organizationInvite = organizationInvite;
         expect(organizationInvite instanceof L.OrganizationInvite);
@@ -3930,7 +3955,7 @@ describe("generated", () => {
     /** Test the organizationInvite.invitee query for L.User */
     it("organizationInvite.invitee", async () => {
       if (_organizationInvite) {
-        const organizationInvite_invitee: L.User | undefined = await _organizationInvite.invitee;
+        const organizationInvite_invitee: L.User | undefined | null = await _organizationInvite.invitee;
         expect(organizationInvite_invitee instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No OrganizationInvite found - cannot test organizationInvite.invitee query");
@@ -3940,7 +3965,7 @@ describe("generated", () => {
     /** Test the organizationInvite.inviter query for L.User */
     it("organizationInvite.inviter", async () => {
       if (_organizationInvite) {
-        const organizationInvite_inviter: L.User | undefined = await _organizationInvite.inviter;
+        const organizationInvite_inviter: L.User | undefined | null = await _organizationInvite.inviter;
         expect(organizationInvite_inviter instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No OrganizationInvite found - cannot test organizationInvite.inviter query");
@@ -3950,7 +3975,8 @@ describe("generated", () => {
     /** Test the organizationInvite.organization query for L.Organization */
     it("organizationInvite.organization", async () => {
       if (_organizationInvite) {
-        const organizationInvite_organization: L.Organization | undefined = await _organizationInvite.organization;
+        const organizationInvite_organization: L.Organization | undefined | null =
+          await _organizationInvite.organization;
         expect(organizationInvite_organization instanceof L.Organization);
       } else {
         console.warn(
@@ -3964,7 +3990,7 @@ describe("generated", () => {
   describe("ProjectFilterSuggestion", () => {
     /** Test the root model query for ProjectFilterSuggestion */
     it("projectFilterSuggestion", async () => {
-      const projectFilterSuggestion: L.ProjectFilterSuggestionPayload | undefined =
+      const projectFilterSuggestion: L.ProjectFilterSuggestionPayload | undefined | null =
         await client.projectFilterSuggestion("mock-prompt");
       expect(projectFilterSuggestion instanceof L.ProjectFilterSuggestionPayload);
     });
@@ -3972,12 +3998,12 @@ describe("generated", () => {
 
   /** Test all ProjectLabel queries */
   describe("ProjectLabels", () => {
-    let _projectLabel: L.ProjectLabel | undefined;
-    let _projectLabel_id: string | undefined;
+    let _projectLabel: L.ProjectLabel | undefined | null;
+    let _projectLabel_id: string | undefined | null;
 
     /** Test the root connection query for the ProjectLabel */
     it("projectLabels", async () => {
-      const projectLabels: L.ProjectLabelConnection | undefined = await client.projectLabels();
+      const projectLabels: L.ProjectLabelConnection | undefined | null = await client.projectLabels();
       const projectLabel = projectLabels?.nodes?.[0];
       _projectLabel_id = projectLabel?.id;
       expect(projectLabels instanceof L.ProjectLabelConnection);
@@ -3986,7 +4012,7 @@ describe("generated", () => {
     /** Test the root query for a single ProjectLabel */
     it("projectLabel", async () => {
       if (_projectLabel_id) {
-        const projectLabel: L.ProjectLabel | undefined = await client.projectLabel(_projectLabel_id);
+        const projectLabel: L.ProjectLabel | undefined | null = await client.projectLabel(_projectLabel_id);
         _projectLabel = projectLabel;
         expect(projectLabel instanceof L.ProjectLabel);
       } else {
@@ -3997,7 +4023,7 @@ describe("generated", () => {
     /** Test the projectLabel connection query for the ProjectLabel */
     it("projectLabel.children", async () => {
       if (_projectLabel) {
-        const children: L.ProjectLabelConnection | undefined = await _projectLabel.children();
+        const children: L.ProjectLabelConnection | undefined | null = await _projectLabel.children();
         expect(children instanceof L.ProjectLabelConnection);
       } else {
         console.warn("codegen-doc:print: No projectLabel found - cannot test _projectLabel.children query");
@@ -4007,7 +4033,7 @@ describe("generated", () => {
     /** Test the projectLabel connection query for the Project */
     it("projectLabel.projects", async () => {
       if (_projectLabel) {
-        const projects: L.ProjectConnection | undefined = await _projectLabel.projects();
+        const projects: L.ProjectConnection | undefined | null = await _projectLabel.projects();
         expect(projects instanceof L.ProjectConnection);
       } else {
         console.warn("codegen-doc:print: No projectLabel found - cannot test _projectLabel.projects query");
@@ -4017,7 +4043,7 @@ describe("generated", () => {
     /** Test the projectLabel.creator query for L.User */
     it("projectLabel.creator", async () => {
       if (_projectLabel) {
-        const projectLabel_creator: L.User | undefined = await _projectLabel.creator;
+        const projectLabel_creator: L.User | undefined | null = await _projectLabel.creator;
         expect(projectLabel_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No ProjectLabel found - cannot test projectLabel.creator query");
@@ -4027,7 +4053,7 @@ describe("generated", () => {
     /** Test the projectLabel.organization query for L.Organization */
     it("projectLabel.organization", async () => {
       if (_projectLabel) {
-        const projectLabel_organization: L.Organization | undefined = await _projectLabel.organization;
+        const projectLabel_organization: L.Organization | undefined | null = await _projectLabel.organization;
         expect(projectLabel_organization instanceof L.Organization);
       } else {
         console.warn("codegen-doc:print: No ProjectLabel found - cannot test projectLabel.organization query");
@@ -4037,7 +4063,7 @@ describe("generated", () => {
     /** Test the projectLabel.parent query for L.ProjectLabel */
     it("projectLabel.parent", async () => {
       if (_projectLabel) {
-        const projectLabel_parent: L.ProjectLabel | undefined = await _projectLabel.parent;
+        const projectLabel_parent: L.ProjectLabel | undefined | null = await _projectLabel.parent;
         expect(projectLabel_parent instanceof L.ProjectLabel);
       } else {
         console.warn("codegen-doc:print: No ProjectLabel found - cannot test projectLabel.parent query");
@@ -4047,7 +4073,7 @@ describe("generated", () => {
     /** Test the projectLabel.retiredBy query for L.User */
     it("projectLabel.retiredBy", async () => {
       if (_projectLabel) {
-        const projectLabel_retiredBy: L.User | undefined = await _projectLabel.retiredBy;
+        const projectLabel_retiredBy: L.User | undefined | null = await _projectLabel.retiredBy;
         expect(projectLabel_retiredBy instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No ProjectLabel found - cannot test projectLabel.retiredBy query");
@@ -4057,12 +4083,12 @@ describe("generated", () => {
 
   /** Test all ProjectMilestone queries */
   describe("ProjectMilestones", () => {
-    let _projectMilestone: L.ProjectMilestone | undefined;
-    let _projectMilestone_id: string | undefined;
+    let _projectMilestone: L.ProjectMilestone | undefined | null;
+    let _projectMilestone_id: string | undefined | null;
 
     /** Test the root connection query for the ProjectMilestone */
     it("projectMilestones", async () => {
-      const projectMilestones: L.ProjectMilestoneConnection | undefined = await client.projectMilestones();
+      const projectMilestones: L.ProjectMilestoneConnection | undefined | null = await client.projectMilestones();
       const projectMilestone = projectMilestones?.nodes?.[0];
       _projectMilestone_id = projectMilestone?.id;
       expect(projectMilestones instanceof L.ProjectMilestoneConnection);
@@ -4071,7 +4097,8 @@ describe("generated", () => {
     /** Test the root query for a single ProjectMilestone */
     it("projectMilestone", async () => {
       if (_projectMilestone_id) {
-        const projectMilestone: L.ProjectMilestone | undefined = await client.projectMilestone(_projectMilestone_id);
+        const projectMilestone: L.ProjectMilestone | undefined | null =
+          await client.projectMilestone(_projectMilestone_id);
         _projectMilestone = projectMilestone;
         expect(projectMilestone instanceof L.ProjectMilestone);
       } else {
@@ -4081,12 +4108,12 @@ describe("generated", () => {
       }
     });
 
-    let _documentContent: L.DocumentContent | undefined;
+    let _documentContent: L.DocumentContent | undefined | null;
 
     /** Test the projectMilestone model query for ProjectMilestone_DocumentContent */
     it("projectMilestone.documentContent", async () => {
       if (_projectMilestone) {
-        const documentContent: L.DocumentContent | undefined = _projectMilestone.documentContent;
+        const documentContent: L.DocumentContent | undefined | null = _projectMilestone.documentContent;
         _documentContent = documentContent;
         expect(documentContent instanceof L.DocumentContent);
       } else {
@@ -4099,7 +4126,7 @@ describe("generated", () => {
     /** Test the projectMilestone_documentContent model query for ProjectMilestone_DocumentContent_AiPromptRules */
     it("projectMilestone_documentContent.aiPromptRules", async () => {
       if (_documentContent) {
-        const aiPromptRules: L.AiPromptRules | undefined = _documentContent.aiPromptRules;
+        const aiPromptRules: L.AiPromptRules | undefined | null = _documentContent.aiPromptRules;
         expect(aiPromptRules instanceof L.AiPromptRules);
       } else {
         console.warn("codegen-doc:print: No documentContent found - cannot test _documentContent.aiPromptRules query");
@@ -4109,7 +4136,7 @@ describe("generated", () => {
     /** Test the projectMilestone connection query for the Issue */
     it("projectMilestone.issues", async () => {
       if (_projectMilestone) {
-        const issues: L.IssueConnection | undefined = await _projectMilestone.issues();
+        const issues: L.IssueConnection | undefined | null = await _projectMilestone.issues();
         expect(issues instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No projectMilestone found - cannot test _projectMilestone.issues query");
@@ -4119,7 +4146,7 @@ describe("generated", () => {
     /** Test the projectMilestone.project query for L.Project */
     it("projectMilestone.project", async () => {
       if (_projectMilestone) {
-        const projectMilestone_project: L.Project | undefined = await _projectMilestone.project;
+        const projectMilestone_project: L.Project | undefined | null = await _projectMilestone.project;
         expect(projectMilestone_project instanceof L.Project);
       } else {
         console.warn("codegen-doc:print: No ProjectMilestone found - cannot test projectMilestone.project query");
@@ -4129,12 +4156,12 @@ describe("generated", () => {
 
   /** Test all ProjectRelation queries */
   describe("ProjectRelations", () => {
-    let _projectRelation: L.ProjectRelation | undefined;
-    let _projectRelation_id: string | undefined;
+    let _projectRelation: L.ProjectRelation | undefined | null;
+    let _projectRelation_id: string | undefined | null;
 
     /** Test the root connection query for the ProjectRelation */
     it("projectRelations", async () => {
-      const projectRelations: L.ProjectRelationConnection | undefined = await client.projectRelations();
+      const projectRelations: L.ProjectRelationConnection | undefined | null = await client.projectRelations();
       const projectRelation = projectRelations?.nodes?.[0];
       _projectRelation_id = projectRelation?.id;
       expect(projectRelations instanceof L.ProjectRelationConnection);
@@ -4143,7 +4170,7 @@ describe("generated", () => {
     /** Test the root query for a single ProjectRelation */
     it("projectRelation", async () => {
       if (_projectRelation_id) {
-        const projectRelation: L.ProjectRelation | undefined = await client.projectRelation(_projectRelation_id);
+        const projectRelation: L.ProjectRelation | undefined | null = await client.projectRelation(_projectRelation_id);
         _projectRelation = projectRelation;
         expect(projectRelation instanceof L.ProjectRelation);
       } else {
@@ -4156,7 +4183,7 @@ describe("generated", () => {
     /** Test the projectRelation.project query for L.Project */
     it("projectRelation.project", async () => {
       if (_projectRelation) {
-        const projectRelation_project: L.Project | undefined = await _projectRelation.project;
+        const projectRelation_project: L.Project | undefined | null = await _projectRelation.project;
         expect(projectRelation_project instanceof L.Project);
       } else {
         console.warn("codegen-doc:print: No ProjectRelation found - cannot test projectRelation.project query");
@@ -4166,7 +4193,7 @@ describe("generated", () => {
     /** Test the projectRelation.projectMilestone query for L.ProjectMilestone */
     it("projectRelation.projectMilestone", async () => {
       if (_projectRelation) {
-        const projectRelation_projectMilestone: L.ProjectMilestone | undefined =
+        const projectRelation_projectMilestone: L.ProjectMilestone | undefined | null =
           await _projectRelation.projectMilestone;
         expect(projectRelation_projectMilestone instanceof L.ProjectMilestone);
       } else {
@@ -4179,7 +4206,7 @@ describe("generated", () => {
     /** Test the projectRelation.relatedProject query for L.Project */
     it("projectRelation.relatedProject", async () => {
       if (_projectRelation) {
-        const projectRelation_relatedProject: L.Project | undefined = await _projectRelation.relatedProject;
+        const projectRelation_relatedProject: L.Project | undefined | null = await _projectRelation.relatedProject;
         expect(projectRelation_relatedProject instanceof L.Project);
       } else {
         console.warn("codegen-doc:print: No ProjectRelation found - cannot test projectRelation.relatedProject query");
@@ -4189,7 +4216,7 @@ describe("generated", () => {
     /** Test the projectRelation.relatedProjectMilestone query for L.ProjectMilestone */
     it("projectRelation.relatedProjectMilestone", async () => {
       if (_projectRelation) {
-        const projectRelation_relatedProjectMilestone: L.ProjectMilestone | undefined =
+        const projectRelation_relatedProjectMilestone: L.ProjectMilestone | undefined | null =
           await _projectRelation.relatedProjectMilestone;
         expect(projectRelation_relatedProjectMilestone instanceof L.ProjectMilestone);
       } else {
@@ -4202,7 +4229,7 @@ describe("generated", () => {
     /** Test the projectRelation.user query for L.User */
     it("projectRelation.user", async () => {
       if (_projectRelation) {
-        const projectRelation_user: L.User | undefined = await _projectRelation.user;
+        const projectRelation_user: L.User | undefined | null = await _projectRelation.user;
         expect(projectRelation_user instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No ProjectRelation found - cannot test projectRelation.user query");
@@ -4212,12 +4239,12 @@ describe("generated", () => {
 
   /** Test all ProjectStatus queries */
   describe("ProjectStatuses", () => {
-    let _projectStatus: L.ProjectStatus | undefined;
-    let _projectStatus_id: string | undefined;
+    let _projectStatus: L.ProjectStatus | undefined | null;
+    let _projectStatus_id: string | undefined | null;
 
     /** Test the root connection query for the ProjectStatus */
     it("projectStatuses", async () => {
-      const projectStatuses: L.ProjectStatusConnection | undefined = await client.projectStatuses();
+      const projectStatuses: L.ProjectStatusConnection | undefined | null = await client.projectStatuses();
       const projectStatus = projectStatuses?.nodes?.[0];
       _projectStatus_id = projectStatus?.id;
       expect(projectStatuses instanceof L.ProjectStatusConnection);
@@ -4226,7 +4253,7 @@ describe("generated", () => {
     /** Test the root query for a single ProjectStatus */
     it("projectStatus", async () => {
       if (_projectStatus_id) {
-        const projectStatus: L.ProjectStatus | undefined = await client.projectStatus(_projectStatus_id);
+        const projectStatus: L.ProjectStatus | undefined | null = await client.projectStatus(_projectStatus_id);
         expect(projectStatus instanceof L.ProjectStatus);
       } else {
         console.warn("codegen-doc:print: No first ProjectStatus found in connection - cannot test projectStatus query");
@@ -4236,12 +4263,12 @@ describe("generated", () => {
 
   /** Test all ProjectUpdate queries */
   describe("ProjectUpdates", () => {
-    let _projectUpdate: L.ProjectUpdate | undefined;
-    let _projectUpdate_id: string | undefined;
+    let _projectUpdate: L.ProjectUpdate | undefined | null;
+    let _projectUpdate_id: string | undefined | null;
 
     /** Test the root connection query for the ProjectUpdate */
     it("projectUpdates", async () => {
-      const projectUpdates: L.ProjectUpdateConnection | undefined = await client.projectUpdates();
+      const projectUpdates: L.ProjectUpdateConnection | undefined | null = await client.projectUpdates();
       const projectUpdate = projectUpdates?.nodes?.[0];
       _projectUpdate_id = projectUpdate?.id;
       expect(projectUpdates instanceof L.ProjectUpdateConnection);
@@ -4250,7 +4277,7 @@ describe("generated", () => {
     /** Test the root query for a single ProjectUpdate */
     it("projectUpdate", async () => {
       if (_projectUpdate_id) {
-        const projectUpdate: L.ProjectUpdate | undefined = await client.projectUpdate(_projectUpdate_id);
+        const projectUpdate: L.ProjectUpdate | undefined | null = await client.projectUpdate(_projectUpdate_id);
         _projectUpdate = projectUpdate;
         expect(projectUpdate instanceof L.ProjectUpdate);
       } else {
@@ -4261,7 +4288,7 @@ describe("generated", () => {
     /** Test the projectUpdate connection query for the Comment */
     it("projectUpdate.comments", async () => {
       if (_projectUpdate) {
-        const comments: L.CommentConnection | undefined = await _projectUpdate.comments();
+        const comments: L.CommentConnection | undefined | null = await _projectUpdate.comments();
         expect(comments instanceof L.CommentConnection);
       } else {
         console.warn("codegen-doc:print: No projectUpdate found - cannot test _projectUpdate.comments query");
@@ -4271,7 +4298,7 @@ describe("generated", () => {
     /** Test the projectUpdate.project query for L.Project */
     it("projectUpdate.project", async () => {
       if (_projectUpdate) {
-        const projectUpdate_project: L.Project | undefined = await _projectUpdate.project;
+        const projectUpdate_project: L.Project | undefined | null = await _projectUpdate.project;
         expect(projectUpdate_project instanceof L.Project);
       } else {
         console.warn("codegen-doc:print: No ProjectUpdate found - cannot test projectUpdate.project query");
@@ -4281,7 +4308,7 @@ describe("generated", () => {
     /** Test the projectUpdate.user query for L.User */
     it("projectUpdate.user", async () => {
       if (_projectUpdate) {
-        const projectUpdate_user: L.User | undefined = await _projectUpdate.user;
+        const projectUpdate_user: L.User | undefined | null = await _projectUpdate.user;
         expect(projectUpdate_user instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No ProjectUpdate found - cannot test projectUpdate.user query");
@@ -4291,12 +4318,12 @@ describe("generated", () => {
 
   /** Test all Project queries */
   describe("Projects", () => {
-    let _project: L.Project | undefined;
-    let _project_id: string | undefined;
+    let _project: L.Project | undefined | null;
+    let _project_id: string | undefined | null;
 
     /** Test the root connection query for the Project */
     it("projects", async () => {
-      const projects: L.ProjectConnection | undefined = await client.projects();
+      const projects: L.ProjectConnection | undefined | null = await client.projects();
       const project = projects?.nodes?.[0];
       _project_id = project?.id;
       expect(projects instanceof L.ProjectConnection);
@@ -4305,7 +4332,7 @@ describe("generated", () => {
     /** Test the root query for a single Project */
     it("project", async () => {
       if (_project_id) {
-        const project: L.Project | undefined = await client.project(_project_id);
+        const project: L.Project | undefined | null = await client.project(_project_id);
         _project = project;
         expect(project instanceof L.Project);
       } else {
@@ -4316,19 +4343,19 @@ describe("generated", () => {
     /** Test the project connection query for the Comment */
     it("project.comments", async () => {
       if (_project) {
-        const comments: L.CommentConnection | undefined = await _project.comments();
+        const comments: L.CommentConnection | undefined | null = await _project.comments();
         expect(comments instanceof L.CommentConnection);
       } else {
         console.warn("codegen-doc:print: No project found - cannot test _project.comments query");
       }
     });
 
-    let _documentContent: L.DocumentContent | undefined;
+    let _documentContent: L.DocumentContent | undefined | null;
 
     /** Test the project model query for Project_DocumentContent */
     it("project.documentContent", async () => {
       if (_project) {
-        const documentContent: L.DocumentContent | undefined = _project.documentContent;
+        const documentContent: L.DocumentContent | undefined | null = _project.documentContent;
         _documentContent = documentContent;
         expect(documentContent instanceof L.DocumentContent);
       } else {
@@ -4339,7 +4366,7 @@ describe("generated", () => {
     /** Test the project_documentContent model query for Project_DocumentContent_AiPromptRules */
     it("project_documentContent.aiPromptRules", async () => {
       if (_documentContent) {
-        const aiPromptRules: L.AiPromptRules | undefined = _documentContent.aiPromptRules;
+        const aiPromptRules: L.AiPromptRules | undefined | null = _documentContent.aiPromptRules;
         expect(aiPromptRules instanceof L.AiPromptRules);
       } else {
         console.warn("codegen-doc:print: No documentContent found - cannot test _documentContent.aiPromptRules query");
@@ -4349,7 +4376,7 @@ describe("generated", () => {
     /** Test the project connection query for the Document */
     it("project.documents", async () => {
       if (_project) {
-        const documents: L.DocumentConnection | undefined = await _project.documents();
+        const documents: L.DocumentConnection | undefined | null = await _project.documents();
         expect(documents instanceof L.DocumentConnection);
       } else {
         console.warn("codegen-doc:print: No project found - cannot test _project.documents query");
@@ -4359,7 +4386,7 @@ describe("generated", () => {
     /** Test the project connection query for the EntityExternalLink */
     it("project.externalLinks", async () => {
       if (_project) {
-        const externalLinks: L.EntityExternalLinkConnection | undefined = await _project.externalLinks();
+        const externalLinks: L.EntityExternalLinkConnection | undefined | null = await _project.externalLinks();
         expect(externalLinks instanceof L.EntityExternalLinkConnection);
       } else {
         console.warn("codegen-doc:print: No project found - cannot test _project.externalLinks query");
@@ -4369,7 +4396,7 @@ describe("generated", () => {
     /** Test the project connection query for the ProjectHistory */
     it("project.history", async () => {
       if (_project) {
-        const history: L.ProjectHistoryConnection | undefined = await _project.history();
+        const history: L.ProjectHistoryConnection | undefined | null = await _project.history();
         expect(history instanceof L.ProjectHistoryConnection);
       } else {
         console.warn("codegen-doc:print: No project found - cannot test _project.history query");
@@ -4379,7 +4406,7 @@ describe("generated", () => {
     /** Test the project connection query for the Initiative */
     it("project.initiatives", async () => {
       if (_project) {
-        const initiatives: L.InitiativeConnection | undefined = await _project.initiatives();
+        const initiatives: L.InitiativeConnection | undefined | null = await _project.initiatives();
         expect(initiatives instanceof L.InitiativeConnection);
       } else {
         console.warn("codegen-doc:print: No project found - cannot test _project.initiatives query");
@@ -4389,7 +4416,7 @@ describe("generated", () => {
     /** Test the project connection query for the ProjectRelation */
     it("project.inverseRelations", async () => {
       if (_project) {
-        const inverseRelations: L.ProjectRelationConnection | undefined = await _project.inverseRelations();
+        const inverseRelations: L.ProjectRelationConnection | undefined | null = await _project.inverseRelations();
         expect(inverseRelations instanceof L.ProjectRelationConnection);
       } else {
         console.warn("codegen-doc:print: No project found - cannot test _project.inverseRelations query");
@@ -4399,7 +4426,7 @@ describe("generated", () => {
     /** Test the project connection query for the Issue */
     it("project.issues", async () => {
       if (_project) {
-        const issues: L.IssueConnection | undefined = await _project.issues();
+        const issues: L.IssueConnection | undefined | null = await _project.issues();
         expect(issues instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No project found - cannot test _project.issues query");
@@ -4409,7 +4436,7 @@ describe("generated", () => {
     /** Test the project connection query for the ProjectLabel */
     it("project.labels", async () => {
       if (_project) {
-        const labels: L.ProjectLabelConnection | undefined = await _project.labels();
+        const labels: L.ProjectLabelConnection | undefined | null = await _project.labels();
         expect(labels instanceof L.ProjectLabelConnection);
       } else {
         console.warn("codegen-doc:print: No project found - cannot test _project.labels query");
@@ -4419,7 +4446,7 @@ describe("generated", () => {
     /** Test the project connection query for the User */
     it("project.members", async () => {
       if (_project) {
-        const members: L.UserConnection | undefined = await _project.members();
+        const members: L.UserConnection | undefined | null = await _project.members();
         expect(members instanceof L.UserConnection);
       } else {
         console.warn("codegen-doc:print: No project found - cannot test _project.members query");
@@ -4429,7 +4456,7 @@ describe("generated", () => {
     /** Test the project connection query for the CustomerNeed */
     it("project.needs", async () => {
       if (_project) {
-        const needs: L.CustomerNeedConnection | undefined = await _project.needs();
+        const needs: L.CustomerNeedConnection | undefined | null = await _project.needs();
         expect(needs instanceof L.CustomerNeedConnection);
       } else {
         console.warn("codegen-doc:print: No project found - cannot test _project.needs query");
@@ -4439,7 +4466,7 @@ describe("generated", () => {
     /** Test the project connection query for the ProjectMilestone */
     it("project.projectMilestones", async () => {
       if (_project) {
-        const projectMilestones: L.ProjectMilestoneConnection | undefined = await _project.projectMilestones();
+        const projectMilestones: L.ProjectMilestoneConnection | undefined | null = await _project.projectMilestones();
         expect(projectMilestones instanceof L.ProjectMilestoneConnection);
       } else {
         console.warn("codegen-doc:print: No project found - cannot test _project.projectMilestones query");
@@ -4449,7 +4476,7 @@ describe("generated", () => {
     /** Test the project connection query for the ProjectUpdate */
     it("project.projectUpdates", async () => {
       if (_project) {
-        const projectUpdates: L.ProjectUpdateConnection | undefined = await _project.projectUpdates();
+        const projectUpdates: L.ProjectUpdateConnection | undefined | null = await _project.projectUpdates();
         expect(projectUpdates instanceof L.ProjectUpdateConnection);
       } else {
         console.warn("codegen-doc:print: No project found - cannot test _project.projectUpdates query");
@@ -4459,7 +4486,7 @@ describe("generated", () => {
     /** Test the project connection query for the ProjectRelation */
     it("project.relations", async () => {
       if (_project) {
-        const relations: L.ProjectRelationConnection | undefined = await _project.relations();
+        const relations: L.ProjectRelationConnection | undefined | null = await _project.relations();
         expect(relations instanceof L.ProjectRelationConnection);
       } else {
         console.warn("codegen-doc:print: No project found - cannot test _project.relations query");
@@ -4469,7 +4496,7 @@ describe("generated", () => {
     /** Test the project connection query for the Team */
     it("project.teams", async () => {
       if (_project) {
-        const teams: L.TeamConnection | undefined = await _project.teams();
+        const teams: L.TeamConnection | undefined | null = await _project.teams();
         expect(teams instanceof L.TeamConnection);
       } else {
         console.warn("codegen-doc:print: No project found - cannot test _project.teams query");
@@ -4479,7 +4506,7 @@ describe("generated", () => {
     /** Test the project.convertedFromIssue query for L.Issue */
     it("project.convertedFromIssue", async () => {
       if (_project) {
-        const project_convertedFromIssue: L.Issue | undefined = await _project.convertedFromIssue;
+        const project_convertedFromIssue: L.Issue | undefined | null = await _project.convertedFromIssue;
         expect(project_convertedFromIssue instanceof L.Issue);
       } else {
         console.warn("codegen-doc:print: No Project found - cannot test project.convertedFromIssue query");
@@ -4489,7 +4516,7 @@ describe("generated", () => {
     /** Test the project.creator query for L.User */
     it("project.creator", async () => {
       if (_project) {
-        const project_creator: L.User | undefined = await _project.creator;
+        const project_creator: L.User | undefined | null = await _project.creator;
         expect(project_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Project found - cannot test project.creator query");
@@ -4499,7 +4526,7 @@ describe("generated", () => {
     /** Test the project.favorite query for L.Favorite */
     it("project.favorite", async () => {
       if (_project) {
-        const project_favorite: L.Favorite | undefined = await _project.favorite;
+        const project_favorite: L.Favorite | undefined | null = await _project.favorite;
         expect(project_favorite instanceof L.Favorite);
       } else {
         console.warn("codegen-doc:print: No Project found - cannot test project.favorite query");
@@ -4509,7 +4536,8 @@ describe("generated", () => {
     /** Test the project.integrationsSettings query for L.IntegrationsSettings */
     it("project.integrationsSettings", async () => {
       if (_project) {
-        const project_integrationsSettings: L.IntegrationsSettings | undefined = await _project.integrationsSettings;
+        const project_integrationsSettings: L.IntegrationsSettings | undefined | null =
+          await _project.integrationsSettings;
         expect(project_integrationsSettings instanceof L.IntegrationsSettings);
       } else {
         console.warn("codegen-doc:print: No Project found - cannot test project.integrationsSettings query");
@@ -4519,7 +4547,7 @@ describe("generated", () => {
     /** Test the project.lastAppliedTemplate query for L.Template */
     it("project.lastAppliedTemplate", async () => {
       if (_project) {
-        const project_lastAppliedTemplate: L.Template | undefined = await _project.lastAppliedTemplate;
+        const project_lastAppliedTemplate: L.Template | undefined | null = await _project.lastAppliedTemplate;
         expect(project_lastAppliedTemplate instanceof L.Template);
       } else {
         console.warn("codegen-doc:print: No Project found - cannot test project.lastAppliedTemplate query");
@@ -4529,7 +4557,7 @@ describe("generated", () => {
     /** Test the project.lastUpdate query for L.ProjectUpdate */
     it("project.lastUpdate", async () => {
       if (_project) {
-        const project_lastUpdate: L.ProjectUpdate | undefined = await _project.lastUpdate;
+        const project_lastUpdate: L.ProjectUpdate | undefined | null = await _project.lastUpdate;
         expect(project_lastUpdate instanceof L.ProjectUpdate);
       } else {
         console.warn("codegen-doc:print: No Project found - cannot test project.lastUpdate query");
@@ -4539,7 +4567,7 @@ describe("generated", () => {
     /** Test the project.lead query for L.User */
     it("project.lead", async () => {
       if (_project) {
-        const project_lead: L.User | undefined = await _project.lead;
+        const project_lead: L.User | undefined | null = await _project.lead;
         expect(project_lead instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Project found - cannot test project.lead query");
@@ -4549,7 +4577,7 @@ describe("generated", () => {
     /** Test the project.status query for L.ProjectStatus */
     it("project.status", async () => {
       if (_project) {
-        const project_status: L.ProjectStatus | undefined = await _project.status;
+        const project_status: L.ProjectStatus | undefined | null = await _project.status;
         expect(project_status instanceof L.ProjectStatus);
       } else {
         console.warn("codegen-doc:print: No Project found - cannot test project.status query");
@@ -4561,7 +4589,8 @@ describe("generated", () => {
   describe("PushSubscriptionTest", () => {
     /** Test the root model query for PushSubscriptionTest */
     it("pushSubscriptionTest", async () => {
-      const pushSubscriptionTest: L.PushSubscriptionTestPayload | undefined = await client.pushSubscriptionTest();
+      const pushSubscriptionTest: L.PushSubscriptionTestPayload | undefined | null =
+        await client.pushSubscriptionTest();
       expect(pushSubscriptionTest instanceof L.PushSubscriptionTestPayload);
     });
   });
@@ -4570,19 +4599,19 @@ describe("generated", () => {
   describe("RateLimitStatus", () => {
     /** Test the root model query for RateLimitStatus */
     it("rateLimitStatus", async () => {
-      const rateLimitStatus: L.RateLimitPayload | undefined = await client.rateLimitStatus;
+      const rateLimitStatus: L.RateLimitPayload | undefined | null = await client.rateLimitStatus;
       expect(rateLimitStatus instanceof L.RateLimitPayload);
     });
   });
 
   /** Test all RoadmapToProject queries */
   describe("RoadmapToProjects", () => {
-    let _roadmapToProject: L.RoadmapToProject | undefined;
-    let _roadmapToProject_id: string | undefined;
+    let _roadmapToProject: L.RoadmapToProject | undefined | null;
+    let _roadmapToProject_id: string | undefined | null;
 
     /** Test the root connection query for the RoadmapToProject */
     it("roadmapToProjects", async () => {
-      const roadmapToProjects: L.RoadmapToProjectConnection | undefined = await client.roadmapToProjects();
+      const roadmapToProjects: L.RoadmapToProjectConnection | undefined | null = await client.roadmapToProjects();
       const roadmapToProject = roadmapToProjects?.nodes?.[0];
       _roadmapToProject_id = roadmapToProject?.id;
       expect(roadmapToProjects instanceof L.RoadmapToProjectConnection);
@@ -4591,7 +4620,8 @@ describe("generated", () => {
     /** Test the root query for a single RoadmapToProject */
     it("roadmapToProject", async () => {
       if (_roadmapToProject_id) {
-        const roadmapToProject: L.RoadmapToProject | undefined = await client.roadmapToProject(_roadmapToProject_id);
+        const roadmapToProject: L.RoadmapToProject | undefined | null =
+          await client.roadmapToProject(_roadmapToProject_id);
         _roadmapToProject = roadmapToProject;
         expect(roadmapToProject instanceof L.RoadmapToProject);
       } else {
@@ -4604,7 +4634,7 @@ describe("generated", () => {
     /** Test the roadmapToProject.project query for L.Project */
     it("roadmapToProject.project", async () => {
       if (_roadmapToProject) {
-        const roadmapToProject_project: L.Project | undefined = await _roadmapToProject.project;
+        const roadmapToProject_project: L.Project | undefined | null = await _roadmapToProject.project;
         expect(roadmapToProject_project instanceof L.Project);
       } else {
         console.warn("codegen-doc:print: No RoadmapToProject found - cannot test roadmapToProject.project query");
@@ -4614,7 +4644,7 @@ describe("generated", () => {
     /** Test the roadmapToProject.roadmap query for L.Roadmap */
     it("roadmapToProject.roadmap", async () => {
       if (_roadmapToProject) {
-        const roadmapToProject_roadmap: L.Roadmap | undefined = await _roadmapToProject.roadmap;
+        const roadmapToProject_roadmap: L.Roadmap | undefined | null = await _roadmapToProject.roadmap;
         expect(roadmapToProject_roadmap instanceof L.Roadmap);
       } else {
         console.warn("codegen-doc:print: No RoadmapToProject found - cannot test roadmapToProject.roadmap query");
@@ -4624,12 +4654,12 @@ describe("generated", () => {
 
   /** Test all Roadmap queries */
   describe("Roadmaps", () => {
-    let _roadmap: L.Roadmap | undefined;
-    let _roadmap_id: string | undefined;
+    let _roadmap: L.Roadmap | undefined | null;
+    let _roadmap_id: string | undefined | null;
 
     /** Test the root connection query for the Roadmap */
     it("roadmaps", async () => {
-      const roadmaps: L.RoadmapConnection | undefined = await client.roadmaps();
+      const roadmaps: L.RoadmapConnection | undefined | null = await client.roadmaps();
       const roadmap = roadmaps?.nodes?.[0];
       _roadmap_id = roadmap?.id;
       expect(roadmaps instanceof L.RoadmapConnection);
@@ -4638,7 +4668,7 @@ describe("generated", () => {
     /** Test the root query for a single Roadmap */
     it("roadmap", async () => {
       if (_roadmap_id) {
-        const roadmap: L.Roadmap | undefined = await client.roadmap(_roadmap_id);
+        const roadmap: L.Roadmap | undefined | null = await client.roadmap(_roadmap_id);
         _roadmap = roadmap;
         expect(roadmap instanceof L.Roadmap);
       } else {
@@ -4649,7 +4679,7 @@ describe("generated", () => {
     /** Test the roadmap connection query for the Project */
     it("roadmap.projects", async () => {
       if (_roadmap) {
-        const projects: L.ProjectConnection | undefined = await _roadmap.projects();
+        const projects: L.ProjectConnection | undefined | null = await _roadmap.projects();
         expect(projects instanceof L.ProjectConnection);
       } else {
         console.warn("codegen-doc:print: No roadmap found - cannot test _roadmap.projects query");
@@ -4659,7 +4689,7 @@ describe("generated", () => {
     /** Test the roadmap.creator query for L.User */
     it("roadmap.creator", async () => {
       if (_roadmap) {
-        const roadmap_creator: L.User | undefined = await _roadmap.creator;
+        const roadmap_creator: L.User | undefined | null = await _roadmap.creator;
         expect(roadmap_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Roadmap found - cannot test roadmap.creator query");
@@ -4669,7 +4699,7 @@ describe("generated", () => {
     /** Test the roadmap.organization query for L.Organization */
     it("roadmap.organization", async () => {
       if (_roadmap) {
-        const roadmap_organization: L.Organization | undefined = await _roadmap.organization;
+        const roadmap_organization: L.Organization | undefined | null = await _roadmap.organization;
         expect(roadmap_organization instanceof L.Organization);
       } else {
         console.warn("codegen-doc:print: No Roadmap found - cannot test roadmap.organization query");
@@ -4679,7 +4709,7 @@ describe("generated", () => {
     /** Test the roadmap.owner query for L.User */
     it("roadmap.owner", async () => {
       if (_roadmap) {
-        const roadmap_owner: L.User | undefined = await _roadmap.owner;
+        const roadmap_owner: L.User | undefined | null = await _roadmap.owner;
         expect(roadmap_owner instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Roadmap found - cannot test roadmap.owner query");
@@ -4691,7 +4721,7 @@ describe("generated", () => {
   describe("SearchDocuments", () => {
     /** Test the root connection query for the DocumentSearchResult */
     it("searchDocuments", async () => {
-      const searchDocuments: L.DocumentSearchPayload | undefined = await client.searchDocuments("mock-term");
+      const searchDocuments: L.DocumentSearchPayload | undefined | null = await client.searchDocuments("mock-term");
       expect(searchDocuments instanceof L.DocumentSearchPayload);
     });
   });
@@ -4700,7 +4730,7 @@ describe("generated", () => {
   describe("SearchIssues", () => {
     /** Test the root connection query for the IssueSearchResult */
     it("searchIssues", async () => {
-      const searchIssues: L.IssueSearchPayload | undefined = await client.searchIssues("mock-term");
+      const searchIssues: L.IssueSearchPayload | undefined | null = await client.searchIssues("mock-term");
       expect(searchIssues instanceof L.IssueSearchPayload);
     });
   });
@@ -4709,7 +4739,7 @@ describe("generated", () => {
   describe("SearchProjects", () => {
     /** Test the root connection query for the ProjectSearchResult */
     it("searchProjects", async () => {
-      const searchProjects: L.ProjectSearchPayload | undefined = await client.searchProjects("mock-term");
+      const searchProjects: L.ProjectSearchPayload | undefined | null = await client.searchProjects("mock-term");
       expect(searchProjects instanceof L.ProjectSearchPayload);
     });
   });
@@ -4718,7 +4748,7 @@ describe("generated", () => {
   describe("SemanticSearch", () => {
     /** Test the root model query for SemanticSearch */
     it("semanticSearch", async () => {
-      const semanticSearch: L.SemanticSearchPayload | undefined = await client.semanticSearch("mock-query");
+      const semanticSearch: L.SemanticSearchPayload | undefined | null = await client.semanticSearch("mock-query");
       expect(semanticSearch instanceof L.SemanticSearchPayload);
     });
   });
@@ -4727,7 +4757,7 @@ describe("generated", () => {
   describe("SsoUrlFromEmail", () => {
     /** Test the root model query for SsoUrlFromEmail */
     it("ssoUrlFromEmail", async () => {
-      const ssoUrlFromEmail: L.SsoUrlFromEmailResponse | undefined = await client.ssoUrlFromEmail(
+      const ssoUrlFromEmail: L.SsoUrlFromEmailResponse | undefined | null = await client.ssoUrlFromEmail(
         "mock-email",
         L.IdentityProviderType.General
       );
@@ -4737,12 +4767,12 @@ describe("generated", () => {
 
   /** Test all TeamMembership queries */
   describe("TeamMemberships", () => {
-    let _teamMembership: L.TeamMembership | undefined;
-    let _teamMembership_id: string | undefined;
+    let _teamMembership: L.TeamMembership | undefined | null;
+    let _teamMembership_id: string | undefined | null;
 
     /** Test the root connection query for the TeamMembership */
     it("teamMemberships", async () => {
-      const teamMemberships: L.TeamMembershipConnection | undefined = await client.teamMemberships();
+      const teamMemberships: L.TeamMembershipConnection | undefined | null = await client.teamMemberships();
       const teamMembership = teamMemberships?.nodes?.[0];
       _teamMembership_id = teamMembership?.id;
       expect(teamMemberships instanceof L.TeamMembershipConnection);
@@ -4751,7 +4781,7 @@ describe("generated", () => {
     /** Test the root query for a single TeamMembership */
     it("teamMembership", async () => {
       if (_teamMembership_id) {
-        const teamMembership: L.TeamMembership | undefined = await client.teamMembership(_teamMembership_id);
+        const teamMembership: L.TeamMembership | undefined | null = await client.teamMembership(_teamMembership_id);
         _teamMembership = teamMembership;
         expect(teamMembership instanceof L.TeamMembership);
       } else {
@@ -4764,7 +4794,7 @@ describe("generated", () => {
     /** Test the teamMembership.team query for L.Team */
     it("teamMembership.team", async () => {
       if (_teamMembership) {
-        const teamMembership_team: L.Team | undefined = await _teamMembership.team;
+        const teamMembership_team: L.Team | undefined | null = await _teamMembership.team;
         expect(teamMembership_team instanceof L.Team);
       } else {
         console.warn("codegen-doc:print: No TeamMembership found - cannot test teamMembership.team query");
@@ -4774,7 +4804,7 @@ describe("generated", () => {
     /** Test the teamMembership.user query for L.User */
     it("teamMembership.user", async () => {
       if (_teamMembership) {
-        const teamMembership_user: L.User | undefined = await _teamMembership.user;
+        const teamMembership_user: L.User | undefined | null = await _teamMembership.user;
         expect(teamMembership_user instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No TeamMembership found - cannot test teamMembership.user query");
@@ -4784,12 +4814,12 @@ describe("generated", () => {
 
   /** Test all Team queries */
   describe("Teams", () => {
-    let _team: L.Team | undefined;
-    let _team_id: string | undefined;
+    let _team: L.Team | undefined | null;
+    let _team_id: string | undefined | null;
 
     /** Test the root connection query for the Team */
     it("teams", async () => {
-      const teams: L.TeamConnection | undefined = await client.teams();
+      const teams: L.TeamConnection | undefined | null = await client.teams();
       const team = teams?.nodes?.[0];
       _team_id = team?.id;
       expect(teams instanceof L.TeamConnection);
@@ -4798,7 +4828,7 @@ describe("generated", () => {
     /** Test the root query for a single Team */
     it("team", async () => {
       if (_team_id) {
-        const team: L.Team | undefined = await client.team(_team_id);
+        const team: L.Team | undefined | null = await client.team(_team_id);
         _team = team;
         expect(team instanceof L.Team);
       } else {
@@ -4809,7 +4839,7 @@ describe("generated", () => {
     /** Test the team connection query for the Cycle */
     it("team.cycles", async () => {
       if (_team) {
-        const cycles: L.CycleConnection | undefined = await _team.cycles();
+        const cycles: L.CycleConnection | undefined | null = await _team.cycles();
         expect(cycles instanceof L.CycleConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.cycles query");
@@ -4819,7 +4849,8 @@ describe("generated", () => {
     /** Test the team connection query for the GitAutomationState */
     it("team.gitAutomationStates", async () => {
       if (_team) {
-        const gitAutomationStates: L.GitAutomationStateConnection | undefined = await _team.gitAutomationStates();
+        const gitAutomationStates: L.GitAutomationStateConnection | undefined | null =
+          await _team.gitAutomationStates();
         expect(gitAutomationStates instanceof L.GitAutomationStateConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.gitAutomationStates query");
@@ -4829,7 +4860,7 @@ describe("generated", () => {
     /** Test the team connection query for the Issue */
     it("team.issues", async () => {
       if (_team) {
-        const issues: L.IssueConnection | undefined = await _team.issues();
+        const issues: L.IssueConnection | undefined | null = await _team.issues();
         expect(issues instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.issues query");
@@ -4839,7 +4870,7 @@ describe("generated", () => {
     /** Test the team connection query for the IssueLabel */
     it("team.labels", async () => {
       if (_team) {
-        const labels: L.IssueLabelConnection | undefined = await _team.labels();
+        const labels: L.IssueLabelConnection | undefined | null = await _team.labels();
         expect(labels instanceof L.IssueLabelConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.labels query");
@@ -4849,7 +4880,7 @@ describe("generated", () => {
     /** Test the team connection query for the User */
     it("team.members", async () => {
       if (_team) {
-        const members: L.UserConnection | undefined = await _team.members();
+        const members: L.UserConnection | undefined | null = await _team.members();
         expect(members instanceof L.UserConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.members query");
@@ -4859,7 +4890,7 @@ describe("generated", () => {
     /** Test the team connection query for the TeamMembership */
     it("team.memberships", async () => {
       if (_team) {
-        const memberships: L.TeamMembershipConnection | undefined = await _team.memberships();
+        const memberships: L.TeamMembershipConnection | undefined | null = await _team.memberships();
         expect(memberships instanceof L.TeamMembershipConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.memberships query");
@@ -4869,7 +4900,7 @@ describe("generated", () => {
     /** Test the team connection query for the Project */
     it("team.projects", async () => {
       if (_team) {
-        const projects: L.ProjectConnection | undefined = await _team.projects();
+        const projects: L.ProjectConnection | undefined | null = await _team.projects();
         expect(projects instanceof L.ProjectConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.projects query");
@@ -4879,7 +4910,7 @@ describe("generated", () => {
     /** Test the team connection query for the WorkflowState */
     it("team.states", async () => {
       if (_team) {
-        const states: L.WorkflowStateConnection | undefined = await _team.states();
+        const states: L.WorkflowStateConnection | undefined | null = await _team.states();
         expect(states instanceof L.WorkflowStateConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.states query");
@@ -4889,7 +4920,7 @@ describe("generated", () => {
     /** Test the team connection query for the Template */
     it("team.templates", async () => {
       if (_team) {
-        const templates: L.TemplateConnection | undefined = await _team.templates();
+        const templates: L.TemplateConnection | undefined | null = await _team.templates();
         expect(templates instanceof L.TemplateConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.templates query");
@@ -4899,7 +4930,7 @@ describe("generated", () => {
     /** Test the team connection query for the Webhook */
     it("team.webhooks", async () => {
       if (_team) {
-        const webhooks: L.WebhookConnection | undefined = await _team.webhooks();
+        const webhooks: L.WebhookConnection | undefined | null = await _team.webhooks();
         expect(webhooks instanceof L.WebhookConnection);
       } else {
         console.warn("codegen-doc:print: No team found - cannot test _team.webhooks query");
@@ -4909,7 +4940,7 @@ describe("generated", () => {
     /** Test the team.activeCycle query for L.Cycle */
     it("team.activeCycle", async () => {
       if (_team) {
-        const team_activeCycle: L.Cycle | undefined = await _team.activeCycle;
+        const team_activeCycle: L.Cycle | undefined | null = await _team.activeCycle;
         expect(team_activeCycle instanceof L.Cycle);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.activeCycle query");
@@ -4919,7 +4950,7 @@ describe("generated", () => {
     /** Test the team.defaultIssueState query for L.WorkflowState */
     it("team.defaultIssueState", async () => {
       if (_team) {
-        const team_defaultIssueState: L.WorkflowState | undefined = await _team.defaultIssueState;
+        const team_defaultIssueState: L.WorkflowState | undefined | null = await _team.defaultIssueState;
         expect(team_defaultIssueState instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.defaultIssueState query");
@@ -4929,7 +4960,7 @@ describe("generated", () => {
     /** Test the team.defaultProjectTemplate query for L.Template */
     it("team.defaultProjectTemplate", async () => {
       if (_team) {
-        const team_defaultProjectTemplate: L.Template | undefined = await _team.defaultProjectTemplate;
+        const team_defaultProjectTemplate: L.Template | undefined | null = await _team.defaultProjectTemplate;
         expect(team_defaultProjectTemplate instanceof L.Template);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.defaultProjectTemplate query");
@@ -4939,7 +4970,7 @@ describe("generated", () => {
     /** Test the team.defaultTemplateForMembers query for L.Template */
     it("team.defaultTemplateForMembers", async () => {
       if (_team) {
-        const team_defaultTemplateForMembers: L.Template | undefined = await _team.defaultTemplateForMembers;
+        const team_defaultTemplateForMembers: L.Template | undefined | null = await _team.defaultTemplateForMembers;
         expect(team_defaultTemplateForMembers instanceof L.Template);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.defaultTemplateForMembers query");
@@ -4949,7 +4980,8 @@ describe("generated", () => {
     /** Test the team.defaultTemplateForNonMembers query for L.Template */
     it("team.defaultTemplateForNonMembers", async () => {
       if (_team) {
-        const team_defaultTemplateForNonMembers: L.Template | undefined = await _team.defaultTemplateForNonMembers;
+        const team_defaultTemplateForNonMembers: L.Template | undefined | null =
+          await _team.defaultTemplateForNonMembers;
         expect(team_defaultTemplateForNonMembers instanceof L.Template);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.defaultTemplateForNonMembers query");
@@ -4959,7 +4991,7 @@ describe("generated", () => {
     /** Test the team.draftWorkflowState query for L.WorkflowState */
     it("team.draftWorkflowState", async () => {
       if (_team) {
-        const team_draftWorkflowState: L.WorkflowState | undefined = await _team.draftWorkflowState;
+        const team_draftWorkflowState: L.WorkflowState | undefined | null = await _team.draftWorkflowState;
         expect(team_draftWorkflowState instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.draftWorkflowState query");
@@ -4969,7 +5001,7 @@ describe("generated", () => {
     /** Test the team.integrationsSettings query for L.IntegrationsSettings */
     it("team.integrationsSettings", async () => {
       if (_team) {
-        const team_integrationsSettings: L.IntegrationsSettings | undefined = await _team.integrationsSettings;
+        const team_integrationsSettings: L.IntegrationsSettings | undefined | null = await _team.integrationsSettings;
         expect(team_integrationsSettings instanceof L.IntegrationsSettings);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.integrationsSettings query");
@@ -4979,7 +5011,7 @@ describe("generated", () => {
     /** Test the team.markedAsDuplicateWorkflowState query for L.WorkflowState */
     it("team.markedAsDuplicateWorkflowState", async () => {
       if (_team) {
-        const team_markedAsDuplicateWorkflowState: L.WorkflowState | undefined =
+        const team_markedAsDuplicateWorkflowState: L.WorkflowState | undefined | null =
           await _team.markedAsDuplicateWorkflowState;
         expect(team_markedAsDuplicateWorkflowState instanceof L.WorkflowState);
       } else {
@@ -4990,7 +5022,7 @@ describe("generated", () => {
     /** Test the team.mergeWorkflowState query for L.WorkflowState */
     it("team.mergeWorkflowState", async () => {
       if (_team) {
-        const team_mergeWorkflowState: L.WorkflowState | undefined = await _team.mergeWorkflowState;
+        const team_mergeWorkflowState: L.WorkflowState | undefined | null = await _team.mergeWorkflowState;
         expect(team_mergeWorkflowState instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.mergeWorkflowState query");
@@ -5000,7 +5032,7 @@ describe("generated", () => {
     /** Test the team.mergeableWorkflowState query for L.WorkflowState */
     it("team.mergeableWorkflowState", async () => {
       if (_team) {
-        const team_mergeableWorkflowState: L.WorkflowState | undefined = await _team.mergeableWorkflowState;
+        const team_mergeableWorkflowState: L.WorkflowState | undefined | null = await _team.mergeableWorkflowState;
         expect(team_mergeableWorkflowState instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.mergeableWorkflowState query");
@@ -5010,7 +5042,7 @@ describe("generated", () => {
     /** Test the team.organization query for L.Organization */
     it("team.organization", async () => {
       if (_team) {
-        const team_organization: L.Organization | undefined = await _team.organization;
+        const team_organization: L.Organization | undefined | null = await _team.organization;
         expect(team_organization instanceof L.Organization);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.organization query");
@@ -5020,7 +5052,7 @@ describe("generated", () => {
     /** Test the team.reviewWorkflowState query for L.WorkflowState */
     it("team.reviewWorkflowState", async () => {
       if (_team) {
-        const team_reviewWorkflowState: L.WorkflowState | undefined = await _team.reviewWorkflowState;
+        const team_reviewWorkflowState: L.WorkflowState | undefined | null = await _team.reviewWorkflowState;
         expect(team_reviewWorkflowState instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.reviewWorkflowState query");
@@ -5030,7 +5062,7 @@ describe("generated", () => {
     /** Test the team.startWorkflowState query for L.WorkflowState */
     it("team.startWorkflowState", async () => {
       if (_team) {
-        const team_startWorkflowState: L.WorkflowState | undefined = await _team.startWorkflowState;
+        const team_startWorkflowState: L.WorkflowState | undefined | null = await _team.startWorkflowState;
         expect(team_startWorkflowState instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.startWorkflowState query");
@@ -5040,7 +5072,7 @@ describe("generated", () => {
     /** Test the team.triageIssueState query for L.WorkflowState */
     it("team.triageIssueState", async () => {
       if (_team) {
-        const team_triageIssueState: L.WorkflowState | undefined = await _team.triageIssueState;
+        const team_triageIssueState: L.WorkflowState | undefined | null = await _team.triageIssueState;
         expect(team_triageIssueState instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.triageIssueState query");
@@ -5050,7 +5082,7 @@ describe("generated", () => {
     /** Test the team.triageResponsibility query for L.TriageResponsibility */
     it("team.triageResponsibility", async () => {
       if (_team) {
-        const team_triageResponsibility: L.TriageResponsibility | undefined = await _team.triageResponsibility;
+        const team_triageResponsibility: L.TriageResponsibility | undefined | null = await _team.triageResponsibility;
         expect(team_triageResponsibility instanceof L.TriageResponsibility);
       } else {
         console.warn("codegen-doc:print: No Team found - cannot test team.triageResponsibility query");
@@ -5062,7 +5094,7 @@ describe("generated", () => {
   describe("Template", () => {
     /** Test the root model query for Template */
     it("template", async () => {
-      const template: L.Template | undefined = await client.template("mock-id");
+      const template: L.Template | undefined | null = await client.template("mock-id");
       expect(template instanceof L.Template);
     });
   });
@@ -5071,7 +5103,7 @@ describe("generated", () => {
   describe("Templates", () => {
     /** Test the root model query for Templates */
     it("templates", async () => {
-      const templates: L.Template[] | undefined = await client.templates;
+      const templates: L.Template[] | undefined | null = await client.templates;
       templates?.map(node => expect(node instanceof L.Template));
     });
   });
@@ -5080,7 +5112,7 @@ describe("generated", () => {
   describe("TemplatesForIntegration", () => {
     /** Test the root model query for TemplatesForIntegration */
     it("templatesForIntegration", async () => {
-      const templatesForIntegration: L.Template[] | undefined =
+      const templatesForIntegration: L.Template[] | undefined | null =
         await client.templatesForIntegration("mock-integrationType");
       templatesForIntegration?.map(node => expect(node instanceof L.Template));
     });
@@ -5088,12 +5120,12 @@ describe("generated", () => {
 
   /** Test all TimeSchedule queries */
   describe("TimeSchedules", () => {
-    let _timeSchedule: L.TimeSchedule | undefined;
-    let _timeSchedule_id: string | undefined;
+    let _timeSchedule: L.TimeSchedule | undefined | null;
+    let _timeSchedule_id: string | undefined | null;
 
     /** Test the root connection query for the TimeSchedule */
     it("timeSchedules", async () => {
-      const timeSchedules: L.TimeScheduleConnection | undefined = await client.timeSchedules();
+      const timeSchedules: L.TimeScheduleConnection | undefined | null = await client.timeSchedules();
       const timeSchedule = timeSchedules?.nodes?.[0];
       _timeSchedule_id = timeSchedule?.id;
       expect(timeSchedules instanceof L.TimeScheduleConnection);
@@ -5102,7 +5134,7 @@ describe("generated", () => {
     /** Test the root query for a single TimeSchedule */
     it("timeSchedule", async () => {
       if (_timeSchedule_id) {
-        const timeSchedule: L.TimeSchedule | undefined = await client.timeSchedule(_timeSchedule_id);
+        const timeSchedule: L.TimeSchedule | undefined | null = await client.timeSchedule(_timeSchedule_id);
         _timeSchedule = timeSchedule;
         expect(timeSchedule instanceof L.TimeSchedule);
       } else {
@@ -5113,7 +5145,7 @@ describe("generated", () => {
     /** Test the timeSchedule.integration query for L.Integration */
     it("timeSchedule.integration", async () => {
       if (_timeSchedule) {
-        const timeSchedule_integration: L.Integration | undefined = await _timeSchedule.integration;
+        const timeSchedule_integration: L.Integration | undefined | null = await _timeSchedule.integration;
         expect(timeSchedule_integration instanceof L.Integration);
       } else {
         console.warn("codegen-doc:print: No TimeSchedule found - cannot test timeSchedule.integration query");
@@ -5123,7 +5155,7 @@ describe("generated", () => {
     /** Test the timeSchedule.organization query for L.Organization */
     it("timeSchedule.organization", async () => {
       if (_timeSchedule) {
-        const timeSchedule_organization: L.Organization | undefined = await _timeSchedule.organization;
+        const timeSchedule_organization: L.Organization | undefined | null = await _timeSchedule.organization;
         expect(timeSchedule_organization instanceof L.Organization);
       } else {
         console.warn("codegen-doc:print: No TimeSchedule found - cannot test timeSchedule.organization query");
@@ -5133,12 +5165,12 @@ describe("generated", () => {
 
   /** Test all TriageResponsibility queries */
   describe("TriageResponsibilities", () => {
-    let _triageResponsibility: L.TriageResponsibility | undefined;
-    let _triageResponsibility_id: string | undefined;
+    let _triageResponsibility: L.TriageResponsibility | undefined | null;
+    let _triageResponsibility_id: string | undefined | null;
 
     /** Test the root connection query for the TriageResponsibility */
     it("triageResponsibilities", async () => {
-      const triageResponsibilities: L.TriageResponsibilityConnection | undefined =
+      const triageResponsibilities: L.TriageResponsibilityConnection | undefined | null =
         await client.triageResponsibilities();
       const triageResponsibility = triageResponsibilities?.nodes?.[0];
       _triageResponsibility_id = triageResponsibility?.id;
@@ -5148,7 +5180,7 @@ describe("generated", () => {
     /** Test the root query for a single TriageResponsibility */
     it("triageResponsibility", async () => {
       if (_triageResponsibility_id) {
-        const triageResponsibility: L.TriageResponsibility | undefined =
+        const triageResponsibility: L.TriageResponsibility | undefined | null =
           await client.triageResponsibility(_triageResponsibility_id);
         _triageResponsibility = triageResponsibility;
         expect(triageResponsibility instanceof L.TriageResponsibility);
@@ -5162,7 +5194,7 @@ describe("generated", () => {
     /** Test the triageResponsibility model query for TriageResponsibility_ManualSelection */
     it("triageResponsibility.manualSelection", async () => {
       if (_triageResponsibility) {
-        const manualSelection: L.TriageResponsibilityManualSelection | undefined =
+        const manualSelection: L.TriageResponsibilityManualSelection | undefined | null =
           _triageResponsibility.manualSelection;
         expect(manualSelection instanceof L.TriageResponsibilityManualSelection);
       } else {
@@ -5175,7 +5207,7 @@ describe("generated", () => {
     /** Test the triageResponsibility.currentUser query for L.User */
     it("triageResponsibility.currentUser", async () => {
       if (_triageResponsibility) {
-        const triageResponsibility_currentUser: L.User | undefined = await _triageResponsibility.currentUser;
+        const triageResponsibility_currentUser: L.User | undefined | null = await _triageResponsibility.currentUser;
         expect(triageResponsibility_currentUser instanceof L.User);
       } else {
         console.warn(
@@ -5187,7 +5219,7 @@ describe("generated", () => {
     /** Test the triageResponsibility.team query for L.Team */
     it("triageResponsibility.team", async () => {
       if (_triageResponsibility) {
-        const triageResponsibility_team: L.Team | undefined = await _triageResponsibility.team;
+        const triageResponsibility_team: L.Team | undefined | null = await _triageResponsibility.team;
         expect(triageResponsibility_team instanceof L.Team);
       } else {
         console.warn("codegen-doc:print: No TriageResponsibility found - cannot test triageResponsibility.team query");
@@ -5197,7 +5229,8 @@ describe("generated", () => {
     /** Test the triageResponsibility.timeSchedule query for L.TimeSchedule */
     it("triageResponsibility.timeSchedule", async () => {
       if (_triageResponsibility) {
-        const triageResponsibility_timeSchedule: L.TimeSchedule | undefined = await _triageResponsibility.timeSchedule;
+        const triageResponsibility_timeSchedule: L.TimeSchedule | undefined | null =
+          await _triageResponsibility.timeSchedule;
         expect(triageResponsibility_timeSchedule instanceof L.TimeSchedule);
       } else {
         console.warn(
@@ -5209,21 +5242,21 @@ describe("generated", () => {
 
   /** Test UserSettings query */
   describe("UserSettings", () => {
-    let _userSettings: L.UserSettings | undefined;
+    let _userSettings: L.UserSettings | undefined | null;
 
     /** Test the root model query for UserSettings */
     it("userSettings", async () => {
-      const userSettings: L.UserSettings | undefined = await client.userSettings;
+      const userSettings: L.UserSettings | undefined | null = await client.userSettings;
       _userSettings = userSettings;
       expect(userSettings instanceof L.UserSettings);
     });
 
-    let _notificationCategoryPreferences: L.NotificationCategoryPreferences | undefined;
+    let _notificationCategoryPreferences: L.NotificationCategoryPreferences | undefined | null;
 
     /** Test the userSettings model query for UserSettings_NotificationCategoryPreferences */
     it("userSettings.notificationCategoryPreferences", async () => {
       if (_userSettings) {
-        const notificationCategoryPreferences: L.NotificationCategoryPreferences | undefined =
+        const notificationCategoryPreferences: L.NotificationCategoryPreferences | undefined | null =
           _userSettings.notificationCategoryPreferences;
         _notificationCategoryPreferences = notificationCategoryPreferences;
         expect(notificationCategoryPreferences instanceof L.NotificationCategoryPreferences);
@@ -5237,7 +5270,7 @@ describe("generated", () => {
     /** Test the userSettings_notificationCategoryPreferences model query for UserSettings_NotificationCategoryPreferences_AppsAndIntegrations */
     it("userSettings_notificationCategoryPreferences.appsAndIntegrations", async () => {
       if (_notificationCategoryPreferences) {
-        const appsAndIntegrations: L.NotificationChannelPreferences | undefined =
+        const appsAndIntegrations: L.NotificationChannelPreferences | undefined | null =
           _notificationCategoryPreferences.appsAndIntegrations;
         expect(appsAndIntegrations instanceof L.NotificationChannelPreferences);
       } else {
@@ -5250,7 +5283,8 @@ describe("generated", () => {
     /** Test the userSettings_notificationCategoryPreferences model query for UserSettings_NotificationCategoryPreferences_Assignments */
     it("userSettings_notificationCategoryPreferences.assignments", async () => {
       if (_notificationCategoryPreferences) {
-        const assignments: L.NotificationChannelPreferences | undefined = _notificationCategoryPreferences.assignments;
+        const assignments: L.NotificationChannelPreferences | undefined | null =
+          _notificationCategoryPreferences.assignments;
         expect(assignments instanceof L.NotificationChannelPreferences);
       } else {
         console.warn(
@@ -5262,7 +5296,7 @@ describe("generated", () => {
     /** Test the userSettings_notificationCategoryPreferences model query for UserSettings_NotificationCategoryPreferences_CommentsAndReplies */
     it("userSettings_notificationCategoryPreferences.commentsAndReplies", async () => {
       if (_notificationCategoryPreferences) {
-        const commentsAndReplies: L.NotificationChannelPreferences | undefined =
+        const commentsAndReplies: L.NotificationChannelPreferences | undefined | null =
           _notificationCategoryPreferences.commentsAndReplies;
         expect(commentsAndReplies instanceof L.NotificationChannelPreferences);
       } else {
@@ -5275,7 +5309,8 @@ describe("generated", () => {
     /** Test the userSettings_notificationCategoryPreferences model query for UserSettings_NotificationCategoryPreferences_Customers */
     it("userSettings_notificationCategoryPreferences.customers", async () => {
       if (_notificationCategoryPreferences) {
-        const customers: L.NotificationChannelPreferences | undefined = _notificationCategoryPreferences.customers;
+        const customers: L.NotificationChannelPreferences | undefined | null =
+          _notificationCategoryPreferences.customers;
         expect(customers instanceof L.NotificationChannelPreferences);
       } else {
         console.warn(
@@ -5287,7 +5322,7 @@ describe("generated", () => {
     /** Test the userSettings_notificationCategoryPreferences model query for UserSettings_NotificationCategoryPreferences_DocumentChanges */
     it("userSettings_notificationCategoryPreferences.documentChanges", async () => {
       if (_notificationCategoryPreferences) {
-        const documentChanges: L.NotificationChannelPreferences | undefined =
+        const documentChanges: L.NotificationChannelPreferences | undefined | null =
           _notificationCategoryPreferences.documentChanges;
         expect(documentChanges instanceof L.NotificationChannelPreferences);
       } else {
@@ -5300,7 +5335,7 @@ describe("generated", () => {
     /** Test the userSettings_notificationCategoryPreferences model query for UserSettings_NotificationCategoryPreferences_Feed */
     it("userSettings_notificationCategoryPreferences.feed", async () => {
       if (_notificationCategoryPreferences) {
-        const feed: L.NotificationChannelPreferences | undefined = _notificationCategoryPreferences.feed;
+        const feed: L.NotificationChannelPreferences | undefined | null = _notificationCategoryPreferences.feed;
         expect(feed instanceof L.NotificationChannelPreferences);
       } else {
         console.warn(
@@ -5312,7 +5347,7 @@ describe("generated", () => {
     /** Test the userSettings_notificationCategoryPreferences model query for UserSettings_NotificationCategoryPreferences_Mentions */
     it("userSettings_notificationCategoryPreferences.mentions", async () => {
       if (_notificationCategoryPreferences) {
-        const mentions: L.NotificationChannelPreferences | undefined = _notificationCategoryPreferences.mentions;
+        const mentions: L.NotificationChannelPreferences | undefined | null = _notificationCategoryPreferences.mentions;
         expect(mentions instanceof L.NotificationChannelPreferences);
       } else {
         console.warn(
@@ -5324,7 +5359,7 @@ describe("generated", () => {
     /** Test the userSettings_notificationCategoryPreferences model query for UserSettings_NotificationCategoryPreferences_PostsAndUpdates */
     it("userSettings_notificationCategoryPreferences.postsAndUpdates", async () => {
       if (_notificationCategoryPreferences) {
-        const postsAndUpdates: L.NotificationChannelPreferences | undefined =
+        const postsAndUpdates: L.NotificationChannelPreferences | undefined | null =
           _notificationCategoryPreferences.postsAndUpdates;
         expect(postsAndUpdates instanceof L.NotificationChannelPreferences);
       } else {
@@ -5337,7 +5372,8 @@ describe("generated", () => {
     /** Test the userSettings_notificationCategoryPreferences model query for UserSettings_NotificationCategoryPreferences_Reactions */
     it("userSettings_notificationCategoryPreferences.reactions", async () => {
       if (_notificationCategoryPreferences) {
-        const reactions: L.NotificationChannelPreferences | undefined = _notificationCategoryPreferences.reactions;
+        const reactions: L.NotificationChannelPreferences | undefined | null =
+          _notificationCategoryPreferences.reactions;
         expect(reactions instanceof L.NotificationChannelPreferences);
       } else {
         console.warn(
@@ -5349,7 +5385,8 @@ describe("generated", () => {
     /** Test the userSettings_notificationCategoryPreferences model query for UserSettings_NotificationCategoryPreferences_Reminders */
     it("userSettings_notificationCategoryPreferences.reminders", async () => {
       if (_notificationCategoryPreferences) {
-        const reminders: L.NotificationChannelPreferences | undefined = _notificationCategoryPreferences.reminders;
+        const reminders: L.NotificationChannelPreferences | undefined | null =
+          _notificationCategoryPreferences.reminders;
         expect(reminders instanceof L.NotificationChannelPreferences);
       } else {
         console.warn(
@@ -5361,7 +5398,7 @@ describe("generated", () => {
     /** Test the userSettings_notificationCategoryPreferences model query for UserSettings_NotificationCategoryPreferences_Reviews */
     it("userSettings_notificationCategoryPreferences.reviews", async () => {
       if (_notificationCategoryPreferences) {
-        const reviews: L.NotificationChannelPreferences | undefined = _notificationCategoryPreferences.reviews;
+        const reviews: L.NotificationChannelPreferences | undefined | null = _notificationCategoryPreferences.reviews;
         expect(reviews instanceof L.NotificationChannelPreferences);
       } else {
         console.warn(
@@ -5373,7 +5410,7 @@ describe("generated", () => {
     /** Test the userSettings_notificationCategoryPreferences model query for UserSettings_NotificationCategoryPreferences_StatusChanges */
     it("userSettings_notificationCategoryPreferences.statusChanges", async () => {
       if (_notificationCategoryPreferences) {
-        const statusChanges: L.NotificationChannelPreferences | undefined =
+        const statusChanges: L.NotificationChannelPreferences | undefined | null =
           _notificationCategoryPreferences.statusChanges;
         expect(statusChanges instanceof L.NotificationChannelPreferences);
       } else {
@@ -5386,7 +5423,7 @@ describe("generated", () => {
     /** Test the userSettings_notificationCategoryPreferences model query for UserSettings_NotificationCategoryPreferences_Subscriptions */
     it("userSettings_notificationCategoryPreferences.subscriptions", async () => {
       if (_notificationCategoryPreferences) {
-        const subscriptions: L.NotificationChannelPreferences | undefined =
+        const subscriptions: L.NotificationChannelPreferences | undefined | null =
           _notificationCategoryPreferences.subscriptions;
         expect(subscriptions instanceof L.NotificationChannelPreferences);
       } else {
@@ -5399,7 +5436,7 @@ describe("generated", () => {
     /** Test the userSettings_notificationCategoryPreferences model query for UserSettings_NotificationCategoryPreferences_System */
     it("userSettings_notificationCategoryPreferences.system", async () => {
       if (_notificationCategoryPreferences) {
-        const system: L.NotificationChannelPreferences | undefined = _notificationCategoryPreferences.system;
+        const system: L.NotificationChannelPreferences | undefined | null = _notificationCategoryPreferences.system;
         expect(system instanceof L.NotificationChannelPreferences);
       } else {
         console.warn(
@@ -5411,7 +5448,7 @@ describe("generated", () => {
     /** Test the userSettings_notificationCategoryPreferences model query for UserSettings_NotificationCategoryPreferences_Triage */
     it("userSettings_notificationCategoryPreferences.triage", async () => {
       if (_notificationCategoryPreferences) {
-        const triage: L.NotificationChannelPreferences | undefined = _notificationCategoryPreferences.triage;
+        const triage: L.NotificationChannelPreferences | undefined | null = _notificationCategoryPreferences.triage;
         expect(triage instanceof L.NotificationChannelPreferences);
       } else {
         console.warn(
@@ -5423,7 +5460,7 @@ describe("generated", () => {
     /** Test the userSettings model query for UserSettings_NotificationChannelPreferences */
     it("userSettings.notificationChannelPreferences", async () => {
       if (_userSettings) {
-        const notificationChannelPreferences: L.NotificationChannelPreferences | undefined =
+        const notificationChannelPreferences: L.NotificationChannelPreferences | undefined | null =
           _userSettings.notificationChannelPreferences;
         expect(notificationChannelPreferences instanceof L.NotificationChannelPreferences);
       } else {
@@ -5433,12 +5470,12 @@ describe("generated", () => {
       }
     });
 
-    let _notificationDeliveryPreferences: L.NotificationDeliveryPreferences | undefined;
+    let _notificationDeliveryPreferences: L.NotificationDeliveryPreferences | undefined | null;
 
     /** Test the userSettings model query for UserSettings_NotificationDeliveryPreferences */
     it("userSettings.notificationDeliveryPreferences", async () => {
       if (_userSettings) {
-        const notificationDeliveryPreferences: L.NotificationDeliveryPreferences | undefined =
+        const notificationDeliveryPreferences: L.NotificationDeliveryPreferences | undefined | null =
           _userSettings.notificationDeliveryPreferences;
         _notificationDeliveryPreferences = notificationDeliveryPreferences;
         expect(notificationDeliveryPreferences instanceof L.NotificationDeliveryPreferences);
@@ -5449,12 +5486,13 @@ describe("generated", () => {
       }
     });
 
-    let _mobile: L.NotificationDeliveryPreferencesChannel | undefined;
+    let _mobile: L.NotificationDeliveryPreferencesChannel | undefined | null;
 
     /** Test the userSettings_notificationDeliveryPreferences model query for UserSettings_NotificationDeliveryPreferences_Mobile */
     it("userSettings_notificationDeliveryPreferences.mobile", async () => {
       if (_notificationDeliveryPreferences) {
-        const mobile: L.NotificationDeliveryPreferencesChannel | undefined = _notificationDeliveryPreferences.mobile;
+        const mobile: L.NotificationDeliveryPreferencesChannel | undefined | null =
+          _notificationDeliveryPreferences.mobile;
         _mobile = mobile;
         expect(mobile instanceof L.NotificationDeliveryPreferencesChannel);
       } else {
@@ -5464,12 +5502,12 @@ describe("generated", () => {
       }
     });
 
-    let _theme: L.UserSettingsTheme | undefined;
+    let _theme: L.UserSettingsTheme | undefined | null;
 
     /** Test the userSettings model query for UserSettings_Theme */
     it("userSettings.theme", async () => {
       if (_userSettings) {
-        const theme: L.UserSettingsTheme | undefined = _userSettings.theme;
+        const theme: L.UserSettingsTheme | undefined | null = _userSettings.theme;
         _theme = theme;
         expect(theme instanceof L.UserSettingsTheme);
       } else {
@@ -5477,12 +5515,12 @@ describe("generated", () => {
       }
     });
 
-    let _custom: L.UserSettingsCustomTheme | undefined;
+    let _custom: L.UserSettingsCustomTheme | undefined | null;
 
     /** Test the userSettings_theme model query for UserSettings_Theme_Custom */
     it("userSettings_theme.custom", async () => {
       if (_theme) {
-        const custom: L.UserSettingsCustomTheme | undefined = _theme.custom;
+        const custom: L.UserSettingsCustomTheme | undefined | null = _theme.custom;
         _custom = custom;
         expect(custom instanceof L.UserSettingsCustomTheme);
       } else {
@@ -5493,12 +5531,12 @@ describe("generated", () => {
 
   /** Test all User queries */
   describe("Users", () => {
-    let _user: L.User | undefined;
-    let _user_id: string | undefined;
+    let _user: L.User | undefined | null;
+    let _user_id: string | undefined | null;
 
     /** Test the root connection query for the User */
     it("users", async () => {
-      const users: L.UserConnection | undefined = await client.users();
+      const users: L.UserConnection | undefined | null = await client.users();
       const user = users?.nodes?.[0];
       _user_id = user?.id;
       expect(users instanceof L.UserConnection);
@@ -5507,7 +5545,7 @@ describe("generated", () => {
     /** Test the root query for a single User */
     it("user", async () => {
       if (_user_id) {
-        const user: L.User | undefined = await client.user(_user_id);
+        const user: L.User | undefined | null = await client.user(_user_id);
         _user = user;
         expect(user instanceof L.User);
       } else {
@@ -5518,7 +5556,7 @@ describe("generated", () => {
     /** Test the user connection query for the Issue */
     it("user.assignedIssues", async () => {
       if (_user) {
-        const assignedIssues: L.IssueConnection | undefined = await _user.assignedIssues();
+        const assignedIssues: L.IssueConnection | undefined | null = await _user.assignedIssues();
         expect(assignedIssues instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No user found - cannot test _user.assignedIssues query");
@@ -5528,7 +5566,7 @@ describe("generated", () => {
     /** Test the user connection query for the Issue */
     it("user.createdIssues", async () => {
       if (_user) {
-        const createdIssues: L.IssueConnection | undefined = await _user.createdIssues();
+        const createdIssues: L.IssueConnection | undefined | null = await _user.createdIssues();
         expect(createdIssues instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No user found - cannot test _user.createdIssues query");
@@ -5538,7 +5576,7 @@ describe("generated", () => {
     /** Test the user connection query for the Issue */
     it("user.delegatedIssues", async () => {
       if (_user) {
-        const delegatedIssues: L.IssueConnection | undefined = await _user.delegatedIssues();
+        const delegatedIssues: L.IssueConnection | undefined | null = await _user.delegatedIssues();
         expect(delegatedIssues instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No user found - cannot test _user.delegatedIssues query");
@@ -5548,7 +5586,7 @@ describe("generated", () => {
     /** Test the user connection query for the Draft */
     it("user.drafts", async () => {
       if (_user) {
-        const drafts: L.DraftConnection | undefined = await _user.drafts();
+        const drafts: L.DraftConnection | undefined | null = await _user.drafts();
         expect(drafts instanceof L.DraftConnection);
       } else {
         console.warn("codegen-doc:print: No user found - cannot test _user.drafts query");
@@ -5558,7 +5596,7 @@ describe("generated", () => {
     /** Test the user connection query for the TeamMembership */
     it("user.teamMemberships", async () => {
       if (_user) {
-        const teamMemberships: L.TeamMembershipConnection | undefined = await _user.teamMemberships();
+        const teamMemberships: L.TeamMembershipConnection | undefined | null = await _user.teamMemberships();
         expect(teamMemberships instanceof L.TeamMembershipConnection);
       } else {
         console.warn("codegen-doc:print: No user found - cannot test _user.teamMemberships query");
@@ -5568,7 +5606,7 @@ describe("generated", () => {
     /** Test the user connection query for the Team */
     it("user.teams", async () => {
       if (_user) {
-        const teams: L.TeamConnection | undefined = await _user.teams();
+        const teams: L.TeamConnection | undefined | null = await _user.teams();
         expect(teams instanceof L.TeamConnection);
       } else {
         console.warn("codegen-doc:print: No user found - cannot test _user.teams query");
@@ -5578,7 +5616,7 @@ describe("generated", () => {
     /** Test the user.organization query for L.Organization */
     it("user.organization", async () => {
       if (_user) {
-        const user_organization: L.Organization | undefined = await _user.organization;
+        const user_organization: L.Organization | undefined | null = await _user.organization;
         expect(user_organization instanceof L.Organization);
       } else {
         console.warn("codegen-doc:print: No User found - cannot test user.organization query");
@@ -5590,19 +5628,21 @@ describe("generated", () => {
   describe("VerifyGitHubEnterpriseServerInstallation", () => {
     /** Test the root model query for VerifyGitHubEnterpriseServerInstallation */
     it("verifyGitHubEnterpriseServerInstallation", async () => {
-      const verifyGitHubEnterpriseServerInstallation: L.GitHubEnterpriseServerInstallVerificationPayload | undefined =
-        await client.verifyGitHubEnterpriseServerInstallation("mock-integrationId");
+      const verifyGitHubEnterpriseServerInstallation:
+        | L.GitHubEnterpriseServerInstallVerificationPayload
+        | undefined
+        | null = await client.verifyGitHubEnterpriseServerInstallation("mock-integrationId");
       expect(verifyGitHubEnterpriseServerInstallation instanceof L.GitHubEnterpriseServerInstallVerificationPayload);
     });
   });
 
   /** Test Viewer query */
   describe("Viewer", () => {
-    let _viewer: L.User | undefined;
+    let _viewer: L.User | undefined | null;
 
     /** Test the root model query for Viewer */
     it("viewer", async () => {
-      const viewer: L.User | undefined = await client.viewer;
+      const viewer: L.User | undefined | null = await client.viewer;
       _viewer = viewer;
       expect(viewer instanceof L.User);
     });
@@ -5610,7 +5650,7 @@ describe("generated", () => {
     /** Test the viewer connection query for the Issue */
     it("viewer.assignedIssues", async () => {
       if (_viewer) {
-        const assignedIssues: L.IssueConnection | undefined = await _viewer.assignedIssues();
+        const assignedIssues: L.IssueConnection | undefined | null = await _viewer.assignedIssues();
         expect(assignedIssues instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No viewer found - cannot test _viewer.assignedIssues query");
@@ -5620,7 +5660,7 @@ describe("generated", () => {
     /** Test the viewer connection query for the Issue */
     it("viewer.createdIssues", async () => {
       if (_viewer) {
-        const createdIssues: L.IssueConnection | undefined = await _viewer.createdIssues();
+        const createdIssues: L.IssueConnection | undefined | null = await _viewer.createdIssues();
         expect(createdIssues instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No viewer found - cannot test _viewer.createdIssues query");
@@ -5630,7 +5670,7 @@ describe("generated", () => {
     /** Test the viewer connection query for the Issue */
     it("viewer.delegatedIssues", async () => {
       if (_viewer) {
-        const delegatedIssues: L.IssueConnection | undefined = await _viewer.delegatedIssues();
+        const delegatedIssues: L.IssueConnection | undefined | null = await _viewer.delegatedIssues();
         expect(delegatedIssues instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No viewer found - cannot test _viewer.delegatedIssues query");
@@ -5640,7 +5680,7 @@ describe("generated", () => {
     /** Test the viewer connection query for the Draft */
     it("viewer.drafts", async () => {
       if (_viewer) {
-        const drafts: L.DraftConnection | undefined = await _viewer.drafts();
+        const drafts: L.DraftConnection | undefined | null = await _viewer.drafts();
         expect(drafts instanceof L.DraftConnection);
       } else {
         console.warn("codegen-doc:print: No viewer found - cannot test _viewer.drafts query");
@@ -5650,7 +5690,7 @@ describe("generated", () => {
     /** Test the viewer connection query for the TeamMembership */
     it("viewer.teamMemberships", async () => {
       if (_viewer) {
-        const teamMemberships: L.TeamMembershipConnection | undefined = await _viewer.teamMemberships();
+        const teamMemberships: L.TeamMembershipConnection | undefined | null = await _viewer.teamMemberships();
         expect(teamMemberships instanceof L.TeamMembershipConnection);
       } else {
         console.warn("codegen-doc:print: No viewer found - cannot test _viewer.teamMemberships query");
@@ -5660,7 +5700,7 @@ describe("generated", () => {
     /** Test the viewer connection query for the Team */
     it("viewer.teams", async () => {
       if (_viewer) {
-        const teams: L.TeamConnection | undefined = await _viewer.teams();
+        const teams: L.TeamConnection | undefined | null = await _viewer.teams();
         expect(teams instanceof L.TeamConnection);
       } else {
         console.warn("codegen-doc:print: No viewer found - cannot test _viewer.teams query");
@@ -5670,12 +5710,12 @@ describe("generated", () => {
 
   /** Test all Webhook queries */
   describe("Webhooks", () => {
-    let _webhook: L.Webhook | undefined;
-    let _webhook_id: string | undefined;
+    let _webhook: L.Webhook | undefined | null;
+    let _webhook_id: string | undefined | null;
 
     /** Test the root connection query for the Webhook */
     it("webhooks", async () => {
-      const webhooks: L.WebhookConnection | undefined = await client.webhooks();
+      const webhooks: L.WebhookConnection | undefined | null = await client.webhooks();
       const webhook = webhooks?.nodes?.[0];
       _webhook_id = webhook?.id;
       expect(webhooks instanceof L.WebhookConnection);
@@ -5684,7 +5724,7 @@ describe("generated", () => {
     /** Test the root query for a single Webhook */
     it("webhook", async () => {
       if (_webhook_id) {
-        const webhook: L.Webhook | undefined = await client.webhook(_webhook_id);
+        const webhook: L.Webhook | undefined | null = await client.webhook(_webhook_id);
         _webhook = webhook;
         expect(webhook instanceof L.Webhook);
       } else {
@@ -5695,7 +5735,7 @@ describe("generated", () => {
     /** Test the webhook.creator query for L.User */
     it("webhook.creator", async () => {
       if (_webhook) {
-        const webhook_creator: L.User | undefined = await _webhook.creator;
+        const webhook_creator: L.User | undefined | null = await _webhook.creator;
         expect(webhook_creator instanceof L.User);
       } else {
         console.warn("codegen-doc:print: No Webhook found - cannot test webhook.creator query");
@@ -5705,7 +5745,7 @@ describe("generated", () => {
     /** Test the webhook.team query for L.Team */
     it("webhook.team", async () => {
       if (_webhook) {
-        const webhook_team: L.Team | undefined = await _webhook.team;
+        const webhook_team: L.Team | undefined | null = await _webhook.team;
         expect(webhook_team instanceof L.Team);
       } else {
         console.warn("codegen-doc:print: No Webhook found - cannot test webhook.team query");
@@ -5715,12 +5755,12 @@ describe("generated", () => {
 
   /** Test all WorkflowState queries */
   describe("WorkflowStates", () => {
-    let _workflowState: L.WorkflowState | undefined;
-    let _workflowState_id: string | undefined;
+    let _workflowState: L.WorkflowState | undefined | null;
+    let _workflowState_id: string | undefined | null;
 
     /** Test the root connection query for the WorkflowState */
     it("workflowStates", async () => {
-      const workflowStates: L.WorkflowStateConnection | undefined = await client.workflowStates();
+      const workflowStates: L.WorkflowStateConnection | undefined | null = await client.workflowStates();
       const workflowState = workflowStates?.nodes?.[0];
       _workflowState_id = workflowState?.id;
       expect(workflowStates instanceof L.WorkflowStateConnection);
@@ -5729,7 +5769,7 @@ describe("generated", () => {
     /** Test the root query for a single WorkflowState */
     it("workflowState", async () => {
       if (_workflowState_id) {
-        const workflowState: L.WorkflowState | undefined = await client.workflowState(_workflowState_id);
+        const workflowState: L.WorkflowState | undefined | null = await client.workflowState(_workflowState_id);
         _workflowState = workflowState;
         expect(workflowState instanceof L.WorkflowState);
       } else {
@@ -5740,7 +5780,7 @@ describe("generated", () => {
     /** Test the workflowState connection query for the Issue */
     it("workflowState.issues", async () => {
       if (_workflowState) {
-        const issues: L.IssueConnection | undefined = await _workflowState.issues();
+        const issues: L.IssueConnection | undefined | null = await _workflowState.issues();
         expect(issues instanceof L.IssueConnection);
       } else {
         console.warn("codegen-doc:print: No workflowState found - cannot test _workflowState.issues query");
@@ -5750,7 +5790,7 @@ describe("generated", () => {
     /** Test the workflowState.inheritedFrom query for L.WorkflowState */
     it("workflowState.inheritedFrom", async () => {
       if (_workflowState) {
-        const workflowState_inheritedFrom: L.WorkflowState | undefined = await _workflowState.inheritedFrom;
+        const workflowState_inheritedFrom: L.WorkflowState | undefined | null = await _workflowState.inheritedFrom;
         expect(workflowState_inheritedFrom instanceof L.WorkflowState);
       } else {
         console.warn("codegen-doc:print: No WorkflowState found - cannot test workflowState.inheritedFrom query");
@@ -5760,7 +5800,7 @@ describe("generated", () => {
     /** Test the workflowState.team query for L.Team */
     it("workflowState.team", async () => {
       if (_workflowState) {
-        const workflowState_team: L.Team | undefined = await _workflowState.team;
+        const workflowState_team: L.Team | undefined | null = await _workflowState.team;
         expect(workflowState_team instanceof L.Team);
       } else {
         console.warn("codegen-doc:print: No WorkflowState found - cannot test workflowState.team query");


### PR DESCRIPTION
GraphQL can send `null` values for nullable fields, not only `undefined`. This PR updates our types to reflect that by introducing an explicit `| null` to all generated nullable fields. I think this should be a relatively safe change to make, and not break backwards compatability. Consider the following code:

```js
const issue = await linearClient.issue('LIN-123');
if (issue.assigneeId !== undefined) {
  await notifyAssignee(issue.assigneeId)
}
```

This code will now raise a type error because the nullcase now falls though to `notifyAssignee`, but because we were already always sending that `null` at runtime, the behavior hasn't changed, only the type-checking. If any code is actually broken by the new types, it's likely a bug where code wasn't working in the past. For this reason I attached a minor version bump, rather than a major one.

Also note this diff is quite large, but is mostly generated changes!
