### PR TITLE
ci: cache pnpm store, npx tools, and smoke npm downloads

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,17 +21,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Use node 22
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "22"
-
-      - name: Enable Corepack
-        run: corepack enable
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install
@@ -41,6 +42,12 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+
+      - name: Cache npx tools
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-arethetypeswrong-0.18.2
 
       - name: Validate CJS and ESM resolution for SDK
         # Catch issues like https://github.com/linear/linear/issues/830
@@ -93,12 +100,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
+
+      - name: Cache npm downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-smoke-node${{ matrix.node }}-ts${{ matrix.typescript }}
 
       - name: Download SDK artifact
         uses: actions/download-artifact@v4
@@ -127,12 +140,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
+
+      - name: Cache npm downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-smoke-import-node${{ matrix.node }}
 
       - name: Download import artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -14,17 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Use node 22
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "22"
-
-      - name: Enable Corepack
-        run: corepack enable
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,11 +23,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Use node 22
         uses: actions/setup-node@v4
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
 
       # Ensure npm >= 11.5.1 for OIDC trusted publishers (https://docs.npmjs.com/trusted-publishers#github-actions-configuration)
       # Two-step upgrade works around broken npm in Node 22.22.2 (nodejs/node#62425)
@@ -38,9 +42,6 @@ jobs:
             npm install -g npm@10 && npm install -g npm@latest
           fi
 
-      - name: Enable Corepack
-        run: corepack enable
-
       - name: Install dependencies
         run: pnpm install
 
@@ -49,6 +50,12 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+
+      - name: Cache npx tools
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-arethetypeswrong-0.18.2
 
       - name: Validate CJS and ESM resolution for SDK
         # Catch issues like https://github.com/linear/linear/issues/830

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -16,17 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Use node 22
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "22"
-
-      - name: Enable Corepack
-        run: corepack enable
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install
@@ -44,6 +45,12 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+
+      - name: Cache npx tools
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-arethetypeswrong-0.18.2
 
       - name: Validate CJS and ESM resolution for SDK
         # Catch issues like https://github.com/linear/linear/issues/830


### PR DESCRIPTION
## Summary
- Adds pnpm store caching to all four workflows (`build`, `release`, `schema`, `dependencies`) via `pnpm/action-setup@v4` + `actions/setup-node@v4` with `cache: pnpm`, keyed on `pnpm-lock.yaml`.
- Caches `~/.npm` for the pinned `npx @arethetypeswrong/cli@0.18.2` step (build, release, schema) and for the per-matrix `npm install` in the smoke and smoke-import jobs.
- Bumps `actions/checkout` and `actions/setup-node` to v4, clearing the Node 20 deprecation warnings.

The 65s `pnpm build` is untouched — it would need a build-cache layer (turbo/nx) to improve, which is a separate, larger change.

## Test plan
- [x] First CI run on this PR populates caches; confirm jobs still succeed end-to-end.
- [x] Subsequent run on the same lockfile shows pnpm-store cache hit and faster install.
- [x] arethetypeswrong step shows cache hit and skips the npx download.
- [x] Smoke matrix variants show cache hits per `(node, typescript)` combo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)