### PR TITLE
fix(sdk): skip OverlappingFieldsCanBeMerged validation rule in codegen

### DIFF
--- a/packages/sdk/codegen.sdk.yml
+++ b/packages/sdk/codegen.sdk.yml
@@ -7,6 +7,12 @@ hooks:
 config:
   documentFile: ./_generated_documents
   dedupeFragments: true
+  # graphql-js v15's OverlappingFieldsCanBeMerged rule incorrectly flags field type conflicts between
+  # distinct concrete types in a union (e.g. differing nullability on `args` subfields across
+  # AiConversation*ToolCall types). These can never overlap at runtime. Fixed in graphql-js v16+.
+  skipDocumentsValidation:
+    ignoreRules:
+      - OverlappingFieldsCanBeMerged
   skipComments:
     - "[Internal]"
     - "[INTERNAL]"

--- a/packages/sdk/codegen.test.yml
+++ b/packages/sdk/codegen.test.yml
@@ -6,6 +6,9 @@ hooks:
     - prettier --write
 config:
   dedupeFragments: true
+  skipDocumentsValidation:
+    ignoreRules:
+      - OverlappingFieldsCanBeMerged
   skipComments:
     - "[Internal]"
     - "[INTERNAL]"


### PR DESCRIPTION
The daily schema workflow fails because graphql-js v15's `OverlappingFieldsCanBeMerged` validation rule incorrectly flags field type conflicts between distinct concrete types in a union — e.g. differing nullability on `args` subfields across `AiConversation*ToolCall` union members. These fields can never overlap at runtime (this is a known v15 limitation, fixed in graphql-js v16+).

Adds `skipDocumentsValidation.ignoreRules` for this rule in both `codegen.sdk.yml` and `codegen.test.yml`.