### PR TITLE
chore: include timestamp value in invalid timestamp error

### DIFF
--- a/packages/sdk/src/webhooks/client.ts
+++ b/packages/sdk/src/webhooks/client.ts
@@ -280,7 +280,7 @@ export class LinearWebhookClient {
     if (timestamp) {
       const timestampMs = typeof timestamp === "string" ? parseInt(timestamp, 10) : timestamp;
       if (isNaN(timestampMs)) {
-        throw new Error("Invalid webhook timestamp");
+        throw new Error(`Invalid webhook timestamp: ${timestamp}`);
       }
       const timeDiff = Math.abs(new Date().getTime() - timestampMs);
       // Throw error if more than one minute delta between provided ts and current time


### PR DESCRIPTION
Including feedback from https://linear.app/linear/review/featwebhooks-support-linear-timestamp-header-f24c3ea9eb2e#comment-14762cb4