### PR TITLE
Add write permissions for issues and PRs to stale checker

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,6 +7,10 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v10
         with:


### PR DESCRIPTION
Adds the [recommended permissions](https://github.com/actions/stale?tab=readme-ov-file#recommended-permissions) for the stale issue and PR checker. Missed this when the dry-run passed because it didn't attempt to create a comment or close the issue, and was silently failing instead of loudly. This should add the appropriate permissions to the token being used by the stale checker to actually comment on and close issues / PRs.
