### PR TITLE
Notify Slack when packages are published to npm

### DIFF
--- a/.github/workflows/notify-npm-publish.yaml
+++ b/.github/workflows/notify-npm-publish.yaml
@@ -36,7 +36,7 @@ jobs:
             if $old == null then
               "\u2022 (new) \($name)@\($new)"
             else
-              ([$old, $new] | map(split(".") | map(tonumber))) as [[$om, $omi, $op], [$nm, $nmi, $np]] |
+              ([$old, $new] | map(split("-") | .[0] | split(".") | map(tonumber))) as [[$om, $omi, $op], [$nm, $nmi, $np]] |
               (if $nm > $om then "major" elif $nmi > $omi then "minor" else "patch" end) as $bump |
               "\u2022 (\($bump)) \($name)@\($old) \u2192 \($new)"
             end

--- a/.github/workflows/notify-npm-publish.yaml
+++ b/.github/workflows/notify-npm-publish.yaml
@@ -1,0 +1,53 @@
+name: Notify npm publish
+
+on:
+  workflow_call:
+    inputs:
+      publishedPackages:
+        required: true
+        type: string
+      prePublishVersions:
+        required: true
+        type: string
+      actor:
+        required: true
+        type: string
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: true
+
+jobs:
+  notify:
+    name: Notify Slack
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Notify Slack of published packages
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          PUBLISHED_PACKAGES: ${{ inputs.publishedPackages }}
+          PRE_PUBLISH_VERSIONS: ${{ inputs.prePublishVersions }}
+        run: |
+          PACKAGE_COUNT=$(echo "$PUBLISHED_PACKAGES" | jq 'length')
+          PACKAGE_LIST=$(echo "$PUBLISHED_PACKAGES" | jq -r --argjson prev "$PRE_PUBLISH_VERSIONS" '
+            .[] |
+            .name as $name | .version as $new |
+            ($prev[$name] // null) as $old |
+            if $old == null then
+              "\u2022 (new) \($name)@\($new)"
+            else
+              ([$old, $new] | map(split(".") | map(tonumber))) as [[$om, $omi, $op], [$nm, $nmi, $np]] |
+              (if $nm > $om then "major" elif $nmi > $omi then "minor" else "patch" end) as $bump |
+              "\u2022 (\($bump)) \($name)@\($old) \u2192 \($new)"
+            end
+          ')
+
+          PAYLOAD=$(jq -n \
+            --arg text ":package: *${PACKAGE_COUNT} package(s) published to npm* by <${{ github.server_url }}/${{ inputs.actor }}|@${{ inputs.actor }}>
+
+          ${PACKAGE_LIST}
+
+          <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" \
+            '{text: $text}')
+
+          curl -fsS -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,6 +68,7 @@ jobs:
         run: |
           VERSIONS='{}'
           for dir in packages/*/; do
+            [ "$(jq -r '.private // false' "$dir/package.json")" = "true" ] && continue
             NAME=$(jq -r '.name' "$dir/package.json")
             VER=$(npm view "$NAME" version 2>/dev/null || echo "")
             [ -n "$VER" ] && VERSIONS=$(echo "$VERSIONS" | jq --arg n "$NAME" --arg v "$VER" '. + {($n): $v}')

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,10 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
+      prePublishVersions: ${{ steps.npm-versions.outputs.versions }}
     permissions:
       actions: read
       contents: write
@@ -59,7 +63,19 @@ jobs:
       - name: Check for no generated changes
         run: git update-index --refresh && git diff-index HEAD
 
+      - name: Capture current npm versions
+        id: npm-versions
+        run: |
+          VERSIONS='{}'
+          for dir in packages/*/; do
+            NAME=$(jq -r '.name' "$dir/package.json")
+            VER=$(npm view "$NAME" version 2>/dev/null || echo "")
+            [ -n "$VER" ] && VERSIONS=$(echo "$VERSIONS" | jq --arg n "$NAME" --arg v "$VER" '. + {($n): $v}')
+          done
+          echo "versions=$(echo "$VERSIONS" | jq -c .)" >> "$GITHUB_OUTPUT"
+
       - name: Create Release Pull Request or Publish to npm
+        id: changesets
         uses: changesets/action@master
         with:
           commit: "chore(release): version packages"
@@ -67,6 +83,17 @@ jobs:
           publish: pnpm ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  notify-npm-publish:
+    needs: [release]
+    if: needs.release.outputs.published == 'true'
+    uses: ./.github/workflows/notify-npm-publish.yaml
+    with:
+      publishedPackages: ${{ needs.release.outputs.publishedPackages }}
+      prePublishVersions: ${{ needs.release.outputs.prePublishVersions }}
+      actor: ${{ github.actor }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   notify-slack:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds an aggregated Slack notification when packages are published to npm via changesets. The message includes bump type (major/minor/patch) and old → new version for each package.


```
:package: 3 package(s) published to npm by @itsmingjie

(patch) @linear/sdk@1.2.2 → 1.2.3
…
```

Gives us more visibility into what was published, hopefully, in the mix of everything happening with the js ecosystem