### PR TITLE
ci: continue-on-error for graphql-inspector to unblock schema PR

### DIFF
--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Compare schema for changes
         uses: kamilkisiela/graphql-inspector@master
+        continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           schema: "master:packages/sdk/src/schema.graphql"


### PR DESCRIPTION
Follow-up to #1109. The `annotations: false` flag was respected, but the action's initial `checks.update` call (with summary, no annotations) is still failing — likely because at ~1900 changes the rendered summary is large enough to either exceed GitHub's 65KB cap or trigger a connection reset. Adding `continue-on-error: true` so the failing inspector doesn't block the subsequent `create-pull-request` step. Since `fail-on-breaking: false`, the inspector wasn't gating anything anyway.