### PR TITLE
fix(sdk): handle invalid rate-limit headers

### DIFF
--- a/packages/sdk/src/error.ts
+++ b/packages/sdk/src/error.ts
@@ -152,8 +152,8 @@ export class RatelimitedLinearError extends LinearError {
     if (value === undefined || value === null || value === "") {
       return undefined;
     }
-    // eslint-disable-next-line no-constant-binary-expression
-    return Number(value) ?? undefined;
+    const parsedValue = Number(value);
+    return Number.isNaN(parsedValue) ? undefined : parsedValue;
   }
 }
 


### PR DESCRIPTION
## Summary

- Treat malformed rate-limit response headers as absent instead of exposing `NaN`.
- Remove the unreachable nullish-coalescing fallback and its lint suppression.

## Test plan

- `pnpm --filter @linear/sdk build:types`
- `pnpm exec eslint --max-warnings 0 packages/sdk/src/error.ts`
- `pnpm exec prettier --check packages/sdk/src/error.ts`

Fixes SEC-1279
