### PR TITLE
Pin workflow dependencies to exact commits

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,7 @@ jobs:
         run: npx @arethetypeswrong/cli@0.18.2 --pack packages/sdk
 
       - name: Compare schema for changes
-        uses: kamilkisiela/graphql-inspector@master
+        uses: graphql-hive/graphql-inspector@e198fcf208b30d4e3337094262583280c7bf93e7 # @graphql-inspector/action@5.0.20
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           schema: "master:packages/sdk/src/schema.graphql"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
         run: npx @arethetypeswrong/cli@0.18.2 --pack packages/sdk
 
       - name: Compare schema for changes
-        uses: kamilkisiela/graphql-inspector@master
+        uses: graphql-hive/graphql-inspector@e198fcf208b30d4e3337094262583280c7bf93e7 # @graphql-inspector/action@5.0.20
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           schema: "master:packages/sdk/src/schema.graphql"
@@ -72,7 +72,7 @@ jobs:
         run: git update-index --refresh && git diff-index HEAD
 
       - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@master
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           commit: "chore(release): version packages"
           title: "chore(release): version packages"

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -57,7 +57,7 @@ jobs:
         run: npx @arethetypeswrong/cli@0.18.2 --pack packages/sdk
 
       - name: Compare schema for changes
-        uses: kamilkisiela/graphql-inspector@master
+        uses: graphql-hive/graphql-inspector@e198fcf208b30d4e3337094262583280c7bf93e7 # @graphql-inspector/action@5.0.20
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           schema: "master:packages/sdk/src/schema.graphql"


### PR DESCRIPTION
- Pins `changesets/action` to 1.8.0: https://github.com/changesets/action/commit/63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b
- Pins `graphql-hive/graphql-inspector` to `5.0.20`: https://github.com/graphql-hive/graphql-inspector/commit/e198fcf208b30d4e3337094262583280c7bf93e7

Note that `graphql-inspector` has been moved from `kamilkisiela` to `graphql-hive`. Trying to access the old path [kamilkisiela/graphql-inspector](https://github.com/kamilkisiela/graphql-inspector) redirects to the new path [graphql-hive/graphql-inspector](https://github.com/graphql-hive/graphql-inspector), so this aligns the dependency with the new path as well. 

Fixes #1136