### PR TITLE
ci: use native pnpm setup

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,9 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+        with:
+          install: false
 
       - name: Use node 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -20,7 +20,9 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+        with:
+          install: false
 
       - name: Use node 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,9 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+        with:
+          install: false
 
       - name: Use node 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -23,7 +23,9 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+        with:
+          install: false
 
       - name: Use node 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/README.md
+++ b/README.md
@@ -57,7 +57,11 @@ Open source packages:
 
 ### Get Started
 
-Make sure you have Node 18+ and Corepack enabled (`corepack enable`).
+Make sure you have Node 18+ and install pnpm 12.3.1 with the [pnpm 12 standalone installer](https://pnpm.io/installation#installing-pnpm-12):
+
+```shell
+curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=12.3.1 sh -
+```
 
 ```shell
 # install dependencies

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Open source packages:
 
 ### Get Started
 
-Make sure you have Node 18+ and install pnpm 12.3.1 with the [pnpm 12 standalone installer](https://pnpm.io/installation#installing-pnpm-12):
+Make sure you have Node 18+, then install the pnpm version pinned by this repository with the [standalone installer](https://pnpm.io/installation#using-a-standalone-script):
 
 ```shell
-curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=12.3.1 sh -
+curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION="$(node -p "require('./package.json').packageManager.split('@')[1]")" sh -
 ```
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -57,11 +57,7 @@ Open source packages:
 
 ### Get Started
 
-Make sure you have Node 18+, then install the pnpm version pinned by this repository with the [standalone installer](https://pnpm.io/installation#using-a-standalone-script):
-
-```shell
-curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION="$(node -p "require('./package.json').packageManager.split('@')[1]")" sh -
-```
+Make sure you have Node 18+ and pnpm installed.
 
 ```shell
 # install dependencies

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -57,7 +57,11 @@ Open source packages:
 
 ### Get Started
 
-Make sure you have Node 18+ and Corepack enabled (`corepack enable`).
+Make sure you have Node 18+ and install pnpm 12.3.1 with the [pnpm 12 standalone installer](https://pnpm.io/installation#installing-pnpm-12):
+
+```shell
+curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=12.3.1 sh -
+```
 
 ```shell
 # install dependencies

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -57,10 +57,10 @@ Open source packages:
 
 ### Get Started
 
-Make sure you have Node 18+ and install pnpm 12.3.1 with the [pnpm 12 standalone installer](https://pnpm.io/installation#installing-pnpm-12):
+Make sure you have Node 18+, then install the pnpm version pinned by this repository with the [standalone installer](https://pnpm.io/installation#using-a-standalone-script):
 
 ```shell
-curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=12.3.1 sh -
+curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION="$(node -p "require('./package.json').packageManager.split('@')[1]")" sh -
 ```
 
 ```shell

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -57,11 +57,7 @@ Open source packages:
 
 ### Get Started
 
-Make sure you have Node 18+, then install the pnpm version pinned by this repository with the [standalone installer](https://pnpm.io/installation#using-a-standalone-script):
-
-```shell
-curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION="$(node -p "require('./package.json').packageManager.split('@')[1]")" sh -
-```
+Make sure you have Node 18+ and pnpm installed.
 
 ```shell
 # install dependencies


### PR DESCRIPTION
Use pnpm's native setup action in CI and remove Corepack from the contributor setup guide.

pnpm ships self-contained binaries. This avoids the npm package wrapper while keeping Node setup and caching unchanged.
