### PR TITLE
test(sdk): gate auth bundle test behind E2E

### DIFF
--- a/packages/sdk/src/_tests/bundle.test.ts
+++ b/packages/sdk/src/_tests/bundle.test.ts
@@ -87,7 +87,7 @@ Object.entries(bundles).map(([bundleFormat, bundle]) =>
       return issue;
     }
 
-    it("throw auth error", async () => {
+    it.skipIf(!process.env.E2E)("throw auth error", async () => {
       const client = new ClientConstructor({ apiKey: "fake api key" });
 
       await expectError(


### PR DESCRIPTION
Skip the bundle authentication assertion outside E2E runs. This prevents standard SDK tests from calling the production API and depending on its error classification.

Tested with `pnpm --filter @linear/sdk build:sdk && pnpm --filter @linear/sdk test src/_tests/bundle.test.ts --run`.