### PR TITLE
fix(import): route duplicate-state CSV rows to the canceled state

### DIFF
--- a/.changeset/import-skip-duplicate-states.md
+++ b/.changeset/import-skip-duplicate-states.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": patch
+---
+
+fix(import): route CSV statuses that match a workflow state of type `duplicate` to the team's canceled state instead of passing the duplicate-type state id to `createIssue`, which the server rejects with `Cannot create an issue in a duplicate state`

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -261,9 +261,20 @@ export const importIssues = async (
   const labelMapping = await handleLabels(client, importData, teamId, [...allTeamLabels, ...allWorkspaceLabels]);
 
   const existingStateMap = {} as { [name: string]: string };
+  const canceledStateId = workflowStates?.nodes?.find(state => state.type === "canceled")?.id;
   for (const state of workflowStates?.nodes ?? []) {
     const stateName = state.name?.toLowerCase();
-    if (stateName && state.id && !existingStateMap[stateName]) {
+    if (!stateName || !state.id) {
+      continue;
+    }
+    if (state.type === "duplicate") {
+      // duplicate-type states are rejected by createIssue; route incoming statuses with this name to canceled instead
+      if (canceledStateId && !existingStateMap[stateName]) {
+        existingStateMap[stateName] = canceledStateId;
+      }
+      continue;
+    }
+    if (!existingStateMap[stateName]) {
       existingStateMap[stateName] = state.id;
     }
   }


### PR DESCRIPTION
## Summary
- The CLI importer (`@linear/import`) maps CSV statuses to existing workflow states by name. When a team has a workflow state of type `duplicate` (e.g. created by the server-side migration of an old canceled "Duplicate" state), the importer would pass that state's id to `createIssue`, which the server rejects with `Cannot create an issue in a duplicate state`, aborting the entire import.
- Fix: when building the name→id map, route duplicate-type states to the team's canceled state id instead of their own id. Non-duplicate states map normally; if the team has no canceled state, the name falls through to the existing `createWorkflowState` branch.
- Fixes LIN-71057.

## Test plan
- [ ] Manually: against a team that has a `duplicate`-type state named "Duplicate", import a CSV containing a row with `status="Duplicate"` and verify the issue is created in the canceled state instead of failing the import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)