### PR TITLE
chore: bump pnpm to 11.1.3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Use node 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Use node 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Use node 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Use node 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/package.json
+++ b/package.json
@@ -94,5 +94,5 @@
       }
     }
   },
-  "packageManager": "pnpm@10.25.0"
+  "packageManager": "pnpm@11.1.3"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,12 +18,11 @@ catalog:
   tsdown: ^0.17.2
   typescript: ^5.9
 
-onlyBuiltDependencies:
-  - es5-ext
-  - esbuild
-  - husky
-  - jss
-  - spawn-sync
+allowBuilds:
+  esbuild: true
+  es5-ext: false
+  jss: false
+  spawn-sync: false
 
 # 1 day in minutes
 minimumReleaseAge: 1440


### PR DESCRIPTION
Mirrors internal version bump

## Summary

- Bump the repo package manager from `pnpm@10.25.0` to `pnpm@11.1.3`
- Update GitHub Actions to use `pnpm/action-setup` v6.0.8
- Replace the deprecated pnpm 10 `onlyBuiltDependencies` setting with pnpm 11 `allowBuilds`
- Allow the required `esbuild` install script and explicitly deny non-essential install scripts for `es5-ext`, `jss`, and `spawn-sync`

## Validation

- `pnpm --version` -> `11.1.3`
- `CI=true pnpm install --frozen-lockfile`
- `pnpm run build`
- `git diff --check`