### PR TITLE
fix(deps): patch lodash advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,7 @@ overrides:
   '@tootallnate/once@<3.0.1': 3.0.1
   graphql: ^15.4.0
   immutable@<3.8.3: 5.1.5
+  lodash@<4.17.12: 4.18.1
   minimatch@>=4.0.0 <4.2.5: 4.2.5
   moment@<2.29.4: 2.30.1
   node-fetch@^2: 2.6.7
@@ -4017,12 +4018,6 @@ packages:
   lodash.upperfirst@4.3.1:
     resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
 
-  lodash@3.10.1:
-    resolution: {integrity: sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==}
-
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
-
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
@@ -6776,7 +6771,7 @@ snapshots:
       common-tags: 1.8.2
       graphql: 15.10.1
       import-from: 4.0.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       tslib: 2.4.1
 
   '@graphql-codegen/plugin-helpers@3.1.2(graphql@15.10.1)':
@@ -6786,7 +6781,7 @@ snapshots:
       common-tags: 1.8.2
       graphql: 15.10.1
       import-from: 4.0.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       tslib: 2.4.1
 
   '@graphql-codegen/plugin-helpers@6.1.0(graphql@15.10.1)':
@@ -6796,7 +6791,7 @@ snapshots:
       common-tags: 1.8.2
       graphql: 15.10.1
       import-from: 4.0.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       tslib: 2.6.3
 
   '@graphql-codegen/schema-ast@2.6.1(graphql@15.10.1)':
@@ -9936,7 +9931,7 @@ snapshots:
       cli-cursor: 1.0.2
       figures: 1.7.0
       inquirer: 1.2.3
-      lodash: 3.10.1
+      lodash: 4.18.1
       rx-lite: 4.0.8
       util: 0.10.4
 
@@ -10443,10 +10438,6 @@ snapshots:
   lodash.uniq@4.5.0: {}
 
   lodash.upperfirst@4.3.1: {}
-
-  lodash@3.10.1: {}
-
-  lodash@4.17.23: {}
 
   lodash@4.18.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ overrides:
   '@tootallnate/once@<3.0.1': 3.0.1
   graphql: ^15.4.0
   immutable@<3.8.3: 5.1.5
-  lodash@<4.17.12: 4.18.1
+  lodash@<4.17.21: 4.18.1
   minimatch@>=4.0.0 <4.2.5: 4.2.5
   moment@<2.29.4: 2.30.1
   node-fetch@^2: 2.6.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,7 @@ overrides:
   "@tootallnate/once@<3.0.1": 3.0.1
   graphql: "catalog:"
   immutable@<3.8.3: 5.1.5
+  lodash@<4.17.12: 4.18.1
   minimatch@>=4.0.0 <4.2.5: 4.2.5
   moment@<2.29.4: 2.30.1
   node-fetch@^2: 2.6.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,7 +32,7 @@ overrides:
   "@tootallnate/once@<3.0.1": 3.0.1
   graphql: "catalog:"
   immutable@<3.8.3: 5.1.5
-  lodash@<4.17.12: 4.18.1
+  lodash@<4.17.21: 4.18.1
   minimatch@>=4.0.0 <4.2.5: 4.2.5
   moment@<2.29.4: 2.30.1
   node-fetch@^2: 2.6.7


### PR DESCRIPTION
## Summary

Patches the critical lodash audit finding on `master` and broadens the guardrail for the related high-severity lodash prototype pollution range:

- Critical advisory: `GHSA-jf85-cpcp-j695` (`Prototype Pollution in lodash`)
- Related high advisory: `GHSA-35jh-r3h4-6jhm`, patched in `lodash@4.17.21`
- Affected critical path: `packages/import > inquirer-file-path > lodash@3.10.1`
- Fix: add a scoped pnpm override for lodash versions below `4.17.21`:

```yaml
lodash@<4.17.21: 4.18.1
```

`inquirer-file-path` has no newer release than `1.0.1`, so this keeps the existing package and resolves through the workspace lodash version.

The regenerated lockfile resolves lodash to `4.18.1` across the workspace and removes the stale `3.10.1` and `4.17.23` lockfile entries.

## Validation

Ran locally:

- `pnpm install --no-frozen-lockfile`
- `CI=true pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm test` - 680 passed, 2 skipped
- `pnpm run lint`
- `pnpm audit --audit-level critical` - no critical findings remain
- `pnpm audit --json | rg '"module_name": "lodash"|GHSA-jf85|GHSA-35jh|lodash'` - no lodash audit matches

## Notes

The full audit still reports existing low/moderate/high findings unrelated to lodash.