### PR TITLE
chore: add sdk package support metadata

### DIFF
--- a/.changeset/sdk-support-metadata.md
+++ b/.changeset/sdk-support-metadata.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": patch
+---
+
+Add npm homepage and bugs metadata for the SDK package.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -5,6 +5,10 @@
   "author": "Linear Orbit, Inc",
   "license": "MIT",
   "repository": "https://github.com/linear/linear",
+  "homepage": "https://linear.app/developers/sdk",
+  "bugs": {
+    "url": "https://github.com/linear/linear/issues"
+  },
   "type": "module",
   "engines": {
     "node": ">=18.x"


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata for `@linear/sdk`
- add npm `bugs.url` metadata pointing to the GitHub issue tracker
- add a patch changeset for the metadata update

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('packages/sdk/package.json','utf8')); console.log('package.json OK')"`
- `git diff --check`
