### PR TITLE
Allow to import tickets from ClickUp

### DIFF
--- a/packages/import/src/cli.ts
+++ b/packages/import/src/cli.ts
@@ -4,6 +4,7 @@ import inquirer from "inquirer";
 import inquirerFilePath from "inquirer-file-path";
 import { importIssues } from "./importIssues.ts";
 import { asanaCsvImport } from "./importers/asanaCsv/index.ts";
+import { clickupCsvImport } from "./importers/clickupCsv/index.ts";
 import { githubImport } from "./importers/github/index.ts";
 import { gitlabCsvImporter } from "./importers/gitlabCsv/index.ts";
 import { jiraCsvImport } from "./importers/jiraCsv/index.ts";
@@ -45,6 +46,10 @@ inquirer.registerPrompt("filePath", inquirerFilePath);
             value: "asanaCsv",
           },
           {
+            name: "ClickUp (CSV export)",
+            value: "clickupCsv",
+          },
+          {
             name: "Pivotal (CSV export)",
             value: "pivotalCsv",
           },
@@ -78,6 +83,9 @@ inquirer.registerPrompt("filePath", inquirerFilePath);
         break;
       case "asanaCsv":
         importer = await asanaCsvImport();
+        break;
+      case "clickupCsv":
+        importer = await clickupCsvImport();
         break;
       case "pivotalCsv":
         importer = await pivotalCsvImport();

--- a/packages/import/src/importers/clickupCsv/ClickupImporter.ts
+++ b/packages/import/src/importers/clickupCsv/ClickupImporter.ts
@@ -1,0 +1,270 @@
+import csv from "csvtojson";
+
+import type { Comment, Importer, ImportResult, IssuePriority, IssueStatus } from "../../types.ts";
+
+/**
+ * ClickUp CSV export rows. Some column names carry a leading space
+ * (e.g. " Task Name") depending on the export, so we access them via
+ * a helper that tries both variants.
+ */
+interface ClickupRow {
+  [key: string]: string;
+}
+
+// — helpers ——————————————————————————————————————————————————————————————
+
+/** Access a CSV column value, tolerating a leading-space variant of the key. */
+const col = (row: ClickupRow, name: string): string => {
+  const raw = row[name] ?? row[` ${name}`] ?? "";
+  return raw.trim();
+};
+
+/**
+ * ClickUp exports array-like fields as `[value1, value2]`.
+ * Parse that into a trimmed string array, filtering empties.
+ */
+const parseArray = (value: string): string[] => {
+  if (!value || value === "[]") {
+    return [];
+  }
+  // Strip surrounding brackets then split on comma
+  const inner = value.replace(/^\[/, "").replace(/\]$/, "");
+  return inner
+    .split(",")
+    .map(s => s.trim())
+    .filter(Boolean);
+};
+
+/** Map ClickUp numeric priority (1 = Urgent … 4 = Low) to Linear priority. */
+const mapPriority = (value: string): IssuePriority => {
+  switch (value) {
+    case "1":
+      return 1; // Urgent  → Linear Urgent
+    case "2":
+      return 2; // High    → Linear High
+    case "3":
+      return 3; // Normal  → Linear Medium
+    case "4":
+      return 4; // Low     → Linear Low
+    default:
+      return 0; // null / missing → No priority
+  }
+};
+
+/** Map a ClickUp status string to a Linear status category. */
+const mapStatusType = (status: string): IssueStatus => {
+  const s = status.toLowerCase();
+  if (["done", "shipped", "closed", "complete", "completed"].some(k => s.includes(k))) {
+    return "completed";
+  }
+  if (["cancel", "reject", "void"].some(k => s.includes(k))) {
+    return "canceled";
+  }
+  if (
+    ["in progress", "in development", "in design", "in review", "testing", "qa", "validation", "blocked"].some(k =>
+      s.includes(k)
+    )
+  ) {
+    return "started";
+  }
+  if (["to do", "todo", "open"].some(k => s.includes(k))) {
+    return "unstarted";
+  }
+  return "backlog";
+};
+
+/**
+ * Map a ClickUp status to a standard Linear workflow state name.
+ * These names match the default states created with a new Linear team,
+ * so `importIssues` will find them by name and skip creating new ones.
+ */
+const mapToStandardLinearStatus = (status: string): string => {
+  switch (mapStatusType(status)) {
+    case "completed":
+      return "Done";
+    case "canceled":
+      return "Canceled";
+    case "started":
+      return "In Progress";
+    case "unstarted":
+      return "Todo";
+    case "backlog":
+    default:
+      return "Backlog";
+  }
+};
+
+/** Parse a millisecond-epoch timestamp string into a Date (or undefined). */
+const msToDate = (value: string): Date | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  const n = Number(value);
+  if (Number.isNaN(n) || n <= 0) {
+    return undefined;
+  }
+  return new Date(n);
+};
+
+interface ClickupComment {
+  text?: string;
+  by?: string;
+  date?: string;
+  resolved?: string;
+}
+
+/** Best-effort parse of the Comments JSON column. */
+const parseComments = (value: string): Comment[] => {
+  if (!value || value === "[]") {
+    return [];
+  }
+  try {
+    const arr: ClickupComment[] = JSON.parse(value);
+    return arr
+      .filter(c => c.text)
+      .map(c => ({
+        body: c.text,
+        userId: c.by ?? "Unknown",
+        createdAt: c.date ? new Date(c.date) : undefined,
+      }));
+  } catch {
+    return [];
+  }
+};
+
+// — importer —————————————————————————————————————————————————————————————
+
+/** Options controlling how the ClickUp CSV import behaves. */
+export interface ClickupImportOptions {
+  /** When true, tags / list / space labels are included and will be created in Linear. */
+  createLabels: boolean;
+  /** When true, ClickUp statuses are imported as-is. When false, they are mapped to standard Linear statuses. */
+  importStatuses: boolean;
+}
+
+/**
+ * Import issues from a ClickUp CSV export.
+ *
+ * @param filePath  Path to the exported CSV file
+ * @param options   Import behaviour options
+ */
+export class ClickupCsvImporter implements Importer {
+  public constructor(
+    private filePath: string,
+    private options: ClickupImportOptions
+  ) {}
+
+  public get name(): string {
+    return "ClickUp (CSV)";
+  }
+
+  public get defaultTeamName(): string {
+    return "ClickUp";
+  }
+
+  public import = async (): Promise<ImportResult> => {
+    const data = (await csv().fromFile(this.filePath)) as ClickupRow[];
+
+    const importData: ImportResult = {
+      issues: [],
+      labels: {},
+      users: {},
+      statuses: {},
+    };
+
+    for (const row of data) {
+      const taskId = col(row, "Task ID");
+      const customId = col(row, "Task Custom ID");
+      const title = col(row, "Task Name");
+      const description = col(row, "Task Content") || undefined;
+      const rawStatus = col(row, "Status");
+      const status = this.options.importStatuses ? rawStatus : mapToStandardLinearStatus(rawStatus);
+      const priority = mapPriority(col(row, "Priority"));
+      const assignees = parseArray(col(row, "Assignees"));
+      const tags = this.options.createLabels ? parseArray(col(row, "Tags")) : [];
+      const listName = this.options.createLabels ? col(row, "List Name") : "";
+      const spaceName = this.options.createLabels ? col(row, "Space Name") : "";
+      const createdAt = msToDate(col(row, "Date Created"));
+      const dueDate = msToDate(col(row, "Due Date"));
+      const startedAt = msToDate(col(row, "Start Date"));
+      const comments = parseComments(col(row, "Comments"));
+
+      // Build the URL — prefer custom ID if present
+      const displayId = customId || taskId;
+      const url = taskId ? `https://app.clickup.com/t/${taskId}` : undefined;
+
+      // Collect users
+      for (const name of assignees) {
+        if (!importData.users[name]) {
+          importData.users[name] = { name };
+        }
+      }
+      // Collect users from comments
+      for (const c of comments) {
+        if (c.userId && !importData.users[c.userId]) {
+          importData.users[c.userId] = { name: c.userId };
+        }
+      }
+
+      // Collect labels from tags
+      for (const tag of tags) {
+        if (!importData.labels[tag]) {
+          importData.labels[tag] = { name: tag };
+        }
+      }
+
+      // Add List Name and Space Name as labels for grouping context
+      const labels: string[] = [...tags];
+      if (listName) {
+        const listLabel = `List: ${listName}`;
+        labels.push(listLabel);
+        if (!importData.labels[listLabel]) {
+          importData.labels[listLabel] = { name: listLabel };
+        }
+      }
+      if (spaceName) {
+        const spaceLabel = `Space: ${spaceName}`;
+        labels.push(spaceLabel);
+        if (!importData.labels[spaceLabel]) {
+          importData.labels[spaceLabel] = { name: spaceLabel };
+        }
+      }
+
+      // Collect statuses (only when importing custom statuses)
+      if (this.options.importStatuses && status && importData.statuses && !importData.statuses[status]) {
+        importData.statuses[status] = {
+          name: status,
+          type: mapStatusType(status),
+        };
+      }
+
+      // Build description with link back to ClickUp
+      const descriptionParts: string[] = [];
+      if (description) {
+        descriptionParts.push(description);
+      }
+      if (url) {
+        descriptionParts.push(`[View original issue in ClickUp](${url})`);
+      }
+      if (customId) {
+        descriptionParts.push(`ClickUp ID: ${displayId}`);
+      }
+
+      importData.issues.push({
+        title,
+        description: descriptionParts.length > 0 ? descriptionParts.join("\n\n") : undefined,
+        status: status || undefined,
+        priority,
+        url,
+        assigneeId: assignees.length > 0 ? assignees[0] : undefined,
+        labels,
+        comments: comments.length > 0 ? comments : undefined,
+        createdAt,
+        dueDate,
+        startedAt,
+      });
+    }
+
+    return importData;
+  };
+}

--- a/packages/import/src/importers/clickupCsv/index.ts
+++ b/packages/import/src/importers/clickupCsv/index.ts
@@ -1,0 +1,42 @@
+import inquirer from "inquirer";
+
+import type { Importer } from "../../types.ts";
+import { ClickupCsvImporter } from "./ClickupImporter.ts";
+
+const BASE_PATH = process.cwd();
+
+export const clickupCsvImport = async (): Promise<Importer> => {
+  const answers = await inquirer.prompt<ClickupImportAnswers>(questions);
+  return new ClickupCsvImporter(answers.csvFilePath, {
+    createLabels: answers.createLabels,
+    importStatuses: answers.importStatuses,
+  });
+};
+
+interface ClickupImportAnswers {
+  csvFilePath: string;
+  createLabels: boolean;
+  importStatuses: boolean;
+}
+
+const questions = [
+  {
+    basePath: BASE_PATH,
+    type: "filePath",
+    name: "csvFilePath",
+    message: "Select your exported CSV file of ClickUp issues",
+  },
+  {
+    type: "confirm",
+    name: "createLabels",
+    message: "Do you want to create missing labels from ClickUp tags, lists, and spaces?",
+    default: true,
+  },
+  {
+    type: "confirm",
+    name: "importStatuses",
+    message:
+      "Do you want to import ClickUp statuses as-is? (If no, they will be mapped to standard Linear statuses: Backlog, Todo, In Progress, Done, Canceled)",
+    default: false,
+  },
+];


### PR DESCRIPTION
#### Summary

Adds a new **ClickUp (CSV export)** option to the `linear-import` CLI, allowing users to import issues from a ClickUp CSV export into Linear. The importer handles the specific quirks of the ClickUp export format (leading-space column names, bracket-wrapped arrays, millisecond-epoch timestamps, numeric priorities) and gives users control over how labels and statuses are imported.

### Changes

**New/rewritten files:**

- Full implementation of `ClickupCsvImporter`,  it handles:
  - Column name normalization (ClickUp exports have inconsistent leading spaces)
  - Mapping numeric priorities (`1`–`4` / `null`) → Linear's `IssuePriority` (0–4)
  - Parsing millisecond-epoch timestamps for `createdAt`, `dueDate`, `startedAt`
  - Best-effort JSON parsing of the `Comments` column
  - Mapping 16+ ClickUp statuses to Linear's 5 status categories
  - Appending ClickUp link and custom ID to issue descriptions

**Modified files:**

- **`packages/import/src/cli.ts`** — Registered `"ClickUp (CSV export)"` in the service selection menu and switch statement

### Import options

| Prompt | Default | Yes | No |
|---|---|---|---|
| Create missing labels? | Yes | Tags, `List: <name>`, `Space: <name>` labels are created in Linear | Labels are omitted from all imported issues |
| Import statuses as-is? | No | ClickUp statuses (e.g. `in development`, `qa`, `scoping`) are created as new workflow states | Statuses are mapped to standard Linear states: `Backlog`, `Todo`, `In Progress`, `Done`, `Canceled` |

### Example CLI output

Input your Linear API key (
https://linear.app/settings/account/security
): lin_api_•••
Which service would you like to import from? → ClickUp (CSV export)
Select your exported CSV file of ClickUp issues: clickup-export-osi-all.csv
Do you want to create missing labels from ClickUp tags, lists, and spaces? → Yes
Do you want to import ClickUp statuses as-is? → No
Do you want to create a new team for imported issues? → No
Import into team: [ENG] Engineering
Do you want to include comments in the issue description? → Yes
Do you want to assign these issues to yourself? → No
Assign to user: [Provided assignee]
████████████████████████████████████████ 100% | 682/682
✅ ClickUp (CSV) issues imported to your team: 
https://linear.app/team/ENG/all


### Status mapping reference

| ClickUp status | Linear category | Linear state (when mapped) |
|---|---|---|
| `backlog`, `scoping` | backlog | `Backlog` |
| `to do`, `open`, `Open` | unstarted | `Todo` |
| `in progress`, `in development`, `in design`, `in review`, `testing`, `qa`, `validation`, `blocked` | started | `In Progress` |
| `done`, `shipped`, `Closed` | completed | `Done` |
| `cancelled` | canceled | `Canceled` |

### Example of successful import:

<img width="1392" height="210" alt="image" src="https://github.com/user-attachments/assets/706c0dd6-731f-4cb1-bfa4-09f8329bf89d" />
