### PR TITLE
Publish git tags on release

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "pnpm -r test",
     "update:dependencies": "pnpm up && pnpm run -r generate:changeset:dependencies",
     "update:schema": "pnpm run -r generate:schema && pnpm run -r generate:changeset:schema",
-    "ci:publish": "pnpm publish -r"
+    "ci:publish": "pnpm publish -r && changeset tag"
   },
   "devDependencies": {
     "@changesets/cli": "^2.14.1",


### PR DESCRIPTION
When I [updated the repo to use `pnpm publish -r`](https://github.com/linear/linear/pull/982) to publish packages, it removed the default functionality of `changesets` to create and push git tags when releasing. `changesets/actions` does this by [scanning the script output for tags to create](https://github.com/changesets/action/blob/master/src/run.ts#L91). This PR attempts to fix the issue by running `changesets tag` after publishing, such that this can be picked up the GitHub action. 
