### PR TITLE
fix(sdk): handle arg collisions and list test gen

### DIFF
--- a/packages/codegen-doc/src/print-operation.ts
+++ b/packages/codegen-doc/src/print-operation.ts
@@ -149,6 +149,11 @@ export function printOperations(
       /** Find an object matching the type of this query */
       const object = findObject(context, lastField);
 
+      /** Names of input args already declared by the existing chain — used to detect collisions
+       * with a child field's args, which would produce duplicate variable declarations
+       * (e.g. releaseSearch's $filter clashing with its child documents' $filter). */
+      const existingArgNames = new Set(fields.flatMap(f => (f.arguments ?? []).map(a => a.name.value)));
+
       const fieldOperations = object?.fields?.map(field => {
         if (
           /** No need to go further than scalar fields */
@@ -162,7 +167,12 @@ export function printOperations(
           /** Skip connection fields on nested types that aren't directly fetchable via a root query. Connection methods
            * require re-querying the parent by ID (e.g. issue_comments calls issue(id) { comments }), which isn't
            * currently possible for types like DocumentContent that are only accessible as nested fields. */
-          (fields.length > 1 && reduceTypeName(field.type)?.endsWith("Connection"))
+          (fields.length > 1 && reduceTypeName(field.type)?.endsWith("Connection")) ||
+          /** Skip when the child's args would collide with the chain's existing args. The generated
+           * operation flattens args from every step in the chain into a single variable list, so any
+           * shared arg name (e.g. `filter`, `first`) on both the parent and child produces invalid
+           * GraphQL with duplicate variable declarations. */
+          (field.arguments ?? []).some(arg => existingArgNames.has(arg.name.value))
         ) {
           return undefined;
         } else {

--- a/packages/codegen-doc/src/print-operation.ts
+++ b/packages/codegen-doc/src/print-operation.ts
@@ -149,9 +149,6 @@ export function printOperations(
       /** Find an object matching the type of this query */
       const object = findObject(context, lastField);
 
-      /** Names of input args already declared by the existing chain — used to detect collisions
-       * with a child field's args, which would produce duplicate variable declarations
-       * (e.g. releaseSearch's $filter clashing with its child documents' $filter). */
       const existingArgNames = new Set(fields.flatMap(f => (f.arguments ?? []).map(a => a.name.value)));
 
       const fieldOperations = object?.fields?.map(field => {

--- a/packages/codegen-test/src/print-test.ts
+++ b/packages/codegen-test/src/print-test.ts
@@ -412,8 +412,7 @@ function printConnectionQueryTest(context: SdkPluginContext, operation: SdkOpera
                         field.type,
                         operation.print.list
                       )} = await _${itemField}.${field.name}`,
-                      /** When the field itself returns a list (e.g. ReleaseNote.releases: [Release]),
-                       * iterate the items for the instanceof check — `instanceof Foo[]` is not valid TS. */
+                      /** `instanceof Foo[]` is not valid TS; iterate items when the field returns a list. */
                       field.type.endsWith("[]")
                         ? `${itemField}_${field.name}?.map(node => expect(node instanceof ${field.type.slice(0, -2)}))`
                         : operation.print.list

--- a/packages/codegen-test/src/print-test.ts
+++ b/packages/codegen-test/src/print-test.ts
@@ -412,9 +412,13 @@ function printConnectionQueryTest(context: SdkPluginContext, operation: SdkOpera
                         field.type,
                         operation.print.list
                       )} = await _${itemField}.${field.name}`,
-                      operation.print.list
-                        ? `${itemField}_${field.name}?.map(node => expect(node instanceof ${field.type}))`
-                        : `expect(${itemField}_${field.name} instanceof ${field.type})`,
+                      /** When the field itself returns a list (e.g. ReleaseNote.releases: [Release]),
+                       * iterate the items for the instanceof check — `instanceof Foo[]` is not valid TS. */
+                      field.type.endsWith("[]")
+                        ? `${itemField}_${field.name}?.map(node => expect(node instanceof ${field.type.slice(0, -2)}))`
+                        : operation.print.list
+                          ? `${itemField}_${field.name}?.map(node => expect(node instanceof ${field.type}))`
+                          : `expect(${itemField}_${field.name} instanceof ${field.type})`,
                     ]),
                     `No ${connectionType} found - cannot test ${itemField}.${field.name} query`
                   )


### PR DESCRIPTION
[#72852](https://github.com/linear/linear-app/pull/72852) promoted release fields out of `[ALPHA]`, exposing two latent codegen bugs that together break the schema CI on `master`.

**Doc codegen — variable name collisions.** `releaseSearch` is a list-returning root query with its own `$filter: ReleaseFilter` and `$first`. Recursing into its children produces operations like `releaseSearch_documents` that flatten args from every chain step, declaring `$filter` and `$first` twice. Skip a child whose arg names overlap the chain's existing args.

**Test codegen — `instanceof Foo[]`.** `ReleaseNote.releases: [Release]` makes the connection-query test path emit `expect(... instanceof L.Release[])`, which prettier rejects as invalid TS. The `itemQueries` branch checked the parent connection's list flag instead of the field's own type. Iterate elements when `field.type` ends with `[]`.

Fixes LIN-69025

## Test plan

- [x] `pnpm update:schema && pnpm build` succeeds locally against the current production schema (previously failed with 8 GraphQL validation errors, then with the prettier syntax error)
- [x] `pnpm test` passes (670 tests, 2 skipped)
- [x] Re-run the schema workflow once merged to confirm a clean `feat(sdk): update schema` PR is produced: https://github.com/linear/linear/actions/runs/25355726392/job/74344450868