### PR TITLE
Fix schema CI GraphQL Inspector action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,7 +56,7 @@ jobs:
         run: npx @arethetypeswrong/cli@0.18.2 --pack packages/sdk
 
       - name: Compare schema for changes
-        uses: graphql-hive/graphql-inspector@e198fcf208b30d4e3337094262583280c7bf93e7 # @graphql-inspector/action@5.0.20
+        uses: graphql-hive/graphql-inspector@8733c10560f98b868d3eb4db1325c8edf64936b3 # @graphql-inspector/action@5.0.21
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           schema: "master:packages/sdk/src/schema.graphql"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
         run: npx @arethetypeswrong/cli@0.18.2 --pack packages/sdk
 
       - name: Compare schema for changes
-        uses: graphql-hive/graphql-inspector@e198fcf208b30d4e3337094262583280c7bf93e7 # @graphql-inspector/action@5.0.20
+        uses: graphql-hive/graphql-inspector@8733c10560f98b868d3eb4db1325c8edf64936b3 # @graphql-inspector/action@5.0.21
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           schema: "master:packages/sdk/src/schema.graphql"

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -59,7 +59,7 @@ jobs:
         run: npx @arethetypeswrong/cli@0.18.2 --pack packages/sdk
 
       - name: Compare schema for changes
-        uses: graphql-hive/graphql-inspector@e198fcf208b30d4e3337094262583280c7bf93e7 # @graphql-inspector/action@5.0.20
+        uses: graphql-hive/graphql-inspector@8733c10560f98b868d3eb4db1325c8edf64936b3 # @graphql-inspector/action@5.0.21
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           schema: "master:packages/sdk/src/schema.graphql"


### PR DESCRIPTION
## Summary

Updates the pinned `graphql-hive/graphql-inspector` action from `@graphql-inspector/action@5.0.20` to `5.0.21` in the build, release, and scheduled schema workflows.

## Why

The scheduled schema job was failing after GitHub Actions started forcing Node 20 actions to run on Node 24. The schema generation, build, and tests completed successfully; the failure happened when the pinned GraphQL Inspector action started up. Upstream `5.0.21` fixes Node 24 compatibility and declares `runs.using: node24`.

## Validation

- `git diff --cached --check`
- Parsed the touched workflow YAML files with Ruby `YAML.load_file`
- Confirmed the replacement action metadata uses `runs.using: node24`

Run successful: https://github.com/linear/linear/actions/runs/27984630141/job/82823031730