### PR TITLE
feat(import): support issue dependencies in linear CSV import

### DIFF
--- a/.changeset/issue-dependencies-csv-import.md
+++ b/.changeset/issue-dependencies-csv-import.md
@@ -1,0 +1,5 @@
+---
+"@linear/import": minor
+---
+
+Support issue dependencies in Linear CSV import. Optional `Blocks` and `Blocked By` columns resolve references to other issues in the same import file (by row `Id` or title), create the issues, then wire the dependencies as `blocks` relations. Unresolvable, ambiguous, self-referencing, or mutually-contradictory references abort the import before any issue is created so a re-run never duplicates a half-imported backlog.

--- a/packages/import/README.md
+++ b/packages/import/README.md
@@ -124,7 +124,7 @@ The following fields are supported:
 - `Blocks` - Comma-separated references to issues in this import that this issue blocks
 - `Blocked By` - Comma-separated references to issues in this import that block this issue
 
-The `Blocks` and `Blocked By` columns are optional. Each reference is resolved against the other issues in the same import file, matching first on the row `Id` column, then on an issue's title (case-insensitive). A reference that matches no issue or more than one issue aborts the import before any issue is created, so a re-run never duplicates a half-imported backlog. A dependency expressed in both columns is created once.
+The `Blocks` and `Blocked By` columns are optional. Each reference is resolved against the other issues in the same import file, matching first on the row `Id` column, then on an issue's title (case-insensitive). A reference that matches no issue or more than one issue aborts the import before any issue is created, so a re-run never duplicates a half-imported backlog. Self-references, a dependency declared in both directions, and duplicate row `Id`s are rejected the same way. A dependency expressed in both columns is created once.
 
 ### GitLab CSV
 

--- a/packages/import/README.md
+++ b/packages/import/README.md
@@ -121,6 +121,10 @@ The following fields are supported:
 - `Estimate` - Issue estimate
 - `Created` - Issue creation date
 - `Completed` - Issue completion date (if has completed status)
+- `Blocks` - Comma-separated references to issues in this import that this issue blocks
+- `Blocked By` - Comma-separated references to issues in this import that block this issue
+
+The `Blocks` and `Blocked By` columns are optional. Each reference is resolved against the other issues in the same import file, matching first on the row `Id` column, then on an issue's title (case-insensitive). A reference that matches no issue or more than one issue aborts the import before any issue is created, so a re-run never duplicates a half-imported backlog. A dependency expressed in both columns is created once.
 
 ### GitLab CSV
 

--- a/packages/import/src/_tests/issueDependencies.test.ts
+++ b/packages/import/src/_tests/issueDependencies.test.ts
@@ -33,15 +33,6 @@ describe("resolveDependencies", () => {
     expect(pairs(resolveDependencies(issues))).toEqual([["Login page", "Auth"]]);
   });
 
-  it("deduplicates one dependency expressed in both columns", () => {
-    const issues = [
-      issue({ title: "Auth", blocks: ["Login page"], blockedBy: ["Login page"] }),
-      issue({ title: "Login page" }),
-    ];
-
-    expect(pairs(resolveDependencies(issues))).toEqual([["Auth", "Login page"]]);
-  });
-
   it("deduplicates the same dependency referenced from two rows", () => {
     const issues = [
       issue({ title: "Auth", blocks: ["Login page"] }),
@@ -49,6 +40,37 @@ describe("resolveDependencies", () => {
     ];
 
     expect(pairs(resolveDependencies(issues))).toEqual([["Auth", "Login page"]]);
+  });
+
+  it("throws when one row declares the same dependency in both columns", () => {
+    const issues = [
+      issue({ title: "Auth", blocks: ["Login page"], blockedBy: ["Login page"] }),
+      issue({ title: "Login page" }),
+    ];
+
+    expect(() => resolveDependencies(issues)).toThrow(/both directions/);
+  });
+
+  it("throws when two rows declare opposing blocks relations", () => {
+    const issues = [issue({ title: "Auth", blocks: ["Login page"] }), issue({ title: "Login page", blocks: ["Auth"] })];
+
+    expect(() => resolveDependencies(issues)).toThrow(/both directions/);
+  });
+
+  it("throws when a row declares a self-reference", () => {
+    const issues = [issue({ title: "Auth", blocks: ["Auth"] })];
+
+    expect(() => resolveDependencies(issues)).toThrow(/refers to the issue itself/);
+  });
+
+  it("throws when a row Id is duplicated and referenced", () => {
+    const issues = [
+      issue({ title: "Auth", blocks: ["CSV-7"] }),
+      issue({ title: "Login page", externalId: "CSV-7" }),
+      issue({ title: "Signup", externalId: "CSV-7" }),
+    ];
+
+    expect(() => resolveDependencies(issues)).toThrow(/row Ids must be unique/);
   });
 
   it("resolves a chain of dependencies order-independently", () => {

--- a/packages/import/src/_tests/issueDependencies.test.ts
+++ b/packages/import/src/_tests/issueDependencies.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { resolveDependencies } from "../importIssues.ts";
+import type { Issue } from "../types.ts";
+
+const issue = (overrides: Partial<Issue> & Pick<Issue, "title">): Issue => ({
+  externalId: undefined,
+  blocks: undefined,
+  blockedBy: undefined,
+  ...overrides,
+});
+
+// Resolved dependencies hold the exact issue objects from the input array, so compare by title pair
+// rather than by object identity (which callers cannot observe).
+const pairs = (deps: { blocker: Issue; blocked: Issue }[]): [string, string][] =>
+  deps.map(dep => [dep.blocker.title, dep.blocked.title]);
+
+describe("resolveDependencies", () => {
+  it("resolves a reference by source-row external id", () => {
+    const issues = [issue({ title: "Auth", blocks: ["CSV-7"] }), issue({ title: "Login page", externalId: "CSV-7" })];
+
+    expect(pairs(resolveDependencies(issues))).toEqual([["Auth", "Login page"]]);
+  });
+
+  it("resolves a reference by case-insensitive trimmed title", () => {
+    const issues = [issue({ title: "Auth", blocks: ["  login PAGE "] }), issue({ title: "Login page" })];
+
+    expect(pairs(resolveDependencies(issues))).toEqual([["Auth", "Login page"]]);
+  });
+
+  it("swaps ids for a Blocked By reference so the blocker is first", () => {
+    const issues = [issue({ title: "Auth", blockedBy: ["Login page"] }), issue({ title: "Login page" })];
+
+    expect(pairs(resolveDependencies(issues))).toEqual([["Login page", "Auth"]]);
+  });
+
+  it("deduplicates one dependency expressed in both columns", () => {
+    const issues = [
+      issue({ title: "Auth", blocks: ["Login page"], blockedBy: ["Login page"] }),
+      issue({ title: "Login page" }),
+    ];
+
+    expect(pairs(resolveDependencies(issues))).toEqual([["Auth", "Login page"]]);
+  });
+
+  it("deduplicates the same dependency referenced from two rows", () => {
+    const issues = [
+      issue({ title: "Auth", blocks: ["Login page"] }),
+      issue({ title: "Login page", blockedBy: ["Auth"] }),
+    ];
+
+    expect(pairs(resolveDependencies(issues))).toEqual([["Auth", "Login page"]]);
+  });
+
+  it("resolves a chain of dependencies order-independently", () => {
+    const issues = [
+      issue({ title: "Auth", blockedBy: ["Login page"] }),
+      issue({ title: "Login page" }),
+      issue({ title: "Onboarding", blocks: ["Login page"] }),
+    ];
+
+    expect(pairs(resolveDependencies(issues))).toEqual([
+      ["Login page", "Auth"],
+      ["Onboarding", "Login page"],
+    ]);
+  });
+
+  it("throws when a reference matches no issue", () => {
+    const issues = [issue({ title: "Auth", blocks: ["Nonexistent"] })];
+
+    expect(() => resolveDependencies(issues)).toThrow("matched 0 issues");
+  });
+
+  it("throws when a title reference is ambiguous", () => {
+    const issues = [issue({ title: "Auth", blocks: ["Setup"] }), issue({ title: "Setup" }), issue({ title: "Setup" })];
+
+    expect(() => resolveDependencies(issues)).toThrow(/matched 2 issues/);
+  });
+
+  it("returns an empty list when no issue declares dependencies", () => {
+    const issues = [issue({ title: "Auth" }), issue({ title: "Login page" })];
+
+    expect(resolveDependencies(issues)).toEqual([]);
+  });
+});

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -65,6 +65,11 @@ export const importIssues = async (
   const client = new LinearClient({ apiKey, apiUrl });
   const importData = await importer.import();
 
+  // Resolve and validate dependency references against the source batch before any workspace mutation
+  // (team creation, label creation, or issue creation). A bad reference must abort before anything is
+  // created, otherwise a re-run would duplicate issues or strand a half-mutated workspace.
+  const resolvedDependencies = resolveDependencies(importData.issues);
+
   const viewerQuery = await client.viewer;
 
   let spinner = ora("Fetching teams and users").start();
@@ -308,11 +313,8 @@ export const importIssues = async (
   issuesProgressBar.start(importData.issues.length, 0);
   let issueCursor = 0;
 
-  // Resolve and validate dependency references against the source batch before creating anything.
-  // A bad reference must abort before any issue is created, otherwise a re-run would duplicate issues.
-  const resolvedDependencies = resolveDependencies(importData.issues);
-
-  const createdIssueIds: CreatedIssueIds = new Map();
+  // Only track created ids when dependencies need to be linked afterwards.
+  const createdIssueIds: CreatedIssueIds | undefined = resolvedDependencies.length > 0 ? new Map() : undefined;
 
   // Create issues
   for (const issue of importData.issues) {
@@ -370,27 +372,35 @@ export const importIssues = async (
     const formattedDueDate = issue.dueDate ? format(issue.dueDate, "yyyy-MM-dd") : undefined;
 
     try {
-      const createdIssue = await createIssueWithRetries(client, {
-        teamId,
-        projectId,
-        title: issue.title,
-        description,
-        priority: issue.priority,
-        labelIds,
-        stateId,
-        assigneeId,
-        createdAt: issue.createdAt,
-        completedAt: issue.completedAt,
-        dueDate: formattedDueDate,
-        estimate: issue.estimate,
-      });
+      const createdIssue = await withRateLimitRetries(() =>
+        client.createIssue({
+          teamId,
+          projectId,
+          title: issue.title,
+          description,
+          priority: issue.priority,
+          labelIds,
+          stateId,
+          assigneeId,
+          createdAt: issue.createdAt,
+          completedAt: issue.completedAt,
+          dueDate: formattedDueDate,
+          estimate: issue.estimate,
+        })
+      );
 
       if (issue.archived) {
         await (await createdIssue.issue)?.archive();
       }
 
-      const createdIssueId = (await createdIssue.issue)?.id;
-      if (createdIssueId) {
+      const createdIssueId = createdIssue.issueId;
+      if (createdIssue.success === false || !createdIssueId) {
+        issuesProgressBar.stop();
+        throw new Error(
+          `Failed to create issue "${issue.title}": the API rejected the creation (no issue id returned).`
+        );
+      }
+      if (createdIssueIds) {
         createdIssueIds.set(issue, createdIssueId);
       }
 
@@ -404,7 +414,7 @@ export const importIssues = async (
 
   issuesProgressBar.stop();
 
-  if (resolvedDependencies.length > 0) {
+  if (resolvedDependencies.length > 0 && createdIssueIds) {
     spinner = ora("Creating issue dependencies").start();
     try {
       await createRelations(client, resolvedDependencies, createdIssueIds);
@@ -436,19 +446,19 @@ const buildComments = async (
   return `${description}\n\n---\n\n${newComments.join("\n\n")}`;
 };
 
-const createIssueWithRetries = async (
-  client: LinearClient,
-  input: Parameters<LinearClient["createIssue"]>[0],
-  retries = 3
-): ReturnType<LinearClient["createIssue"]> => {
+/**
+ * Run a Linear request, retrying up to `retries` times when the API rate-limits the caller. Both issue
+ * creation and relation creation ride this wrapper so a rate-limited import does not fail midway.
+ */
+const withRateLimitRetries = async <T>(request: () => Promise<T>, retries = 3): Promise<T> => {
   try {
-    return await client.createIssue(input);
+    return await request();
   } catch (error) {
     if (error.type === "Ratelimited" && retries > 0) {
       // Hard-coded to 1 minute for now; when we do LIN-17685, we can use the X-RateLimit-Endpoint-Requests-Remaining
       // header to find out how long to wait.
       await new Promise(resolve => setTimeout(resolve, 60000));
-      return createIssueWithRetries(client, input, retries - 1);
+      return withRateLimitRetries(request, retries - 1);
     } else {
       throw error;
     }
@@ -460,39 +470,42 @@ const createIssueWithRetries = async (
  * dependency pairs to create. Each reference is matched, in order, against:
  *
  * 1. a source issue's externalId (its row `Id`),
- * 2. an issue identifier in the batch (a bare identifier string is also matched case-insensitively
- *    against titles as the final fallback),
- * 3. a case-insensitive, trimmed title match.
+ * 2. a case-insensitive, trimmed title match.
  *
  * A reference that matches zero issues or more than one issue aborts the import before any issue is created.
  * Pairs are canonicalized (the blocking issue first) and deduplicated so one dependency expressed in both
  * the `Blocks` and `Blocked By` columns is created only once.
  */
 export const resolveDependencies = (issues: Issue[]): ResolvedDependency[] => {
-  const byExternalId = new Map<string, Issue>();
+  const byExternalId = new Map<string, Issue[]>();
   const byLowerTitle = new Map<string, Issue[]>();
 
   for (const issue of issues) {
     if (issue.externalId) {
-      byExternalId.set(issue.externalId, issue);
+      const idMatches = byExternalId.get(issue.externalId) ?? [];
+      idMatches.push(issue);
+      byExternalId.set(issue.externalId, idMatches);
     }
-    const lowerTitle = issue.title?.trim().toLowerCase();
-    if (lowerTitle) {
-      const existing = byLowerTitle.get(lowerTitle) ?? [];
-      existing.push(issue);
-      byLowerTitle.set(lowerTitle, existing);
-    }
+    const lowerTitle = issue.title.trim().toLowerCase();
+    const titleMatches = byLowerTitle.get(lowerTitle) ?? [];
+    titleMatches.push(issue);
+    byLowerTitle.set(lowerTitle, titleMatches);
   }
 
   const match = (reference: string): Issue => {
     const trimmed = reference.trim();
-    const byId = byExternalId.get(trimmed);
-    if (byId) {
-      return byId;
+    const idMatches = byExternalId.get(trimmed);
+    if (idMatches) {
+      if (idMatches.length > 1) {
+        throw new Error(
+          `dependency reference "${reference}" matched ${idMatches.length} issues in this import (row Ids must be unique)`
+        );
+      }
+      return idMatches[0];
     }
 
     const titleMatches = byLowerTitle.get(trimmed.toLowerCase());
-    if (!titleMatches || titleMatches.length === 0) {
+    if (!titleMatches) {
       throw new Error(`dependency reference "${reference}" matched 0 issues in this import`);
     }
     if (titleMatches.length > 1) {
@@ -503,29 +516,53 @@ export const resolveDependencies = (issues: Issue[]): ResolvedDependency[] => {
     return titleMatches[0];
   };
 
-  // Collect raw pairs first so the row/column context survives resolution errors.
-  const resolved: ResolvedDependency[] = [];
-  for (const issue of issues) {
-    for (const reference of issue.blocks ?? []) {
-      const target = match(reference);
-      resolved.push({ blocker: issue, blocked: target });
-    }
-    for (const reference of issue.blockedBy ?? []) {
-      const target = match(reference);
-      resolved.push({ blocker: target, blocked: issue });
-    }
-  }
+  // Two issues can only share one `blocks` relation regardless of which column expressed it, so key the
+  // seen-set on the ordered pair of issue indices and keep first-occurrence order. A pair declared in both
+  // directions (row A blocks B and row B blocks A) is rejected rather than silently collapsed, and a
+  // self-reference is rejected too, so malformed graphs fail before any issue is created.
+  const indexByIdentity = new Map<Issue, number>();
+  issues.forEach((issue, index) => indexByIdentity.set(issue, index));
 
-  // Canonicalize and dedupe. Two issues can only share one `blocks` relation regardless of which column
-  // expressed it, so key on the unordered pair of issues.
   const seen = new Set<string>();
   const unique: ResolvedDependency[] = [];
-  for (const dep of resolved) {
-    const pair = [dep.blocker, dep.blocked].sort((a, b) => (a.title < b.title ? -1 : 1));
-    const key = `${pair[0].title}\u0000${pair[1].title}`;
-    if (!seen.has(key)) {
-      seen.add(key);
-      unique.push(dep);
+  for (const issue of issues) {
+    for (const reference of issue.blocks ?? []) {
+      const blocked = match(reference);
+      if (blocked === issue) {
+        throw new Error(`dependency reference "${reference}" refers to the issue itself in Blocks`);
+      }
+      const blockerIdx = indexByIdentity.get(issue)!;
+      const blockedIdx = indexByIdentity.get(blocked)!;
+      const key = `${blockerIdx}:${blockedIdx}`;
+      const reverseKey = `${blockedIdx}:${blockerIdx}`;
+      if (seen.has(reverseKey)) {
+        throw new Error(
+          `dependency reference "${reference}" declares a blocks relation in both directions (rows reference each other)`
+        );
+      }
+      if (!seen.has(key)) {
+        seen.add(key);
+        unique.push({ blocker: issue, blocked });
+      }
+    }
+    for (const reference of issue.blockedBy ?? []) {
+      const blocker = match(reference);
+      if (blocker === issue) {
+        throw new Error(`dependency reference "${reference}" refers to the issue itself in Blocked By`);
+      }
+      const blockerIdx = indexByIdentity.get(issue)!;
+      const blockedIdx = indexByIdentity.get(blocker)!;
+      const key = `${blockedIdx}:${blockerIdx}`;
+      const reverseKey = `${blockerIdx}:${blockedIdx}`;
+      if (seen.has(reverseKey)) {
+        throw new Error(
+          `dependency reference "${reference}" declares a blocks relation in both directions (rows reference each other)`
+        );
+      }
+      if (!seen.has(key)) {
+        seen.add(key);
+        unique.push({ blocker, blocked: issue });
+      }
     }
   }
   return unique;
@@ -555,32 +592,17 @@ const createRelations = async (
       continue;
     }
 
-    const result = await createIssueRelationWithRetries(client, {
-      issueId,
-      relatedIssueId,
-      type: IssueRelationType.Blocks,
-    });
+    const result = await withRateLimitRetries(() =>
+      client.createIssueRelation({
+        issueId,
+        relatedIssueId,
+        type: IssueRelationType.Blocks,
+      })
+    );
     if (result.success === false) {
       throw new Error(
         `Failed to create dependency between "${dep.blocker.title}" and "${dep.blocked.title}": the API rejected the relation.`
       );
-    }
-  }
-};
-
-const createIssueRelationWithRetries = async (
-  client: LinearClient,
-  input: Parameters<LinearClient["createIssueRelation"]>[0],
-  retries = 3
-): ReturnType<LinearClient["createIssueRelation"]> => {
-  try {
-    return await client.createIssueRelation(input);
-  } catch (error) {
-    if (error.type === "Ratelimited" && retries > 0) {
-      await new Promise(resolve => setTimeout(resolve, 60000));
-      return createIssueRelationWithRetries(client, input, retries - 1);
-    } else {
-      throw error;
     }
   }
 };

--- a/packages/import/src/importIssues.ts
+++ b/packages/import/src/importIssues.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { LinearClient } from "@linear/sdk";
+import { IssueRelationType, LinearClient } from "@linear/sdk";
 import chalk from "chalk";
 import { Presets, SingleBar } from "cli-progress";
 import { format } from "date-fns";
@@ -7,7 +7,7 @@ import inquirer from "inquirer";
 import uniq from "lodash/uniq.js";
 import ora from "ora";
 import { handleLabels } from "./helpers/labelManager.ts";
-import type { Comment, Importer, ImportResult } from "./types.ts";
+import type { Comment, Importer, ImportResult, Issue } from "./types.ts";
 import { replaceImagesInMarkdown } from "./utils/replaceImages.ts";
 
 type Id = string;
@@ -40,6 +40,17 @@ interface NonInteractiveFlags {
   includeComments?: boolean;
   selfAssign?: boolean;
 }
+
+/** One resolved dependency between two source-batch issues. Holds the source issues until creation maps them to Linear ids. */
+interface ResolvedDependency {
+  /** The issue that blocks. */
+  blocker: Issue;
+  /** The issue that is blocked. */
+  blocked: Issue;
+}
+
+/** Maps a source issue to the Linear id created for it during the import loop. */
+type CreatedIssueIds = Map<Issue, string>;
 
 /**
  * Import issues into Linear via the API.
@@ -297,6 +308,12 @@ export const importIssues = async (
   issuesProgressBar.start(importData.issues.length, 0);
   let issueCursor = 0;
 
+  // Resolve and validate dependency references against the source batch before creating anything.
+  // A bad reference must abort before any issue is created, otherwise a re-run would duplicate issues.
+  const resolvedDependencies = resolveDependencies(importData.issues);
+
+  const createdIssueIds: CreatedIssueIds = new Map();
+
   // Create issues
   for (const issue of importData.issues) {
     const issueDescription = issue.description
@@ -372,6 +389,11 @@ export const importIssues = async (
         await (await createdIssue.issue)?.archive();
       }
 
+      const createdIssueId = (await createdIssue.issue)?.id;
+      if (createdIssueId) {
+        createdIssueIds.set(issue, createdIssueId);
+      }
+
       issueCursor++;
       issuesProgressBar.update(issueCursor);
     } catch (error) {
@@ -381,6 +403,15 @@ export const importIssues = async (
   }
 
   issuesProgressBar.stop();
+
+  if (resolvedDependencies.length > 0) {
+    spinner = ora("Creating issue dependencies").start();
+    try {
+      await createRelations(client, resolvedDependencies, createdIssueIds);
+    } finally {
+      spinner.stop();
+    }
+  }
 
   console.info(chalk.green(`${importer.name} issues imported to your team: https://linear.app/team/${teamKey}/all`));
 };
@@ -418,6 +449,136 @@ const createIssueWithRetries = async (
       // header to find out how long to wait.
       await new Promise(resolve => setTimeout(resolve, 60000));
       return createIssueWithRetries(client, input, retries - 1);
+    } else {
+      throw error;
+    }
+  }
+};
+
+/**
+ * Resolve every `blocks` / `blockedBy` reference against the source batch and return the deduplicated
+ * dependency pairs to create. Each reference is matched, in order, against:
+ *
+ * 1. a source issue's externalId (its row `Id`),
+ * 2. an issue identifier in the batch (a bare identifier string is also matched case-insensitively
+ *    against titles as the final fallback),
+ * 3. a case-insensitive, trimmed title match.
+ *
+ * A reference that matches zero issues or more than one issue aborts the import before any issue is created.
+ * Pairs are canonicalized (the blocking issue first) and deduplicated so one dependency expressed in both
+ * the `Blocks` and `Blocked By` columns is created only once.
+ */
+export const resolveDependencies = (issues: Issue[]): ResolvedDependency[] => {
+  const byExternalId = new Map<string, Issue>();
+  const byLowerTitle = new Map<string, Issue[]>();
+
+  for (const issue of issues) {
+    if (issue.externalId) {
+      byExternalId.set(issue.externalId, issue);
+    }
+    const lowerTitle = issue.title?.trim().toLowerCase();
+    if (lowerTitle) {
+      const existing = byLowerTitle.get(lowerTitle) ?? [];
+      existing.push(issue);
+      byLowerTitle.set(lowerTitle, existing);
+    }
+  }
+
+  const match = (reference: string): Issue => {
+    const trimmed = reference.trim();
+    const byId = byExternalId.get(trimmed);
+    if (byId) {
+      return byId;
+    }
+
+    const titleMatches = byLowerTitle.get(trimmed.toLowerCase());
+    if (!titleMatches || titleMatches.length === 0) {
+      throw new Error(`dependency reference "${reference}" matched 0 issues in this import`);
+    }
+    if (titleMatches.length > 1) {
+      throw new Error(
+        `dependency reference "${reference}" matched ${titleMatches.length} issues in this import (titles must be unique)`
+      );
+    }
+    return titleMatches[0];
+  };
+
+  // Collect raw pairs first so the row/column context survives resolution errors.
+  const resolved: ResolvedDependency[] = [];
+  for (const issue of issues) {
+    for (const reference of issue.blocks ?? []) {
+      const target = match(reference);
+      resolved.push({ blocker: issue, blocked: target });
+    }
+    for (const reference of issue.blockedBy ?? []) {
+      const target = match(reference);
+      resolved.push({ blocker: target, blocked: issue });
+    }
+  }
+
+  // Canonicalize and dedupe. Two issues can only share one `blocks` relation regardless of which column
+  // expressed it, so key on the unordered pair of issues.
+  const seen = new Set<string>();
+  const unique: ResolvedDependency[] = [];
+  for (const dep of resolved) {
+    const pair = [dep.blocker, dep.blocked].sort((a, b) => (a.title < b.title ? -1 : 1));
+    const key = `${pair[0].title}\u0000${pair[1].title}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      unique.push(dep);
+    }
+  }
+  return unique;
+};
+
+/**
+ * Create the resolved `blocks` relations once every issue in the batch has been created. The source issues
+ * resolved at validation time are mapped to their created Linear ids; any issue whose creation did not return
+ * an id is skipped and reported. Each relation creation is retried on rate limits, and its `success` flag is
+ * checked so a silent partial graph is never reported as a successful import.
+ */
+const createRelations = async (
+  client: LinearClient,
+  dependencies: ResolvedDependency[],
+  createdIssueIds: CreatedIssueIds
+): Promise<void> => {
+  for (const dep of dependencies) {
+    const issueId = createdIssueIds.get(dep.blocker);
+    const relatedIssueId = createdIssueIds.get(dep.blocked);
+
+    if (!issueId || !relatedIssueId) {
+      console.error(
+        chalk.yellow(
+          `Skipped dependency "${dep.blocked.title}" blocked by "${dep.blocker.title}": a referenced issue could not be matched to a created issue.`
+        )
+      );
+      continue;
+    }
+
+    const result = await createIssueRelationWithRetries(client, {
+      issueId,
+      relatedIssueId,
+      type: IssueRelationType.Blocks,
+    });
+    if (result.success === false) {
+      throw new Error(
+        `Failed to create dependency between "${dep.blocker.title}" and "${dep.blocked.title}": the API rejected the relation.`
+      );
+    }
+  }
+};
+
+const createIssueRelationWithRetries = async (
+  client: LinearClient,
+  input: Parameters<LinearClient["createIssueRelation"]>[0],
+  retries = 3
+): ReturnType<LinearClient["createIssueRelation"]> => {
+  try {
+    return await client.createIssueRelation(input);
+  } catch (error) {
+    if (error.type === "Ratelimited" && retries > 0) {
+      await new Promise(resolve => setTimeout(resolve, 60000));
+      return createIssueRelationWithRetries(client, input, retries - 1);
     } else {
       throw error;
     }

--- a/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
+++ b/packages/import/src/importers/linearCsv/LinearCsvImporter.ts
@@ -26,6 +26,8 @@ interface LinearIssueType {
   Completed: string;
   Canceled: string;
   Archived: string;
+  Blocks: string;
+  "Blocked By": string;
 }
 
 /**
@@ -72,6 +74,9 @@ export class LinearCsvImporter implements Importer {
       const tags = row.Labels ? row.Labels.split(", ") : [];
       const labels = tags.filter(tag => !!tag);
 
+      const blocks = splitReferences(row.Blocks);
+      const blockedBy = splitReferences(row["Blocked By"]);
+
       importData.issues.push({
         title: stripLeadingSingleQuote(row.Title),
         description: stripLeadingSingleQuote(row.Description),
@@ -83,6 +88,9 @@ export class LinearCsvImporter implements Importer {
         startedAt: !!row.Started ? new Date(row.Started) : undefined,
         estimate: safeParseInt(row.Estimate),
         labels,
+        externalId: row.Id || undefined,
+        blocks,
+        blockedBy,
       });
 
       for (const lab of labels) {
@@ -106,6 +114,19 @@ export class LinearCsvImporter implements Importer {
 // as a formula. When we're sending the data to the API, we need to strip that leading single quote.
 function stripLeadingSingleQuote(input: string): string {
   return input.replace(/^'([+\-=@∑√∏<>＜＞≤≥＝≠±÷×])/, "$1");
+}
+
+// Dependency columns hold comma-separated references to other issues in the same import. Split on the same ", "
+// separator used by the Labels column and drop empties.
+function splitReferences(input: string | undefined): string[] | undefined {
+  if (!input) {
+    return undefined;
+  }
+  const refs = input
+    .split(", ")
+    .map(ref => stripLeadingSingleQuote(ref.trim()))
+    .filter(ref => !!ref);
+  return refs.length > 0 ? refs : undefined;
 }
 
 const mapPriority = (input: LinearPriority) => {

--- a/packages/import/src/importers/linearCsv/_tests/LinearCsvImporter.test.ts
+++ b/packages/import/src/importers/linearCsv/_tests/LinearCsvImporter.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LinearCsvImporter } from "../LinearCsvImporter.ts";
+
+const tempDirs: string[] = [];
+
+// Header must include every column the importer reads, matching a real Linear CSV export.
+const HEADER =
+  "Id,Team,Title,Description,Status,Estimate,Priority,Project,Creator,Assignee,Labels,Cycle Number,Cycle Name,Cycle Start,Cycle End,Created,Updated,Started,Completed,Canceled,Archived,Blocks,Blocked By";
+
+const importCsv = async (header: string, ...rows: string[]) => {
+  const dir = mkdtempSync(join(tmpdir(), "linear-csv-test-"));
+  tempDirs.push(dir);
+  const filePath = join(dir, "issues.csv");
+  writeFileSync(filePath, [header, ...rows].join("\n"));
+  return new LinearCsvImporter(filePath).import();
+};
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("LinearCsvImporter", () => {
+  it("parses Blocks and Blocked By columns into dependency references", async () => {
+    const result = await importCsv(
+      HEADER,
+      'CSV-1,ENG,Auth,"","","","",Project,,,,"","","","","","","","","","","CSV-2, CSV-3",""',
+      'CSV-2,ENG,Login page,"","","","",Project,,,,"","","","","","","","","","","",""',
+      'CSV-3,ENG,Onboarding,"","","","",Project,,,,"","","","","","","","","","","Login page",""'
+    );
+
+    const [auth, login, onboarding] = result.issues;
+    expect(auth.externalId).toBe("CSV-1");
+    expect(auth.blocks).toEqual(["CSV-2", "CSV-3"]);
+    expect(auth.blockedBy).toBeUndefined();
+    expect(login.blocks).toBeUndefined();
+    expect(onboarding.blocks).toEqual(["Login page"]);
+  });
+
+  it("maps the row Id onto externalId even without dependency values", async () => {
+    const result = await importCsv(
+      HEADER,
+      'CSV-9,ENG,Only issue,"","","","",Project,,,,"","","","","","","","","","","",""'
+    );
+
+    expect(result.issues[0].externalId).toBe("CSV-9");
+    expect(result.issues[0].blocks).toBeUndefined();
+  });
+
+  it("handles a CSV exported before the dependency columns existed", async () => {
+    const result = await importCsv(
+      "Id,Team,Title,Description,Status,Estimate,Priority,Project,Creator,Assignee,Labels,Cycle Number,Cycle Name,Cycle Start,Cycle End,Created,Updated,Started,Completed,Canceled,Archived",
+      'CSV-1,ENG,Auth,"","","","",Project,,,,"","","","","","","","","",""'
+    );
+
+    const [issue] = result.issues;
+    expect(issue.blocks).toBeUndefined();
+    expect(issue.blockedBy).toBeUndefined();
+    expect(issue.externalId).toBe("CSV-1");
+  });
+});

--- a/packages/import/src/importers/linearCsv/_tests/LinearCsvImporter.test.ts
+++ b/packages/import/src/importers/linearCsv/_tests/LinearCsvImporter.test.ts
@@ -29,8 +29,9 @@ describe("LinearCsvImporter", () => {
     const result = await importCsv(
       HEADER,
       'CSV-1,ENG,Auth,"","","","",Project,,,,"","","","","","","","","","","CSV-2, CSV-3",""',
-      'CSV-2,ENG,Login page,"","","","",Project,,,,"","","","","","","","","","","",""',
-      'CSV-3,ENG,Onboarding,"","","","",Project,,,,"","","","","","","","","","","Login page",""'
+      'CSV-2,ENG,Login page,"","","","",Project,,,,"","","","","","","","","","","","CSV-4"',
+      'CSV-3,ENG,Onboarding,"","","","",Project,,,,"","","","","","","","","","","Login page","CSV-1"',
+      'CSV-4,ENG,Signup,"","","","",Project,,,,"","","","","","","","","","","",""'
     );
 
     const [auth, login, onboarding] = result.issues;
@@ -38,7 +39,9 @@ describe("LinearCsvImporter", () => {
     expect(auth.blocks).toEqual(["CSV-2", "CSV-3"]);
     expect(auth.blockedBy).toBeUndefined();
     expect(login.blocks).toBeUndefined();
+    expect(login.blockedBy).toEqual(["CSV-4"]);
     expect(onboarding.blocks).toEqual(["Login page"]);
+    expect(onboarding.blockedBy).toEqual(["CSV-1"]);
   });
 
   it("maps the row Id onto externalId even without dependency values", async () => {

--- a/packages/import/src/types.ts
+++ b/packages/import/src/types.ts
@@ -30,6 +30,12 @@ export interface Issue {
   archived?: boolean;
   /** Issue estimate */
   estimate?: number;
+  /** External id of the issue in the source system. Used to resolve cross-references within an import batch. */
+  externalId?: string;
+  /** Issue identifiers (source row Ids, issue identifiers, or titles) that this issue blocks. */
+  blocks?: string[];
+  /** Issue identifiers (source row Ids, issue identifiers, or titles) that block this issue. */
+  blockedBy?: string[];
 }
 
 /** Issue comment */


### PR DESCRIPTION
## Summary

Linear CSV import can now carry issue dependencies. Add optional `Blocks` and `Blocked By` columns; each reference resolves to another issue in the same import file, and once every issue is created the links are wired as `blocks` relations.

A reference that cannot be resolved is a hard error, raised before any issue, team, or label is created. Self-references, dependencies declared in both directions, and duplicate row `Id`s are rejected the same way. This keeps a re-run from ever duplicating a half-imported backlog, because a bad file never gets far enough to create anything.

## Design notes

- Resolution matches first on the row `Id` column, then on a case-insensitive title. A dependency expressed in both columns (row A `Blocks=B` plus row B `Blocked By=A`) is deduplicated to a single relation.
- Relation and issue creation share one rate-limit retry wrapper, and the created issue id is read synchronously from the mutation payload rather than issuing a second GraphQL fetch per issue.
- `@linear/sdk` already exposes `createIssueRelation` with a `blocks` relation type; no SDK change was needed.

## Validation

`pnpm --filter './packages/import' test` passes 27 tests across 3 files (12 pre-existing plus new coverage for parsing, resolution, dedupe, and the validation errors). Typecheck and lint are clean.

## Unapplied review findings

- [ ] P2 - packages/import/src/importIssues.ts - Title normalization differs between the importer (strips a leading quote from formula-safe titles) and the resolver (only trims/lowercases), so a reference to a formula-like title can silently fail. Suggested fix: one shared normalization function used for both indexing and matching.
- [ ] P2 - packages/import/src/importIssues.ts - The `CreatedIssueIds | undefined` union threads an invariant guard through the creation loop, allocating a throwaway Map per issue on dependency-free imports. Suggested fix: hoist the branch so the Map is created once only when dependencies exist.
- [ ] P2 - packages/import/src/importIssues.ts - The rate-limit retry wrapper re-throws while the issue loop re-wraps its call site in an identical catch-and-throw; `error.type` is read untyped. Suggested fix: an `onRetry` hook plus type narrowing.
- [ ] P2 - packages/import/src/importIssues.ts - A dependency reference to an archived row (dropped by the importer) aborts the whole import before anything is created. The user must hand-edit the CSV. Suggested fix: warn and skip edges that reference an excluded archived row.
- [ ] P2 - packages/import/src/importIssues.ts - The relation-creation phase (direction of ids, `success === false` abort, missing-id skip) is not exercised by any test; `createRelations` is not exported and there is no `LinearClient` mock harness in the package.
- [ ] P2 - packages/import/src/importIssues.ts - A relation-phase failure (a relation rejected after all issues exist) leaves a partial graph whose natural recovery (re-running the CSV) duplicates every issue. Suggested fix: aggregate relation failures into one error that warns issues were already created.
- [ ] P3 - packages/import/src/importIssues.ts - The rate-limit retry sleeps a fixed 60s and ignores the SDK's parsed `retryAfter` / `requestsResetAt`. Suggested fix: honor the server reset hint when present.

Review run: `20260903-091604-01e96716`
