### PR TITLE
fix(sdk): preserve SLA start mode enum casing

### DIFF
--- a/packages/sdk/naming-override/index.js
+++ b/packages/sdk/naming-override/index.js
@@ -6,7 +6,7 @@ import * as changeCaseAll from "change-case-all";
 const duplicateQueries = ["ProjectMilestone", "ProjectMilestones"];
 
 // We have some non pascal cased types that we need to keep as is.
-const incorrectCase = ["SLADayCountType"];
+const incorrectCase = ["SLADayCountType", "SLAStartMode"];
 
 // Object containing counters of how many times we've seen each DuplicateQueryNameArgs type.
 const deduplicate = Object.fromEntries(duplicateQueries.map(query => [`Query${query}Args`, 0]));


### PR DESCRIPTION
Preserve the schema casing for `SLAStartMode` during SDK document generation. This keeps the generated document export aligned with the SDK re-export and fixes the schema workflow build failure.

Verified against the current live schema by regenerating the SDK and running the SDK bundle build.