### PR TITLE
Add sort support to root releases query

### DIFF
--- a/packages/sdk/src/_generated_documents.ts
+++ b/packages/sdk/src/_generated_documents.ts
@@ -19246,6 +19246,7 @@ export type QueryReleasesArgs = {
   includeArchived?: InputMaybe<Scalars["Boolean"]>;
   last?: InputMaybe<Scalars["Int"]>;
   orderBy?: InputMaybe<PaginationOrderBy>;
+  sort?: InputMaybe<Array<ReleaseSortInput>>;
 };
 
 export type QueryRoadmapArgs = {

--- a/packages/sdk/src/schema.graphql
+++ b/packages/sdk/src/schema.graphql
@@ -34064,6 +34064,10 @@ type Query {
     By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
     """
     orderBy: PaginationOrderBy
+    """
+    [ALPHA] Sort returned releases.
+    """
+    sort: [ReleaseSortInput!]
   ): ReleaseConnection!
   """
   One specific roadmap.


### PR DESCRIPTION
Adds `sort: [ReleaseSortInput!]` to the root `releases` query in the SDK schema, matching the existing sort support on `releasePipeline.releases`.

This lets clients fetch releases across multiple pipelines in a single query with server-side sorting (e.g. `sort: [{ stage: { order: Ascending } }]`) instead of needing N per-pipeline queries plus client-side sort logic.