### PR TITLE
fix: skip OverlappingFieldsCanBeMerged validation for union type conflicts

### DIFF
--- a/packages/sdk/codegen.sdk.yml
+++ b/packages/sdk/codegen.sdk.yml
@@ -7,6 +7,13 @@ hooks:
 config:
   documentFile: ./_generated_documents
   dedupeFragments: true
+  # Skip OverlappingFieldsCanBeMerged validation: union types like AiConversationToolCall
+  # have members with shared field names (e.g. args.type) that differ in nullability across
+  # concrete types. graphql-js flags these as conflicts even though they're on mutually
+  # exclusive types and can never overlap at runtime.
+  skipDocumentsValidation:
+    ignoreRules:
+      - OverlappingFieldsCanBeMergedRule
   skipComments:
     - "[Internal]"
     - "[INTERNAL]"

--- a/packages/sdk/codegen.test.yml
+++ b/packages/sdk/codegen.test.yml
@@ -6,6 +6,9 @@ hooks:
     - prettier --write
 config:
   dedupeFragments: true
+  skipDocumentsValidation:
+    ignoreRules:
+      - OverlappingFieldsCanBeMergedRule
   skipComments:
     - "[Internal]"
     - "[INTERNAL]"


### PR DESCRIPTION
Skip `OverlappingFieldsCanBeMergedRule` document validation in SDK and test codegen configs to fix the daily schema CI workflow

The API schema includes union types (e.g. `AiConversationToolCall`, `AiConversationWidget`) whose concrete members share field names like `args` but with intentionally different nullability on sub-fields:

| **Field** | **Type A** | **Type B** |
| -- | -- | -- |
| `args.type` | `String!` (CreateEntity) | `String` (SearchEntities) |
| `args.entity` | `Entity!` (DeleteEntity, UpdateEntity, …) | `Entity` (QueryUpdates) |
| `args.entities` | `[Entity!]!` (RetrieveEntities) | `[Entity!]` (QueryActivity) |
| `args.query` | `String!` (Research) | `String` (SuggestValues, WebSearch) |
| `args.action` | `EntityCardWidgetArgsAction` | `EntityListWidgetArgsAction` |

These nullability differences are correct — they match the Zod source-of-truth definitions in `linear-app/common/src/models/AiConversationTool.ts` where some fields are `.optional()`and others are required depending on the tool.

graphql-js’s `OverlappingFieldsCanBeMergedRule` flags these as conflicts because it checks type compatibility even for fields on mutually exclusive concrete types within a union. Since two different union members can never appear in the same response object, the fields can never actually overlap at runtime — the validation is overly strict for this pattern.

Fixes [LIN-62389](https://linear.app/linear/issue/LIN-62389/sdk-ci-check-fails-on-master-branch)