### PR TITLE
feat(import): add idShort field to Trello JSON importer

### DIFF
--- a/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
+++ b/packages/import/src/importers/trelloJson/TrelloJsonImporter.ts
@@ -20,6 +20,7 @@ interface TrelloCard {
   }[];
   id: string;
   idList: string;
+  idShort?: number;
 }
 
 interface TrelloList {
@@ -139,9 +140,10 @@ export class TrelloJsonImporter implements Importer {
         .join("\n");
       const cardList = trelloLists.find(list => list.id === card.idList);
 
+      const cardIdInfo = card.idShort !== undefined ? `Trello Card #${card.idShort} | ` : "";
       const description = `${mdDesc}${formattedChecklists && `\n\nChecklists:\n${formattedChecklists}`}${
         formattedAttachments && `\n\nAttachments:\n${formattedAttachments}`
-      }\n\n[View original card in Trello](${url})`;
+      }\n\n${cardIdInfo}[View original card in Trello](${url})`;
       const labels = card.labels?.map(l => l.id);
 
       if (this.discardArchivedCards && card.closed) {


### PR DESCRIPTION
## Summary

Include the Trello card's `idShort` field in the imported issue description, allowing users to reference their original Trello card numbers after migration.

## Changes

- Add `idShort` (optional number) to the `TrelloCard` interface
- Include the card number in the description footer when available (e.g., `Trello Card #42 | [View original card in Trello](url)`)
- Handle cards without `idShort` gracefully (no card number shown)

## Example Output

**Card with idShort:**
```
Trello Card #42 | [View original card in Trello](https://trello.com/c/abc123)
```

**Card without idShort:**
```
[View original card in Trello](https://trello.com/c/abc123)
```

## Testing

- [x] Ran lint (`pnpm lint`)
- [x] Ran build (`pnpm build`)
- [x] Ran tests (`pnpm test`)
- [x] Manually verified with sample Trello JSON export

Closes #974