### PR TITLE
ci: re-enable graphql-inspector annotations and failure

### DIFF
--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -51,12 +51,10 @@ jobs:
 
       - name: Compare schema for changes
         uses: kamilkisiela/graphql-inspector@master
-        continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           schema: "master:packages/sdk/src/schema.graphql"
           fail-on-breaking: false
-          annotations: false
 
       - name: Create schema pull request
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
## Summary

Reverts the temporary mitigations from #1109 and #1110 now that the backlog of schema changes has been released:

- #1109 added `annotations: false` to silence the graphql-inspector PR annotations.
- #1110 added `continue-on-error: true` so the step couldn't block the daily schema PR.

With #1102 (and the resulting `@linear/sdk@82.0.0` release) merged, the schema is caught up and we can put the inspector back in its normal blocking + annotating mode.

## Test plan

- [ ] Next daily run of `schema.yaml` on `master` posts annotations and treats a failing inspector step as a failure.