### PR TITLE
chore: fix unhandled rejection in bundle test and improve test assertions

### DIFF
--- a/packages/sdk/src/_tests/LinearClient.test.ts
+++ b/packages/sdk/src/_tests/LinearClient.test.ts
@@ -54,8 +54,9 @@ describe("LinearClient", () => {
 
     try {
       await client.viewer;
+      expect.unreachable("Expected an authentication error");
     } catch (error) {
-      expect(error.message).toEqual(expect.stringContaining("GraphQL Error (Code: 401) - Unauthorized"));
+      expect(error.message).toContain("GraphQL Error (Code: 401) - Unauthorized");
       expect(error.type).toEqual(LinearErrorType.AuthenticationError);
     }
   });
@@ -65,8 +66,9 @@ describe("LinearClient", () => {
 
     try {
       await client.rawRequest("");
+      expect.unreachable("Expected an authentication error");
     } catch (error) {
-      expect(error.message).toEqual(expect.stringContaining("GraphQL Error (Code: 401) - Unauthorized"));
+      expect(error.message).toContain("GraphQL Error (Code: 401) - Unauthorized");
       expect(error.type).toEqual(LinearErrorType.AuthenticationError);
     }
   });

--- a/packages/sdk/src/_tests/LinearSdk.test.ts
+++ b/packages/sdk/src/_tests/LinearSdk.test.ts
@@ -59,8 +59,9 @@ describe("LinearSdk", () => {
 
     try {
       await sdk.viewer;
+      expect.unreachable("Expected an error");
     } catch (error: any) {
-      expect(error.message).toEqual(expect.stringContaining("test error"));
+      expect(error.message).toContain("test error");
     }
   });
 });

--- a/packages/sdk/src/_tests/bundle.test.ts
+++ b/packages/sdk/src/_tests/bundle.test.ts
@@ -28,10 +28,11 @@ function uuid() {
 async function expectError(shouldError: () => unknown, type: LinearErrorType, message: string) {
   try {
     await shouldError();
+    expect.unreachable("Expected an error");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
     expect(error.type).toEqual(type);
-    expect(error.message).toEqual(expect.stringContaining(message));
+    expect(error.message).toContain(message);
   }
 }
 
@@ -89,7 +90,7 @@ Object.entries(bundles).map(([bundleFormat, bundle]) =>
     it("throw auth error", async () => {
       const client = new ClientConstructor({ apiKey: "fake api key" });
 
-      expectError(
+      await expectError(
         () => client.viewer,
         LinearErrorType.AuthenticationError,
         "Authentication required, not authenticated - You need to authenticate to access this operation."
@@ -106,8 +107,8 @@ Object.entries(bundles).map(([bundleFormat, bundle]) =>
         await getSomeTeam();
       });
 
-      it("query for fake team", async () => {
-        expectError(
+      it.skipIf(!process.env.E2E)("query for fake team", async () => {
+        await expectError(
           () => linearClient.team("not a real team id"),
           LinearErrorType.InvalidInput,
           "Entity not found - Could not find referenced Team"
@@ -118,8 +119,8 @@ Object.entries(bundles).map(([bundleFormat, bundle]) =>
         await getSomeIssue();
       });
 
-      it("query for fake issue", async () => {
-        expectError(
+      it.skipIf(!process.env.E2E)("query for fake issue", async () => {
+        await expectError(
           () => linearClient.issue("not a real issue id"),
           LinearErrorType.InvalidInput,
           "Entity not found - Could not find referenced Issue"


### PR DESCRIPTION
- Await `expectError` calls in bundle.test.ts to prevent unhandled rejections, which could lead to CI flaking/errors (since the validation code implicity ran as fire-and-forget). 
- Skip mock-incompatible error tests in non-E2E mode, since graphql-faker returns fake data for any input. We weren't catching these seemingly due to the above ^, not awaiting the code that validated things.
- Add `expect.unreachable()` guards and simplify `toContain` assertions across bundle, LinearClient, and LinearSdk tests.

It's _possible_ there's some real transient failure that happens with the `AuthenticationError` depending on Linear's GQL response, but we'll be able to better pinpoint after these fixes regardless. We may want to avoid making a request to the real API for that anyway.