### PR TITLE
fix(sdk): prefer signed webhook timestamp

### DIFF
--- a/.changeset/fix-webhook-replay-bypass.md
+++ b/.changeset/fix-webhook-replay-bypass.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": patch
+---
+
+Fix webhook replay bypass where a fresh unsigned `linear-timestamp` header could override a stale signed `webhookTimestamp` in the body. The signed body timestamp now takes precedence over the header.

--- a/packages/sdk/src/_tests/webhook-handler.test.ts
+++ b/packages/sdk/src/_tests/webhook-handler.test.ts
@@ -4,7 +4,7 @@ import getPort from "get-port";
 import http from "http";
 import { v4 as uuidv4 } from "uuid";
 import { describe, expect, it } from "vitest";
-import { LINEAR_WEBHOOK_SIGNATURE_HEADER, LinearWebhookClient } from "../webhooks/index.js";
+import { LINEAR_WEBHOOK_SIGNATURE_HEADER, LINEAR_WEBHOOK_TS_HEADER, LinearWebhookClient } from "../webhooks/index.js";
 
 export interface SignedBody {
   body: Buffer;
@@ -161,6 +161,72 @@ describe("webhooks handlers", () => {
 
       const expectedIds = [issueIds.actorId, commentIds.actorId].sort();
       expect(receivedActorIds.sort()).toEqual(expectedIds);
+    } finally {
+      server.close();
+      handler.removeAllListeners();
+    }
+  });
+
+  it("rejects a stale signed body even when a fresh linear-timestamp header is supplied (fetch-style)", async () => {
+    const secret = "SECRET";
+    const client = new LinearWebhookClient(secret);
+    const handler = client.createHandler();
+
+    let invoked = 0;
+    handler.on("*", () => {
+      invoked += 1;
+    });
+
+    const staleTimestamp = Date.now() - 10 * 60 * 1000;
+    const { payload } = generateIssuePayload({ timestamp: staleTimestamp });
+    const { body, signature } = createSignedBody(secret, payload);
+
+    const headers = new Map<string, string>([
+      [LINEAR_WEBHOOK_SIGNATURE_HEADER, signature],
+      [LINEAR_WEBHOOK_TS_HEADER, String(Date.now())],
+      ["content-type", "application/json"],
+    ]);
+    const req = {
+      method: "POST",
+      headers: { get: (key: string) => headers.get(key.toLowerCase()) ?? null },
+      arrayBuffer: async () => body,
+    } as unknown as Request;
+
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    expect(invoked).toBe(0);
+  });
+
+  it("rejects a stale signed body even when a fresh linear-timestamp header is supplied (express server)", async () => {
+    const secret = "SECRET";
+    const client = new LinearWebhookClient(secret);
+    const handler = client.createHandler();
+    const app = express();
+    const port = await getPort();
+    let invoked = 0;
+    handler.on("*", () => {
+      invoked += 1;
+    });
+    app.post("/", (req, res) => {
+      void handler(req, res);
+    });
+    const server = app.listen(port);
+    try {
+      const staleTimestamp = Date.now() - 10 * 60 * 1000;
+      const { payload } = generateIssuePayload({ timestamp: staleTimestamp });
+      const { body, signature } = createSignedBody(secret, payload);
+
+      const result = await httpPost(
+        port,
+        "/",
+        {
+          [LINEAR_WEBHOOK_SIGNATURE_HEADER]: signature,
+          [LINEAR_WEBHOOK_TS_HEADER]: String(Date.now()),
+        },
+        body
+      );
+      expect(result.status).toBe(400);
+      expect(invoked).toBe(0);
     } finally {
       server.close();
       handler.removeAllListeners();

--- a/packages/sdk/src/webhooks/client.ts
+++ b/packages/sdk/src/webhooks/client.ts
@@ -208,7 +208,7 @@ export class LinearWebhookClient {
    *
    * @param rawBody - Raw request body as a Buffer
    * @param signature - The value of the `linear-signature` header
-   * @param timestampHeader - The value of the `linear-timestamp` header (preferred over body field)
+   * @param timestampHeader - The value of the `linear-timestamp` header (used only when the signed body has no timestamp)
    * @returns The verified and parsed webhook payload
    */
   private parseVerifiedPayload(
@@ -217,7 +217,7 @@ export class LinearWebhookClient {
     timestampHeader: string | null
   ): LinearWebhookPayload {
     const parsedBody = this.parseBodyAsWebhookPayload(rawBody);
-    const timestamp = timestampHeader ?? parsedBody.webhookTimestamp;
+    const timestamp = parsedBody.webhookTimestamp ?? timestampHeader;
 
     const verified = this.verify(rawBody, signature, timestamp);
     if (!verified) {


### PR DESCRIPTION
Fixes a webhook replay bypass where `createHandler()` trusted the unsigned `linear-timestamp` header before the signed `webhookTimestamp` body field. The SDK now uses the signed body timestamp first, keeping the header only as a fallback for payloads without that field.

This prevents stale signed webhook bodies from being replayed with a fresh header, and adds fetch-style and Express regression coverage for that scenario.

Added test