### PR TITLE
fix(ci): retry SDK schema comparison

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,6 +56,16 @@ jobs:
         run: npx @arethetypeswrong/cli@0.18.2 --pack packages/sdk
 
       - name: Compare schema for changes
+        id: compare_schema
+        continue-on-error: true
+        uses: graphql-hive/graphql-inspector@8733c10560f98b868d3eb4db1325c8edf64936b3 # @graphql-inspector/action@5.0.21
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          schema: "master:packages/sdk/src/schema.graphql"
+          fail-on-breaking: false
+
+      - name: Retry schema comparison
+        if: steps.compare_schema.outcome == 'failure'
         uses: graphql-hive/graphql-inspector@8733c10560f98b868d3eb4db1325c8edf64936b3 # @graphql-inspector/action@5.0.21
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,6 +65,16 @@ jobs:
         run: npx @arethetypeswrong/cli@0.18.2 --pack packages/sdk
 
       - name: Compare schema for changes
+        id: compare_schema
+        continue-on-error: true
+        uses: graphql-hive/graphql-inspector@8733c10560f98b868d3eb4db1325c8edf64936b3 # @graphql-inspector/action@5.0.21
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          schema: "master:packages/sdk/src/schema.graphql"
+          fail-on-breaking: false
+
+      - name: Retry schema comparison
+        if: steps.compare_schema.outcome == 'failure'
         uses: graphql-hive/graphql-inspector@8733c10560f98b868d3eb4db1325c8edf64936b3 # @graphql-inspector/action@5.0.21
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -59,6 +59,16 @@ jobs:
         run: npx @arethetypeswrong/cli@0.18.2 --pack packages/sdk
 
       - name: Compare schema for changes
+        id: compare_schema
+        continue-on-error: true
+        uses: graphql-hive/graphql-inspector@8733c10560f98b868d3eb4db1325c8edf64936b3 # @graphql-inspector/action@5.0.21
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          schema: "master:packages/sdk/src/schema.graphql"
+          fail-on-breaking: false
+
+      - name: Retry schema comparison
+        if: steps.compare_schema.outcome == 'failure'
         uses: graphql-hive/graphql-inspector@8733c10560f98b868d3eb4db1325c8edf64936b3 # @graphql-inspector/action@5.0.21
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Retry GraphQL Inspector once in the schema, build, and release workflows. This handles transient GitHub API failures while preserving persistent failures.

Tested with `pnpm exec prettier --check .github/workflows/build.yaml .github/workflows/release.yaml .github/workflows/schema.yaml`.