### PR TITLE
fix(sdk): require signed webhook timestamps

### DIFF
--- a/.changeset/require-webhook-timestamp.md
+++ b/.changeset/require-webhook-timestamp.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": patch
+---
+
+Require a finite numeric `webhookTimestamp` in the signed body and enforce the existing one-minute replay window in all webhook verification APIs. Unsigned timestamp headers and legacy timestamp arguments can no longer bypass this check. The optional third argument to `verify()` and `parseData()` is retained for source compatibility but ignored; callers can omit it. Payloads without a signed timestamp, including header-only payloads, are now rejected.

--- a/packages/sdk/src/_tests/LinearWebhooks.test.ts
+++ b/packages/sdk/src/_tests/LinearWebhooks.test.ts
@@ -41,6 +41,20 @@ describe("webhooks", () => {
     });
   });
 
+  it.each([undefined, null, 0, "", "not-a-number"])(
+    "rejects signed timestamp %j even with a fresh external timestamp",
+    timestamp => {
+      const client = new LinearWebhookClient("SECRET");
+      requestBody.webhookTimestamp = timestamp;
+      const body = Buffer.from(JSON.stringify(requestBody));
+      const signature = crypto.createHmac("sha256", "SECRET").update(body).digest("hex");
+      const error =
+        timestamp === undefined || timestamp === null ? "Missing webhook timestamp" : "Invalid webhook timestamp";
+      expect(() => client.verify(body, signature, Date.now())).toThrowError(error);
+      expect(() => client.parseData(body, signature, String(Date.now()))).toThrowError(error);
+    }
+  );
+
   describe("verify", () => {
     it("incorrect signature, should fail verification", async () => {
       const webhook = new LinearWebhookClient("SECRET");
@@ -50,45 +64,44 @@ describe("webhooks", () => {
 
     it("correct signature, invalid timestamp should fail verification", async () => {
       const webhook = new LinearWebhookClient("SECRET");
+      requestBody.webhookTimestamp = Date.now() - 1_000_000;
+      rawBody = Buffer.from(JSON.stringify(requestBody));
       const signature = crypto.createHmac("sha256", "SECRET").update(rawBody).digest("hex");
-      const invalidTimestamp = new Date().getTime() - 1_000_000;
-      expect(() => webhook.verify(rawBody, signature, invalidTimestamp)).toThrowError("Invalid webhook timestamp");
+      expect(() => webhook.verify(rawBody, signature, Date.now())).toThrowError("Invalid webhook timestamp");
     });
 
-    it("correct signature, no timestamp, should pass verification", async () => {
+    it("correct signature, signed body timestamp without a separate argument should pass verification", async () => {
       const webhook = new LinearWebhookClient("SECRET");
       const signature = crypto.createHmac("sha256", "SECRET").update(rawBody).digest("hex");
-      expect(() => webhook.verify(rawBody, signature)).toBeTruthy();
+      expect(webhook.verify(rawBody, signature)).toBe(true);
     });
 
     it("correct signature, correct timestamp should pass verification", async () => {
       const webhook = new LinearWebhookClient("SECRET");
       const signature = crypto.createHmac("sha256", "SECRET").update(rawBody).digest("hex");
-      expect(() =>
-        webhook.verify(rawBody, signature, (parsedBody as Record<string, number>)[LINEAR_WEBHOOK_TS_FIELD])
-      ).toBeTruthy();
+      expect(webhook.verify(rawBody, signature, (parsedBody as Record<string, number>)[LINEAR_WEBHOOK_TS_FIELD])).toBe(
+        true
+      );
     });
 
     it("correct signature, string timestamp from header should pass verification", async () => {
       const webhook = new LinearWebhookClient("SECRET");
       const signature = crypto.createHmac("sha256", "SECRET").update(rawBody).digest("hex");
       const timestampString = String(new Date().getTime());
-      expect(() => webhook.verify(rawBody, signature, timestampString)).toBeTruthy();
+      expect(webhook.verify(rawBody, signature, timestampString)).toBe(true);
     });
 
-    it("correct signature, invalid string timestamp from header should fail verification", async () => {
+    it("fresh signed body ignores a stale timestamp header", async () => {
       const webhook = new LinearWebhookClient("SECRET");
       const signature = crypto.createHmac("sha256", "SECRET").update(rawBody).digest("hex");
       const invalidTimestampString = String(new Date().getTime() - 1_000_000);
-      expect(() => webhook.verify(rawBody, signature, invalidTimestampString)).toThrowError(
-        "Invalid webhook timestamp"
-      );
+      expect(webhook.verify(rawBody, signature, invalidTimestampString)).toBe(true);
     });
 
-    it("correct signature, non-numeric string timestamp should fail verification", async () => {
+    it("fresh signed body ignores a non-numeric timestamp header", async () => {
       const webhook = new LinearWebhookClient("SECRET");
       const signature = crypto.createHmac("sha256", "SECRET").update(rawBody).digest("hex");
-      expect(() => webhook.verify(rawBody, signature, "not-a-number")).toThrowError("Invalid webhook timestamp");
+      expect(webhook.verify(rawBody, signature, "not-a-number")).toBe(true);
     });
   });
 
@@ -116,9 +129,10 @@ describe("webhooks", () => {
 
     it("should throw an error if the timestamp is invalid", () => {
       const client = new LinearWebhookClient("SECRET");
+      requestBody.webhookTimestamp = Date.now() - 1_000_000;
+      rawBody = Buffer.from(JSON.stringify(requestBody));
       const signature = crypto.createHmac("sha256", "SECRET").update(rawBody).digest("hex");
-      const invalidTimestamp = new Date().getTime() - 1_000_000;
-      expect(() => client.parseData(rawBody, signature, invalidTimestamp)).toThrowError("Invalid webhook timestamp");
+      expect(() => client.parseData(rawBody, signature, Date.now())).toThrowError("Invalid webhook timestamp");
     });
   });
 });

--- a/packages/sdk/src/_tests/webhook-handler.test.ts
+++ b/packages/sdk/src/_tests/webhook-handler.test.ts
@@ -233,6 +233,36 @@ describe("webhooks handlers", () => {
     }
   });
 
+  it.each([undefined, "fresh"])("rejects a body without a timestamp with header %s", async timestampHeader => {
+    const secret = "SECRET";
+    const client = new LinearWebhookClient(secret);
+    const handler = client.createHandler();
+    let invoked = 0;
+    handler.on("*", () => {
+      invoked += 1;
+    });
+
+    const { payload } = generateIssuePayload();
+    delete payload.webhookTimestamp;
+    const { body, signature } = createSignedBody(secret, payload);
+    const headers = new Map<string, string>([
+      [LINEAR_WEBHOOK_SIGNATURE_HEADER, signature],
+      ["content-type", "application/json"],
+    ]);
+    if (timestampHeader) {
+      headers.set(LINEAR_WEBHOOK_TS_HEADER, String(Date.now()));
+    }
+    const req = {
+      method: "POST",
+      headers: { get: (key: string) => headers.get(key.toLowerCase()) ?? null },
+      arrayBuffer: async () => body,
+    } as unknown as Request;
+
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    expect(invoked).toBe(0);
+  });
+
   it("listens to 'Issue' and 'Comment' specifically (express server)", async () => {
     const secret = "SECRET";
     const client = new LinearWebhookClient(secret);

--- a/packages/sdk/src/webhooks/client.ts
+++ b/packages/sdk/src/webhooks/client.ts
@@ -206,13 +206,13 @@ export class LinearWebhookClient {
   }
 
   /**
-   * Parses the JSON body and verifies signature and optional timestamp.
+   * Parses the JSON body and verifies signature and signed body timestamp.
    *
    * Throws if the JSON is invalid, the signature is invalid, or the timestamp check fails.
    *
    * @param rawBody - Raw request body as a Buffer
    * @param signature - The value of the `linear-signature` header
-   * @param timestampHeader - The value of the `linear-timestamp` header (used only when the signed body has no timestamp)
+   * @param timestampHeader - Legacy timestamp header; verify() only trusts the signed body timestamp.
    * @returns The verified and parsed webhook payload
    */
   private parseVerifiedPayload(
@@ -261,12 +261,11 @@ export class LinearWebhookClient {
   /**
    * Verify the webhook signature
    *
-   * Throws an error if the signature or timestamp is invalid.
+   * Throws if the signature is invalid or the signed body timestamp is missing or invalid.
    *
    * @param rawBody The webhook request raw body
    * @param signature The signature to verify
-   * @param timestamp The timestamp value - either from the `linear-timestamp` header (string)
-   *                  or the `webhookTimestamp` field from the request parsed body (number)
+   * @param timestamp Deprecated and ignored. Only webhookTimestamp in the signed body is trusted.
    * @returns True if the signature is valid
    */
   public verify(rawBody: Buffer, signature: string, timestamp?: number | string): boolean {
@@ -281,16 +280,18 @@ export class LinearWebhookClient {
       throw new Error("Invalid webhook signature");
     }
 
-    if (timestamp) {
-      const timestampMs = typeof timestamp === "string" ? parseInt(timestamp, 10) : timestamp;
-      if (isNaN(timestampMs)) {
-        throw new Error(`Invalid webhook timestamp: ${timestamp}`);
-      }
-      const timeDiff = Math.abs(new Date().getTime() - timestampMs);
-      // Throw error if more than one minute delta between provided ts and current time
-      if (timeDiff > 1000 * 60) {
-        throw new Error("Invalid webhook timestamp");
-      }
+    // Only the timestamp in the signed body can establish freshness.
+    timestamp = this.parseBodyAsWebhookPayload(rawBody)?.webhookTimestamp;
+    if (timestamp === undefined || timestamp === null) {
+      throw new Error("Missing webhook timestamp");
+    }
+    if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) {
+      throw new Error("Invalid webhook timestamp");
+    }
+    const timeDiff = Math.abs(Date.now() - timestamp);
+    // Throw error if more than one minute delta between provided ts and current time
+    if (timeDiff > 1000 * 60) {
+      throw new Error("Invalid webhook timestamp");
     }
 
     return true;
@@ -301,8 +302,7 @@ export class LinearWebhookClient {
    *
    * @param rawBody The webhook request raw body
    * @param signature The signature to verify
-   * @param timestamp The timestamp value - either from the `linear-timestamp` header (string)
-   *                  or the `webhookTimestamp` field from the request parsed body (number)
+   * @param timestamp Deprecated and ignored. Only webhookTimestamp in the signed body is trusted.
    */
   public parseData(rawBody: Buffer, signature: string, timestamp?: number | string): LinearWebhookPayload {
     const verified = this.verify(rawBody, signature, timestamp);


### PR DESCRIPTION
Webhook verification could skip freshness checks when the timestamp argument was omitted, and a fresh unsigned timestamp could allow replay of an old signed payload. Require a finite numeric `webhookTimestamp` from the signed body in `verify()` and enforce the existing one-minute window across direct calls and HTTP handlers.

The optional third argument to `verify()` and `parseData()` remains accepted for source compatibility but is ignored. Two-argument calls validate the body timestamp automatically. This intentionally removes the ability to skip freshness checks: header-only payloads and delayed verification of old queued payloads now fail. Verify on receipt before queueing.

Includes focused missing/invalid timestamp and fresh-header replay regressions, corrected success assertions, and a patch changeset. This bounds replay age; consumers still need deduplication for repeated events within the window.

Validation: SDK build and type checks, ESLint, Prettier, and full SDK suite (711 passed, 3 skipped).

Fixes SEC-1277.
