### PR TITLE
fix: defends against JSDoc comment injection in the SDK codegen

### DIFF
--- a/.changeset/huge-bees-sink.md
+++ b/.changeset/huge-bees-sink.md
@@ -1,0 +1,5 @@
+---
+"@linear/codegen-doc": patch
+---
+
+defends against JSDoc comment injection in the SDK codegen

--- a/packages/codegen-doc/package.json
+++ b/packages/codegen-doc/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "build:codegen-doc": "tsdown --clean --exports --dts",
-    "build:types": "tsc --noEmit"
+    "build:types": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+    "test": "vitest"
   },
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "catalog:",
@@ -25,7 +26,8 @@
   },
   "devDependencies": {
     "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "^4.0.15"
   },
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",

--- a/packages/codegen-doc/src/_tests/print.test.ts
+++ b/packages/codegen-doc/src/_tests/print.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { printComment } from "../print.js";
+
+describe("printComment", () => {
+  it("wraps a single line in a JSDoc block", () => {
+    expect(printComment(["hello world"])).toEqual("/** hello world */");
+  });
+
+  it("wraps multiple lines in a JSDoc block", () => {
+    expect(printComment(["first line", "second line"])).toEqual("/**\n * first line\n * second line\n */");
+  });
+
+  it("splits a line containing newlines", () => {
+    expect(printComment(["first\nsecond"])).toEqual("/**\n * first\n * second\n */");
+  });
+
+  it("filters out empty and undefined lines", () => {
+    expect(printComment(["", undefined, "only"])).toEqual("/** only */");
+  });
+
+  it("escapes */ in a single line so the comment cannot terminate early", () => {
+    expect(printComment(["hello */ world"])).toEqual("/** hello * / world */");
+  });
+
+  it("escapes */ on every line in a multi-line block", () => {
+    expect(printComment(["first */ break", "second */ break"])).toEqual(
+      "/**\n * first * / break\n * second * / break\n */"
+    );
+  });
+
+  it("escapes multiple */ occurrences on the same line", () => {
+    expect(printComment(["a */ b */ c"])).toEqual("/** a * / b * / c */");
+  });
+
+  it("escapes */ that appear after a newline split", () => {
+    expect(printComment(["safe\nthen */ unsafe"])).toEqual("/**\n * safe\n * then * / unsafe\n */");
+  });
+});

--- a/packages/codegen-doc/src/print.ts
+++ b/packages/codegen-doc/src/print.ts
@@ -60,7 +60,8 @@ export function wrapString(str: string, length = 100): string {
 export function printComment(lines: (string | undefined)[]): string {
   const parsed = lines
     .filter(line => line && line !== "")
-    .reduce((prev, line) => [...prev, ...(line as string).split("\n")], [] as string[]);
+    .reduce((prev, line) => [...prev, ...(line as string).split("\n")], [] as string[])
+    .map(line => line.replace(/\*\//g, "* /"));
 
   return parsed.length > 1 ? printLines(["/**", ...parsed.map(line => ` * ${line}`), " */"]) : `/** ${parsed[0]} */`;
 }

--- a/packages/codegen-doc/tsconfig.json
+++ b/packages/codegen-doc/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist"
-  }
+  },
+  "exclude": ["src/_tests", "dist"]
 }

--- a/packages/codegen-doc/tsconfig.test.json
+++ b/packages/codegen-doc/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/_tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.15
+        version: 4.0.15(@types/node@24.10.2)(jiti@1.17.1)(yaml@2.9.0)
 
   packages/codegen-sdk:
     dependencies:


### PR DESCRIPTION
printComment` receives GraphQL `description` values controlled by the Linear-owned schema. A description containing `*/` would close the JSDoc block early and let trailing text be parsed as real code in the SDK.