### PR TITLE
fix(ci): make dependency changeset generation pre-build safe

### DIFF
--- a/packages/sdk/scripts/generate-dependencies-changeset.ts
+++ b/packages/sdk/scripts/generate-dependencies-changeset.ts
@@ -1,9 +1,12 @@
-import { logger, printLines } from "@linear/codegen-doc";
 import { writeFile } from "fs";
 import path from "path";
 import { promisify } from "util";
 
 const filename = path.resolve(`../../.changeset/_generated_dependencies.md`);
+
+function printLines(lines: (string | undefined)[]): string {
+  return lines.filter(Boolean).join("\n");
+}
 
 const changeset = printLines([
   "---",
@@ -24,10 +27,9 @@ async function generateChangeset() {
 
 generateChangeset()
   .then(() => {
-    logger.info("script:generate-dependencies-changeset: Generated changeset for dependencies");
+    process.stdout.write("script:generate-dependencies-changeset: Generated changeset for dependencies\n");
   })
   .catch(error => {
-    logger.error("script:generate-dependencies-changeset: Generating changeset for dependencies");
-    logger.fatal(error);
+    process.stderr.write("script:generate-dependencies-changeset: Generating changeset for dependencies\n");
     throw error;
   });


### PR DESCRIPTION
## Summary

Fixes LIN-71752 by removing the dependency changeset script's import of `@linear/codegen-doc`.

The dependencies workflow runs `pnpm update:dependencies` before `pnpm build`, so importing the workspace package required `packages/codegen-doc/dist/index.mjs` before it existed on a fresh CI checkout. The script only needs line joining and status logging, so this keeps it self-contained and safe to run before package builds.

## Verification

- `pnpm --filter @linear/sdk generate:changeset:dependencies`
- `pnpm exec eslint packages/sdk/scripts/generate-dependencies-changeset.ts`
- `pnpm exec prettier --check packages/sdk/scripts/generate-dependencies-changeset.ts`
- `pnpm exec tsc --noEmit --project packages/sdk/tsconfig.json --pretty false`