### PR TITLE
Move Shortcut importer images to server-side uploads

### DIFF
--- a/.changeset/shortcut-importer-image-handling.md
+++ b/.changeset/shortcut-importer-image-handling.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": minor
+---
+
+fix(import): stop pre-uploading images via `imageUploadFromUrl` in the Shortcut CSV importer.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,11 @@ export default defineConfig(
   {
     languageOptions: {
       parserOptions: {
-        project: ["./packages/*/tsconfig.json", "./packages/sdk/tsconfig.test.json"],
+        project: [
+          "./packages/*/tsconfig.json",
+          "./packages/import/tsconfig.test.json",
+          "./packages/sdk/tsconfig.test.json",
+        ],
       },
     },
   },

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -20,11 +20,11 @@
     "dist"
   ],
   "scripts": {
-    "cli": "ts-node src/cli",
-    "cli:local": "NODE_TLS_REJECT_UNAUTHORIZED=0 ts-node src/cli --apiUrl https://local.linear.dev:8090/graphql",
-    "dev:import": "NODE_ENV=development pnpm run build:import",
+    "cli": "TS_NODE_TRANSPILE_ONLY=true node --loader ts-node/esm src/cli.ts",
+    "cli:local": "NODE_TLS_REJECT_UNAUTHORIZED=0 TS_NODE_TRANSPILE_ONLY=true node --loader ts-node/esm src/cli.ts --apiUrl https://local.linear.dev:8090/graphql",
     "build:import": "tsdown --clean --format cjs src/cli.ts",
-    "build:types": "tsc --noEmit"
+    "build:types": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+    "test": "vitest"
   },
   "dependencies": {
     "@linear/sdk": "workspace:*",
@@ -45,7 +45,8 @@
     "@types/node-fetch": "^2.5.7",
     "tsdown": "catalog:",
     "ts-node": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "^4.0.15"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/import/src/_tests/appendImageUrlSuffix.test.ts
+++ b/packages/import/src/_tests/appendImageUrlSuffix.test.ts
@@ -47,4 +47,41 @@ describe("appendImageUrlSuffix", () => {
       '<img src="https://media.app.shortcut.com/a.png?token=t">'
     );
   });
+
+  it("does not append the suffix to backslash-escaped image markers", () => {
+    expect(appendImageUrlSuffix("\\![literal](https://media.app.shortcut.com/a.png)", "?token=t", options)).toBe(
+      "\\![literal](https://media.app.shortcut.com/a.png)"
+    );
+  });
+
+  it("treats a doubly-escaped backslash as a literal backslash, so the image IS rewritten", () => {
+    expect(appendImageUrlSuffix("\\\\![alt](https://media.app.shortcut.com/a.png)", "?token=t", options)).toBe(
+      "\\\\![alt](https://media.app.shortcut.com/a.png?token=t)"
+    );
+  });
+
+  it("does not append the suffix to images inside inline code spans", () => {
+    expect(
+      appendImageUrlSuffix("see `![alt](https://media.app.shortcut.com/a.png)` for syntax", "?token=t", options)
+    ).toBe("see `![alt](https://media.app.shortcut.com/a.png)` for syntax");
+  });
+
+  it("does not append the suffix to images inside fenced code blocks", () => {
+    const input = "```\n![alt](https://media.app.shortcut.com/a.png)\n```";
+    expect(appendImageUrlSuffix(input, "?token=t", options)).toBe(input);
+  });
+
+  it("does not append the suffix to HTML img tags inside inline code spans", () => {
+    expect(appendImageUrlSuffix('`<img src="https://media.app.shortcut.com/a.png">`', "?token=t", options)).toBe(
+      '`<img src="https://media.app.shortcut.com/a.png">`'
+    );
+  });
+
+  it("still rewrites images that sit outside a code block in the same document", () => {
+    const input =
+      "![one](https://media.app.shortcut.com/a.png)\n\n```\n![two](https://media.app.shortcut.com/b.png)\n```\n\n![three](https://media.app.shortcut.com/c.png)";
+    expect(appendImageUrlSuffix(input, "?token=t", options)).toBe(
+      "![one](https://media.app.shortcut.com/a.png?token=t)\n\n```\n![two](https://media.app.shortcut.com/b.png)\n```\n\n![three](https://media.app.shortcut.com/c.png?token=t)"
+    );
+  });
 });

--- a/packages/import/src/_tests/appendImageUrlSuffix.test.ts
+++ b/packages/import/src/_tests/appendImageUrlSuffix.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { appendImageUrlSuffix } from "../utils/appendImageUrlSuffix.ts";
+
+const options = { allowedHostSuffixes: ["shortcut.com", "clubhouse.io"] };
+
+describe("appendImageUrlSuffix", () => {
+  it("keeps literal parentheses in markdown image URLs intact", () => {
+    expect(
+      appendImageUrlSuffix(
+        "![Screenshot](https://media.app.shortcut.com/files/Screen%20Shot%20(1).png)",
+        "?token=t",
+        options
+      )
+    ).toBe("![Screenshot](https://media.app.shortcut.com/files/Screen%20Shot%20(1).png?token=t)");
+  });
+
+  it("uses an ampersand when the image URL already has a query string", () => {
+    expect(appendImageUrlSuffix("![Image](https://media.clubhouse.io/a.png?size=large)", "?token=t", options)).toBe(
+      "![Image](https://media.clubhouse.io/a.png?size=large&token=t)"
+    );
+  });
+
+  it("inserts the suffix before URL fragments", () => {
+    expect(
+      appendImageUrlSuffix("![Image](https://media.clubhouse.io/a.png?size=large#preview)", "?token=t", options)
+    ).toBe("![Image](https://media.clubhouse.io/a.png?size=large&token=t#preview)");
+  });
+
+  it("appends the suffix to markdown image URLs with titles", () => {
+    expect(appendImageUrlSuffix('![Image](https://media.clubhouse.io/a.png "Preview")', "?token=t", options)).toBe(
+      '![Image](https://media.clubhouse.io/a.png?token=t "Preview")'
+    );
+  });
+
+  it("does not append the suffix to markdown links or disallowed image hosts", () => {
+    expect(
+      appendImageUrlSuffix(
+        "[PDF](https://media.app.shortcut.com/file.pdf) ![External](https://example.com/image.png)",
+        "?token=t",
+        options
+      )
+    ).toBe("[PDF](https://media.app.shortcut.com/file.pdf) ![External](https://example.com/image.png)");
+  });
+
+  it("appends the suffix to HTML image tags", () => {
+    expect(appendImageUrlSuffix('<img src="https://media.app.shortcut.com/a.png">', "?token=t", options)).toBe(
+      '<img src="https://media.app.shortcut.com/a.png?token=t">'
+    );
+  });
+});

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -289,7 +289,9 @@ export const importIssues = async (
   // Create issues
   for (const issue of importData.issues) {
     const issueDescription = issue.description
-      ? await replaceImagesInMarkdown(client, issue.description, importData.resourceURLSuffix)
+      ? importData.skipImageReplacement
+        ? issue.description
+        : await replaceImagesInMarkdown(client, issue.description, importData.resourceURLSuffix)
       : undefined;
 
     const description =
@@ -384,7 +386,9 @@ const buildComments = async (
     const user = importData.users[comment.userId];
     const date = comment.createdAt ? comment.createdAt.toISOString().split("T")[0] : undefined;
 
-    const body = await replaceImagesInMarkdown(client, comment.body || "", importData.resourceURLSuffix);
+    const body = importData.skipImageReplacement
+      ? comment.body || ""
+      : await replaceImagesInMarkdown(client, comment.body || "", importData.resourceURLSuffix);
     newComments.push(`**${user.name}**${" " + date}\n\n${body}\n`);
   }
   return `${description}\n\n---\n\n${newComments.join("\n\n")}`;

--- a/packages/import/src/importers/shortcutCsv/ShortcutCsvImporter.ts
+++ b/packages/import/src/importers/shortcutCsv/ShortcutCsvImporter.ts
@@ -2,6 +2,7 @@
 /* eslint-disable eqeqeq */
 import csv from "csvtojson";
 import type { Importer, ImportResult } from "../../types.ts";
+import { appendImageUrlSuffix } from "../../utils/appendImageUrlSuffix.ts";
 import { safeParseInt } from "../../utils/parseInt.ts";
 
 type ShortcutStoryType = "feature" | "bug" | "chore";
@@ -101,7 +102,9 @@ export class ShortcutCsvImporter implements Importer {
       labels: {},
       users: {},
       statuses: {},
-      resourceURLSuffix: "?token=" + this.apiToken,
+      // Skip the client-side pre-upload of images. Linear's API will fetch the
+      // token-bearing URLs server-side.
+      skipImageReplacement: true,
     };
 
     const assignees = Array.from(new Set(data.map(row => row.owners).flat()));
@@ -113,6 +116,12 @@ export class ShortcutCsvImporter implements Importer {
       };
     }
 
+    const tokenSuffix = "?token=" + this.apiToken;
+    // Only hosts that we know are auth-gated by the Shortcut API token. Restricting the
+    // allowlist prevents the token from leaking to unrelated third-party hosts that may
+    // appear in story descriptions.
+    const shortcutHostSuffixes = ["clubhouse.io", "shortcut.com"];
+
     for (const row of data) {
       const title = row.name;
       if (!title) {
@@ -120,13 +129,21 @@ export class ShortcutCsvImporter implements Importer {
       }
 
       const url = this.shortcutBaseURL + "/story/" + row.id;
+      // Rewrite the legacy Clubhouse media host to its current Shortcut equivalent.
+      // The legacy host 301-redirects, but Linear's image downloader does not follow
+      // redirects, which would otherwise cause the upload to fail.
+      const rewrittenDescription = (row.description ?? "").replaceAll("media.clubhouse.io", "media.app.shortcut.com");
       const descriptionParts = [
-        row.description,
+        rewrittenDescription,
         row.tasks.map(t => `- ${t}`).join("\n"),
         row.external_tickets.map(externalUrl => `* **External Link:** ${externalUrl}`).join("\n"),
         `[View original issue in Shortcut](${url})`,
       ];
-      const description = descriptionParts.filter(s => s.length > 0).join("\n\n");
+      // Embed the token in image URLs so Linear's API can fetch them; the API rewrites
+      // these to Linear-hosted URLs before persisting, so the token never lands in stored content.
+      const description = appendImageUrlSuffix(descriptionParts.filter(s => s.length > 0).join("\n\n"), tokenSuffix, {
+        allowedHostSuffixes: shortcutHostSuffixes,
+      });
 
       const tags = row.labels;
       tags.push(row.type);

--- a/packages/import/src/types.ts
+++ b/packages/import/src/types.ts
@@ -70,6 +70,10 @@ export interface ImportResult {
   };
   /// A suffix to be appended to each resource URL (e.g. to authenticate requests)
   resourceURLSuffix?: string;
+  /// When true, the CLI skips the client-side image pre-upload step and leaves image
+  /// URLs untouched in descriptions and comments. Use this when descriptions already
+  /// contain URLs that Linear's API will fetch and rewrite server-side.
+  skipImageReplacement?: boolean;
 }
 
 /**

--- a/packages/import/src/utils/appendImageUrlSuffix.ts
+++ b/packages/import/src/utils/appendImageUrlSuffix.ts
@@ -1,5 +1,42 @@
 const IMAGE_TAG_REGEX = /(<img[^>]*?src=")(https?:\/\/[^"]+)(")/g;
 
+function isBackslashEscaped(text: string, index: number): boolean {
+  let count = 0;
+  for (let i = index - 1; i >= 0 && text[i] === "\\"; i--) {
+    count++;
+  }
+  return count % 2 === 1;
+}
+
+function findCodeRanges(text: string): [number, number][] {
+  const ranges: [number, number][] = [];
+
+  // Fenced code blocks: 3+ backticks or tildes at line start (0-3 spaces of indent).
+  // Unclosed fences extend to end of input.
+  const fence = /(?:^|\n)[ \t]{0,3}(`{3,}|~{3,})[^\n]*(?:\n[\s\S]*?(?:\n[ \t]{0,3}\1[ \t]*(?=\n|$)|$)|$)/g;
+  let m: RegExpExecArray | null;
+  while ((m = fence.exec(text)) !== null) {
+    const start = m[0].startsWith("\n") ? m.index + 1 : m.index;
+    ranges.push([start, m.index + m[0].length]);
+  }
+
+  // Inline code spans: matching runs of backticks on the same line.
+  const inline = /`+[^`\n]+?`+/g;
+  while ((m = inline.exec(text)) !== null) {
+    const idx = m.index;
+    if (ranges.some(([s, e]) => idx >= s && idx < e)) {
+      continue;
+    }
+    ranges.push([idx, idx + m[0].length]);
+  }
+
+  return ranges;
+}
+
+function inCodeRange(index: number, ranges: [number, number][]): boolean {
+  return ranges.some(([s, e]) => index >= s && index < e);
+}
+
 function mergeQuery(url: string, suffix: string): string {
   const fragmentStart = url.indexOf("#");
   const urlWithoutFragment = fragmentStart === -1 ? url : url.slice(0, fragmentStart);
@@ -115,7 +152,11 @@ function findMarkdownImageTitleEnd(text: string, start: number): number {
   return -1;
 }
 
-function appendMarkdownImageUrlSuffix(text: string, apply: (url: string) => string): string {
+function appendMarkdownImageUrlSuffix(
+  text: string,
+  apply: (url: string) => string,
+  codeRanges: [number, number][]
+): string {
   let result = "";
   let cursor = 0;
 
@@ -124,6 +165,13 @@ function appendMarkdownImageUrlSuffix(text: string, apply: (url: string) => stri
     if (imageStart === -1) {
       result += text.slice(cursor);
       break;
+    }
+
+    // Skip escaped markers (\![…]) and markers inside code spans/blocks — they don't render as images.
+    if (isBackslashEscaped(text, imageStart) || inCodeRange(imageStart, codeRanges)) {
+      result += text.slice(cursor, imageStart + 1);
+      cursor = imageStart + 1;
+      continue;
     }
 
     const urlStart = text.indexOf("](", imageStart + 2);
@@ -158,6 +206,11 @@ function appendMarkdownImageUrlSuffix(text: string, apply: (url: string) => stri
  * Append a query suffix to every external image URL in a markdown string.
  *
  * Handles both markdown images (`![alt](https://…)`) and HTML `<img src="https://…">` tags.
+ * Skips markers that would not render as images, so the suffix is not embedded into
+ * literal text the server-side image pipeline won't rewrite away:
+ * - Backslash-escaped markdown image markers (`\![…](…)`), respecting `\\` → literal backslash.
+ * - URLs inside inline code spans (`` `…` ``) and fenced code blocks (```` ```…``` ````).
+ *
  * When the source URL already contains a query string and the suffix starts with `?`,
  * the suffix is joined with `&` so the resulting URL stays well-formed.
  *
@@ -180,8 +233,13 @@ export function appendImageUrlSuffix(
     }
     return mergeQuery(url, suffix);
   };
-  return appendMarkdownImageUrlSuffix(text, apply).replace(
-    IMAGE_TAG_REGEX,
-    (_match, pre: string, url: string, post: string) => `${pre}${apply(url)}${post}`
-  );
+  const codeRangesInput = findCodeRanges(text);
+  const afterMarkdown = appendMarkdownImageUrlSuffix(text, apply, codeRangesInput);
+  const codeRangesAfter = findCodeRanges(afterMarkdown);
+  return afterMarkdown.replace(IMAGE_TAG_REGEX, (match, pre: string, url: string, post: string, offset: number) => {
+    if (isBackslashEscaped(afterMarkdown, offset) || inCodeRange(offset, codeRangesAfter)) {
+      return match;
+    }
+    return `${pre}${apply(url)}${post}`;
+  });
 }

--- a/packages/import/src/utils/appendImageUrlSuffix.ts
+++ b/packages/import/src/utils/appendImageUrlSuffix.ts
@@ -1,0 +1,187 @@
+const IMAGE_TAG_REGEX = /(<img[^>]*?src=")(https?:\/\/[^"]+)(")/g;
+
+function mergeQuery(url: string, suffix: string): string {
+  const fragmentStart = url.indexOf("#");
+  const urlWithoutFragment = fragmentStart === -1 ? url : url.slice(0, fragmentStart);
+  const fragment = fragmentStart === -1 ? "" : url.slice(fragmentStart);
+
+  if (suffix.startsWith("?") && urlWithoutFragment.includes("?")) {
+    return urlWithoutFragment + "&" + suffix.slice(1) + fragment;
+  }
+  return urlWithoutFragment + suffix + fragment;
+}
+
+function hostMatches(url: string, allowedHostSuffixes: string[]): boolean {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return allowedHostSuffixes.some(suffix => {
+    const lower = suffix.toLowerCase();
+    return host === lower || host.endsWith("." + lower);
+  });
+}
+
+function findMarkdownImageUrlEnd(text: string, start: number): number | undefined {
+  let depth = 0;
+  for (let index = start; index < text.length; index++) {
+    const char = text[index];
+    if (char === "\\") {
+      index++;
+      continue;
+    }
+    if (char === "(") {
+      depth++;
+      continue;
+    }
+    if (char === ")") {
+      if (depth === 0) {
+        return index;
+      }
+      depth--;
+      continue;
+    }
+    if (depth === 0 && /\s/.test(char)) {
+      return hasMarkdownImageClosingDelimiter(text, index) ? index : undefined;
+    }
+  }
+  return undefined;
+}
+
+function hasMarkdownImageClosingDelimiter(text: string, start: number): boolean {
+  let index = skipWhitespace(text, start);
+
+  if (text[index] === ")") {
+    return true;
+  }
+
+  index = findMarkdownImageTitleEnd(text, index);
+  if (index === -1) {
+    return false;
+  }
+
+  index = skipWhitespace(text, index);
+  return text[index] === ")";
+}
+
+function skipWhitespace(text: string, start: number): number {
+  let index = start;
+  while (index < text.length && /\s/.test(text[index])) {
+    index++;
+  }
+  return index;
+}
+
+function findMarkdownImageTitleEnd(text: string, start: number): number {
+  const delimiter = text[start];
+  if (delimiter === '"' || delimiter === "'") {
+    for (let index = start + 1; index < text.length; index++) {
+      if (text[index] === "\\") {
+        index++;
+        continue;
+      }
+      if (text[index] === delimiter) {
+        return index + 1;
+      }
+    }
+    return -1;
+  }
+
+  if (delimiter !== "(") {
+    return -1;
+  }
+
+  let depth = 0;
+  for (let index = start; index < text.length; index++) {
+    const char = text[index];
+    if (char === "\\") {
+      index++;
+      continue;
+    }
+    if (char === "(") {
+      depth++;
+      continue;
+    }
+    if (char === ")") {
+      depth--;
+      if (depth === 0) {
+        return index + 1;
+      }
+    }
+  }
+
+  return -1;
+}
+
+function appendMarkdownImageUrlSuffix(text: string, apply: (url: string) => string): string {
+  let result = "";
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const imageStart = text.indexOf("![", cursor);
+    if (imageStart === -1) {
+      result += text.slice(cursor);
+      break;
+    }
+
+    const urlStart = text.indexOf("](", imageStart + 2);
+    if (urlStart === -1) {
+      result += text.slice(cursor);
+      break;
+    }
+
+    const urlContentStart = urlStart + 2;
+    if (!text.startsWith("http://", urlContentStart) && !text.startsWith("https://", urlContentStart)) {
+      result += text.slice(cursor, urlContentStart);
+      cursor = urlContentStart;
+      continue;
+    }
+
+    const urlContentEnd = findMarkdownImageUrlEnd(text, urlContentStart);
+    if (urlContentEnd === undefined) {
+      result += text.slice(cursor, urlContentStart);
+      cursor = urlContentStart;
+      continue;
+    }
+
+    result += text.slice(cursor, urlContentStart);
+    result += apply(text.slice(urlContentStart, urlContentEnd));
+    cursor = urlContentEnd;
+  }
+
+  return result;
+}
+
+/**
+ * Append a query suffix to every external image URL in a markdown string.
+ *
+ * Handles both markdown images (`![alt](https://…)`) and HTML `<img src="https://…">` tags.
+ * When the source URL already contains a query string and the suffix starts with `?`,
+ * the suffix is joined with `&` so the resulting URL stays well-formed.
+ *
+ * If `allowedHostSuffixes` is provided, the suffix is only appended to URLs whose host
+ * exactly matches or is a subdomain of one of the listed suffixes — guards against
+ * leaking auth tokens to third-party hosts that happen to be embedded in descriptions.
+ */
+export function appendImageUrlSuffix(
+  text: string,
+  suffix: string,
+  options?: { allowedHostSuffixes?: string[] }
+): string {
+  if (!text || !suffix) {
+    return text;
+  }
+  const allowed = options?.allowedHostSuffixes;
+  const apply = (url: string): string => {
+    if (allowed && !hostMatches(url, allowed)) {
+      return url;
+    }
+    return mergeQuery(url, suffix);
+  };
+  return appendMarkdownImageUrlSuffix(text, apply).replace(
+    IMAGE_TAG_REGEX,
+    (_match, pre: string, url: string, post: string) => `${pre}${apply(url)}${post}`
+  );
+}

--- a/packages/import/tsconfig.test.json
+++ b/packages/import/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src/_tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,6 +286,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.15
+        version: 4.0.15(@types/node@24.10.2)(jiti@1.17.1)(jsdom@16.7.0)(terser@5.44.1)(yaml@2.8.2)
 
   packages/sdk:
     dependencies:


### PR DESCRIPTION
This PR aims at modernizing image uploads from Shortcut CSV imports:
-  Moves image management to the server
- Uses the user-provided token to downloaded private assets
- Replaces old `media.clubhouse.io` URLS with their current equivalent `media.app.shortcut.com` as these otherwise return a 301 that the linear API will not follow.