### PR TITLE
fix(sdk): reject empty webhook secret in LinearWebhookClient constructor

### DIFF
--- a/.changeset/webhook-empty-secret-guard.md
+++ b/.changeset/webhook-empty-secret-guard.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": patch
+---
+
+fix(sdk): throw early when `LinearWebhookClient` is constructed with an empty or non-string secret, instead of silently HMAC'ing with an empty key

--- a/packages/sdk/src/_tests/LinearWebhooks.test.ts
+++ b/packages/sdk/src/_tests/LinearWebhooks.test.ts
@@ -30,6 +30,17 @@ describe("webhooks", () => {
     parsedBody = JSON.parse(rawBody.toString());
   });
 
+  describe("constructor", () => {
+    it("should throw if the secret is an empty string", () => {
+      expect(() => new LinearWebhookClient("")).toThrowError(/non-empty string/);
+    });
+
+    it("should throw if the secret is not a string", () => {
+      expect(() => new LinearWebhookClient(undefined as unknown as string)).toThrowError(/non-empty string/);
+      expect(() => new LinearWebhookClient(null as unknown as string)).toThrowError(/non-empty string/);
+    });
+  });
+
   describe("verify", () => {
     it("incorrect signature, should fail verification", async () => {
       const webhook = new LinearWebhookClient("SECRET");

--- a/packages/sdk/src/webhooks/client.ts
+++ b/packages/sdk/src/webhooks/client.ts
@@ -38,7 +38,11 @@ export class LinearWebhookClient {
    * Creates a new LinearWebhookClient instance
    * @param secret The webhook signing secret. See https://linear.app/developers/webhooks#securing-webhooks.
    */
-  public constructor(private secret: string) {}
+  public constructor(private secret: string) {
+    if (typeof secret !== "string" || secret.length === 0) {
+      throw new TypeError("LinearWebhookClient: secret must be a non-empty string");
+    }
+  }
 
   /**
    * Creates a webhook handler function that can process Linear webhook requests


### PR DESCRIPTION
Fixes SEC-740. `LinearWebhookClient` previously accepted an empty/non-string `secret` in its constructor and would silently HMAC with that key, masking misconfiguration (e.g. an unset `process.env.WEBHOOK_SECRET`). The constructor now throws `TypeError` early so the failure is loud. Added tests for empty-string and non-string inputs, plus a patch changeset.