### PR TITLE
ci: consolidate SDK generation and releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.5.0/schema.json",
   "changelog": "@changesets/cli/changelog",
-  "commit": true,
+  "commit": false,
   "linked": [],
   "access": "public",
   "baseBranch": "master",

--- a/.github/scripts/create-release-summary.mjs
+++ b/.github/scripts/create-release-summary.mjs
@@ -1,0 +1,20 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const plan = JSON.parse(fs.readFileSync(path.join(process.env.RUNNER_TEMP, "release-plan.json"), "utf8"));
+const releases = plan.releases.filter(({ type }) => type !== "none");
+const lines = [
+  "This single pull request contains the generated schema and SDK updates plus all pending changesets. Merging it publishes the listed packages to npm; no second release pull request will be created.",
+  "",
+  "| Package | Current | Release | Bump |",
+  "| --- | --- | --- | --- |",
+  ...releases.map(({ name, oldVersion, newVersion, type }) => `| ${name} | ${oldVersion} | ${newVersion} | ${type} |`),
+  "",
+  "Full release notes are available in the changed `CHANGELOG.md` files. This pull request updates daily and whenever changes are merged to `master`.",
+  "",
+];
+const body = lines.join("\n");
+
+fs.writeFileSync(path.join(process.env.RUNNER_TEMP, "release-body.md"), body);
+fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, body);

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,18 +6,21 @@ on:
       - master
   workflow_dispatch:
 
+concurrency:
+  group: sdk-publish
+  cancel-in-progress: false
+  # Preserve every queued release snapshot so later master pushes cannot replace one.
+  queue: max
+
 permissions: {}
 
 jobs:
   release:
     name: Release
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:
-      actions: read
       contents: write
-      checks: write
-      pull-requests: write
-      statuses: read
       id-token: write # Required for OIDC (https://docs.npmjs.com/trusted-publishers#github-actions-configuration)
     steps:
       - name: Checkout code
@@ -50,11 +53,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Run lint
-        run: pnpm lint
-
       - name: Build packages
         run: pnpm build
+
+      - name: Run lint
+        run: pnpm lint
 
       - name: Run tests
         run: pnpm test
@@ -69,21 +72,14 @@ jobs:
         # Catch issues like https://github.com/linear/linear/issues/830
         run: npx @arethetypeswrong/cli@0.18.2 --pack packages/sdk
 
-      - name: Compare schema for changes
-        uses: graphql-hive/graphql-inspector@8733c10560f98b868d3eb4db1325c8edf64936b3 # @graphql-inspector/action@5.0.21
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          schema: "master:packages/sdk/src/schema.graphql"
-          fail-on-breaking: false
-
       - name: Check for no generated changes
-        run: git update-index --refresh && git diff-index HEAD
+        run: test -z "$(git status --porcelain)"
 
-      - name: Create Release Pull Request or Publish to npm
+      # schema.yaml is the only workflow that prepares release pull requests; pending changesets must be versioned there.
+      - name: Publish to npm
+        if: hashFiles('.changeset/*.md', '!.changeset/README.md') == ''
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
-          commit: "chore(release): version packages"
-          title: "chore(release): version packages"
           publish: pnpm ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,13 @@ jobs:
     permissions:
       contents: write
       id-token: write # Required for OIDC (https://docs.npmjs.com/trusted-publishers#github-actions-configuration)
+    env:
+      SKIP_RELEASE: ${{ github.event_name == 'push' && contains(github.event.head_commit.message, '[skip release]') }}
     steps:
+      - name: Report skipped release
+        if: env.SKIP_RELEASE == 'true'
+        run: echo 'Publishing skipped by [skip release]. Validation still runs.' >> "$GITHUB_STEP_SUMMARY"
+
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -77,7 +83,7 @@ jobs:
 
       # schema.yaml is the only workflow that prepares release pull requests; pending changesets must be versioned there.
       - name: Publish to npm
-        if: hashFiles('.changeset/*.md', '!.changeset/README.md') == ''
+        if: env.SKIP_RELEASE != 'true' && hashFiles('.changeset/*.md', '!.changeset/README.md') == ''
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           publish: pnpm ci:publish

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -8,9 +8,14 @@ on:
     - cron: "0 19 * * *"
       timezone: America/Los_Angeles
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Generate and validate a release without creating a pull request
+        type: boolean
+        default: false
 
 concurrency:
-  group: sdk-prepare-release
+  group: sdk-prepare-release-${{ github.ref }}
   cancel-in-progress: false
 
 permissions: {}
@@ -18,7 +23,7 @@ permissions: {}
 jobs:
   schema:
     name: Prepare release
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' || inputs.dry_run
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -29,7 +34,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: master
+          ref: ${{ inputs.dry_run && github.ref || 'master' }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -91,6 +96,7 @@ jobs:
           fail-on-breaking: false
 
       - name: Create or update release pull request
+        if: ${{ !inputs.dry_run }}
         id: release-pr
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
@@ -104,7 +110,7 @@ jobs:
       # GITHUB_TOKEN pushes do not trigger build workflows, so dispatch the release branch explicitly.
       # This includes unchanged open pull requests so reruns retry failed or missing checks.
       - name: Run build for release pull request
-        if: steps.release-pr.outputs.pull-request-number != '' && steps.release-pr.outputs.pull-request-operation != 'closed'
+        if: ${{ !inputs.dry_run && steps.release-pr.outputs.pull-request-number != '' && steps.release-pr.outputs.pull-request-operation != 'closed' }}
         run: gh workflow run build.yaml --ref changeset-release/master
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -116,7 +122,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-    if: ${{ always() && github.ref_name == 'master' && contains(needs.*.result, 'failure') }}
+    if: ${{ always() && !inputs.dry_run && github.ref_name == 'master' && contains(needs.*.result, 'failure') }}
     steps:
       - uses: ravsamhq/notify-slack-action@bca2d7f5660b833a27bda4f6b8bef389ebfefd25 # 2.3.0
         with:

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -38,6 +38,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Set Changesets base branch for dry runs
+        if: inputs.dry_run && github.ref != 'refs/heads/master'
+        run: git branch master origin/master
+
       - name: Install pnpm
         uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -57,32 +57,7 @@ jobs:
       - name: Create release summary
         run: |
           pnpm changeset status --output "$RUNNER_TEMP/release-plan.json"
-          node <<'NODE'
-          const fs = require("node:fs");
-          const path = require("node:path");
-
-          const plan = JSON.parse(
-            fs.readFileSync(path.join(process.env.RUNNER_TEMP, "release-plan.json"), "utf8"),
-          );
-          const releases = plan.releases.filter(({ type }) => type !== "none");
-          const lines = [
-            "This single pull request contains the generated schema and SDK updates plus all pending changesets. Merging it publishes the listed packages to npm; no second release pull request will be created.",
-            "",
-            "| Package | Current | Release | Bump |",
-            "| --- | --- | --- | --- |",
-            ...releases.map(
-              ({ name, oldVersion, newVersion, type }) =>
-                `| ${name} | ${oldVersion} | ${newVersion} | ${type} |`,
-            ),
-            "",
-            "Full release notes are available in the changed `CHANGELOG.md` files. This pull request updates daily and whenever changes are merged to `master`.",
-            "",
-          ];
-          const body = lines.join("\n");
-
-          fs.writeFileSync(path.join(process.env.RUNNER_TEMP, "release-body.md"), body);
-          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, body);
-          NODE
+          node .github/scripts/create-release-summary.mjs
 
       - name: Version packages
         run: |

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -1,17 +1,27 @@
 name: schema
 
 on:
+  push:
+    branches:
+      - master
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 19 * * *"
+      timezone: America/Los_Angeles
   workflow_dispatch:
+
+concurrency:
+  group: sdk-prepare-release
+  cancel-in-progress: false
 
 permissions: {}
 
 jobs:
   schema:
-    name: Schema
+    name: Prepare release
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       checks: write
       pull-requests: write
@@ -19,6 +29,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          ref: master
           fetch-depth: 0
           persist-credentials: false
 
@@ -36,16 +47,53 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build packages
-        # update:schema depends on utilities from other packages, so we have to build them first, then rebuild once
-        # we've generated the updated schema.
-        run: pnpm build
+      - name: Build schema update prerequisites
+        # Changeset generation imports utilities from @linear/codegen-doc.
+        run: pnpm --filter @linear/codegen-doc build:codegen-doc
 
       - name: Update schema
         run: pnpm update:schema
 
-      - name: Build packages with updated schema
+      - name: Create release summary
+        run: |
+          pnpm changeset status --output "$RUNNER_TEMP/release-plan.json"
+          node <<'NODE'
+          const fs = require("node:fs");
+          const path = require("node:path");
+
+          const plan = JSON.parse(
+            fs.readFileSync(path.join(process.env.RUNNER_TEMP, "release-plan.json"), "utf8"),
+          );
+          const releases = plan.releases.filter(({ type }) => type !== "none");
+          const lines = [
+            "This single pull request contains the generated schema and SDK updates plus all pending changesets. Merging it publishes the listed packages to npm; no second release pull request will be created.",
+            "",
+            "| Package | Current | Release | Bump |",
+            "| --- | --- | --- | --- |",
+            ...releases.map(
+              ({ name, oldVersion, newVersion, type }) =>
+                `| ${name} | ${oldVersion} | ${newVersion} | ${type} |`,
+            ),
+            "",
+            "Full release notes are available in the changed `CHANGELOG.md` files. This pull request updates daily and whenever changes are merged to `master`.",
+            "",
+          ];
+          const body = lines.join("\n");
+
+          fs.writeFileSync(path.join(process.env.RUNNER_TEMP, "release-body.md"), body);
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, body);
+          NODE
+
+      - name: Version packages
+        run: |
+          pnpm changeset version
+          pnpm install --lockfile-only
+
+      - name: Build packages
         run: pnpm build
+
+      - name: Run lint
+        run: pnpm lint
 
       - name: Run tests
         run: pnpm test
@@ -67,15 +115,24 @@ jobs:
           schema: "master:packages/sdk/src/schema.graphql"
           fail-on-breaking: false
 
-      - name: Create schema pull request
+      - name: Create or update release pull request
+        id: release-pr
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           sign-commits: true
-          commit-message: "feat(sdk): update schema"
-          title: "feat(sdk): update schema"
-          body: "Update schema, regenerate types and SDK"
-          branch: schema
+          commit-message: "chore(release): update schema and version packages"
+          title: "chore(release): update schema and version packages"
+          body-path: ${{ runner.temp }}/release-body.md
+          branch: changeset-release/master
           base: master
+
+      # GITHUB_TOKEN pushes do not trigger build workflows, so dispatch the release branch explicitly.
+      # This includes unchanged open pull requests so reruns retry failed or missing checks.
+      - name: Run build for release pull request
+        if: steps.release-pr.outputs.pull-request-number != '' && steps.release-pr.outputs.pull-request-operation != 'closed'
+        run: gh workflow run build.yaml --ref changeset-release/master
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   notify-slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -30,7 +30,13 @@ jobs:
       contents: write
       checks: write
       pull-requests: write
+    env:
+      SKIP_RELEASE: ${{ github.event_name == 'push' && contains(github.event.head_commit.message, '[skip release]') }}
     steps:
+      - name: Report skipped release
+        if: env.SKIP_RELEASE == 'true'
+        run: echo 'Release preparation skipped by [skip release]. Validation still runs.' >> "$GITHUB_STEP_SUMMARY"
+
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -57,18 +63,22 @@ jobs:
         run: pnpm install
 
       - name: Build schema update prerequisites
+        if: env.SKIP_RELEASE != 'true'
         # Changeset generation imports utilities from @linear/codegen-doc.
         run: pnpm --filter @linear/codegen-doc build:codegen-doc
 
       - name: Update schema
+        if: env.SKIP_RELEASE != 'true'
         run: pnpm update:schema
 
       - name: Create release summary
+        if: env.SKIP_RELEASE != 'true'
         run: |
           pnpm changeset status --output "$RUNNER_TEMP/release-plan.json"
           node .github/scripts/create-release-summary.mjs
 
       - name: Version packages
+        if: env.SKIP_RELEASE != 'true'
         run: |
           pnpm changeset version
           pnpm install --lockfile-only
@@ -100,7 +110,7 @@ jobs:
           fail-on-breaking: false
 
       - name: Create or update release pull request
-        if: ${{ !inputs.dry_run }}
+        if: ${{ !inputs.dry_run && env.SKIP_RELEASE != 'true' }}
         id: release-pr
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
@@ -114,7 +124,7 @@ jobs:
       # GITHUB_TOKEN pushes do not trigger build workflows, so dispatch the release branch explicitly.
       # This includes unchanged open pull requests so reruns retry failed or missing checks.
       - name: Run build for release pull request
-        if: ${{ !inputs.dry_run && steps.release-pr.outputs.pull-request-number != '' && steps.release-pr.outputs.pull-request-operation != 'closed' }}
+        if: ${{ !inputs.dry_run && env.SKIP_RELEASE != 'true' && steps.release-pr.outputs.pull-request-number != '' && steps.release-pr.outputs.pull-request-operation != 'closed' }}
         run: gh workflow run build.yaml --ref changeset-release/master
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -104,5 +104,9 @@ export default defineConfig(
       "jsdoc/newline-after-description": "off",
       "no-extra-boolean-cast": "off",
     },
+  },
+  {
+    files: [".github/scripts/*.mjs"],
+    extends: [tseslint.configs.disableTypeChecked],
   }
 );


### PR DESCRIPTION
Combine schema generation and versioning into one human-reviewed release PR, refreshed daily at 7 p.m. Pacific (so it's after US work hours) and after pushes to master.

Merging it publishes the packages without a second approval. Manual dry runs can validate a branch without creating a release PR or publishing packages. A `[skip release]` marker in the merge commit defers release work for that push while validation still runs; scheduled and manual runs remain enabled.

New release flow: [TypeScript SDK Release flow (New/Staging)](https://linear.app/linear/document/typescript-sdk-release-flow-newstaging-f51a42e98bc4).

Dry run: [https://github.com/linear/linear/actions/runs/33996298152/job/101387333997](<https://github.com/linear/linear/actions/runs/33996298152/job/101387333997>)

Fixes [LIN-82583](https://linear.app/linear/issue/LIN-82583/consolidate-sdk-generate-and-release-workflows).