### PR TITLE
ci: run lint checks and fix dependency updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Run lint
+        run: pnpm lint
+
       - name: Build packages
         run: pnpm build
 

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -31,6 +31,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Build dependency update prerequisites
+        # Changeset generation imports utilities from @linear/codegen-doc.
+        run: pnpm --filter @linear/codegen-doc build:codegen-doc
+
       - name: Update dependencies
         run: pnpm update:dependencies
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Run lint
+        run: pnpm lint
+
       - name: Build packages
         run: pnpm build
 


### PR DESCRIPTION
Run `pnpm lint` in branch builds and the `master` release workflow.

Lint errors previously did not block merges or releases. 

Also fixes a small problem with the `dependency` workflow - for clarity it's no longer automatically run (#886), but currently it errors when run manually too.