### PR TITLE
ci: notify Slack after SDK package releases

### DIFF
--- a/.github/scripts/create-release-slack-message.mjs
+++ b/.github/scripts/create-release-slack-message.mjs
@@ -66,7 +66,6 @@ try {
   // Approval context is best effort and should never block a release notification.
 }
 
-const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-const text = `:rocket: New releases${approval}${pullRequestContext}\n${releaseLines.join("\n")}\n<${runUrl}|View Run>`;
+const text = `:rocket: New releases${approval}${pullRequestContext}\n${releaseLines.join("\n")}`;
 
 fs.writeFileSync(path.join(process.env.RUNNER_TEMP, "sdk-release-slack.json"), JSON.stringify({ text }));

--- a/.github/scripts/create-release-slack-message.mjs
+++ b/.github/scripts/create-release-slack-message.mjs
@@ -17,7 +17,7 @@ const releaseLines = publishedPackages.map(({ name, version }) => {
   const npmUrl = `https://www.npmjs.com/package/${name}/v/${version}`;
   const versionChange = previousVersion ? `v${previousVersion} → ` : "";
 
-  return `• ${name} [${releaseType}] ${versionChange}*<${npmUrl}|v${version}>*`;
+  return `• ${name} [${releaseType}] ${versionChange}<${npmUrl}|v${version}>`;
 });
 
 const githubApi = endpoint =>
@@ -29,7 +29,7 @@ const githubApi = endpoint =>
   );
 
 let approval = "";
-let pullRequestLink = "";
+let pullRequestContext = "";
 try {
   const pullRequests = githubApi(`commits/${process.env.GITHUB_SHA}/pulls`);
   const pullRequest = pullRequests.find(({ merged_at: mergedAt }) => mergedAt);
@@ -56,13 +56,17 @@ try {
     }
 
     const pullRequestUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/pull/${pullRequest.number}`;
-    pullRequestLink = ` — <${pullRequestUrl}|#${pullRequest.number}>`;
+    const author =
+      pullRequest.user.login === "github-actions[bot]"
+        ? "CI"
+        : `<https://github.com/${pullRequest.user.login}|@${pullRequest.user.login}>`;
+    pullRequestContext = ` — <${pullRequestUrl}|#${pullRequest.number}> by ${author}`;
   }
 } catch {
   // Approval context is best effort and should never block a release notification.
 }
 
 const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-const text = `:rocket: SDK release published by ${process.env.GITHUB_ACTOR}${approval}${pullRequestLink} — <${runUrl}|View Run>\n${releaseLines.join("\n")}`;
+const text = `:rocket: New releases published by ${process.env.GITHUB_ACTOR}${approval}${pullRequestContext} — <${runUrl}|View Run>\n${releaseLines.join("\n")}`;
 
 fs.writeFileSync(path.join(process.env.RUNNER_TEMP, "sdk-release-slack.json"), JSON.stringify({ text }));

--- a/.github/scripts/create-release-slack-message.mjs
+++ b/.github/scripts/create-release-slack-message.mjs
@@ -1,0 +1,68 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const publishedPackages = JSON.parse(process.env.PUBLISHED_PACKAGES);
+
+const releaseLines = publishedPackages.map(({ name, version }) => {
+  const packageDirectory = path.join("packages", name.split("/").at(-1));
+  const changelogPath = path.join(packageDirectory, "CHANGELOG.md");
+  const changelog = fs.existsSync(changelogPath) ? fs.readFileSync(changelogPath, "utf8") : "";
+
+  const versions = [...changelog.matchAll(/^## ([0-9]\S*)$/gm)].map(match => match[1]);
+  const previousVersion = versions.find(candidate => candidate !== version);
+  const currentRelease = changelog.split(`## ${version}\n`)[1]?.split(/^## /m)[0] ?? "";
+  const releaseType = currentRelease.match(/^### (Major|Minor|Patch) Changes$/m)?.[1].toLowerCase() ?? "";
+  const npmUrl = `https://www.npmjs.com/package/${name}/v/${version}`;
+  const versionChange = previousVersion ? `v${previousVersion} → ` : "";
+
+  return `• ${name} [${releaseType}] ${versionChange}*<${npmUrl}|v${version}>*`;
+});
+
+const githubApi = endpoint =>
+  JSON.parse(
+    execFileSync("gh", ["api", `repos/${process.env.GITHUB_REPOSITORY}/${endpoint}`], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+  );
+
+let approval = "";
+let pullRequestLink = "";
+try {
+  const pullRequests = githubApi(`commits/${process.env.GITHUB_SHA}/pulls`);
+  const pullRequest = pullRequests.find(({ merged_at: mergedAt }) => mergedAt);
+  if (pullRequest) {
+    const reviews = githubApi(`pulls/${pullRequest.number}/reviews?per_page=100`);
+    const latestDecisions = new Map();
+    for (const review of reviews) {
+      if (!["APPROVED", "CHANGES_REQUESTED", "DISMISSED"].includes(review.state)) {
+        continue;
+      }
+      const previous = latestDecisions.get(review.user.login);
+      if (!previous || review.submitted_at > previous.submitted_at) {
+        latestDecisions.set(review.user.login, review);
+      }
+    }
+
+    const approvers = [...latestDecisions.values()]
+      .filter(({ state }) => state === "APPROVED")
+      .map(({ user }) => `<https://github.com/${user.login}|@${user.login}>`)
+      .sort()
+      .join(", ");
+    if (approvers) {
+      approval = `, approved by ${approvers}`;
+    }
+
+    const pullRequestUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/pull/${pullRequest.number}`;
+    pullRequestLink = ` — <${pullRequestUrl}|#${pullRequest.number}>`;
+  }
+} catch {
+  // Approval context is best effort and should never block a release notification.
+}
+
+const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+const text = `:rocket: SDK release published by ${process.env.GITHUB_ACTOR}${approval}${pullRequestLink} — <${runUrl}|View Run>\n${releaseLines.join("\n")}`;
+
+fs.writeFileSync(path.join(process.env.RUNNER_TEMP, "sdk-release-slack.json"), JSON.stringify({ text }));

--- a/.github/scripts/create-release-slack-message.mjs
+++ b/.github/scripts/create-release-slack-message.mjs
@@ -11,22 +11,24 @@ const releaseLines = publishedPackages.map(({ name, version }) => {
   const changelog = fs.existsSync(changelogPath) ? fs.readFileSync(changelogPath, "utf8") : "";
 
   const versions = [...changelog.matchAll(/^## ([0-9]\S*)$/gm)].map(match => match[1]);
-  const previousVersion = versions.find(candidate => candidate !== version);
+  const versionIndex = versions.indexOf(version);
+  const previousVersion = versionIndex >= 0 ? versions[versionIndex + 1] : undefined;
   const currentRelease = changelog.split(`## ${version}\n`)[1]?.split(/^## /m)[0] ?? "";
   const releaseType = currentRelease.match(/^### (Major|Minor|Patch) Changes$/m)?.[1].toLowerCase() ?? "";
+  const releaseLabel = releaseType ? ` [${releaseType}]` : "";
   const npmUrl = `https://www.npmjs.com/package/${name}/v/${version}`;
   const versionChange = previousVersion ? `v${previousVersion} → ` : "";
 
-  return `• ${name} [${releaseType}] ${versionChange}<${npmUrl}|v${version}>`;
+  return `• ${name}${releaseLabel} ${versionChange}<${npmUrl}|v${version}>`;
 });
 
 const githubApi = endpoint =>
   JSON.parse(
-    execFileSync("gh", ["api", `repos/${process.env.GITHUB_REPOSITORY}/${endpoint}`], {
+    execFileSync("gh", ["api", "--paginate", "--slurp", `repos/${process.env.GITHUB_REPOSITORY}/${endpoint}`], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     })
-  );
+  ).flat();
 
 let approval = "";
 let pullRequestContext = "";
@@ -34,6 +36,13 @@ try {
   const pullRequests = githubApi(`commits/${process.env.GITHUB_SHA}/pulls`);
   const pullRequest = pullRequests.find(({ merged_at: mergedAt }) => mergedAt);
   if (pullRequest) {
+    const pullRequestUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/pull/${pullRequest.number}`;
+    const author =
+      pullRequest.user.login === "github-actions[bot]"
+        ? "CI"
+        : `<https://github.com/${pullRequest.user.login}|@${pullRequest.user.login}>`;
+    pullRequestContext = ` — <${pullRequestUrl}|#${pullRequest.number}> by ${author}`;
+
     const reviews = githubApi(`pulls/${pullRequest.number}/reviews?per_page=100`);
     const latestDecisions = new Map();
     for (const review of reviews) {
@@ -54,13 +63,6 @@ try {
     if (approvers) {
       approval = `, approved by ${approvers}`;
     }
-
-    const pullRequestUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/pull/${pullRequest.number}`;
-    const author =
-      pullRequest.user.login === "github-actions[bot]"
-        ? "CI"
-        : `<https://github.com/${pullRequest.user.login}|@${pullRequest.user.login}>`;
-    pullRequestContext = ` — <${pullRequestUrl}|#${pullRequest.number}> by ${author}`;
   }
 } catch {
   // Approval context is best effort and should never block a release notification.

--- a/.github/scripts/create-release-slack-message.mjs
+++ b/.github/scripts/create-release-slack-message.mjs
@@ -67,6 +67,6 @@ try {
 }
 
 const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-const text = `:rocket: New releases published by ${process.env.GITHUB_ACTOR}${approval}${pullRequestContext} — <${runUrl}|View Run>\n${releaseLines.join("\n")}`;
+const text = `:rocket: New releases${approval}${pullRequestContext}\n${releaseLines.join("\n")}\n<${runUrl}|View Run>`;
 
 fs.writeFileSync(path.join(process.env.RUNNER_TEMP, "sdk-release-slack.json"), JSON.stringify({ text }));

--- a/.github/scripts/create-release-slack-message.mjs
+++ b/.github/scripts/create-release-slack-message.mjs
@@ -19,7 +19,7 @@ const releaseLines = publishedPackages.map(({ name, version }) => {
   const npmUrl = `https://www.npmjs.com/package/${name}/v/${version}`;
   const versionChange = previousVersion ? `v${previousVersion} → ` : "";
 
-  return `• ${name}${releaseLabel} ${versionChange}<${npmUrl}|v${version}>`;
+  return `• \`${name}\`${releaseLabel} ${versionChange}<${npmUrl}|v${version}>`;
 });
 
 const githubApi = endpoint =>

--- a/.github/scripts/create-release-slack-message.mjs
+++ b/.github/scripts/create-release-slack-message.mjs
@@ -15,11 +15,11 @@ const releaseLines = publishedPackages.map(({ name, version }) => {
   const previousVersion = versionIndex >= 0 ? versions[versionIndex + 1] : undefined;
   const currentRelease = changelog.split(`## ${version}\n`)[1]?.split(/^## /m)[0] ?? "";
   const releaseType = currentRelease.match(/^### (Major|Minor|Patch) Changes$/m)?.[1].toLowerCase() ?? "";
-  const releaseLabel = releaseType ? ` [${releaseType}]` : "";
+  const releaseLabel = releaseType ? `[${releaseType}] ` : "";
   const npmUrl = `https://www.npmjs.com/package/${name}/v/${version}`;
   const versionChange = previousVersion ? `v${previousVersion} → ` : "";
 
-  return `• \`${name}\`${releaseLabel} ${versionChange}<${npmUrl}|v${version}>`;
+  return `• ${releaseLabel}\`${name}\`: ${versionChange}<${npmUrl}|v${version}>`;
 });
 
 const githubApi = endpoint =>

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,11 +5,6 @@ on:
     branches:
       - master
   workflow_dispatch:
-    inputs:
-      send_test_notification:
-        description: Send a sample SDK release Slack notification without running the release
-        type: boolean
-        default: false
 
 concurrency:
   group: sdk-publish
@@ -22,7 +17,7 @@ permissions: {}
 jobs:
   release:
     name: Release
-    if: github.ref == 'refs/heads/master' && !inputs.send_test_notification
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -103,79 +98,10 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLI_CHANNEL_WEBHOOK_URL }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTOR: ${{ github.actor }}
           PUBLISHED_PACKAGES: ${{ steps.publish.outputs.publishedPackages }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          RELEASES=$(
-            jq -r '.[] | [.name, .version] | @tsv' <<< "$PUBLISHED_PACKAGES" |
-              while IFS=$'\t' read -r NAME VERSION; do
-                PACKAGE_DIR="packages/${NAME##*/}"
-                PREVIOUS_VERSION=""
-                RELEASE_TYPE=""
-                if [[ -f "$PACKAGE_DIR/CHANGELOG.md" ]]; then
-                  PREVIOUS_VERSION=$(awk '/^## [0-9]/ && $2 != version { print $2; exit }' version="$VERSION" "$PACKAGE_DIR/CHANGELOG.md")
-                  RELEASE_TYPE=$(awk '
-                    $0 == "## " version { in_release = 1; next }
-                    in_release && /^## / { exit }
-                    in_release && /^### (Major|Minor|Patch) Changes$/ { print tolower($2); exit }
-                  ' version="$VERSION" "$PACKAGE_DIR/CHANGELOG.md")
-                fi
-
-                NPM_URL="https://www.npmjs.com/package/${NAME}/v/${VERSION}"
-                if [[ -n "$PREVIOUS_VERSION" ]]; then
-                  printf '• %s [%s] v%s → *<%s|v%s>*\n' "$NAME" "$RELEASE_TYPE" "$PREVIOUS_VERSION" "$NPM_URL" "$VERSION"
-                else
-                  printf '• %s [%s] *<%s|v%s>*\n' "$NAME" "$RELEASE_TYPE" "$NPM_URL" "$VERSION"
-                fi
-              done
-          )
-
-          PR_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" 2>/dev/null || true)
-          PR_NUMBER=$(jq -r 'map(select(.merged_at != null)) | first | .number // empty' <<< "${PR_JSON:-[]}" 2>/dev/null || true)
-          APPROVAL=""
-          PR_LINK=""
-          if [[ -n "$PR_NUMBER" ]]; then
-            PR_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}"
-            PR_LINK=" — <${PR_URL}|#${PR_NUMBER}>"
-            REVIEWS=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" 2>/dev/null || true)
-            APPROVERS=$(jq -r '
-              map(select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED"))
-              | group_by(.user.login)
-              | map(max_by(.submitted_at) | select(.state == "APPROVED") | "<https://github.com/\(.user.login)|@\(.user.login)>")
-              | join(", ")
-            ' <<< "${REVIEWS:-[]}" 2>/dev/null || true)
-            if [[ -n "$APPROVERS" ]]; then
-              APPROVAL=", approved by ${APPROVERS}"
-            fi
-          fi
-
-          curl -s -X POST "$SLACK_WEBHOOK_URL" \
-            -H 'Content-Type: application/json' \
-            -d "$(jq -n \
-              --arg text ":rocket: SDK release published by ${ACTOR}${APPROVAL}${PR_LINK} — <${RUN_URL}|View Run>
-          ${RELEASES}" \
-              '{text: $text}')"
-
-  test-slack-notification:
-    name: Test Slack notification
-    if: inputs.send_test_notification
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - name: Notify Slack
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLI_CHANNEL_WEBHOOK_URL }}
-          ACTOR: ${{ github.actor }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          curl -sS --fail-with-body -X POST "$SLACK_WEBHOOK_URL" \
-            -H 'Content-Type: application/json' \
-            -d "$(jq -n \
-              --arg text ":rocket: [TEST] SDK release published by ${ACTOR}, approved by <https://github.com/${ACTOR}|@${ACTOR}> — <${RUN_URL}|View Run>
-          • @linear/sdk [major] v93.0.1 → *<https://www.npmjs.com/package/@linear/sdk/v/94.0.0|v94.0.0>*
-          • @linear/import [patch] v3.2.11 → *<https://www.npmjs.com/package/@linear/import/v/3.2.12|v3.2.12>*" \
-              '{text: $text}')"
+          node .github/scripts/create-release-slack-message.mjs
+          curl -s -X POST "$SLACK_WEBHOOK_URL" -H 'Content-Type: application/json' --data @"$RUNNER_TEMP/sdk-release-slack.json"
 
   notify-slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,10 +107,29 @@ jobs:
           PUBLISHED_PACKAGES: ${{ steps.publish.outputs.publishedPackages }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          RELEASES=$(jq -r '
-            map("• <https://www.npmjs.com/package/\(.name)/v/\(.version)|\(.name) v\(.version)>")
-            | join("\n")
-          ' <<< "$PUBLISHED_PACKAGES")
+          RELEASES=$(
+            jq -r '.[] | [.name, .version] | @tsv' <<< "$PUBLISHED_PACKAGES" |
+              while IFS=$'\t' read -r NAME VERSION; do
+                PACKAGE_DIR="packages/${NAME##*/}"
+                PREVIOUS_VERSION=""
+                RELEASE_TYPE=""
+                if [[ -f "$PACKAGE_DIR/CHANGELOG.md" ]]; then
+                  PREVIOUS_VERSION=$(awk '/^## [0-9]/ && $2 != version { print $2; exit }' version="$VERSION" "$PACKAGE_DIR/CHANGELOG.md")
+                  RELEASE_TYPE=$(awk '
+                    $0 == "## " version { in_release = 1; next }
+                    in_release && /^## / { exit }
+                    in_release && /^### (Major|Minor|Patch) Changes$/ { print tolower($2); exit }
+                  ' version="$VERSION" "$PACKAGE_DIR/CHANGELOG.md")
+                fi
+
+                NPM_URL="https://www.npmjs.com/package/${NAME}/v/${VERSION}"
+                if [[ -n "$PREVIOUS_VERSION" ]]; then
+                  printf '• %s [%s] v%s → *<%s|v%s>*\n' "$NAME" "$RELEASE_TYPE" "$PREVIOUS_VERSION" "$NPM_URL" "$VERSION"
+                else
+                  printf '• %s [%s] *<%s|v%s>*\n' "$NAME" "$RELEASE_TYPE" "$NPM_URL" "$VERSION"
+                fi
+              done
+          )
 
           PR_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" 2>/dev/null || true)
           PR_NUMBER=$(jq -r 'map(select(.merged_at != null)) | first | .number // empty' <<< "${PR_JSON:-[]}" 2>/dev/null || true)
@@ -154,8 +173,8 @@ jobs:
             -H 'Content-Type: application/json' \
             -d "$(jq -n \
               --arg text ":rocket: [TEST] SDK release published by ${ACTOR}, approved by <https://github.com/${ACTOR}|@${ACTOR}> — <${RUN_URL}|View Run>
-          • <https://www.npmjs.com/package/@linear/sdk/v/0.0.0-sample|@linear/sdk v0.0.0-sample>
-          • <https://www.npmjs.com/package/@linear/import/v/0.0.0-sample|@linear/import v0.0.0-sample>" \
+          • @linear/sdk [major] v93.0.1 → *<https://www.npmjs.com/package/@linear/sdk/v/94.0.0|v94.0.0>*
+          • @linear/import [patch] v3.2.11 → *<https://www.npmjs.com/package/@linear/import/v/3.2.12|v3.2.12>*" \
               '{text: $text}')"
 
   notify-slack:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,7 +107,10 @@ jobs:
           PUBLISHED_PACKAGES: ${{ steps.publish.outputs.publishedPackages }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          RELEASES=$(jq -r 'map("\(.name) v\(.version)") | join(", ")' <<< "$PUBLISHED_PACKAGES")
+          RELEASES=$(jq -r '
+            map("• <https://www.npmjs.com/package/\(.name)/v/\(.version)|\(.name) v\(.version)>")
+            | join("\n")
+          ' <<< "$PUBLISHED_PACKAGES")
 
           PR_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" 2>/dev/null || true)
           PR_NUMBER=$(jq -r 'map(select(.merged_at != null)) | first | .number // empty' <<< "${PR_JSON:-[]}" 2>/dev/null || true)
@@ -131,7 +134,8 @@ jobs:
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H 'Content-Type: application/json' \
             -d "$(jq -n \
-              --arg text ":rocket: SDK release ${RELEASES} published by ${ACTOR}${APPROVAL}${PR_LINK} — <${RUN_URL}|View Run>" \
+              --arg text ":rocket: SDK release published by ${ACTOR}${APPROVAL}${PR_LINK} — <${RUN_URL}|View Run>
+          ${RELEASES}" \
               '{text: $text}')"
 
   test-slack-notification:
@@ -149,7 +153,9 @@ jobs:
           curl -sS --fail-with-body -X POST "$SLACK_WEBHOOK_URL" \
             -H 'Content-Type: application/json' \
             -d "$(jq -n \
-              --arg text ":rocket: [TEST] SDK release @linear/sdk v0.0.0-sample published by ${ACTOR}, approved by <https://github.com/${ACTOR}|@${ACTOR}> — <${RUN_URL}|View Run>" \
+              --arg text ":rocket: [TEST] SDK release published by ${ACTOR}, approved by <https://github.com/${ACTOR}|@${ACTOR}> — <${RUN_URL}|View Run>
+          • <https://www.npmjs.com/package/@linear/sdk/v/0.0.0-sample|@linear/sdk v0.0.0-sample>
+          • <https://www.npmjs.com/package/@linear/import/v/0.0.0-sample|@linear/import v0.0.0-sample>" \
               '{text: $text}')"
 
   notify-slack:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,7 +101,7 @@ jobs:
         if: steps.publish.outputs.published == 'true'
         continue-on-error: true
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLI_CHANNEL_WEBHOOK_URL }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTOR: ${{ github.actor }}
           PUBLISHED_PACKAGES: ${{ steps.publish.outputs.publishedPackages }}
@@ -142,7 +142,7 @@ jobs:
     steps:
       - name: Notify Slack
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLI_CHANNEL_WEBHOOK_URL }}
           ACTOR: ${{ github.actor }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,11 @@ on:
     branches:
       - master
   workflow_dispatch:
+    inputs:
+      send_test_notification:
+        description: Send a sample SDK release Slack notification without running the release
+        type: boolean
+        default: false
 
 concurrency:
   group: sdk-publish
@@ -17,11 +22,12 @@ permissions: {}
 jobs:
   release:
     name: Release
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' && !inputs.send_test_notification
     runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write # Required for OIDC (https://docs.npmjs.com/trusted-publishers#github-actions-configuration)
+      pull-requests: read
     env:
       SKIP_RELEASE: ${{ github.event_name == 'push' && contains(github.event.head_commit.message, '[skip release]') }}
     steps:
@@ -83,12 +89,68 @@ jobs:
 
       # schema.yaml is the only workflow that prepares release pull requests; pending changesets must be versioned there.
       - name: Publish to npm
+        id: publish
         if: env.SKIP_RELEASE != 'true' && hashFiles('.changeset/*.md', '!.changeset/README.md') == ''
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           publish: pnpm ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify Slack
+        if: steps.publish.outputs.published == 'true'
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+          PUBLISHED_PACKAGES: ${{ steps.publish.outputs.publishedPackages }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          RELEASES=$(jq -r 'map("\(.name) v\(.version)") | join(", ")' <<< "$PUBLISHED_PACKAGES")
+
+          PR_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" 2>/dev/null || true)
+          PR_NUMBER=$(jq -r 'map(select(.merged_at != null)) | first | .number // empty' <<< "${PR_JSON:-[]}" 2>/dev/null || true)
+          APPROVAL=""
+          PR_LINK=""
+          if [[ -n "$PR_NUMBER" ]]; then
+            PR_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}"
+            PR_LINK=" — <${PR_URL}|#${PR_NUMBER}>"
+            REVIEWS=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" 2>/dev/null || true)
+            APPROVERS=$(jq -r '
+              map(select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED"))
+              | group_by(.user.login)
+              | map(max_by(.submitted_at) | select(.state == "APPROVED") | "<https://github.com/\(.user.login)|@\(.user.login)>")
+              | join(", ")
+            ' <<< "${REVIEWS:-[]}" 2>/dev/null || true)
+            if [[ -n "$APPROVERS" ]]; then
+              APPROVAL=", approved by ${APPROVERS}"
+            fi
+          fi
+
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -n \
+              --arg text ":rocket: SDK release ${RELEASES} published by ${ACTOR}${APPROVAL}${PR_LINK} — <${RUN_URL}|View Run>" \
+              '{text: $text}')"
+
+  test-slack-notification:
+    name: Test Slack notification
+    if: inputs.send_test_notification
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Notify Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          ACTOR: ${{ github.actor }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          curl -sS --fail-with-body -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -n \
+              --arg text ":rocket: [TEST] SDK release @linear/sdk v0.0.0-sample published by ${ACTOR}, approved by <https://github.com/${ACTOR}|@${ACTOR}> — <${RUN_URL}|View Run>" \
+              '{text: $text}')"
 
   notify-slack:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Post a non-blocking Slack notification through `SLACK_CLI_CHANNEL_WEBHOOK_URL` after Changesets publishes packages to npm. Include PR approvers and author, plus each package's release type, version transition, and npm link.

Example using #1261:

> 🚀 New releases, approved by @guillaumelachaud, @itsmingjie — #1261 by CI
>
> • [major] `@linear/sdk`: v93.0.1 → [v94.0.0](https://www.npmjs.com/package/@linear/sdk/v/94.0.0)  
> • [patch] `@linear/import`: v3.2.11 → [v3.2.12](https://www.npmjs.com/package/@linear/import/v/3.2.12)

Message construction lives in `.github/scripts/create-release-slack-message.mjs`; PR metadata is best effort. Existing publication guards, including `[skip release]`, remain unchanged.
