### PR TITLE
ci: disable graphql-inspector annotations to unblock daily schema PR

### DIFF
--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -55,6 +55,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           schema: "master:packages/sdk/src/schema.graphql"
           fail-on-breaking: false
+          annotations: false
 
       - name: Create schema pull request
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
The daily `schema` workflow has been failing on master since 2026-04-13 because the regenerated schema diff is ~1900 changes. `kamilkisiela/graphql-inspector` chunks annotations into batches of 50 but fires all ~39 batches in parallel via `Promise.all`; one socket gets reset ("other side closed"), the whole batch rejects, and the step fails with the misleading "Invalid config. Failed to add annotation". That failure blocks the subsequent `create-pull-request` step, so no schema update PR has opened since #1093 — which is why the diff keeps growing each day.

Setting `annotations: false` skips the annotation upload entirely. Since `fail-on-breaking: false`, the annotations were purely decorative; the step still logs the change count and the schema PR flow resumes.

Tested: https://github.com/linear/linear/actions/runs/24595202345