### PR TITLE
Fix Slack chat.unfurl error_processing_metadata errors

### DIFF
--- a/api/src/eventbus/tasks/slack/RespondSlackUnfurlTask.ts
+++ b/api/src/eventbus/tasks/slack/RespondSlackUnfurlTask.ts
@@ -1,0 +1,534 @@
+import type { Block, KnownBlock, MessageAttachment } from "@slack/bolt";
+import type { ChatUnfurlArguments, ChatUnfurlResponse } from "@slack/web-api";
+import pick from "lodash/pick";
+import { ClientUrlHelper } from "@linear/common/urls/ClientUrlHelper";
+import { RoutePaths, findMatchingRoute, parseIdOrSlugId } from "@linear/common/Routes";
+import { Slack } from "~/services/slack/Slack";
+import { Logger } from "~/logging/Logger";
+import {
+  presentIssuePayload,
+  presentSlackAgentSession,
+  presentSlackCommentCreated,
+  presentSlackCustomView,
+  presentSlackDocument,
+  presentSlackInitiative,
+  presentSlackProject,
+} from "~/services/slack/slackPayloads";
+import { presentSlackPullRequest } from "~/services/slack/slackPayloadsForPullRequests";
+import { sectionBlockForText } from "~/services/slack/slackPayloadBlocks";
+import {
+  AgentSession,
+  Comment,
+  CustomView,
+  FileUpload,
+  Integration,
+  IntegrationService,
+  Issue,
+  Project,
+  ProjectUpdate,
+  Document,
+  Initiative,
+  InitiativeUpdate,
+  PullRequest,
+} from "~/entity";
+import { Flags } from "~/flags";
+import { URLParseHelper } from "~/utils/URLParseHelper";
+import type { Context } from "~/auth/Context";
+import { Config } from "~/config/Config";
+import { escapeTextForSlackLink } from "~/utils/strings";
+import { Iframely } from "~/services/iframely/Iframely";
+import { ScheduledTask, Task } from "~/eventbus/tasks/base/ScheduledTask";
+import { getActionsToExcludeForIssue } from "~/services/slack/slackWorkObjectsPayloads";
+import {
+  generateProjectWorkObjectsEntities,
+  generateInitiativeWorkObjectsEntities,
+  generateIssueWorkObjectsEntities,
+  generateDocumentWorkObjectsEntities,
+  generatePullRequestWorkObjectsEntities,
+} from "~/services/slack/generateWorkObjectsEntities";
+import { SlackHelper } from "~/services/slack/SlackHelper";
+import { findHeadingNameByHash } from "~/services/slack/slackHeadingHelper";
+
+type Props = {
+  /** URLs to unfurl */
+  urls: string[];
+  /** Slack integration ID */
+  integrationId: string;
+  /** Slack channel ID */
+  channel: string;
+  /** Slack message timestamp */
+  messageTs: string;
+  /** Slack thread timestamp */
+  threadTs?: string;
+  /** Whether the unfurl is being triggered by Slack Workflow Builder */
+  isSlackWorkflowBuilder?: boolean;
+};
+
+/**
+ * A task that responds to Slack unfurl requests.
+ */
+@Task()
+export class RespondSlackUnfurlTask extends ScheduledTask<Props> {
+  /** @inheritdoc */
+  public readonly retryStrategy = "defaultExternal";
+
+  /**
+   * Executes the task.
+   * @param {Context} context - The execution context.
+   * @param {Props} props - The task properties.
+   * @returns {Promise<void>} - A promise that resolves when the task is executed.
+   */
+  public override async execute(context: Context, props: Props): Promise<void> {
+    const { urls, integrationId, channel, messageTs, threadTs, isSlackWorkflowBuilder } = props;
+
+    const integration = await Integration.findByIdOrFail(context, integrationId, { includeArchived: false });
+
+    if (integration.organizationId === "cf73833b-ec2a-4656-b1c7-2468c8b1e5f4") {
+      Logger.info("integrations", "Running RespondSlackUnfurlTask for Leela's test workspace", context, {
+        urls,
+        integration: pick(integration, ["id", "service", "serviceId"]),
+      });
+    }
+
+    // Skip unfurling if the message is addressed to the main Slack bot
+    const isAddressedToBot = await SlackHelper.isMessageAddressedToMainSlackBot(
+      context,
+      integration,
+      channel,
+      messageTs,
+      threadTs
+    );
+    if (isAddressedToBot) {
+      return;
+    }
+
+    const canUseWorkObjects = integration.canUseWorkObjects;
+    const [
+      canUseProjectWorkObjects,
+      canUseInitiativeWorkObjects,
+      canUseDocumentWorkObjects,
+      canUsePullRequestWorkObjects,
+    ] = await Promise.all([
+      integration.canUseProjectWorkObjects(context),
+      integration.canUseInitiativeWorkObjects(context),
+      integration.canUseDocumentWorkObjects(context),
+      integration.canUsePullRequestWorkObjects(context),
+    ]);
+
+    const urlUnfurls: { [key: string]: MessageAttachment } = {};
+    const modelUnfurls: { [key: string]: MessageAttachment } = {};
+    const issuesForWorkObjects = [];
+    const documentsForWorkObjects = [];
+    const projectsForWorkObjects: { project: Project; url: string }[] = [];
+    const initiativesForWorkObjects: { initiative: Initiative; url: string }[] = [];
+    const pullRequestsForWorkObjects: { pullRequest: PullRequest; url: string }[] = [];
+    // Track unfurled entity IDs to avoid duplicate unfurls when multiple URLs point to the same entity
+    const unfurledEntityIds = new Set<string>();
+
+    for (const url of urls) {
+      const routeMatch = findMatchingRoute(url, Config.CLIENT_URL) ?? [];
+      const { pathname: path } = new URL(url);
+
+      // Images
+      if (
+        (Config.UPLOAD_BUCKET_DOMAIN && url.startsWith(Config.UPLOAD_BUCKET_DOMAIN)) ||
+        (Config.PUBLIC_BUCKET_DOMAIN && url.startsWith(Config.PUBLIC_BUCKET_DOMAIN))
+      ) {
+        const file = await FileUpload.findByAssetUrl(context, url);
+        if (!file || !file.isImage) {
+          continue;
+        }
+        urlUnfurls[url] = {
+          blocks: [
+            {
+              type: "image",
+              image_url: url,
+              alt_text: file.filename || "Image from Linear",
+            },
+          ],
+        };
+      } else if (Config.SECURE_IMAGE_PROXY_URL && url.startsWith(Config.SECURE_IMAGE_PROXY_URL)) {
+        urlUnfurls[url] = {
+          blocks: [
+            {
+              type: "image",
+              image_url: url,
+              alt_text: "Image from Linear",
+            },
+          ],
+        };
+      } else if (routeMatch) {
+        const [route, params] = routeMatch;
+        if ("orgKey" in params) {
+          const orgKey = params.orgKey;
+          if (orgKey !== context.organization.urlKey) {
+            continue;
+          }
+        }
+
+        // Issue
+        if (route === RoutePaths.issue) {
+          const issue = await Issue.findById(context, params.issueId, { includeArchived: true });
+
+          if (issue?.organizationId !== integration.organizationId) {
+            // Account for edge case in Enterprise Grid where the same identifier can exist in multiple workspaces that
+            // the user has access to
+            continue;
+          }
+          const issueSource = issue?.sourceMetadata?.subType;
+          if (integration.service === IntegrationService.slackAsks && issueSource !== IntegrationService.slackAsks) {
+            // The Asks integration can only unfurl Asks issues
+            continue;
+          }
+          const team = await issue?.loadRelation(context, "team");
+          if (issue && team && !team.private) {
+            const commentHash = URLParseHelper.parseCommentHashFromUrl(url);
+            const agentSessionHash = URLParseHelper.parseAgentSessionHashFromUrl(url);
+            if (commentHash) {
+              const comment = await Comment.findByHash(context, commentHash);
+              // Verify comment belongs to this issue and comment hasn't been unfurled yet
+              if (comment && comment.issueId === issue.id && !unfurledEntityIds.has(`comment:${comment.id}`)) {
+                modelUnfurls[url] = await presentSlackCommentCreated(context, integration, comment, issue, {
+                  includeLinkedUsername: true,
+                  enableIntegrationActions: false,
+                });
+                unfurledEntityIds.add(`comment:${comment.id}`);
+              }
+            } else if (agentSessionHash) {
+              const agentSession = await AgentSession.findByHash(context, agentSessionHash);
+              // Verify agent session belongs to this issue and hasn't been unfurled yet
+              if (
+                agentSession &&
+                agentSession.issueId === issue.id &&
+                !unfurledEntityIds.has(`agentSession:${agentSession.id}`)
+              ) {
+                modelUnfurls[url] = await presentSlackAgentSession(context, integration, agentSession, issue);
+                unfurledEntityIds.add(`agentSession:${agentSession.id}`);
+              }
+            } else if (!unfurledEntityIds.has(`issue:${issue.id}`)) {
+              // Skip if this issue has already been unfurled via a different URL
+              modelUnfurls[url] = await presentIssuePayload(context, integration, issue, {
+                includeDescription: true,
+                includeProject: true,
+                excludeAllActions: isSlackWorkflowBuilder,
+                actionsToExclude: await getActionsToExcludeForIssue(context, integration, issue, {
+                  channel,
+                  messageTs,
+                  threadTs,
+                }),
+              });
+              unfurledEntityIds.add(`issue:${issue.id}`);
+
+              if (canUseWorkObjects) {
+                // Collect issue for work objects generation
+                issuesForWorkObjects.push({
+                  issue,
+                  url,
+                  options: {
+                    includeDescription: true,
+                    includeProject: true,
+                    includeSLA: true,
+                    excludeAllActions: isSlackWorkflowBuilder,
+                    channel,
+                    messageTs,
+                    threadTs,
+                  },
+                });
+              }
+            }
+          }
+        }
+
+        // Following models are only supported in Slack, not Asks
+        if (integration.service === IntegrationService.slack) {
+          // Initiative
+          if (route === RoutePaths.initiative) {
+            const initiativeId = parseIdOrSlugId(params.initiativeId);
+            const initiative = await Initiative.findById(context, initiativeId, { includeArchived: true });
+            if (initiative) {
+              const updateHash = URLParseHelper.parseUpdateHashFromUrl(url, "initiativeUpdate");
+              if (updateHash) {
+                const initiativeUpdate = await InitiativeUpdate.findBySlugId(context, initiative.id, updateHash);
+                if (initiativeUpdate && !unfurledEntityIds.has(`initiativeUpdate:${initiativeUpdate.id}`)) {
+                  const slackUpdatePayload = pick(
+                    await initiativeUpdate.toSlackPayload(context, integration),
+                    "blocks"
+                  );
+                  modelUnfurls[url] = slackUpdatePayload;
+                  unfurledEntityIds.add(`initiativeUpdate:${initiativeUpdate.id}`);
+                }
+              } else if (!unfurledEntityIds.has(`initiative:${initiative.id}`)) {
+                // Check for document heading hash in initiative overview
+                const headingHash = URLParseHelper.parseDocumentHeadingHashFromUrl(url);
+                let headingName: string | undefined;
+                if (headingHash) {
+                  const documentContent = await initiative.loadRelation(context, "documentContent");
+                  headingName = findHeadingNameByHash(documentContent?.getContentData(), headingHash);
+                }
+                modelUnfurls[url] = await presentSlackInitiative(context, initiative, {
+                  headingName,
+                  headingHash,
+                });
+                unfurledEntityIds.add(`initiative:${initiative.id}`);
+
+                if (canUseInitiativeWorkObjects) {
+                  initiativesForWorkObjects.push({ initiative, url });
+                }
+              }
+            }
+          }
+
+          // Project
+          if (route === RoutePaths.project) {
+            const projectId = parseIdOrSlugId(params.projectId);
+            const project = await Project.findById(context, projectId, { includeArchived: false });
+            const teams = await project?.teams(context);
+            if (project && teams && teams.some(team => !team.private)) {
+              const updateHash = URLParseHelper.parseUpdateHashFromUrl(url, "projectUpdate");
+              if (updateHash) {
+                const projectUpdate = await ProjectUpdate.findBySlugId(context, project.id, updateHash);
+                if (projectUpdate && !unfurledEntityIds.has(`projectUpdate:${projectUpdate.id}`)) {
+                  const slackUpdatePayload = pick(await projectUpdate.toSlackPayload(context, integration), "blocks");
+                  modelUnfurls[url] = slackUpdatePayload;
+                  unfurledEntityIds.add(`projectUpdate:${projectUpdate.id}`);
+                }
+              } else if (!unfurledEntityIds.has(`project:${project.id}`)) {
+                // Check for document heading hash in project overview
+                const headingHash = URLParseHelper.parseDocumentHeadingHashFromUrl(url);
+                let headingName: string | undefined;
+                if (headingHash) {
+                  const documentContent = await project.loadRelation(context, "documentContent");
+                  headingName = findHeadingNameByHash(documentContent?.getContentData(), headingHash);
+                }
+                modelUnfurls[url] = await presentSlackProject(context, project, {
+                  headingName,
+                  headingHash,
+                });
+                unfurledEntityIds.add(`project:${project.id}`);
+
+                if (canUseProjectWorkObjects) {
+                  projectsForWorkObjects.push({ project, url });
+                }
+              }
+            }
+          }
+
+          // Custom view
+          if (
+            route === RoutePaths.customView ||
+            route === RoutePaths.projectFacet ||
+            route === RoutePaths.allProjectsFacet ||
+            route === RoutePaths.initiativeFacet ||
+            route === RoutePaths.teamIssuesFacet
+          ) {
+            const customViewId = parseIdOrSlugId(params.customViewId);
+            const customView = await CustomView.findById(context, customViewId, { includeArchived: false });
+            // eslint-disable-next-line linear-app/no-many-to-one-access
+            const team = await customView?.team;
+            if (
+              customView &&
+              customView.shared &&
+              !team?.private &&
+              !unfurledEntityIds.has(`customView:${customView.id}`)
+            ) {
+              modelUnfurls[url] = await presentSlackCustomView(context, customView);
+              unfurledEntityIds.add(`customView:${customView.id}`);
+            }
+          }
+
+          // Document
+          if (route === RoutePaths.document) {
+            const documentId = parseIdOrSlugId(params.documentId);
+            const document = await Document.findById(context, documentId, { includeArchived: false });
+            if (!document) {
+              continue;
+            }
+            const documentContent = await document.loadRelation(context, "documentContent");
+            const commentHash = URLParseHelper.parseCommentHashFromUrl(url);
+            if (documentContent && commentHash) {
+              const comment = await Comment.findByHash(context, commentHash);
+              if (comment && !unfurledEntityIds.has(`comment:${comment.id}`)) {
+                modelUnfurls[url] = await presentSlackCommentCreated(context, integration, comment, document, {
+                  includeLinkedUsername: true,
+                  enableIntegrationActions: false,
+                });
+                unfurledEntityIds.add(`comment:${comment.id}`);
+              }
+            } else if (!unfurledEntityIds.has(`document:${document.id}`)) {
+              const teams = await document.teams(context);
+              // Documents can have no team relations - if so privacy is not a concern
+              if (teams.length === 0 || teams.some(team => !team.private)) {
+                const headingHash = URLParseHelper.parseDocumentHeadingHashFromUrl(url);
+                let headingName: string | undefined;
+                if (headingHash && documentContent) {
+                  headingName = findHeadingNameByHash(documentContent.getContentData(), headingHash);
+                }
+                // Load parent and summary for both forms of unfurl ahead of time
+                const [parent, summary] = await Promise.all([
+                  document.parent(context),
+                  SlackHelper.summarizeDocumentContent(context, document, documentContent),
+                ]);
+                modelUnfurls[url] = await presentSlackDocument(context, integration, document, {
+                  parent,
+                  documentContent,
+                  headingName,
+                  headingHash,
+                  summary,
+                });
+                unfurledEntityIds.add(`document:${document.id}`);
+
+                if (canUseDocumentWorkObjects) {
+                  documentsForWorkObjects.push({
+                    document,
+                    url,
+                    parent,
+                    documentContent,
+                    headingName,
+                    headingHash,
+                    summary,
+                  });
+                }
+              }
+            }
+          }
+
+          // Pull Request Review
+          if (route === RoutePaths.review) {
+            const codeReviewsEnabled = await Flags.variation(Flags.codeReviews, context, false);
+            if (codeReviewsEnabled) {
+              const reviewId = parseIdOrSlugId(params.reviewId);
+              const pullRequest = await PullRequest.findById(context, reviewId, { includeArchived: false });
+              if (
+                pullRequest &&
+                pullRequest.organizationId === integration.organizationId &&
+                !unfurledEntityIds.has(`pullRequest:${pullRequest.id}`)
+              ) {
+                if (canUsePullRequestWorkObjects) {
+                  pullRequestsForWorkObjects.push({ pullRequest, url });
+                } else {
+                  modelUnfurls[url] = await presentSlackPullRequest(context, pullRequest);
+                }
+                unfurledEntityIds.add(`pullRequest:${pullRequest.id}`);
+              }
+            }
+          }
+        }
+      } else if (url.startsWith(Config.CLIENT_URL) && ClientUrlHelper.isWebsiteRouterPath(path)) {
+        // No regular website unfurls for Asks
+        if (integration.service !== IntegrationService.slack) {
+          continue;
+        }
+
+        // Fallback to generic unfurl through Iframely for public pages
+        try {
+          const embed = await Iframely.get(context, `${Config.CLIENT_URL}${path}`);
+
+          if (embed && embed.title) {
+            urlUnfurls[url] = {
+              blocks: [
+                {
+                  ...sectionBlockForText(
+                    `*<${url}|${escapeTextForSlackLink(embed.title)}>*${embed.description ? `\n${embed.description}` : ""}`
+                  ),
+                },
+              ].filter(Boolean) as (Block | KnownBlock)[],
+            };
+
+            if (embed.thumbnailUrl) {
+              urlUnfurls[url].blocks?.unshift({
+                type: "image",
+                image_url: embed.thumbnailUrl,
+                alt_text: embed.title,
+              });
+            }
+          }
+        } catch (error) {
+          // no-op
+        }
+      }
+    }
+
+    for (const unfurl of Object.values(modelUnfurls)) {
+      // Unfurls do not allow the text field, which is a fallback in other situations
+      delete unfurl.text;
+    }
+
+    // Generate Work Objects metadata for issues, projects, initiatives, and documents.
+    // The presence of the metadata field will cause the unfurl to be shown as a Work Objects entity.
+    const [
+      issueWorkObjectsEntities,
+      projectWorkObjectsEntities,
+      initiativeWorkObjectsEntities,
+      documentWorkObjectsEntities,
+      pullRequestWorkObjectsEntities,
+    ] = await Promise.all([
+      generateIssueWorkObjectsEntities(context, integration, issuesForWorkObjects),
+      generateProjectWorkObjectsEntities(context, integration, projectsForWorkObjects),
+      generateInitiativeWorkObjectsEntities(context, integration, initiativesForWorkObjects),
+      generateDocumentWorkObjectsEntities(context, integration, documentsForWorkObjects),
+      generatePullRequestWorkObjectsEntities(context, integration, pullRequestsForWorkObjects),
+    ]);
+    const workObjectsEntities = [
+      ...issueWorkObjectsEntities,
+      ...projectWorkObjectsEntities,
+      ...initiativeWorkObjectsEntities,
+      ...documentWorkObjectsEntities,
+      ...pullRequestWorkObjectsEntities,
+    ];
+
+    // Cap total metadata size to avoid Slack's error_processing_metadata error.
+    // Individual entities are already capped at MAX_METADATA_BYTES (3400), but the combined
+    // payload can exceed Slack's total metadata limit when multiple URLs are unfurled in one message.
+    if (workObjectsEntities.length > 1) {
+      const maxTotalMetadataBytes = SlackHelper.MAX_METADATA_BYTES;
+      const originalCount = workObjectsEntities.length;
+      while (
+        workObjectsEntities.length > 0 &&
+        Buffer.byteLength(JSON.stringify({ entities: workObjectsEntities }), "utf8") > maxTotalMetadataBytes
+      ) {
+        workObjectsEntities.pop();
+      }
+      if (workObjectsEntities.length < originalCount) {
+        Logger.info("integrations", "Dropped Work Object entities to fit total metadata size limit", context, {
+          integration: { id: integration.id },
+          originalCount,
+          finalCount: workObjectsEntities.length,
+        });
+      }
+    }
+
+    // For chat.unfurl, work objects metadata is a JSON string (see L317 comment above)
+    const workObjectsMetadata =
+      workObjectsEntities.length > 0
+        ? {
+            metadata: JSON.stringify({ entities: workObjectsEntities }),
+          }
+        : {};
+
+    const payload = {
+      channel,
+      ts: messageTs,
+      unfurls: { ...modelUnfurls, ...urlUnfurls },
+      ...workObjectsMetadata,
+    };
+
+    // There are specific errors we can't do anything about: https://api.slack.com/methods/chat.unfurl#errors
+    const ignoredErrors = ["cannot_unfurl_message", "cannot_unfurl_url", "cannot_find_message", "fatal_error"];
+    try {
+      await Slack.post<ChatUnfurlArguments, ChatUnfurlResponse>(context, "chat.unfurl", integration, payload, {
+        ignoredErrors,
+      });
+    } catch (error) {
+      if (!ignoredErrors.includes(error)) {
+        Logger.error("integrations", "Error posting to slack chat.unfurl", error, context, {
+          integration: { id: integration.id },
+          slack: {
+            channel,
+            payload: JSON.stringify(payload),
+            props,
+          },
+        });
+      }
+    }
+  }
+}

--- a/api/src/services/slack/Slack.ts
+++ b/api/src/services/slack/Slack.ts
@@ -1,0 +1,543 @@
+import querystring from "querystring";
+import type { WebAPICallResult } from "@slack/web-api";
+import type { OAuthV2Response } from "@slack/oauth";
+import { SlackOAuthAppType } from "@linear/common/models/Integration";
+import { fetch, type Response } from "~/utils/fetch";
+import { type AnyContext, type Context, withTxContext, withTxOrganizationContext } from "~/auth/Context";
+import { InputError, InternalError } from "~/errors/Errors";
+import { RetryAfterHelper } from "~/helpers/RetryAfterHelper";
+import { IntegrationInternalError, RateLimitedError } from "~/services/errors";
+import { Config } from "~/config/Config";
+import type { Integration } from "~/entity";
+import { Logger } from "~/logging/Logger";
+import { formUrlEncode } from "~/utils/formUrlEncode";
+
+/** Extended WebAPICallResult that includes warning fields Slack may return */
+interface SlackAPICallResult extends WebAPICallResult {
+  warning?: string;
+  response_metadata?: { warnings?: string[] };
+}
+
+/** Noisy warnings that we don't need to log */
+const ignoredWarnings = ["superfluous_charset"];
+
+/** Slack's base API endpoint. */
+export const SLACK_API_URL = "https://slack.com/api";
+
+/**
+ * Class to call out to the Slack API.
+ */
+export class Slack {
+  /**
+   * Send a post request to the Slack API.
+   *
+   * @param context Context for the request
+   * @param endpoint Slack endpoint for the request
+   * @param integration Slack integration object whose token we use for the request
+   * @param body Request body
+   * @param options.urlencoded Should the request be sent with urlencoded format
+   * @param options.hookUrl Hook url to override provided endpoint (used with webhooks)
+   * @param options.ignoredErrors List of errors that should be swallowed rather than logged. Only use if you are
+   *  certain you do not want to debug why the request would be failing.
+   * @returns Response from Slack
+   */
+  public static async post<SlackArguments, SlackResponse extends SlackAPICallResult>(
+    context: Context,
+    endpoint: string,
+    integration: Integration,
+    body: SlackArguments,
+    options: { urlencoded?: boolean; hookUrl?: string; ignoredErrors?: string[] } = {}
+  ): Promise<SlackResponse | undefined> {
+    let data: SlackResponse, response: Response;
+    const requestUrl = options.hookUrl || `${SLACK_API_URL}/${endpoint}`;
+
+    const effectiveAccessToken = await integration.effectiveAccessToken(context);
+    try {
+      if (options.urlencoded) {
+        response = await fetch(requestUrl, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${effectiveAccessToken}`,
+            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+          },
+          body: formUrlEncode(body),
+          // @ts-expect-error
+          json: true,
+        });
+        data = await response.json();
+      } else {
+        response = await fetch(requestUrl, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${effectiveAccessToken}`,
+            "Content-Type": "application/json;charset=UTF-8",
+          },
+          body: JSON.stringify(body),
+        });
+        if (response.status === 200 && !response.headers.get("Content-Type")?.includes("application/json")) {
+          // There is no body, so return
+          return;
+        }
+        data = await response.json();
+      }
+    } catch (error) {
+      // We can't do much about timeouts
+      if (
+        error.message.includes("ETIMEDOUT") ||
+        error.message.includes("ECONNRESET") ||
+        error.message.includes("EAI_AGAIN") ||
+        error.message.includes("ECONNREFUSED")
+      ) {
+        return;
+      }
+      throw new Error(error.message);
+    }
+
+    // Check for warnings - Slack can return a warning with either ok: true or ok: false
+    // e.g., metadata_too_large warning when Work Objects metadata exceeds 4000 bytes
+    if (data.warning && !ignoredWarnings.includes(data.warning)) {
+      Logger.warn("integrations", "Slack API returned warning", context, {
+        integration: { id: integration.id },
+        endpoint,
+        ok: data.ok,
+        error: data.error,
+        warning: data.warning,
+        warnings: data.response_metadata?.warnings,
+      });
+    }
+
+    if (data.ok) {
+      return data;
+    }
+
+    if (!data.error) {
+      Logger.debug("integrations", "Slack API call failed with no error", context, {
+        integrationId: integration.id,
+        endpoint,
+        body,
+      });
+      return data;
+    }
+
+    if (data.error === "expired_response_url" && options?.hookUrl && endpoint === "") {
+      // Use chat.postMessage as a fallback for expired response URLs
+      return Slack.post(context, "chat.postMessage", integration, body, { ...options, hookUrl: undefined });
+    }
+
+    // If we're ignoring this error, ignore it and return the data
+    if (options?.ignoredErrors?.includes(data.error)) {
+      return data;
+    }
+
+    // Handle tokens revoked on Slack's side
+    if (["token_revoked", "account_inactive", "invalid_auth"].includes(data.error)) {
+      await withTxOrganizationContext(
+        context,
+        { organization: await integration.loadRelation(context, "organization"), integration },
+        async organizationContext => {
+          Logger.info("auth", "Slack access revoked for integration", organizationContext, {
+            id: integration.id,
+            slack: {
+              error: data,
+              body,
+            },
+          });
+
+          try {
+            await integration.disconnectAndNotifyUser(organizationContext);
+          } catch (error) {
+            // If the token is already invalid, it's pretty useless, so just delete the integration. We really only hit
+            // this for very old integrations during backfills that involve Slack API calls since workspaces actively
+            // using the Slack integration will have valid tokens and/or admin users.
+            if (error instanceof InternalError && error.message.includes("couldn't find an admin user")) {
+              await integration.delete(organizationContext);
+            }
+          }
+        }
+      );
+
+      return data;
+    }
+
+    // If we took too long to respond to this trigger we can't do anything about it now. The user has already seen an
+    // error in Slack at this point, so only action is they can retry.
+    if (data.error === "trigger_expired" || data.error === "expired_trigger_id") {
+      return data;
+    }
+
+    // Handle specific errors that are not dangerous for various API endpoints
+    Slack.handleError(data.error, response, integration, context, {
+      endpoint,
+      ignoredErrors: options.ignoredErrors,
+      data,
+      body: JSON.stringify(body),
+    });
+    return;
+  }
+
+  /**
+   * Makes a request to the Slack API.
+   * @param {string} endpoint - The Slack API endpoint.
+   * @param {querystring.ParsedUrlQueryInput} body - The request body.
+   * @param {string} [token] - The authentication token.
+   * @returns {Promise<any>} - The response data.
+   */
+  public static async request(endpoint: string, body: querystring.ParsedUrlQueryInput, token?: string) {
+    let data, response;
+    try {
+      const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
+      response = await fetch(`${SLACK_API_URL}/${endpoint}?${querystring.stringify(body)}`, {
+        headers,
+      });
+      data = await response.json();
+    } catch (error) {
+      throw new Error(error.message);
+    }
+    if (!data.ok) {
+      Slack.handleError(data.error, response, undefined, undefined, { data });
+    }
+    return data;
+  }
+
+  /**
+   * Posts a request to a Slack webhook endpoint.
+   * @param {Context} context - The request context.
+   * @param {Integration} integration - The Slack webhook integration.
+   * @param {Object} body - The request body.
+   */
+  public static async postWebhook(context: Context, integration: Integration, body: { [key: string]: unknown }) {
+    const url = integration.data && "url" in integration.data ? integration.data.url : undefined;
+    const stringifiedBody = JSON.stringify(body);
+    if (!url) {
+      return;
+    }
+
+    let response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: stringifiedBody,
+      });
+    } catch (error) {
+      Slack.handleError(error.message, response, integration, context, { body: stringifiedBody });
+      return;
+    }
+    if (!response.ok) {
+      const text = await response.text();
+
+      // https://api.slack.com/messaging/webhooks#handling_errors
+      // "no_service" means the webhook is either disabled, removed, or invalid.
+      // "no_active_hooks" is not documented but feels like the same thing.
+      // "team_disabled" means the Slack workspace is no longer active
+      // "invalid_token" means the Slack bot token we have for the integration is invalid
+      // "channel_not_found" means the channel we are trying to post to no longer exists
+      // It's fine to delete the integration and let the user re-add it if needed.
+      const errorsToDisconnectFor = [
+        "no_service",
+        "no_active_hooks",
+        "team_disabled",
+        "invalid_token",
+        "channel_not_found",
+      ];
+      if (errorsToDisconnectFor.includes(text)) {
+        await withTxContext(context, async txContext => {
+          await integration.delete(txContext);
+        });
+        Logger.info("integrations", "Deleted Slack integration due to failure from Slack post webhook", context, {
+          slackError: text,
+        });
+      } else {
+        Slack.handleError(text, response, integration, context, { body: stringifiedBody });
+      }
+    }
+  }
+
+  /**
+   * Produces an OAuth response for a Slack application.
+   *
+   * @param code - The authorization code.
+   * @param app - The type of Slack OAuth app.
+   * @param redirectUri - The redirect URI.
+   * @param useStagingApp - Flag indicating whether to use the staging version of the Slack app.
+   * @returns A promise that resolves to the OAuthV2Response.
+   */
+  public static async oauthAccess(
+    code: string,
+    app: SlackOAuthAppType,
+    redirectUri: string = `${Config.CLIENT_URL || ""}/connect/slack/callback`,
+    useStagingApp?: boolean
+  ): Promise<OAuthV2Response> {
+    const endpoint = "oauth.v2.access";
+
+    // If the workspace is flagged into the staging app and we're not in development, use the staging app's credentials
+    return (await Slack.request(endpoint, {
+      client_id:
+        app === SlackOAuthAppType.Linear
+          ? useStagingApp
+            ? Config.SLACK_STAGING_CLIENT_ID
+            : Config.SLACK_CLIENT_ID
+          : Config.SLACK_INTAKE_APP_CLIENT_ID,
+      client_secret:
+        app === SlackOAuthAppType.Linear
+          ? useStagingApp
+            ? Config.SLACK_STAGING_CLIENT_SECRET
+            : Config.SLACK_CLIENT_SECRET
+          : Config.SLACK_INTAKE_APP_CLIENT_SECRET,
+      redirect_uri: redirectUri,
+      code,
+    })) as OAuthV2Response;
+  }
+
+  private static handleError(
+    error: string,
+    response?: Response,
+    integration?: Integration,
+    context?: AnyContext,
+    options?: {
+      body?: string;
+      endpoint?: string;
+      ignoredErrors?: string[];
+      data?: WebAPICallResult;
+    }
+  ) {
+    if (response?.status === 429 || error === "ratelimited") {
+      // Slack's ratelimited error also comes with a Retry-After header:
+      // https://api.slack.com/methods/chat.postMessage#errors
+      const retryAfterMs = RetryAfterHelper.parseMs(response?.headers.get("Retry-After"));
+      if (retryAfterMs !== undefined) {
+        throw new RateLimitedError("Slack rate limited", retryAfterMs);
+      }
+    } else if (error === "internal_error") {
+      // We can't do much about errors on the Slack end: https://api.slack.com/automation/cli/errors#internal_error
+      // Log details here since this is unusual and we might want to understand what's going on
+      Logger.info("integrations", "Received an internal error from Slack", context, {
+        integration,
+        error,
+        response,
+      });
+      throw new IntegrationInternalError(error);
+    } else if (error === "invalid_arguments") {
+      // Extract detailed error messages from response_metadata if available
+      const responseMetadata = options?.data?.response_metadata;
+      const detailedMessages = responseMetadata?.messages || [];
+
+      let errorMessage = "Invalid arguments";
+      if (detailedMessages.length > 0) {
+        errorMessage = `${errorMessage}: ${detailedMessages.join(", ")}`;
+      }
+
+      Logger.info("integrations", "Received invalid_arguments error from Slack", context, {
+        integration: integration ? { id: integration.id } : undefined,
+        error,
+        detailedMessages,
+        response,
+        data: options?.data,
+      });
+
+      throw new Error(errorMessage);
+    } else if (error === "invalid_attachments") {
+      // `invalid_attachments` is expected if there is poor formatting in the unfurl when we post to a webhook endpoint.
+      // We ideally wouldn't hit this, but Slack is quite finicky on exactly what it accepts so we unintentionally hit
+      // this for things like extra new lines, imperfect truncation of a very long set of blocks, etc. It's a noisy
+      // error that we don't need to throw, but will instead log to debug as needed.
+      Logger.warn("integrations", "Received invalid_attachments when posting to Slack", context, {
+        integration: integration ? { id: integration.id } : undefined,
+        error,
+        response,
+        body: options?.body,
+      });
+      return;
+    } else if (error.includes("message_limit_exceeded")) {
+      // `message_limit_exceeded` is expected if the workspace is a free one and has exceeded its message limit. Both
+      // webhook POSTs and API calls can hit this error. We use .includes here because Slack sends this error as part of
+      // a larger string in the webhook case, whereas the API call case will just return the error string directly.
+      Logger.info(
+        "integrations",
+        "Slack workspace has exceeded its message limit and couldn't receive a message",
+        context,
+        {
+          integration,
+          error,
+          response,
+        }
+      );
+      return;
+    } else if (options?.endpoint === "conversations.info") {
+      // For conversations.info: https://api.slack.com/methods/conversations.info#errors
+      // missing_scope is expected if the app hasn't been reinstalled with new scopes
+      // channel_not_found is expected if we are querying for bot membership in a private channel or DM and the bot isn't
+      // a member
+      if (error === "missing_scope") {
+        Logger.info("integrations", "Slack app is missing the right scopes to query conversations.info", context, {
+          error,
+          response,
+        });
+        return;
+      } else if (error === "channel_not_found") {
+        Logger.info("integrations", "Received channel_not_found error when querying conversations.info", context, {
+          error,
+          response,
+        });
+        return;
+      }
+    }
+    // For conversations.open: https://api.slack.com/methods/conversations.open#errors
+    // missing_scope is expected if the app hasn't been reinstalled with new scopes
+    else if (options?.endpoint === "conversations.open") {
+      if (error === "missing_scope") {
+        Logger.info("integrations", "Slack app is missing the right scopes to call conversations.open", context, {
+          error,
+          response,
+        });
+        return;
+      }
+    } else if (options?.endpoint === "conversations.replies" || options?.endpoint === "conversations.history") {
+      // For conversations.history: https://api.slack.com/methods/conversations.history#errors
+      // For conversations.replies: https://api.slack.com/methods/conversations.replies#errors
+      // We call these endpoints when adding a link to a Slack message as an attachment, so we use InputError since the
+      // issues are usually with the input link or lack of permissions
+      if (error === "not_in_channel" || error === "channel_not_found") {
+        throw new InputError(
+          Slack.inputErrorMessages.botNotInChannel,
+          "Please make sure the Linear Slack bot is in the channel you are trying to link a message from."
+        );
+      } else if (error === "missing_scope") {
+        throw new InputError(
+          Slack.inputErrorMessages.insufficientPermissions,
+          "Please reinstall the Slack integration in Linear to have the scopes needed to use this feature."
+        );
+      } else {
+        Logger.info(
+          "integrations",
+          "Error fetching Slack message details from conversations.replies or conversations.history",
+          context,
+          {
+            error,
+            response,
+          }
+        );
+        throw new InputError(
+          Slack.inputErrorMessages.unableToFetchMessageDetails,
+          "Please verify that your Slack permalink is valid."
+        );
+      }
+    } else if (options?.endpoint === "chat.postEphemeral") {
+      // For chat.postEphemeral: https://api.slack.com/methods/chat.postEphemeral#errors
+      // user_not_in_channel is expected if the bot user isn't in a DM channel
+      // is_archived is expected if the channel is archived. We can't post to archived channels.
+      // channel_not_found is expected if the channel no longer exists
+      if (error === "user_not_in_channel") {
+        Logger.info("integrations", "Slack app tried to post ephemeral message to channel user is not in", context, {
+          error,
+          response,
+        });
+        return;
+      } else if (error === "is_archived" || error === "channel_not_found") {
+        return;
+      }
+    } else if (options?.endpoint === "chat.postMessage") {
+      // For chat.postMessage: https://api.slack.com/methods/chat.postMessage#errors
+      // is_archived is expected if the channel is archived. We can't post to archived channels.
+      // channel_not_found is expected if the channel no longer exists
+      if (error === "is_archived" || error === "channel_not_found") {
+        return;
+      }
+    } else if (options?.endpoint === "chat.unfurl") {
+      // For chat.unfurl: https://api.slack.com/methods/chat.unfurl#errors
+      // cannot_parse_attachment is expected if there is a formatting error in the unfurl. We ideally wouldn't hit this,
+      // but Slack is quite finicky on exactly what it accepts so we unintentionally hit this for things like extra new
+      // lines, imperfect truncation of a very long set of blocks, etc. It's a noisy error that we don't need to throw,
+      // but will instead log to debug as needed.
+      if (error === "cannot_parse_attachment") {
+        Logger.warn("integrations", "Received cannot_parse_attachment for a Slack unfurl", context, {
+          integration: integration ? { id: integration.id } : undefined,
+          error,
+          response,
+        });
+        return;
+      }
+      // error_processing_metadata occurs when the Work Objects metadata payload is too large or malformed for Slack
+      // to process. The unfurl still works without metadata, so this is not a critical error.
+      if (error === "error_processing_metadata") {
+        Logger.warn("integrations", "Received error_processing_metadata for a Slack unfurl", context, {
+          integration: integration ? { id: integration.id } : undefined,
+          error,
+          response,
+        });
+        return;
+      }
+    } else if (options?.endpoint === "chat.update" && error === "is_inactive") {
+      // https://api.slack.com/methods/chat.update#errors
+      // Trying to update a message in a frozen/archived/deleted channel. Nothing much we can do about it.
+      Logger.info("integrations", "Error updating a message in a frozen channel", context, {
+        integration: integration ? { id: integration.id } : undefined,
+        error,
+        response,
+        data: options?.data,
+      });
+      return;
+    } else if (options?.endpoint === "chat.update" && error === "message_not_found") {
+      // https://api.slack.com/methods/chat.update#errors
+      Logger.info("integrations", "Error updating a message that can't be found", context, {
+        integration: integration ? { id: integration.id } : undefined,
+        error,
+        response,
+        data: options?.data,
+      });
+      return;
+    } else if (options?.endpoint === "views.update" && error === "not_found") {
+      // For views.update: https://api.slack.com/methods/views.update#errors
+      // not_found is expected if the modal was closed before we could update it
+      return;
+    } else if (options?.endpoint === "views.publish") {
+      Logger.info("integrations", "Error publishing a view", context, {
+        integration: integration ? { id: integration.id } : undefined,
+        error,
+        response,
+        data: options?.data,
+      });
+    } else if (options?.endpoint === "bots.info" && error === "bot_not_found") {
+      // For bots.info: https://api.slack.com/methods/bots.info#errors
+      // bot_not_found is expected if the bot is no longer in the workspace
+      return;
+    }
+
+    // Throw all other errors unless we explicity want to ignore them
+    if (!options?.ignoredErrors?.includes(error)) {
+      Logger.info("integrations", "Error posting to Slack integration", context, {
+        integration: integration ? { id: integration.id } : undefined,
+        error,
+        response,
+        data: options?.data,
+        // also send the body if it's an invalid_blocks error
+        // so we can see what kind of blocks we sent
+        body: error === "invalid_blocks" ? options?.body : undefined,
+      });
+
+      if (error === "no_text") {
+        const body = options?.body;
+        Logger.info("integrations", "No text to post to Slack integration", context, {
+          integration: integration ? { id: integration.id } : undefined,
+          error,
+          response,
+          data: options?.data,
+          body,
+          bodySize: body ? Buffer.byteLength(body, "utf8") : undefined,
+        });
+        return;
+      }
+
+      throw new Error(error);
+    }
+  }
+
+  /** Known error messages */
+  public static inputErrorMessages = {
+    botNotInChannel: "Slack bot is not in the channel",
+    insufficientPermissions: "Slack integration has insufficient permissions",
+    unableToFetchMessageDetails: "Unable to fetch Slack message details from permalink",
+  };
+}


### PR DESCRIPTION
When multiple Linear URLs are unfurled in a single Slack message, the combined Work Objects metadata payload can exceed Slack's total metadata limit. This caused ~1,000 `error_processing_metadata` errors in a 20-minute window, triggering the SLO burn rate monitor.

**Changes:**

- **Total metadata size validation** (`RespondSlackUnfurlTask.ts`): After assembling Work Object entities, validate the combined metadata size against `MAX_METADATA_BYTES`. If the total exceeds the limit, progressively drop entities (from the end) until it fits. Individual entities were already capped, but there was no check on the combined payload.
- **Graceful error handling** (`Slack.ts`): Handle `error_processing_metadata` in the `chat.unfurl` error handler by logging a warning and returning instead of throwing. The unfurl still renders without Work Objects metadata, so this is non-critical.