### PR TITLE
fix(sdk): validate model query argument types

### DIFF
--- a/.changeset/fix-model-query-matching.md
+++ b/.changeset/fix-model-query-matching.md
@@ -1,0 +1,6 @@
+---
+"@linear/codegen-doc": patch
+"@linear/codegen-sdk": patch
+---
+
+Only reuse model queries when response fields match the argument types. Generate ID getters only when the query selects an ID.

--- a/packages/codegen-doc/src/query.ts
+++ b/packages/codegen-doc/src/query.ts
@@ -1,6 +1,7 @@
 import { FieldDefinitionNode } from "graphql";
 import { getRequiredArgs } from "./args.js";
 import { Doc } from "./constants.js";
+import { printTypescriptType } from "./print.js";
 import { Named, PluginContext } from "./types.js";
 import { nodeHasSkipComment, reduceListType, reduceTypeName } from "./utils.js";
 
@@ -22,8 +23,8 @@ export function findQuery(
 
   /** Get the matching object definition */
   const responseObject = context.objects.find(obj => type === obj.name.value);
-  const responseFieldNames = responseObject?.fields?.map(responseField => responseField.name.value);
-  if (!responseFieldNames?.length) {
+  const responseFields = responseObject?.fields;
+  if (!responseFields?.length) {
     return undefined;
   }
 
@@ -32,7 +33,12 @@ export function findQuery(
     return (
       reduceTypeName(query.type) === type &&
       reduceListType(query.type) === listType &&
-      getRequiredArgs(query.arguments).every(arg => responseFieldNames.includes(arg.name.value))
+      getRequiredArgs(query.arguments).every(arg => {
+        const responseField = responseFields.find(candidate => candidate.name.value === arg.name.value);
+        return (
+          responseField && printTypescriptType(context, responseField.type) === printTypescriptType(context, arg.type)
+        );
+      })
     );
   });
 

--- a/packages/codegen-sdk/src/print-model.ts
+++ b/packages/codegen-sdk/src/print-model.ts
@@ -233,11 +233,10 @@ function printModel(context: SdkPluginContext, model: SdkModel): string {
             const fieldQueryName = `${printPascal(field.query.name.value)}Query`;
             const allOptional = field.args.every(arg => arg.optional);
             const optionalIdArg = field.args.find(arg => arg.name === "id" && arg.optional);
-            const fieldQueryArgs = (
-              allOptional && optionalIdArg ? [optionalIdArg] : field.args.filter(arg => !arg.optional)
-            ).map(arg => `this._${field.name}${field.nonNull ? "" : "?"}.${arg.name}`);
+            const queryArgs = allOptional && optionalIdArg ? [optionalIdArg] : field.args.filter(arg => !arg.optional);
+            const fieldQueryArgs = queryArgs.map(arg => `this._${field.name}${field.nonNull ? "" : "?"}.${arg.name}`);
             const idGetterName = `${field.name}Id`;
-            const skipIdGetter = publicFieldNames.has(idGetterName);
+            const skipIdGetter = publicFieldNames.has(idGetterName) || !queryArgs.some(arg => arg.name === "id");
             const shouldGeneratePrivateField =
               field.args.some(arg => !arg.optional) ||
               (field.args.every(arg => arg.optional) && !!field.args.find(arg => arg.name === "id"));

--- a/packages/sdk/src/_tests/codegen.test.ts
+++ b/packages/sdk/src/_tests/codegen.test.ts
@@ -1,0 +1,60 @@
+import { plugin as generateDocuments } from "@linear/codegen-doc";
+import { plugin as generateSdk } from "@linear/codegen-sdk";
+import { buildSchema, parse, validate } from "graphql";
+import { describe, expect, it } from "vitest";
+
+async function generatePreferenceModel(fieldType: string, argument: string) {
+  const schema = buildSchema(`
+    enum ViewType { issues projects }
+    type ViewPreferences {
+      id: ID!
+      viewType: ${fieldType}
+    }
+    type CustomView {
+      id: ID!
+      preferences: ViewPreferences
+    }
+    type Query {
+      customView(id: String!): CustomView
+      viewPreferences(${argument}): ViewPreferences
+    }
+  `);
+  const documents = await generateDocuments(schema, [], {});
+  if (typeof documents !== "string") {
+    throw new Error("Expected GraphQL documents");
+  }
+  const document = parse(documents);
+  expect(validate(schema, document)).toEqual([]);
+
+  const sdk = await generateSdk(schema, [{ document }], { documentFile: "./documents" });
+  if (typeof sdk === "string") {
+    throw new Error("Expected SDK output");
+  }
+  return sdk.content;
+}
+
+describe("SDK query field generation", () => {
+  it("embeds objects when a string field cannot supply an enum query argument", async () => {
+    const sdk = await generatePreferenceModel("String!", "viewType: ViewType!");
+
+    expect(sdk).toContain("public preferences?: ViewPreferences | null");
+    expect(sdk).not.toContain("get preferences()");
+    expect(sdk).not.toContain("get preferencesId()");
+  });
+
+  it.each(["String!", "ViewType!"])("fetches by a compatible %s field without an ID getter", async type => {
+    const sdk = await generatePreferenceModel(type, `viewType: ${type}`);
+
+    expect(sdk).toContain("get preferences()");
+    expect(sdk).toContain("this._preferences?.viewType");
+    expect(sdk).not.toContain("get preferencesId()");
+  });
+
+  it.each(["String!", "String"])("preserves ID getters for %s ID arguments", async type => {
+    const sdk = await generatePreferenceModel("String!", `id: ${type}`);
+
+    expect(sdk).toContain("get preferences()");
+    expect(sdk).toContain("get preferencesId()");
+    expect(sdk).toContain("return this._preferences?.id");
+  });
+});


### PR DESCRIPTION
The [schema release failed](https://github.com/linear/linear/actions/runs/34411713494) because `userViewPreferences(viewType: ViewType!)` matched a `String` field. Generated getters passed that string as an enum and accessed an unselected `id`.

Require matching field/argument types before reusing a query. Emit ID getters only when the query selects `id`. Adds five regression cases and changesets.

Verified: reproduced all six CI errors; regenerated the live schema and passed SDK type checking; 11 targeted tests; generator type checks; lint; SDK build and type checks against the checked-in schema. Checked-in generated files remain unchanged.