### PR TITLE
fix(sdk): omit variables from GraphQL errors

### DIFF
--- a/.changeset/fix-sdk-graphql-error-leak.md
+++ b/.changeset/fix-sdk-graphql-error-leak.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": patch
+---
+
+Omit GraphQL request variables from error messages.

--- a/packages/sdk/src/graphql-client.ts
+++ b/packages/sdk/src/graphql-client.ts
@@ -16,7 +16,7 @@ export class GraphQLClientError<Data, Variables extends Record<string, unknown>>
   public constructor(response: LinearRawResponse<Data>, request: GraphQLRequestContext<Variables>) {
     const message = `${GraphQLClientError.extractMessage(response)}: ${JSON.stringify({
       response,
-      request,
+      request: { query: request.query },
     })}`;
 
     super(message);


### PR DESCRIPTION
## Summary

- omit GraphQL request variables from GraphQLClientError messages to prevent sensitive inputs from being copied into logs and error trackers
- retain the query in the message and the complete request on the error instance for programmatic debugging
- add an @linear/sdk patch changeset

Linear issue: SEC-1276

## Test plan

- pnpm --filter @linear/sdk test --run
- pnpm --filter @linear/sdk build:types
- pnpm changeset status