### PR TITLE
fix(sdk): require HTTPS for non-local API URLs

### DIFF
--- a/.changeset/secure-sdk-api-url.md
+++ b/.changeset/secure-sdk-api-url.md
@@ -1,0 +1,5 @@
+---
+"@linear/sdk": patch
+---
+
+Require HTTPS for custom API URLs outside local development.

--- a/packages/sdk/src/_tests/LinearClient.test.ts
+++ b/packages/sdk/src/_tests/LinearClient.test.ts
@@ -24,6 +24,28 @@ describe("LinearClient", () => {
     });
   });
 
+  it.each([
+    "https://api.example.com/graphql",
+    "http://localhost:3000/graphql",
+    "http://127.0.0.1:3000/graphql",
+    "http://[::1]:3000/graphql",
+  ])("accepts secure or local apiUrl value %s", apiUrl => {
+    const client = new LinearClient({ apiKey: MOCK_API_KEY, apiUrl });
+
+    expect(client.options.apiUrl).toEqual(apiUrl);
+  });
+
+  it.each([
+    "http://api.example.com/graphql",
+    "http://localhost.example.com/graphql",
+    "http://localhost@api.example.com/graphql",
+    "ftp://api.example.com/graphql",
+  ])("rejects insecure non-local apiUrl value %s", apiUrl => {
+    expect(() => new LinearClient({ apiKey: MOCK_API_KEY, apiUrl })).toThrow(
+      "LinearClient apiUrl must use HTTPS unless it points to a local development server"
+    );
+  });
+
   it("makes query to apiUrl", async () => {
     const client = new LinearClient({ apiKey: MOCK_API_KEY, apiUrl: ctx.url });
     const response = await client.viewer;

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -4,6 +4,25 @@ import { LinearClientOptions, LinearClientParsedOptions } from "./types.js";
 import { serializeUserAgent } from "./utils.js";
 import { LinearSdk } from "./_generated_sdk.js";
 
+const LOCAL_API_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+/**
+ * Require encrypted API connections except for local development servers.
+ */
+function validateApiUrl(apiUrl: string): void {
+  const { hostname, protocol } = new URL(apiUrl);
+
+  if (protocol === "https:") {
+    return;
+  }
+
+  if (protocol === "http:" && LOCAL_API_HOSTNAMES.has(hostname)) {
+    return;
+  }
+
+  throw new Error("LinearClient apiUrl must use HTTPS unless it points to a local development server");
+}
+
 /**
  * Validate and return default LinearGraphQLClient options
  *
@@ -23,6 +42,9 @@ function parseClientOptions({
     );
   }
 
+  const resolvedApiUrl = apiUrl ?? "https://api.linear.app/graphql";
+  validateApiUrl(resolvedApiUrl);
+
   return {
     headers: {
       /** Use bearer if oauth token exists, otherwise use the provided apiKey */
@@ -39,7 +61,7 @@ function parseClientOptions({
       }),
     },
     /** Default to production linear api */
-    apiUrl: apiUrl ?? "https://api.linear.app/graphql",
+    apiUrl: resolvedApiUrl,
     ...opts,
   };
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -6,7 +6,7 @@ export interface LinearClientOptions extends RequestInit {
   apiKey?: string;
   /** The access token returned from oauth endpoints configured in https://linear.app/settings/account/security */
   accessToken?: string;
-  /** The url to the Linear graphql api */
+  /** The HTTPS URL to the Linear GraphQL API. HTTP is supported only for local development servers. */
   apiUrl?: string;
 }
 
@@ -40,20 +40,20 @@ export interface LinearRawResponse<Data> {
  * The error types returned by the Linear API
  */
 export enum LinearErrorType {
-  "FeatureNotAccessible" = "FeatureNotAccessible",
-  "InvalidInput" = "InvalidInput",
-  "Ratelimited" = "Ratelimited",
-  "NetworkError" = "NetworkError",
-  "AuthenticationError" = "AuthenticationError",
-  "Forbidden" = "Forbidden",
-  "BootstrapError" = "BootstrapError",
-  "Unknown" = "Unknown",
-  "InternalError" = "InternalError",
-  "Other" = "Other",
-  "UserError" = "UserError",
-  "GraphqlError" = "GraphqlError",
-  "LockTimeout" = "LockTimeout",
-  "UsageLimitExceeded" = "UsageLimitExceeded",
+  FeatureNotAccessible = "FeatureNotAccessible",
+  InvalidInput = "InvalidInput",
+  Ratelimited = "Ratelimited",
+  NetworkError = "NetworkError",
+  AuthenticationError = "AuthenticationError",
+  Forbidden = "Forbidden",
+  BootstrapError = "BootstrapError",
+  Unknown = "Unknown",
+  InternalError = "InternalError",
+  Other = "Other",
+  UserError = "UserError",
+  GraphqlError = "GraphqlError",
+  LockTimeout = "LockTimeout",
+  UsageLimitExceeded = "UsageLimitExceeded",
 }
 
 /**

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -40,20 +40,20 @@ export interface LinearRawResponse<Data> {
  * The error types returned by the Linear API
  */
 export enum LinearErrorType {
-  FeatureNotAccessible = "FeatureNotAccessible",
-  InvalidInput = "InvalidInput",
-  Ratelimited = "Ratelimited",
-  NetworkError = "NetworkError",
-  AuthenticationError = "AuthenticationError",
-  Forbidden = "Forbidden",
-  BootstrapError = "BootstrapError",
-  Unknown = "Unknown",
-  InternalError = "InternalError",
-  Other = "Other",
-  UserError = "UserError",
-  GraphqlError = "GraphqlError",
-  LockTimeout = "LockTimeout",
-  UsageLimitExceeded = "UsageLimitExceeded",
+  "FeatureNotAccessible" = "FeatureNotAccessible",
+  "InvalidInput" = "InvalidInput",
+  "Ratelimited" = "Ratelimited",
+  "NetworkError" = "NetworkError",
+  "AuthenticationError" = "AuthenticationError",
+  "Forbidden" = "Forbidden",
+  "BootstrapError" = "BootstrapError",
+  "Unknown" = "Unknown",
+  "InternalError" = "InternalError",
+  "Other" = "Other",
+  "UserError" = "UserError",
+  "GraphqlError" = "GraphqlError",
+  "LockTimeout" = "LockTimeout",
+  "UsageLimitExceeded" = "UsageLimitExceeded",
 }
 
 /**


### PR DESCRIPTION
Require HTTPS for SDK `apiUrl` values, with HTTP allowed only for `localhost`, `127.0.0.1`, and `[::1]`. Validation runs when constructing `LinearClient`, so insecure remote endpoints fail before a request can send credentials. Custom HTTPS endpoints remain supported for proxies and testing.

Includes regression coverage for accepted endpoints, deceptive localhost hostnames, and unsupported schemes, public option documentation, and a patch changeset.

Validation: SDK build and full suite passed (712 tests, 3 skipped). After simplifying the validation control flow, all 14 client tests, SDK type-checking, and targeted ESLint passed.

Fixes LIN-84780.
