### PR TITLE
Add npm support metadata for Linear packages

### DIFF
--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -12,6 +12,10 @@
     "linear-import": "bin/linear-import.cjs"
   },
   "repository": "https://github.com/linear/linear",
+  "homepage": "https://github.com/linear/linear/tree/master/packages/import#readme",
+  "bugs": {
+    "url": "https://github.com/linear/linear/issues"
+  },
   "engines": {
     "node": ">=18.x"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -5,6 +5,10 @@
   "author": "Linear Orbit, Inc",
   "license": "MIT",
   "repository": "https://github.com/linear/linear",
+  "homepage": "https://github.com/linear/linear/tree/master/packages/sdk#readme",
+  "bugs": {
+    "url": "https://github.com/linear/linear/issues"
+  },
   "type": "module",
   "engines": {
     "node": ">=18.x"


### PR DESCRIPTION
## Summary

Add standard npm `homepage` and `bugs` metadata to `packages/sdk/package.json` for `@linear/sdk` and to `packages/import/package.json` for `@linear/import`.

The published packages already expose repository and MIT license metadata, but npm metadata does not expose `homepage` or `bugs` fields. This points package consumers to the relevant README and the public issue tracker.

## Validation

- `node -e "const p=require('./packages/sdk/package.json'); if(p.homepage!=='https://github.com/linear/linear/tree/master/packages/sdk#readme') throw new Error('homepage mismatch'); if(p.bugs?.url!=='https://github.com/linear/linear/issues') throw new Error('bugs mismatch'); console.log(JSON.stringify({name:p.name,homepage:p.homepage,bugs:p.bugs,repository:p.repository}, null, 2));"`
- `node -e "const p=require('./packages/import/package.json'); if(p.homepage!=='https://github.com/linear/linear/tree/master/packages/import#readme') throw new Error('homepage mismatch'); if(p.bugs?.url!=='https://github.com/linear/linear/issues') throw new Error('bugs mismatch'); console.log(JSON.stringify({name:p.name,homepage:p.homepage,bugs:p.bugs,repository:p.repository}, null, 2));"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json` from `packages/sdk`
- `npm pack --dry-run --ignore-scripts --json` from `packages/import`

## Scope

Manifest metadata only. No runtime code, dependency, generated output, or lockfile changes.