### PR TITLE
fix(import): validate API key before creating LinearClient

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -146,7 +146,8 @@ jobs:
       - name: Run smoke test
         run: |
           linear-import --version
-          yes '' | linear-import
+          OUTPUT=$(yes '' | linear-import 2>&1 || true)
+          echo "$OUTPUT" | grep -q "No Linear API key"
 
   notify-slack:
     runs-on: ubuntu-latest

--- a/packages/import/src/cli.ts
+++ b/packages/import/src/cli.ts
@@ -89,7 +89,11 @@ const hasFlag = (name: string): boolean => process.argv.includes(`--${name}`);
       service = flagImporter || importAnswers.service;
     }
 
-    // TODO: Validate Linear API
+    if (!linearApiKey) {
+      console.error(chalk.red("No Linear API key provided. Create one here: https://linear.app/settings/account/security"));
+      process.exit(1);
+    }
+
     let importer;
     switch (service) {
       case "github":


### PR DESCRIPTION
PR #1078 (non-interactive mode) refactored the prompt flow so the API key prompt has a `when` guard. Running `yes '' | linear-import` now passes an empty string through to `LinearClient` without validation, causing an unhandled error and breaking the CI smoke test.

This adds an explicit check for a missing API key that exits with a clear error message, and updates the smoke test to assert on that error instead of expecting exit code 0.