### PR TITLE
ci: prepare weekly SDK release PRs and request review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/packages/*/CHANGELOG.md @linear/sdk-maintainers

--- a/.github/scripts/create-release-summary.mjs
+++ b/.github/scripts/create-release-summary.mjs
@@ -11,7 +11,7 @@ const lines = [
   "| --- | --- | --- | --- |",
   ...releases.map(({ name, oldVersion, newVersion, type }) => `| ${name} | ${oldVersion} | ${newVersion} | ${type} |`),
   "",
-  "Full release notes are available in the changed `CHANGELOG.md` files. This pull request updates daily and whenever changes are merged to `master`.",
+  "Full release notes are available in the changed `CHANGELOG.md` files. This pull request updates on Tuesdays at 7 p.m. Pacific or when the schema workflow is run manually.",
   "",
 ];
 const body = lines.join("\n");

--- a/.github/scripts/create-release-summary.mjs
+++ b/.github/scripts/create-release-summary.mjs
@@ -5,13 +5,13 @@ import process from "node:process";
 const plan = JSON.parse(fs.readFileSync(path.join(process.env.RUNNER_TEMP, "release-plan.json"), "utf8"));
 const releases = plan.releases.filter(({ type }) => type !== "none");
 const lines = [
-  "This single pull request contains the generated schema and SDK updates plus all pending changesets. Merging it publishes the listed packages to npm; no second release pull request will be created.",
+  "This is an automated SDK maintenance PR. Merging it will publish the listed packages to npm.",
   "",
   "| Package | Current | Release | Bump |",
   "| --- | --- | --- | --- |",
   ...releases.map(({ name, oldVersion, newVersion, type }) => `| ${name} | ${oldVersion} | ${newVersion} | ${type} |`),
   "",
-  "Full release notes are available in the changed `CHANGELOG.md` files. This pull request updates on Tuesdays at 7 p.m. Pacific or when the schema workflow is run manually.",
+  "Full release notes are available in the changed `CHANGELOG.md` files.",
   "",
 ];
 const body = lines.join("\n");

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -115,6 +115,7 @@ jobs:
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           sign-commits: true
+          reviewers: itsmingjie
           commit-message: "chore(release): update schema and version packages"
           title: "chore(release): update schema and version packages"
           body-path: ${{ runner.temp }}/release-body.md

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -102,7 +102,6 @@ jobs:
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           sign-commits: true
-          reviewers: itsmingjie
           commit-message: "chore(release): update schema and version packages"
           title: "chore(release): update schema and version packages"
           body-path: ${{ runner.temp }}/release-body.md

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -1,11 +1,8 @@
 name: schema
 
 on:
-  push:
-    branches:
-      - master
   schedule:
-    - cron: "0 19 * * *"
+    - cron: "0 19 * * 2"
       timezone: America/Los_Angeles
   workflow_dispatch:
     inputs:
@@ -30,13 +27,7 @@ jobs:
       contents: write
       checks: write
       pull-requests: write
-    env:
-      SKIP_RELEASE: ${{ github.event_name == 'push' && contains(github.event.head_commit.message, '[skip release]') }}
     steps:
-      - name: Report skipped release
-        if: env.SKIP_RELEASE == 'true'
-        run: echo 'Release preparation skipped by [skip release]. Validation still runs.' >> "$GITHUB_STEP_SUMMARY"
-
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -63,22 +54,18 @@ jobs:
         run: pnpm install
 
       - name: Build schema update prerequisites
-        if: env.SKIP_RELEASE != 'true'
         # Changeset generation imports utilities from @linear/codegen-doc.
         run: pnpm --filter @linear/codegen-doc build:codegen-doc
 
       - name: Update schema
-        if: env.SKIP_RELEASE != 'true'
         run: pnpm update:schema
 
       - name: Create release summary
-        if: env.SKIP_RELEASE != 'true'
         run: |
           pnpm changeset status --output "$RUNNER_TEMP/release-plan.json"
           node .github/scripts/create-release-summary.mjs
 
       - name: Version packages
-        if: env.SKIP_RELEASE != 'true'
         run: |
           pnpm changeset version
           pnpm install --lockfile-only
@@ -110,7 +97,7 @@ jobs:
           fail-on-breaking: false
 
       - name: Create or update release pull request
-        if: ${{ !inputs.dry_run && env.SKIP_RELEASE != 'true' }}
+        if: ${{ !inputs.dry_run }}
         id: release-pr
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
@@ -125,7 +112,7 @@ jobs:
       # GITHUB_TOKEN pushes do not trigger build workflows, so dispatch the release branch explicitly.
       # This includes unchanged open pull requests so reruns retry failed or missing checks.
       - name: Run build for release pull request
-        if: ${{ !inputs.dry_run && env.SKIP_RELEASE != 'true' && steps.release-pr.outputs.pull-request-number != '' && steps.release-pr.outputs.pull-request-operation != 'closed' }}
+        if: ${{ !inputs.dry_run && steps.release-pr.outputs.pull-request-number != '' && steps.release-pr.outputs.pull-request-operation != 'closed' }}
         run: gh workflow run build.yaml --ref changeset-release/master
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Prepare schema/version PRs on Tuesdays at 7 p.m. Pacific. Use CODEOWNERS for `/packages/*/CHANGELOG.md` to request review from @linear/sdk-maintainers without an extra automation token. Manual PRs that edit package changelogs also request the team; ordinary code and changeset PRs do not.

Stop generation on pushes to master so code changes and release merges do not open extra release PRs during the week. Manual generation remains available, and publishing after a release PR is merged stays unchanged.

The `[skip release]` override still skips npm publishing for a marked push while validation runs. Only the schema-generation guard is removed: it matched push events, which no longer trigger that workflow. The marker never skipped scheduled or manual generation.
