### PR TITLE
Immidiately close stale issues rather than waiting a week

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -11,5 +11,6 @@ jobs:
       - uses: actions/stale@v10
         with:
           days-before-stale: 180
+          days-before-close: 0
           stale-issue-message: "This issue has seen no recent activity and has been automatically closed for house-keeping purposes."
           stale-pr-message: "This PR has seen no recent activity and has been automatically closed for house-keeping purposes."


### PR DESCRIPTION
The stale issue bot leaves the following message:

> This issue has seen no recent activity and has been automatically closed for house-keeping purposes.

However this is not accurate because by default it waits a week to close the issue. This PR updates the bot to immidiately close issues and PRs to avoid confusion. 
